### PR TITLE
Update python brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ open-source libraries on which **MoltenVK** relies:
 1. Ensure you have `cmake` and `python3` installed:
 
 		brew install cmake
-		brew install python3
+		brew install python
 
    For faster dependency builds, you can also optionally install `ninja`:
 


### PR DESCRIPTION
python3 is renamed to python in Homebrew formula. [Link](https://docs.brew.sh/Homebrew-and-Python)
>> Homebrew provides one formula for Python 3.x (python) and another for Python 2.7.x (python@2).