### PR TITLE
Remove mutex locks on MVKDescriptorPool.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -52,7 +52,7 @@ distribution package, see the main [`README.md`](../README.md) document in the `
 About **MoltenVK**
 ------------------
 
-**MoltenVK** is an implementation of the [*Vulkan*](https://www.khronos.org/vulkan) 
+**MoltenVK** is an implementation of the [*Vulkan 1.0*](https://www.khronos.org/vulkan) 
 graphics and compute API, that runs on Apple's [*Metal*](https://developer.apple.com/metal) 
 graphics and compute framework on both *iOS* and *macOS*.
 
@@ -441,10 +441,10 @@ Known **MoltenVK** Limitations
 
 This section documents the known limitations in this version of **MoltenVK**.
 
-- **MoltenVK** is a Layer-0 driver implementation of *Vulkan*, and currently does not
+- **MoltenVK** is a Layer-0 driver implementation of *Vulkan 1.0*, and currently does not
   support the loading of higher level *Vulkan Layers*.
 
-The following *Vulkan* features have not been implemented in this version of **MoltenVK**:
+The following *Vulkan 1.0* features have not been implemented in this version of **MoltenVK**:
 
 - Tessellation and Geometry shader stages.
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -22,7 +22,6 @@
 #include "MVKCommand.h"
 #include "MVKCommandEncoderState.h"
 #include "MVKCmdPipeline.h"
-#include <mutex>
 #include <vector>
 #include <unordered_map>
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
@@ -29,8 +29,6 @@
 #include "MVKCmdQueries.h"
 #include "MVKMTLBufferAllocation.h"
 #include <unordered_set>
-#include <list>
-#include <mutex>
 
 #import <Metal/Metal.h>
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -23,7 +23,6 @@
 #include <MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h>
 #include <forward_list>
 #include <vector>
-#include <mutex>
 
 using namespace mvk;
 
@@ -289,7 +288,6 @@ protected:
     uint32_t _maxSets;
 	std::forward_list<MVKDescriptorSet*> _allocatedSets;
 	size_t _allocatedSetCount;
-	std::mutex _lock;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -610,10 +610,7 @@ MVKDescriptorSet::MVKDescriptorSet(MVKDevice* device,
 VkResult MVKDescriptorPool::allocateDescriptorSets(uint32_t count,
 												   const VkDescriptorSetLayout* pSetLayouts,
 												   VkDescriptorSet* pDescriptorSets) {
-	lock_guard<mutex> lock(_lock);
-
 	if (_allocatedSetCount + count > _maxSets) {
-//		MVKLogDebug("Pool %p could not allocate %d descriptor sets. There are alreay %d sets, and the maximum for this pool is %d.", this, count, _allocatedSetCount, _maxSets);
 		return mvkNotifyErrorWithText(VK_ERROR_INITIALIZATION_FAILED, "The maximum number of descriptor sets that can be allocated by this descriptor pool is %d.", _maxSets);
 	}
 
@@ -624,14 +621,10 @@ VkResult MVKDescriptorPool::allocateDescriptorSets(uint32_t count,
 		pDescriptorSets[dsIdx] = (VkDescriptorSet)mvkDescSet;
 		_allocatedSetCount++;
 	}
-
-//	MVKLogDebug("Pool %p allocating %d descriptor sets for a new total of %d sets.", this, count, _allocatedSetCount);
 	return VK_SUCCESS;
 }
 
 VkResult MVKDescriptorPool::freeDescriptorSets(uint32_t count, const VkDescriptorSet* pDescriptorSets) {
-	lock_guard<mutex> lock(_lock);
-
 	for (uint32_t dsIdx = 0; dsIdx < count; dsIdx++) {
 		MVKDescriptorSet* mvkDS = (MVKDescriptorSet*)pDescriptorSets[dsIdx];
 		if (mvkDS) {
@@ -640,15 +633,10 @@ VkResult MVKDescriptorPool::freeDescriptorSets(uint32_t count, const VkDescripto
 			mvkDS->destroy();
 		}
 	}
-
-//	MVKLogDebug("Pool %p freed %d descriptor sets for a new total of %d sets.", this, count, _allocatedSetCount);
 	return VK_SUCCESS;
 }
 
 VkResult MVKDescriptorPool::reset(VkDescriptorPoolResetFlags flags) {
-	lock_guard<mutex> lock(_lock);
-
-//	MVKLogDebug("Pool %p resetting and freeing remaining %d descriptor sets.", this, _allocatedSetCount);
 	mvkDestroyContainerContents(_allocatedSets);
 	_allocatedSetCount = 0;
 	return VK_SUCCESS;
@@ -656,7 +644,6 @@ VkResult MVKDescriptorPool::reset(VkDescriptorPoolResetFlags flags) {
 
 MVKDescriptorPool::MVKDescriptorPool(MVKDevice* device,
 									 const VkDescriptorPoolCreateInfo* pCreateInfo) : MVKBaseDeviceObject(device) {
-//	MVKLogDebug("Pool %p created.", this);
 	_maxSets = pCreateInfo->maxSets;
 	_allocatedSetCount = 0;
 }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Introduction
 
 **MoltenVK** contains two products:
 
-- **MoltenVK** is an implementation of the [*Vulkan*](https://www.khronos.org/vulkan) 
+- **MoltenVK** is an implementation of the [*Vulkan 1.0*](https://www.khronos.org/vulkan) 
   graphics and compute API, that runs on Apple's [*Metal*](https://developer.apple.com/metal) 
   graphics and compute framework on both *iOS* and *macOS*.
 
@@ -183,11 +183,11 @@ the contents of that directory out of this **MoltenVK** repository into your own
 **MoltenVK** and *Vulkan* Compliance
 ------------------------------------
 
-**MoltenVK** is designed to be a *Vulkan* driver that runs on *macOS* and *iOS* platforms by mapping *Vulkan*
+**MoltenVK** is designed to be a *Vulkan 1.0* driver that runs on *macOS* and *iOS* platforms by mapping *Vulkan*
 capability to native *Metal* capability.
 
 The fundamental design and development goal of **MoltenVK** is to provide this capability in a way that 
-is both maximally compliant with the *Vulkan* specification, and maximally  performant.
+is both maximally compliant with the *Vulkan 1.0* specification, and maximally  performant.
 
 Such compliance and performance is inherently affected by the capability available through *Metal*, as the 
 native driver on *macOS* and *iOS* platforms. *Vulkan* compliance may fall into one of the following categories:


### PR DESCRIPTION
Update docs to indicate support for Vulkan 1.0, instead of 1.1. Fixes issue #144.