### PR TITLE
correct fragment function suffix

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -203,13 +203,16 @@ string MVKCommandResourceFactory::getFragFunctionSuffix(MTLPixelFormat mtlPixFmt
     string suffix;
     switch (mvkFormatTypeFromMTLPixelFormat(mtlPixFmt)) {
         case kMVKFormatDepthStencil:
-            suffix += "DS";
+            suffix = "DS";
+            break;
         case kMVKFormatColorUInt:
-            suffix += "U";
+            suffix = "U";
+            break;
         case kMVKFormatColorInt:
-            suffix += "I";
+            suffix = "I";
+            break;
         default:
-            suffix += "F";
+            suffix = "F";
             break;
     }
 


### PR DESCRIPTION
Missing break statements created wrong suffix for fragment function (clear command for int/unsigned didn't work)