### PR TITLE
Fix Dota 2 bug with vsync toggling not working (https://github.com/Va…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -195,6 +195,8 @@ MVKSwapchain::MVKSwapchain(MVKDevice* device,
 
 	if (pCreateInfo->presentMode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
 		_mtlLayer.displaySyncEnabledMVK = NO;
+	} else {
+		_mtlLayer.displaySyncEnabledMVK = YES;
 	}
 
 	// TODO: set additional CAMetalLayer properties before extracting drawables:


### PR DESCRIPTION
…lveSoftware/Dota-2-Vulkan/issues/257).  Vsync would be disabled on first swapchain creation, but not re-enabled if swapchain mode switched from IMMEDIATE -> FIFO or back from FIFO -> IMMEDIATE.