### PR TITLE
Correctly handle unsupported compressed formats in MVKPhysicalDevice::getImageFormatProperties

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -105,6 +105,16 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
                                                      VkImageFormatProperties* pImageFormatProperties) {
     if (!pImageFormatProperties) { return VK_SUCCESS; }
 
+    if ((!_features.textureCompressionETC2 &&
+        format >= VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK && format <= VK_FORMAT_EAC_R11G11_SNORM_BLOCK)
+        || (!_features.textureCompressionASTC_LDR &&
+        format >= VK_FORMAT_ASTC_4x4_UNORM_BLOCK && format <= VK_FORMAT_ASTC_12x12_SRGB_BLOCK)
+        || (!_features.textureCompressionBC &&
+        format >= VK_FORMAT_BC1_RGB_UNORM_BLOCK && format <= VK_FORMAT_BC7_SRGB_BLOCK))
+    {
+        return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
+
     VkPhysicalDeviceLimits* pLimits = &_properties.limits;
     VkExtent3D maxExt;
     uint32_t maxLayers;


### PR DESCRIPTION
This can be viewed as a partial fix for #160 . I am aware of some other format limitations in Metal, but I'm not sure what the best way to filter them out here is. For example, I am aware that the `R16_UNorm` format can only be used as a depth-stencil format on `macOS_GPUFamily1_v2` and `macOS_GPUFamily1_v3`. That kind of filtering seems more complicated, whereas this filtering is very straightforward, and the information is readily available.