### PR TITLE
Fix vsync not being enabled in IMMEDIATE present mode. MVK_MACOS was …

### DIFF
--- a/MoltenVK/MoltenVK/Utility/CAMetalLayer+MoltenVK.m
+++ b/MoltenVK/MoltenVK/Utility/CAMetalLayer+MoltenVK.m
@@ -17,6 +17,7 @@
  */
 
 
+#include "MVKCommonEnvironment.h"
 #import "CAMetalLayer+MoltenVK.h"
 
 @implementation CAMetalLayer (MoltenVK)


### PR DESCRIPTION
…not being defined.