### PR TITLE
Updates to Metal resource locking.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.h
@@ -130,14 +130,16 @@ public:
      * maximum size. Because MVKMTLBufferRegions are created with a power-of-two size,
      * the largest size of a MVKMTLBufferAllocation dispensed by this instance will be the
      * next power-of-two value that is at least as big as the specified maximum size.
+	 * If makeThreadSafe is true, a lock will be applied when an allocation is acquired.
      */
-    MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxRegionLength);
+    MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxRegionLength, bool makeThreadSafe = false);
 
     ~MVKMTLBufferAllocator() override;
 
 protected:
     std::vector<MVKMTLBufferAllocationPool*> _regionPools;
     NSUInteger _maxAllocationLength;
+	bool _makeThreadSafe;
 
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -80,11 +80,13 @@ const MVKMTLBufferAllocation* MVKMTLBufferAllocator::acquireMTLBufferRegion(NSUI
 
     // Convert max length to the next power-of-two exponent to use as a lookup
     uint32_t p2Exp = mvkPowerOfTwoExponent(length);
-    return _regionPools[p2Exp]->acquireObjectSafely();
+	MVKMTLBufferAllocationPool* pRP = _regionPools[p2Exp];
+	return _makeThreadSafe ? pRP->acquireObjectSafely() : pRP->acquireObject();
 }
 
-MVKMTLBufferAllocator::MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxAllocationLength) : MVKBaseDeviceObject(device) {
-    _maxAllocationLength = maxAllocationLength;
+MVKMTLBufferAllocator::MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxRegionLength, bool makeThreadSafe) : MVKBaseDeviceObject(device) {
+    _maxAllocationLength = maxRegionLength;
+	_makeThreadSafe = makeThreadSafe;
 
     // Convert max length to the next power-of-two exponent
     uint32_t maxP2Exp = mvkPowerOfTwoExponent(_maxAllocationLength);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -122,5 +122,6 @@ protected:
     id<MTLTexture> _mtlTexture;
     VkDeviceSize _byteCount;
     VkExtent2D _textureSize;
+	std::mutex _lock;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -120,6 +120,7 @@ protected:
 	VkDeviceSize _mapOffset;
 	VkDeviceSize _mapSize;
 	id<MTLBuffer> _mtlBuffer;
+	std::mutex _lock;
 	MTLResourceOptions _mtlResourceOptions;
 	MTLStorageMode _mtlStorageMode;
 	MTLCPUCacheMode _mtlCPUCacheMode;


### PR DESCRIPTION
MVKBufferView add lock when creating MTLTexture.
MVKDeviceMemory add lock when creating MTLBuffer during memory mapping.
MVKMTLBufferAllocator does not need to be threadsafe.
Cleanup syntax on other lock handling to add consistency.