### PR TITLE
Report correct workgroup sizes from MTLDevice.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -383,14 +383,24 @@ static inline VkExtent2D mvkVkExtent2DFromCGSize(CGSize cgSize) {
 	return vkExt;
 }
 
-/** Returns a Metal MTLOrigin constructed from the specified VkOffset3D. */
+/** Returns a Metal MTLOrigin constructed from a VkOffset3D. */
 static inline MTLOrigin mvkMTLOriginFromVkOffset3D(VkOffset3D vkOffset) {
 	return MTLOriginMake(vkOffset.x, vkOffset.y, vkOffset.z);
 }
 
-/** Returns a Metal MTLSize constructed from the specified VkExtent3D. */
+/** Returns a Vulkan VkOffset3D constructed from a Metal MTLOrigin. */
+static inline VkOffset3D mvkVkOffset3DFromMTLSize(MTLOrigin mtlOrigin) {
+	return { (int32_t)mtlOrigin.x, (int32_t)mtlOrigin.y, (int32_t)mtlOrigin.z };
+}
+
+/** Returns a Metal MTLSize constructed from a VkExtent3D. */
 static inline MTLSize mvkMTLSizeFromVkExtent3D(VkExtent3D vkExtent) {
 	return MTLSizeMake(vkExtent.width, vkExtent.height, vkExtent.depth);
+}
+
+/** Returns a Vulkan VkExtent3D  constructed from a Metal MTLSize. */
+static inline VkExtent3D mvkVkExtent3DFromMTLSize(MTLSize mtlSize) {
+	return { (uint32_t)mtlSize.width, (uint32_t)mtlSize.height, (uint32_t)mtlSize.depth };
 }
 
 

--- a/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.m
@@ -39,14 +39,14 @@
 
 -(BOOL) displaySyncEnabledMVK {
 #if MVK_MACOS
-    if ( [self respondsToSelector: @selector(displaySyncEnabled)]) { return self.displaySyncEnabled; }
+    if ( [self respondsToSelector: @selector(displaySyncEnabled)] ) { return self.displaySyncEnabled; }
 #endif
     return YES;
 }
 
 -(void) setDisplaySyncEnabledMVK: (BOOL) enabled {
 #if MVK_MACOS
-    if ( [self respondsToSelector: @selector(setDisplaySyncEnabled:)]) { self.displaySyncEnabled = enabled; }
+    if ( [self respondsToSelector: @selector(setDisplaySyncEnabled:)] ) { self.displaySyncEnabled = enabled; }
 #endif
 }
 

--- a/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
@@ -22,12 +22,12 @@
 @implementation MTLSamplerDescriptor (MoltenVK)
 
 -(MTLCompareFunction) compareFunctionMVK {
-	if ( [self respondsToSelector: @selector(compareFunction)]) { return self.compareFunction; }
+	if ( [self respondsToSelector: @selector(compareFunction)] ) { return self.compareFunction; }
 	return MTLCompareFunctionNever;
 }
 
 -(void) setCompareFunctionMVK: (MTLCompareFunction) cmpFunc {
-	if ( [self respondsToSelector: @selector(setCompareFunction:)]) { self.compareFunction = cmpFunc; }
+	if ( [self respondsToSelector: @selector(setCompareFunction:)] ) { self.compareFunction = cmpFunc; }
 }
 
 @end

--- a/MoltenVK/MoltenVK/OS/MTLTextureDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLTextureDescriptor+MoltenVK.m
@@ -22,21 +22,21 @@
 @implementation MTLTextureDescriptor (MoltenVK)
 
 -(MTLTextureUsage) usageMVK {
-	if ( [self respondsToSelector: @selector(usage)]) { return self.usage; }
+	if ( [self respondsToSelector: @selector(usage)] ) { return self.usage; }
 	return MTLTextureUsageUnknown;
 }
 
 -(void) setUsageMVK: (MTLTextureUsage) usage {
-	if ( [self respondsToSelector: @selector(setUsage:)]) { self.usage = usage; }
+	if ( [self respondsToSelector: @selector(setUsage:)] ) { self.usage = usage; }
 }
 
 -(MTLStorageMode) storageModeMVK {
-	if ( [self respondsToSelector: @selector(storageMode)]) { return self.storageMode; }
+	if ( [self respondsToSelector: @selector(storageMode)] ) { return self.storageMode; }
 	return MTLStorageModeShared;
 }
 
 -(void) setStorageModeMVK: (MTLStorageMode) storageMode {
-	if ( [self respondsToSelector: @selector(setStorageMode:)]) { self.storageMode = storageMode; }
+	if ( [self respondsToSelector: @selector(setStorageMode:)] ) { self.storageMode = storageMode; }
 }
 
 @end


### PR DESCRIPTION
Retrieve workgroup sizesVkPhysicalDeviceLimits::maxComputeWorkGroupSize & maxComputeWorkGroupInvocations & maxComputeSharedMemorySize from MTLDevice.

Fixes issue #198.