### PR TITLE
 Closes #22. Fix "Game Rendering Quality" slider and Pause (F9) in dota2

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -802,11 +802,11 @@ void MVKCmdClearAttachments::encode(MVKCommandEncoder* cmdEncoder) {
     uint32_t caCnt = subpass->getColorAttachmentCount();
     for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
         VkFormat vkAttFmt = subpass->getColorAttachmentFormat(caIdx);
-        //if (_rpsKey.isEnabled(caIdx)) {
+        if (_rpsKey.isEnabled(caIdx)) {
             _rpsKey.attachmentMTLPixelFormats[caIdx] = cmdPool->mtlPixelFormatFromVkFormat(vkAttFmt);
             MTLClearColor mtlCC = mvkMTLClearColorFromVkClearValue(_vkClearValues[caIdx], vkAttFmt);
             _clearColors[caIdx] = { (float)mtlCC.red, (float)mtlCC.green, (float)mtlCC.blue, (float)mtlCC.alpha};
-        //}
+        }
     }
 
     VkFormat vkAttFmt = subpass->getDepthStencilFormat();


### PR DESCRIPTION
* In the case of vkCmdBlitImage with formats that don't match, use the Metal Blit render path and don't return an error.
* Fix MvkCmdBlitImage::populateVertices which had the source and destination y shifted.