### PR TITLE
Change the sorting for Metal devices in the list of physicalDevices t…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -296,7 +296,16 @@ static NSArray<id<MTLDevice>>* getAvailableMTLDevices() {
 		BOOL md1IsLP = md1.isLowPower;
 		BOOL md2IsLP = md2.isLowPower;
 
-		if (md1IsLP == md2IsLP) { return NSOrderedSame; }
+		if (md1IsLP == md2IsLP) {
+			// If one device is headless and the other one is not, select the
+			// one that is not headless first.
+			BOOL md1IsHeadless = md1.isHeadless;
+			BOOL md2IsHeadless = md2.isHeadless;
+			if (md1IsHeadless == md2IsHeadless ) {
+				return NSOrderedSame;
+			}
+			return md2IsHeadless ? NSOrderedAscending : NSOrderedDescending;
+		}
 
 		return md2IsLP ? NSOrderedAscending : NSOrderedDescending;
 	}];


### PR DESCRIPTION
…o be sorted also by whether they are headless.  What was happening is that on a dual FirePro D500 system sometimes the headless GPU would be returned first.  When that happened, Dota 2 would select that GPU and then fail to start because the queue did not support presentation.