### PR TITLE
Fix an issue where the depth format in MVKCmdClearImage was not getting set correctly.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -875,6 +875,7 @@ void MVKCmdClearImage::setContent(VkImage image,
 
     if (_isDepthStencilClear) {
         _rpsKey.enable(kMVKAttachmentFormatDepthStencilIndex);
+        _rpsKey.attachmentMTLPixelFormats[kMVKAttachmentFormatDepthStencilIndex] = _image->getMTLPixelFormat();
         float mtlDepthVal = mvkMTLClearDepthFromVkClearValue(clearValue);
         _clearColors[kMVKAttachmentFormatDepthStencilIndex] = { mtlDepthVal, mtlDepthVal, mtlDepthVal, mtlDepthVal };
         _mtlStencilValue = mvkMTLClearStencilFromVkClearValue(clearValue);


### PR DESCRIPTION
Without this, clearing a depth stencil image causes a runtime crash with this message:

```
-[MTLRenderPipelineDescriptorInternal validateWithDevice:]:2400: failed assertion `No valid pixelFormats set.'
```

The fix is to simply keep track of the pixel format here.