### PR TITLE
fetchDeps: remove -sdk. New opts for LVL, glslang trees

### DIFF
--- a/fetchDependencies
+++ b/fetchDependencies
@@ -4,10 +4,17 @@
 #
 # fetchDependencies - Retrieves the correct versions of all dependencies
 #
-# macOS usage: ./fetchDependencies [-sdk]
+# macOS usage: ./fetchDependencies [--v-lvl-root path] [--glslang-root path]
 #
-#   -sdk = Load for the LunarG SDK, using symlinks to repos in SDK instead of fetching
-#          Vulkan-LoaderAndValidationLayers and glslang repositories.
+#	--v-lvl-root path
+#		"path" specifies a directory path to a
+#		KhronosGroup/Vulkan-LoaderAndValidationLayers repository.
+#		This repository does not have to be built.
+#	--glslang-root path
+#		"path" specifies a directory path to a KhronosGroup/glslang 
+#		repository.  This repository does need to be built and the
+#		build directory must be in the specified directory.
+#		It should be built the same way this script builds it.
 
 
 # ----------------- Functions -------------------
@@ -53,6 +60,25 @@ EXT_DIR=External
 EXT_REV_DIR=ExternalRevisions
 V_LVL_NAME=Vulkan-LoaderAndValidationLayers
 GLSLANG_NAME=glslang
+V_LVL_ROOT=""
+GLSLANG_ROOT=""
+
+while (( "$#" )); do
+  case "$1" in
+	--v-lvl-root)
+	  V_LVL_ROOT=$2
+	  shift 2
+	  ;;
+	--glslang-root)
+	  GLSLANG_ROOT=$2
+	  shift 2
+	  ;;
+	-*|--*=)
+	  echo "Error: Unsupported flag $1" >&2
+	  exit 1
+	  ;;
+  esac
+done
 
 echo
 echo Retrieving MoltenVK dependencies into ${EXT_DIR}.
@@ -60,7 +86,6 @@ echo
 
 mkdir -p ${EXT_DIR}
 cd ${EXT_DIR}
-
 
 # ----------------- Cereal -------------------
 
@@ -89,23 +114,17 @@ REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
 
-# ----------------- Vulkan-LoaderAndValidationLayers, glslang, SPIRV-Tools & SPIRV-Headers -------------------
+# ----------------- Vulkan-LoaderAndValidationLayers -------------------
 
-# When MoltenVK is loaded as a dependency of the LunarG SDK, the LunarG SDK already
-# has Vulkan-LoaderAndValidationLayers & glslang, so create simlinks instead.
-if [ "$1" = "-sdk" ]; then
+# When MoltenVK is built by something that already has a copy of the
+# Vulkan-LoaderAndValidationLayers repo, use it by creating a symlink.
+if [ ! "$V_LVL_ROOT" = "" ]; then
 
 	REPO_NAME=${V_LVL_NAME}
 	rm -rf ${REPO_NAME}
-	ln -sfn ../../.. ${REPO_NAME}
-
-	REPO_NAME=${GLSLANG_NAME}
-	rm -rf ${REPO_NAME}
-	ln -sfn ../../${REPO_NAME} ${REPO_NAME}
+	ln -sfn ${V_LVL_ROOT} ${REPO_NAME}
 
 else
-
-	# ----------------- Vulkan-LoaderAndValidationLayers -------------------
 
 	REPO_NAME=${V_LVL_NAME}
 	REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"
@@ -113,8 +132,19 @@ else
 
 	update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
+fi
 
-	# ----------------- glslang, SPIRV-Tools & SPIRV-Headers ---------------
+# ----------------- glslang, SPIRV-Tools & SPIRV-Headers -------------------
+
+# When MoltenVK is built by something that already has a copy of the
+# glslang repo, use it by creating a symlink.
+if [ ! "$GLSLANG_ROOT" = "" ]; then
+
+	REPO_NAME=${GLSLANG_NAME}
+	rm -rf ${REPO_NAME}
+	ln -sfn ${GLSLANG_ROOT} ${REPO_NAME}
+
+else
 
 	REPO_NAME=${GLSLANG_NAME}
 	REPO_URL=$(cat "${V_LVL_NAME}/external_revisions/glslang_giturl")


### PR DESCRIPTION
Changes to fetchDependencies script:
- remove -sdk option
- Add --v-lvl-root and --glslang-root options (with an arg)
that allow caller to pass in the root dir of these two repos
if the caller already has them.  The script then symlinks to
these instead of fetching and building.

Fixes: #79 #84