### PR TITLE
Fix vkCmdCopyBuffer when copying unaligned regions.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -555,9 +555,6 @@ void MVKCmdCopyBuffer::setContent(VkBuffer srcBuffer,
 }
 
 void MVKCmdCopyBuffer::encode(MVKCommandEncoder* cmdEncoder) {
-
-    id<MTLBlitCommandEncoder> mtlBlitEnc = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyBuffer);
-
     id<MTLBuffer> srcMTLBuff = _srcBuffer->getMTLBuffer();
     NSUInteger srcMTLBuffOffset = _srcBuffer->getMTLBufferOffset();
 
@@ -565,11 +562,37 @@ void MVKCmdCopyBuffer::encode(MVKCommandEncoder* cmdEncoder) {
     NSUInteger dstMTLBuffOffset = _dstBuffer->getMTLBufferOffset();
 
     for (auto& cpyRgn : _mtlBuffCopyRegions) {
-        [mtlBlitEnc copyFromBuffer: srcMTLBuff
-                      sourceOffset: (srcMTLBuffOffset + cpyRgn.srcOffset)
-                          toBuffer: dstMTLBuff
-                 destinationOffset: (dstMTLBuffOffset + cpyRgn.dstOffset)
-                              size: cpyRgn.size];
+#if MVK_MACOS
+        const bool useComputeCopy = cpyRgn.srcOffset % 4 != 0
+            || cpyRgn.dstOffset % 4 != 0
+            || cpyRgn.size % 4 != 0;
+#else
+        const bool useComputeCopy = false;
+#endif
+        if (useComputeCopy)
+        {
+            MVKAssert(
+                cpyRgn.srcOffset <= UINT32_MAX || cpyRgn.dstOffset <= UINT32_MAX || cpyRgn.size <= UINT32_MAX,
+                "Compute buffer copy region offsets and size must fit into a 32-bit unsigned integer.");
+
+            id<MTLComputeCommandEncoder> mtlComputeEnc = cmdEncoder->getMTLComputeEncoder();
+            id<MTLComputePipelineState> pipelineState = cmdEncoder->getCommandEncodingPool()->getCopyBufferBytesComputePipelineState();
+            [mtlComputeEnc setComputePipelineState:pipelineState];
+            [mtlComputeEnc setBuffer:srcMTLBuff offset:srcMTLBuffOffset atIndex:0];
+            [mtlComputeEnc setBuffer:dstMTLBuff offset:dstMTLBuffOffset atIndex:1];
+            uint32_t copyInfo[3] = { (uint32_t)cpyRgn.srcOffset,  (uint32_t)cpyRgn.dstOffset, (uint32_t)cpyRgn.size };
+            [mtlComputeEnc setBytes:copyInfo length:sizeof(copyInfo) atIndex:2];
+            [mtlComputeEnc dispatchThreads:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
+        }
+        else
+        {
+            id<MTLBlitCommandEncoder> mtlBlitEnc = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyBuffer);
+            [mtlBlitEnc copyFromBuffer: srcMTLBuff
+                          sourceOffset: (srcMTLBuffOffset + cpyRgn.srcOffset)
+                              toBuffer: dstMTLBuff
+                     destinationOffset: (dstMTLBuffOffset + cpyRgn.dstOffset)
+                                  size: cpyRgn.size];
+        }
     }
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.h
@@ -30,7 +30,7 @@
 #pragma mark MVKCommandEncodingPool
 
 /** 
- * Represents a pool containing trainsient resources that commands can use during encoding
+ * Represents a pool containing transient resources that commands can use during encoding
  * onto a queue. This is distinct from a command pool, which contains resources that can be 
  * assigned to commands when their content is established.
  *
@@ -93,7 +93,12 @@ public:
      * reused by subsequent transfers in the same encoding run.
      */
     MVKImage* getTransferMVKImage(MVKImageDescriptorData& imgData);
-
+    
+    /**
+     * Returns an MTLComputePipelineState dedicated to copying bytes between two buffers
+     * with unaligned copy regions.
+     */
+    id<MTLComputePipelineState> getCopyBufferBytesComputePipelineState();
 
 #pragma mark Construction
 
@@ -117,5 +122,6 @@ private:
     id<MTLDepthStencilState> _cmdClearStencilOnlyDepthStencilState;
     id<MTLDepthStencilState> _cmdClearDepthAndStencilDepthStencilState;
     id<MTLDepthStencilState> _cmdClearDefaultDepthStencilState;
+    id<MTLComputePipelineState> _mtlCopyBufferBytesComputePipelineState;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
@@ -111,6 +111,12 @@ MVKImage* MVKCommandEncodingPool::getTransferMVKImage(MVKImageDescriptorData& im
     return mvkImg;
 }
 
+id<MTLComputePipelineState> MVKCommandEncodingPool::getCopyBufferBytesComputePipelineState() {
+    if (_mtlCopyBufferBytesComputePipelineState == nil) {
+        _mtlCopyBufferBytesComputePipelineState = _device->getCommandResourceFactory()->newCopyBytesMTLComputePipelineState();
+    }
+    return _mtlCopyBufferBytesComputePipelineState;
+}
 
 #pragma mark Construction
 
@@ -123,6 +129,7 @@ MVKCommandEncodingPool::MVKCommandEncodingPool(MVKDevice* device) : MVKBaseDevic
     _cmdClearDepthOnlyDepthStencilState = nil;
     _cmdClearStencilOnlyDepthStencilState = nil;
     _cmdClearDefaultDepthStencilState = nil;
+    _mtlCopyBufferBytesComputePipelineState = nil;
 
     initTextureDeviceMemory();
 }
@@ -174,5 +181,8 @@ void MVKCommandEncodingPool::destroyMetalResources() {
 
     [_cmdClearDefaultDepthStencilState release];
     _cmdClearDefaultDepthStencilState = nil;
+
+    [_mtlCopyBufferBytesComputePipelineState release];
+    _mtlCopyBufferBytesComputePipelineState = nil;
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
@@ -193,6 +193,21 @@ fragment uint4 fragCmdClearAttachments0U(VaryingsPos varyings [[stage_in]],     
                                         constant ClearColorsIn& ccIn [[buffer(0)]]) {                           \n\
     return uint4(ccIn.colors[0]);                                                                               \n\
 };                                                                                                              \n\
+                                                                                                                \n\
+struct CopyInfo                                                                                                 \n\
+{                                                                                                               \n\
+    uint32_t SrcOffset;                                                                                         \n\
+    uint32_t DstOffset;                                                                                         \n\
+    uint32_t CopySize;                                                                                          \n\
+};                                                                                                              \n\
+                                                                                                                \n\
+kernel void compCopyBufferBytes(device uint8_t* src [[ buffer(0) ]],                                            \n\
+                                device uint8_t* dst [[ buffer(1) ]],                                            \n\
+                                constant CopyInfo& info [[ buffer(2) ]]) {                                      \n\
+    for (size_t i = 0; i < info.CopySize; i++) {                                                                \n\
+        dst[i + info.DstOffset] = src[i + info.SrcOffset];                                                      \n\
+    }                                                                                                           \n\
+};                                                                                                              \n\
 ";
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -272,6 +272,12 @@ public:
      * temporary image during image transfers.
      */
     MVKImage* newMVKImage(MVKImageDescriptorData& imgData);
+    
+    /**
+     * Returns a new MTLComputePipelineState dedicated to copying bytes between two buffers
+     * with unaligned copy regions.
+     */
+    id<MTLComputePipelineState> newCopyBytesMTLComputePipelineState();
 
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -231,6 +231,17 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newMTLRenderPipelineState(
     return rps;
 }
 
+id<MTLComputePipelineState> MVKCommandResourceFactory::newCopyBytesMTLComputePipelineState() {
+    MTLComputePipelineDescriptor* plDesc = [[[MTLComputePipelineDescriptor alloc] init] autorelease];
+    plDesc.computeFunction = getFunctionNamed("compCopyBufferBytes");
+    plDesc.buffers[0].mutability = MTLMutabilityMutable;
+    plDesc.buffers[1].mutability = MTLMutabilityMutable;
+    NSError* err = nil;
+    id<MTLComputePipelineState> computePipelineState = [getMTLDevice() newComputePipelineStateWithDescriptor:plDesc options:MTLPipelineOptionNone reflection:nil error:&err];
+    MVKAssert( !err, "Could not create %s pipeline state: %s (code %li) %s", plDesc.label.UTF8String, err.localizedDescription.UTF8String, (long)err.code, err.localizedFailureReason.UTF8String);
+    return computePipelineState;
+}
+
 #pragma mark Construction
 
 MVKCommandResourceFactory::MVKCommandResourceFactory(MVKDevice* device) : MVKBaseDeviceObject(device) {


### PR DESCRIPTION
This fixes #62.

* Vulkan allows any valid copy regions to be used in this function. However, Metal's blit command encoder only allows copy offsets and sizes which are multiples of 4 bytes on macOS.
* Before this change, attempting to copy such a region would cause Metal validation errors to trigger.
* This adds logic to detect such copy regions and uses a special compute shader to perform a byte-by-byte copy from the source buffer to the destination buffer with the appropriate offsets.
* This new code path is only needed on macOS, because iOS does not share the same copy region restrictions.

@billhollings This is my first submission, so please let me know if there's something I have missed, or something I should be doing differently. I've tried to match the patterns and style that are nearby.