### PR TITLE
fetchDependencies: Use ninja if available to build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ open-source libraries on which **MoltenVK** relies:
 		brew install cmake
 		brew install python3
 
+   For faster dependencies build, you can also install Ninja:
+
+		brew install ninja
+
 2. Clone the `MoltenVK` repository:
 
 		git clone https://github.com/KhronosGroup/MoltenVK.git

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -48,8 +48,13 @@ build_repo() {
 
 	mkdir -p $1/build
 	cd $1/build
-	cmake ..
-	make
+	if type ninja >/dev/null 2>&1 ; then
+		cmake .. -G Ninja
+		ninja
+	else
+		cmake ..
+		make
+	fi
 	cd -
 }
 


### PR DESCRIPTION
If the ninja build system is installed, ask CMake to generate Ninja build files and use
it for the build.

[Ninja](https://ninja-build.org) is globally faster than Make, and automatically parallelize builds depending on the number of CPUs in the system.

On my machine, the execution time of `fetchDependencies` drops from ~10 minutes to ~1 min 30 when ninja is used.