### PR TITLE
Closes issue #17.  Modify MVKImageView::populateMTLRenderPassAttachme…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -518,14 +518,14 @@ MVKImage::~MVKImage() {
 
 
 void MVKImageView::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
-    mtlAttDesc.texture = _image->getMTLTexture();           // Use underlying image texture, since RP attachment handles subresource
+    mtlAttDesc.texture = getMTLTexture();           // Use image view, necessary if image view format differs from image format
     mtlAttDesc.level = _subresourceRange.baseMipLevel;
     mtlAttDesc.slice = _subresourceRange.baseArrayLayer;
     mtlAttDesc.depthPlane = 0;
 }
 
 void MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
-    mtlAttDesc.resolveTexture = _image->getMTLTexture();    // Use underlying image texture, since RP attachment handles subresource
+    mtlAttDesc.resolveTexture = getMTLTexture();    // Use image view, necessary if image view format differs from image format
     mtlAttDesc.resolveLevel = _subresourceRange.baseMipLevel;
     mtlAttDesc.resolveSlice = _subresourceRange.baseArrayLayer;
     mtlAttDesc.resolveDepthPlane = 0;


### PR DESCRIPTION
…ntDescriptor and MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve to use the MTLTextureView rather than MTLTexture.  This makes sure that the texture view with the correct format is used for the renderpass.  For example, in the case of a mutable image with sRGB and UNORM format, the correct format will be used for the renderpass attachment.