### PR TITLE
Add printf-like macros to MVKLogImpl and mvkNotifyErrorWithText.

### DIFF
--- a/Common/MVKLogging.h
+++ b/Common/MVKLogging.h
@@ -176,6 +176,7 @@ extern "C" {
  * Combine the specified log level and format string, then log
  * the specified args to one or both of ASL and printf.
  */
+static inline void MVKLogImplV(bool logToPrintf, bool logToASL, int aslLvl, const char* lvlStr, const char* format, va_list args) __printflike(5, 0);
 static inline void MVKLogImplV(bool logToPrintf, bool logToASL, int aslLvl, const char* lvlStr, const char* format, va_list args) {
 
 	// Combine the level and format string
@@ -190,6 +191,7 @@ static inline void MVKLogImplV(bool logToPrintf, bool logToASL, int aslLvl, cons
  * Combine the specified log level and format string, then log 
  * the specified args to one or both of ASL and printf.
  */
+static inline void MVKLogImpl(bool logToPrintf, bool logToASL, int aslLvl, const char* lvlStr, const char* format, ...) __printflike(5, 6);
 static inline void MVKLogImpl(bool logToPrintf, bool logToASL, int aslLvl, const char* lvlStr, const char* format, ...) {
 	va_list args;
 	va_start(args, format);

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -103,7 +103,7 @@ char* mvkResultName(VkResult vkResult, char* name);
  *
  * - Logs the error code and message to the console
  */
-VkResult mvkNotifyErrorWithText(VkResult vkErr, const char* errFmt, ...);
+VkResult mvkNotifyErrorWithText(VkResult vkErr, const char* errFmt, ...) __printflike(2, 3);
 
 
 #pragma mark -


### PR DESCRIPTION
This will make the compiler point out improper formatting of variadic functions.