### PR TITLE
 Don't use CAMetalLayer displaySyncEnabled property if it is not available.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   3
+#define MVK_VERSION_PATCH   4
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
@@ -78,6 +78,7 @@ typedef struct {
     VkBool32 ioSurfaces;                        /**< If true, VkImages can be underlaid by IOSurfaces via the vkUseIOSurfaceMVK() function, to support inter-process image transfers. */
     VkBool32 texelBuffers;                      /**< If true, texel buffers are supported, allowing the contents of a buffer to be interpreted as an image via a VkBufferView. */
     VkBool32 depthClipMode;                     /**< If true, the device supports both depth clipping and depth clamping per the depthClampEnable flag of VkPipelineRasterizationStateCreateInfo in VkGraphicsPipelineCreateInfo. */
+	VkBool32 presentModeImmediate;              /**< If true, the device supports immediate surface present mode (VK_PRESENT_MODE_IMMEDIATE_KHR), allowing a swapchain image to be presented immediately, without waiting for the vertical sync period of the display. */
 	uint32_t maxPerStageBufferCount;            /**< The total number of per-stage Metal buffers available for shader uniform content and attributes. */
     uint32_t maxPerStageTextureCount;           /**< The total number of per-stage Metal textures available for shader uniform content. */
     uint32_t maxPerStageSamplerCount;           /**< The total number of per-stage Metal samplers available for shader uniform content. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -232,11 +232,9 @@ VkResult MVKPhysicalDevice::getSurfacePresentModes(MVKSurface* surface,
 	vector<VkPresentModeKHR> presentModes;
 	presentModes.push_back(VK_PRESENT_MODE_FIFO_KHR);
 
-#if MVK_MACOS
-	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
+	if (_metalFeatures.presentModeImmediate) {
 		presentModes.push_back(VK_PRESENT_MODE_IMMEDIATE_KHR);
 	}
-#endif
 
 	uint32_t presentModesCnt = uint32_t(presentModes.size());
 
@@ -356,6 +354,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
         _metalFeatures.mslVersion = SPIRVToMSLConverterOptions::makeMSLVersion(2);
         _metalFeatures.texelBuffers = true;
+		_metalFeatures.presentModeImmediate = true;
     }
 #endif
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -189,11 +189,10 @@ MVKSwapchain::MVKSwapchain(MVKDevice* device,
                                                                                VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                                                                                VK_IMAGE_USAGE_SAMPLED_BIT |
                                                                                VK_IMAGE_USAGE_STORAGE_BIT));
-#if MVK_MACOS
-	if ( pCreateInfo->presentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
-		_mtlLayer.displaySyncEnabled = NO;
+
+	if (pCreateInfo->presentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
+		_mtlLayer.displaySyncEnabledMVK = NO;
 	}
-#endif
 
 	// TODO: set additional CAMetalLayer properties before extracting drawables:
 	//	- presentsWithTransaction

--- a/MoltenVK/MoltenVK/Utility/MVKOSExtensions.h
+++ b/MoltenVK/MoltenVK/Utility/MVKOSExtensions.h
@@ -72,18 +72,17 @@ double mvkGetElapsedMilliseconds(uint64_t startTimestamp = 0, uint64_t endTimest
 /** 
  * Replacement for the usage property.
  *
- * This property allows support under iOS 8. Delegates to the usage property
- * if it is available. otherwise, returns MTLTextureUsageUnknown when read
- * and does nothing when set.
+ * This property allows support under all OS versions. Delegates to the usage property if it
+ * is available. otherwise, returns MTLTextureUsageUnknown when read and does nothing when set.
  */
 @property(nonatomic, readwrite) MTLTextureUsage usageMVK;
 
 /**
  * Replacement for the storageMode property.
  *
- * This property allows support under iOS 8. Delegates to the storageMode property
- * if it is available. otherwise, returns MTLStorageModeShared when read and does 
- * nothing when set.
+ * This property allows support under all OS versions. Delegates to the storageMode
+ * property if it is available. otherwise, returns MTLStorageModeShared when read
+ * and does nothing when set.
  */
 @property(nonatomic, readwrite) MTLStorageMode storageModeMVK;
 
@@ -99,9 +98,9 @@ double mvkGetElapsedMilliseconds(uint64_t startTimestamp = 0, uint64_t endTimest
 /**
  * Replacement for the compareFunction property.
  *
- * This property allows support under iOS 8. Delegates to the compareFunction property
- * if it is available. otherwise, returns MTLTextureUsageUnknown when read and does 
- * nothing when set.
+ * This property allows support under all OS versions. Delegates to the compareFunction
+ * property if it is available. otherwise, returns MTLTextureUsageUnknown when read and
+ * does nothing when set.
  */
 @property(nonatomic, readwrite) MTLCompareFunction compareFunctionMVK;
 
@@ -119,6 +118,14 @@ double mvkGetElapsedMilliseconds(uint64_t startTimestamp = 0, uint64_t endTimest
  * of the bounds property and the contentScale property, and returns the updated value.
  */
 -(CGSize) updatedDrawableSizeMVK;
+
+/**
+ * Replacement for the displaySyncEnabled property.
+ *
+ * This property allows support under all OS versions. Delegates to the displaySyncEnabled
+ * property if it is available. otherwise, returns YES when read and does nothing when set.
+ */
+@property(nonatomic, readwrite) BOOL displaySyncEnabledMVK;
 
 @end
 

--- a/MoltenVK/MoltenVK/Utility/MVKOSExtensions.mm
+++ b/MoltenVK/MoltenVK/Utility/MVKOSExtensions.mm
@@ -145,6 +145,19 @@ __attribute__((constructor)) static void MVKInitTimestamps() {
     return drawSize;
 }
 
+-(BOOL) displaySyncEnabledMVK {
+#if MVK_MACOS
+	if ( [self respondsToSelector: @selector(displaySyncEnabled)]) { return self.displaySyncEnabled; }
+#endif
+	return YES;
+}
+
+-(void) setDisplaySyncEnabledMVK: (BOOL) enabled {
+#if MVK_MACOS
+	if ( [self respondsToSelector: @selector(setDisplaySyncEnabled:)]) { self.displaySyncEnabled = enabled; }
+#endif
+}
+
 @end
 
 


### PR DESCRIPTION
Fixes crash on issue #141.