### PR TITLE
Synchronization and threading fixes.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   8
+#define MVK_VERSION_PATCH   9
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -228,7 +228,7 @@ public:
 	~MVKRenderPipelineCompiler() override;
 
 protected:
-	void compileComplete(id<MTLRenderPipelineState> pipelineState, NSError *error);
+	bool compileComplete(id<MTLRenderPipelineState> pipelineState, NSError *error);
 
 	id<MTLRenderPipelineState> _mtlRenderPipelineState = nil;
 };
@@ -265,7 +265,7 @@ public:
 	~MVKComputePipelineCompiler() override;
 
 protected:
-	void compileComplete(id<MTLComputePipelineState> pipelineState, NSError *error);
+	bool compileComplete(id<MTLComputePipelineState> pipelineState, NSError *error);
 
 	id<MTLComputePipelineState> _mtlComputePipelineState = nil;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -747,18 +747,19 @@ id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(
 	compile(lock, ^{
 		[getMTLDevice() newRenderPipelineStateWithDescriptor: mtlRPLDesc
 										   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
-											   compileComplete(ps, error);
+											   bool isLate = compileComplete(ps, error);
+											   if (isLate) { destroy(); }
 										   }];
 	});
 
 	return [_mtlRenderPipelineState retain];
 }
 
-void MVKRenderPipelineCompiler::compileComplete(id<MTLRenderPipelineState> mtlRenderPipelineState, NSError* compileError) {
+bool MVKRenderPipelineCompiler::compileComplete(id<MTLRenderPipelineState> mtlRenderPipelineState, NSError* compileError) {
 	lock_guard<mutex> lock(_completionLock);
 
 	_mtlRenderPipelineState = [mtlRenderPipelineState retain];		// retained
-	endCompile(compileError);
+	return endCompile(compileError);
 }
 
 #pragma mark Construction
@@ -777,18 +778,19 @@ id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineSta
 	compile(lock, ^{
 		[getMTLDevice() newComputePipelineStateWithFunction: mtlFunction
 										  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
-											  compileComplete(ps, error);
+											  bool isLate = compileComplete(ps, error);
+											  if (isLate) { destroy(); }
 										  }];
 	});
 
 	return [_mtlComputePipelineState retain];
 }
 
-void MVKComputePipelineCompiler::compileComplete(id<MTLComputePipelineState> mtlComputePipelineState, NSError* compileError) {
+bool MVKComputePipelineCompiler::compileComplete(id<MTLComputePipelineState> mtlComputePipelineState, NSError* compileError) {
 	lock_guard<mutex> lock(_completionLock);
 
 	_mtlComputePipelineState = [mtlComputePipelineState retain];		// retained
-	endCompile(compileError);
+	return endCompile(compileError);
 }
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -212,7 +212,7 @@ public:
 	~MVKShaderLibraryCompiler() override;
 
 protected:
-	void compileComplete(id<MTLLibrary> mtlLibrary, NSError *error);
+	bool compileComplete(id<MTLLibrary> mtlLibrary, NSError *error);
 	void handleError() override;
 
 	id<MTLLibrary> _mtlLibrary = nil;
@@ -250,7 +250,7 @@ public:
 	~MVKFunctionSpecializer() override;
 
 protected:
-	void compileComplete(id<MTLFunction> mtlFunction, NSError *error);
+	bool compileComplete(id<MTLFunction> mtlFunction, NSError *error);
 
 	id<MTLFunction> _mtlFunction = nil;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -350,7 +350,8 @@ id<MTLLibrary> MVKShaderLibraryCompiler::newMTLLibrary(NSString* mslSourceCode) 
 		[getMTLDevice() newLibraryWithSource: mslSourceCode
 									 options: options
 						   completionHandler: ^(id<MTLLibrary> mtlLib, NSError* error) {
-							   compileComplete(mtlLib, error);
+							   bool isLate = compileComplete(mtlLib, error);
+							   if (isLate) { destroy(); }
 						   }];
 	});
 
@@ -366,11 +367,11 @@ void MVKShaderLibraryCompiler::handleError() {
 	}
 }
 
-void MVKShaderLibraryCompiler::compileComplete(id<MTLLibrary> mtlLibrary, NSError* compileError) {
+bool MVKShaderLibraryCompiler::compileComplete(id<MTLLibrary> mtlLibrary, NSError* compileError) {
 	lock_guard<mutex> lock(_completionLock);
 
 	_mtlLibrary = [mtlLibrary retain];		// retained
-	endCompile(compileError);
+	return endCompile(compileError);
 }
 
 #pragma mark Construction
@@ -392,18 +393,19 @@ id<MTLFunction> MVKFunctionSpecializer::newMTLFunction(id<MTLLibrary> mtlLibrary
 		[mtlLibrary newFunctionWithName: funcName
 						 constantValues: constantValues
 					  completionHandler: ^(id<MTLFunction> mtlFunc, NSError* error) {
-						  compileComplete(mtlFunc, error);
+						  bool isLate = compileComplete(mtlFunc, error);
+						  if (isLate) { destroy(); }
 					  }];
 	});
 
 	return [_mtlFunction retain];
 }
 
-void MVKFunctionSpecializer::compileComplete(id<MTLFunction> mtlFunction, NSError* compileError) {
+bool MVKFunctionSpecializer::compileComplete(id<MTLFunction> mtlFunction, NSError* compileError) {
 	lock_guard<mutex> lock(_completionLock);
 
 	_mtlFunction = [mtlFunction retain];		// retained
-	endCompile(compileError);
+	return endCompile(compileError);
 }
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
@@ -19,6 +19,7 @@
 #include "MVKSurface.h"
 #include "MVKInstance.h"
 #include "MVKFoundation.h"
+#include "MVKOSExtensions.h"
 
 
 #pragma mark MVKSurface
@@ -29,7 +30,8 @@ MVKSurface::MVKSurface(MVKInstance* mvkInstance,
 					   const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
 					   const VkAllocationCallbacks* pAllocator) {
 
-    CALayer* viewLayer = ((PLATFORM_VIEW_CLASS*)pCreateInfo->pView).layer;
+	__block CALayer* viewLayer = nil;
+	mvkDispatchToMainAndWait(^{ viewLayer = ((PLATFORM_VIEW_CLASS*)pCreateInfo->pView).layer; });
     if ( [viewLayer isKindOfClass: [CAMetalLayer class]] ) {
         _mtlCAMetalLayer = (CAMetalLayer*)[viewLayer retain];		// retained
     } else {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <unordered_set>
+#include <vector>
 
 class MVKFenceSitter;
 
@@ -122,7 +123,8 @@ public:
 	MVKSignalable(MVKDevice* device) : MVKBaseDeviceObject(device) {}
 
 protected:
-	void maybeDestroy();
+	bool decrementSignalerCount();
+	bool markDestroyed();
 
 	std::mutex _signalerLock;
 	uint32_t _signalerCount = 0;
@@ -246,6 +248,7 @@ private:
 
 	void addUnsignaledFence(MVKFence* fence);
 	void fenceSignaled(MVKFence* fence);
+	void getUnsignaledFences(std::vector<MVKFence*>& fences);
 
 	std::mutex _lock;
 	std::unordered_set<MVKFence*> _unsignaledFences;
@@ -295,8 +298,8 @@ public:
 protected:
 	void compile(std::unique_lock<std::mutex>& lock, dispatch_block_t block);
 	virtual void handleError();
-	void endCompile(NSError* compileError);
-	void maybeDestroy();
+	bool endCompile(NSError* compileError);
+	bool markDestroyed();
 
 	NSError* _compileError = nil;
 	uint64_t _startTime = 0;

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.cpp
@@ -26,7 +26,7 @@ using namespace std;
 #pragma mark -
 #pragma mark MVKBaseObject
 
-string MVKBaseObject::className() {
+string MVKBaseObject::getClassName() {
     int status;
     char* demangled = abi::__cxa_demangle(typeid(*this).name(), 0, 0, &status);
     string clzName = demangled;

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -35,7 +35,7 @@ class MVKBaseObject {
 public:
 
     /** Returns the name of the class of which this object is an instance. */
-    std::string className();
+    std::string getClassName();
 
 	/** Destroys this object. Default behaviour simply deletes it. Subclasses may override to delay deletion. */
 	virtual void destroy() { delete this; }

--- a/MoltenVK/MoltenVK/Utility/MVKOSExtensions.h
+++ b/MoltenVK/MoltenVK/Utility/MVKOSExtensions.h
@@ -71,3 +71,11 @@ uint64_t mvkRecommendedMaxWorkingSetSize(id<MTLDevice> mtlDevice);
 /** Populate the propertes with info about the GPU represented by the MTLDevice. */
 void mvkPopulateGPUInfo(VkPhysicalDeviceProperties& devProps, id<MTLDevice> mtlDevice);
 
+/** Ensures the block is executed on the main thread. */
+inline void mvkDispatchToMainAndWait(dispatch_block_t block) {
+	if (NSThread.isMainThread) {
+		block();
+	} else {
+		dispatch_sync(dispatch_get_main_queue(), block);
+	}
+}


### PR DESCRIPTION
Move surface access to UI components to main thread.
Fix deadlock possibility between MVKFence and MVKFenceSitter.
Fix handling of locking on deferred-destruction objects.
Update MoltenVK version to 1.0.9.