### PR TITLE
push constant offset

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -159,8 +159,7 @@ void MVKCmdPushConstants::setContent(VkPipelineLayout layout,
 	_stageFlags = stageFlags;
 	_offset = offset;
 
-    size_t pcBuffSize = mvkAlignByteOffset(size, getDevice()->_pMetalFeatures->mtlBufferAlignment);
-    mvkEnsureSize(_pushConstants, pcBuffSize);
+    mvkEnsureSize(_pushConstants, size);
 	copy_n((char*)pValues, size, _pushConstants.begin());
 }
 


### PR DESCRIPTION
push constant buffer was aligned, which would overwrite other push constant when writing to the buffer (happens when calling push constants with non-increasing offsets)