### PR TITLE
Use MTLDevice recommendedMaxWorkingSetSize to set the heap size rathe…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -840,10 +840,14 @@ void MVKPhysicalDevice::initMemoryProperties() {
 	//		- cmdbuff waitUntilCompleted (or completion handler)
 	//		- buffer/texture getBytes:
 
-	// TODO: determine correct values - particularly heap size
 	_memoryProperties.memoryHeapCount = 1;
 	_memoryProperties.memoryHeaps[0].flags = (VK_MEMORY_HEAP_DEVICE_LOCAL_BIT);
+#if MVK_MACOS
+	_memoryProperties.memoryHeaps[0].size = (VkDeviceSize)[_mtlDevice recommendedMaxWorkingSetSize];
+#else
+	// TODO: determine heap size on iOS where recommenedMaxWorkingSetSize does not exist.
 	_memoryProperties.memoryHeaps[0].size = 0;
+#endif
 
 	_memoryProperties.memoryTypes[0].heapIndex = 0;
 	_memoryProperties.memoryTypes[0].propertyFlags = MVK_VK_MEMORY_TYPE_METAL_PRIVATE;	// Private storage


### PR DESCRIPTION
…r than leaving it at 0 (on macOS).  recommenededMaxWorkingSetSize does not exist on iOS so for iOS continue to leave it at 0 for now.