### PR TITLE
Closes issue #19.  The problem was that MVKRenderPass was ignoring VK…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -99,7 +99,8 @@ public:
     bool populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc,
                                                    MVKRenderSubpass* subpass,
                                                    bool isRenderingEntireAttachment,
-                                                   bool hasResolveAttachment);
+                                                   bool hasResolveAttachment,
+                                                   bool isStencil);
 
     /** Returns whether this attachment should be cleared in the subpass. */
     bool shouldUseClearAttachment(MVKRenderSubpass* subpass);


### PR DESCRIPTION
…AttachmentDescription.stencil[Load|Store]Op and was instead using the regular [load|store]Op for the stencil attachment.  This fixes water reflections/refractions not rendering correctly in Dota 2.