### PR TITLE
Fix vkGetInstanceProcAddr to work with 1.1 loader

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -137,9 +137,11 @@ MVK_PUBLIC_SYMBOL PFN_vkVoidFunction vkGetInstanceProcAddr(
 	if (strcmp(pName, "vkCreateInstance") == 0) { return (PFN_vkVoidFunction)vkCreateInstance; }
 	if (strcmp(pName, "vkEnumerateInstanceExtensionProperties") == 0) { return (PFN_vkVoidFunction)vkEnumerateInstanceExtensionProperties; }
 	if (strcmp(pName, "vkEnumerateInstanceLayerProperties") == 0) { return (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties; }
-
-	MVKInstance* mvkInst = MVKInstance::getMVKInstance(instance);
-	return mvkInst->getProcAddr(pName);
+    if (instance) {
+        MVKInstance* mvkInst = MVKInstance::getMVKInstance(instance);
+        return mvkInst->getProcAddr(pName);
+    }
+    return NULL;
 }
 
 MVK_PUBLIC_SYMBOL PFN_vkVoidFunction vkGetDeviceProcAddr(


### PR DESCRIPTION
In order to determine the instance version, the 1.1 loader takes advantage of the fact that a 1.0 ICD will return NULL for vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion")