### PR TITLE
Move MoltenVK config to instance instead of device.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -365,10 +365,10 @@ you can address the issue as follows:
   
   		#include <MoltenVK/vk_mvk_moltenvk.h>
   		...
-  		MVKDeviceConfiguration mvkConfig;
-  		vkGetMoltenVKDeviceConfigurationMVK(vkDevice, &mvkConfig);
+  		MVKConfiguration mvkConfig;
+  		vkGetMoltenVKConfigurationMVK(vkInstance, &mvkConfig);
   		mvkConfig.debugMode = true;
-  		vkSetMoltenVKDeviceConfigurationMVK(vkDevice, &mvkConfig);
+  		vkSetMoltenVKConfigurationMVK(vkInstance, &mvkConfig);
 
   Performing these steps will enable debug mode in **MoltenVK**, which includes shader conversion 
   logging, and causes both the incoming *SPIR-V* code and the converted *MSL* source code to be 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,18 @@ For best results, use a Markdown reader.*
 
 
 
+MoltenVK 1.0.19
+---------------
+
+Released 2018/08/22
+
+- Move MoltenVK config to instance instead of device.
+- Add MVKConfiguration and deprecate MVKDeviceConfiguration.
+- Add vkGetMoltenVKConfigurationMVK() and deprecate vkGetMoltenVKDeviceConfigurationMVK().
+- Add vkSetMoltenVKConfigurationMVK() and deprecate vkSetMoltenVKDeviceConfigurationMVK().
+- Add build setting overrides for all initial MVKConfiguration member values.
+
+
 MoltenVK 1.0.18
 ---------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -48,13 +48,13 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   18
+#define MVK_VERSION_PATCH   19
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            6
+#define VK_MVK_MOLTENVK_SPEC_VERSION            7
 #define VK_MVK_MOLTENVK_EXTENSION_NAME			"VK_MVK_moltenvk"
 
 /**
@@ -62,20 +62,25 @@ extern "C" {
  *
  * The default value of several of these settings is deterined at build time by the presence
  * of a DEBUG build setting, By default the DEBUG build setting is defined when MoltenVK is
- * compiled in Debug mode, and not defined when compiled in Release mode.
+ * compiled in Debug mode, and not defined when compiled in Release mode. The default values
+ * of the other settings is determined by other compile build settings when MoltenVK is compiled.
+ * See the description of the individual configuration structure members for more information.
+ *
+ * To be active, some configuration settings must be set before a VkDevice is created.
+ * See the description of the individual configuration structure members for more information.
  */
 typedef struct {
-    VkBool32 debugMode;                     /**< If enabled, several debugging capabilities will be enabled. Shader code will be logged during Runtime Shader Conversion. Adjusts settings that might trigger Metal validation but are otherwise acceptable to Metal runtime. Improves support for Xcode GPU Frame Capture. Default value is true in the presence of the DEBUG build setting, and false otherwise. */
-    VkBool32 shaderConversionFlipVertexY;   /**< If enabled, MSL vertex shader code created during Runtime Shader Conversion will flip the Y-axis of each vertex, as Vulkan coordinate system is inverse of OpenGL. Default is true. */
-	VkBool32 synchronousQueueSubmits;       /**< If enabled, queue command submissions (vkQueueSubmit() & vkQueuePresentKHR()) will be processed on the thread that called the submission function. If disabled, processing will be dispatched to a GCD dispatch_queue whose priority is determined by VkDeviceQueueCreateInfo::pQueuePriorities during vkCreateDevice(). This setting affects how much command processing should be performed on the rendering thread, or offloaded to a secondary thread. Default value is false, and command processing will be handled on a prioritizable queue thread. */
-    VkBool32 supportLargeQueryPools;        /**< Metal allows only 8192 occlusion queries per MTLBuffer. If enabled, MoltenVK allocates a MTLBuffer for each query pool, allowing each query pool to support 8192 queries, which may slow performance or cause unexpected behaviour if the query pool is not established prior to a Metal renderpass, or if the query pool is changed within a Metal renderpass. If disabled, one MTLBuffer will be shared by all query pools, which improves performance, but limits the total device queries to 8192. Default value is true. */
-	VkBool32 presentWithCommandBuffer;      /**< If enabled, each surface presentation is scheduled using a command buffer. Enabling this setting may improve rendering frame synchronization, but may result in reduced frame rates. Default value is false if the MVK_PRESENT_WITHOUT_COMMAND_BUFFER build setting is defined when MoltenVK is compiled, and true otherwise. By default the MVK_PRESENT_WITHOUT_COMMAND_BUFFER build setting is not defined and the value of this setting is true. */
-	VkBool32 swapchainMagFilterUseNearest;  /**< If enabled, swapchain images will use simple Nearest sampling when magnifying the swapchain image to fit a physical display surface. If disabled, swapchain images will use Linear sampling when magnifying the swapchain image to fit a physical display surface. Enabling this setting avoids smearing effects when swapchain images are simple interger multiples of display pixels (eg- macOS Retina, and typical of graphics apps and games), but may cause aliasing effects when using non-integer display scaling. Default value is true. */
-    VkBool32 displayWatermark;              /**< If enabled, a MoltenVK logo watermark will be rendered on top of the scene. This can be enabled for publicity during demos. Default value is true if the MVK_DISPLAY_WATERMARK build setting is defined when MoltenVK is compiled, and false otherwise. By default the MVK_DISPLAY_WATERMARK build setting is not defined. */
-    VkBool32 performanceTracking;           /**< If enabled, per-frame performance statistics are tracked, optionally logged, and can be retrieved via the vkGetSwapchainPerformanceMVK() function, and various performance statistics are tracked, logged, and can be retrieved via the vkGetPerformanceStatisticsMVK() function. Default value is true in the presence of the DEBUG build setting, and false otherwise. */
-    uint32_t performanceLoggingFrameCount;  /**< If non-zero, performance statistics will be periodically logged to the console, on a repeating cycle of this many frames per swapchain. The performanceTracking capability must also be enabled. Default value is 300 in the presence of the DEBUG build setting, and zero otherwise. */
-	uint64_t metalCompileTimeout;			/**< The maximum amount of time, in nanoseconds, to wait for a Metal library, function or pipeline state object to be compiled and created. If an internal error occurs with the Metal compiler, it can stall the thread for up to 30 seconds. Setting this value limits the delay to that amount of time. Default value is infinite. */
-} MVKDeviceConfiguration;
+    VkBool32 debugMode;                            /**< If enabled, several debugging capabilities will be enabled. Shader code will be logged during Runtime Shader Conversion. Adjusts settings that might trigger Metal validation but are otherwise acceptable to Metal runtime. Improves support for Xcode GPU Frame Capture. Default value is true in the presence of the DEBUG build setting, and false otherwise. */
+    VkBool32 shaderConversionFlipVertexY;          /**< If enabled, MSL vertex shader code created during Runtime Shader Conversion will flip the Y-axis of each vertex, as Vulkan coordinate system is inverse of OpenGL. Initial value is set by the MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y build setting when MoltenVK is compiled. By default the MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y build setting is set to true. */
+	VkBool32 synchronousQueueSubmits;              /**< If enabled, queue command submissions (vkQueueSubmit() & vkQueuePresentKHR()) will be processed on the thread that called the submission function. If disabled, processing will be dispatched to a GCD dispatch_queue whose priority is determined by VkDeviceQueueCreateInfo::pQueuePriorities during vkCreateDevice(). Initial value is set by the MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS build setting when MoltenVK is compiled. By default the MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS build setting is set to false, and command processing will be handled on a prioritizable queue thread. Changing the value of this parameter must be done before creating a VkDevice, for the change to take effect. */
+    VkBool32 supportLargeQueryPools;               /**< Metal allows only 8192 occlusion queries per MTLBuffer. If enabled, MoltenVK allocates a MTLBuffer for each query pool, allowing each query pool to support 8192 queries, which may slow performance or cause unexpected behaviour if the query pool is not established prior to a Metal renderpass, or if the query pool is changed within a Metal renderpass. If disabled, one MTLBuffer will be shared by all query pools, which improves performance, but limits the total device queries to 8192. Initial value is set by the MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS build setting when MoltenVK is compiled. By default the MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS build setting is set to true. */
+	VkBool32 presentWithCommandBuffer;             /**< If enabled, each surface presentation is scheduled using a command buffer. Enabling this setting may improve rendering frame synchronization, but may result in reduced frame rates. Initial value is set by the MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER build setting when MoltenVK is compiled. By default the MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER build setting is set to true. */
+	VkBool32 swapchainMagFilterUseNearest;         /**< If enabled, swapchain images will use simple Nearest sampling when magnifying the swapchain image to fit a physical display surface. If disabled, swapchain images will use Linear sampling when magnifying the swapchain image to fit a physical display surface. Enabling this setting avoids smearing effects when swapchain images are simple interger multiples of display pixels (eg- macOS Retina, and typical of graphics apps and games), but may cause aliasing effects when using non-integer display scaling. Initial value is set by the MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST build setting when MoltenVK is compiled. By default the MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST build setting is set to true. */
+    VkBool32 displayWatermark;                     /**< If enabled, a MoltenVK logo watermark will be rendered on top of the scene. This can be enabled for publicity during demos. Initial value is set by the MVK_CONFIG_DISPLAY_WATERMARK build setting when MoltenVK is compiled. By default the MVK_CONFIG_DISPLAY_WATERMARK build setting is set to false. */
+    VkBool32 performanceTracking;                  /**< If enabled, per-frame performance statistics are tracked, optionally logged, and can be retrieved via the vkGetSwapchainPerformanceMVK() function, and various performance statistics are tracked, logged, and can be retrieved via the vkGetPerformanceStatisticsMVK() function. Initial value is true in the presence of the DEBUG build setting, and false otherwise. */
+    uint32_t performanceLoggingFrameCount;         /**< If non-zero, performance statistics will be periodically logged to the console, on a repeating cycle of this many frames per swapchain. The performanceTracking capability must also be enabled. Initial value is 300 in the presence of the DEBUG build setting, and zero otherwise. */
+	uint64_t metalCompileTimeout;			       /**< The maximum amount of time, in nanoseconds, to wait for a Metal library, function or pipeline state object to be compiled and created. If an internal error occurs with the Metal compiler, it can stall the thread for up to 30 seconds. Setting this value limits the delay to that amount of time. Initial value is set by the MVK_CONFIG_METAL_COMPILE_TIMEOUT build setting when MoltenVK is compiled. By default the MVK_CONFIG_METAL_COMPILE_TIMEOUT build setting is infinite. */
+} MVKConfiguration;
 
 /** Features provided by the current implementation of Metal on the current device. */
 typedef struct {
@@ -151,8 +156,8 @@ typedef struct {
 #pragma mark -
 #pragma mark Function types
 
-typedef void (VKAPI_PTR *PFN_vkGetMoltenVKDeviceConfigurationMVK)(VkDevice device, MVKDeviceConfiguration* pConfiguration);
-typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKDeviceConfigurationMVK)(VkDevice device, MVKDeviceConfiguration* pConfiguration);
+typedef void (VKAPI_PTR *PFN_vkGetMoltenVKConfigurationMVK)(VkDevice device, MVKConfiguration* pConfiguration);
+typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkDevice device, MVKConfiguration* pConfiguration);
 typedef void (VKAPI_PTR *PFN_vkGetPhysicalDeviceMetalFeaturesMVK)(VkPhysicalDevice physicalDevice, MVKPhysicalDeviceMetalFeatures* pMetalFeatures);
 typedef void (VKAPI_PTR *PFN_vkGetSwapchainPerformanceMVK)(VkDevice device, VkSwapchainKHR swapchain, MVKSwapchainPerformance* pSwapchainPerf);
 typedef void (VKAPI_PTR *PFN_vkGetPerformanceStatisticsMVK)(VkDevice device, MVKPerformanceStatistics* pPerf);
@@ -166,9 +171,12 @@ typedef VkResult (VKAPI_PTR *PFN_vkUseIOSurfaceMVK)(VkImage image, IOSurfaceRef 
 typedef void (VKAPI_PTR *PFN_vkGetIOSurfaceMVK)(VkImage image, IOSurfaceRef* pIOSurface);
 #endif // __OBJC__
 
-#pragma mark Deprecated license functions
-typedef VkResult (VKAPI_PTR *PFN_vkActivateMoltenVKLicenseMVK)(const char* licenseID, const char* licenseKey, VkBool32 acceptLicenseTermsAndConditions);
-typedef VkResult (VKAPI_PTR *PFN_vkActivateMoltenVKLicensesMVK)();
+// Deprecated functions
+typedef MVKConfiguration MVKDeviceConfiguration;
+__attribute__((deprecated("Use PFN_vkGetMoltenVKConfigurationMVK instead.")))
+typedef void (VKAPI_PTR *PFN_vkGetMoltenVKDeviceConfigurationMVK)(VkDevice device, MVKConfiguration* pConfiguration);
+__attribute__((deprecated("Use PFN_vkSetMoltenVKConfigurationMVK instead.")))
+typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKDeviceConfigurationMVK)(VkDevice device, MVKConfiguration* pConfiguration);
 
 
 #pragma mark -
@@ -177,28 +185,32 @@ typedef VkResult (VKAPI_PTR *PFN_vkActivateMoltenVKLicensesMVK)();
 #ifndef VK_NO_PROTOTYPES
 
 /** 
- * Populates the pConfiguration structure with the current MoltenVK configuration settings 
- * of the specified device. 
+ * Populates the pConfiguration structure with the current MoltenVK configuration settings.
  *
- * To change a specific configuration value, call vkGetMoltenVKDeviceConfigurationMVK()
+ * To change a specific configuration value, call vkGetMoltenVKConfigurationMVK()
  * to retrieve the current configuration, make changes, and call 
- * vkSetMoltenVKDeviceConfigurationMVK() to update all of the values.
+ * vkSetMoltenVKConfigurationMVK() to update all of the values.
+ *
+ * To be active, some configuration settings must be set before a VkDevice is created.
+ * See the description of the MVKConfiguration members for more information.
  */
-VKAPI_ATTR void VKAPI_CALL vkGetMoltenVKDeviceConfigurationMVK(
-    VkDevice                                    device,
-    MVKDeviceConfiguration*                     pConfiguration);
+VKAPI_ATTR void VKAPI_CALL vkGetMoltenVKConfigurationMVK(
+    VkInstance                                  instance,
+    MVKConfiguration*                           pConfiguration);
 
 /** 
- * Sets the MoltenVK configuration settings of the specified device to those found in the 
- * pConfiguration structure.
+ * Sets the MoltenVK configuration settings to those found in the pConfiguration structure.
  *
- * To change a specific configuration value, call vkGetMoltenVKDeviceConfigurationMVK()
+ * To change a specific configuration value, call vkGetMoltenVKConfigurationMVK()
  * to retrieve the current configuration, make changes, and call
- * vkSetMoltenVKDeviceConfigurationMVK() to update all of the values.
+ * vkSetMoltenVKConfigurationMVK() to update all of the values.
+ *
+ * To be active, some configuration settings must be set before a VkDevice is created.
+ * See the description of the MVKConfiguration members for more information.
  */
-VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKDeviceConfigurationMVK(
-    VkDevice                                    device,
-    MVKDeviceConfiguration*                     pConfiguration);
+VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKConfigurationMVK(
+    VkInstance                                  instance,
+    MVKConfiguration*                           pConfiguration);
 
 /** 
  * Populates the pMetalFeatures structure with the Metal-specific features
@@ -293,7 +305,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkUseIOSurfaceMVK(
     VkImage                                     image,
     IOSurfaceRef                                ioSurface);
 
-
 /**
  * Returns, in the pIOSurface pointer, the IOSurface currently underlaying the VkImage,
  * as set by the useIOSurfaceMVK() function, or returns null if the VkImage is not using
@@ -302,7 +313,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkUseIOSurfaceMVK(
 VKAPI_ATTR void VKAPI_CALL vkGetIOSurfaceMVK(
     VkImage                                     image,
     IOSurfaceRef*                               pIOSurface);
-
 
 #endif // __OBJC__
 
@@ -347,6 +357,12 @@ typedef uint32_t MVKMSLSPIRVHeader;
 
 #endif // VK_NO_PROTOTYPES
 
+
+// Deprecated functions
+__attribute__((deprecated("Use vkGetMoltenVKConfigurationMVK() instead.")))
+VKAPI_ATTR void VKAPI_CALL vkGetMoltenVKDeviceConfigurationMVK(VkDevice device, MVKDeviceConfiguration* pConfiguration);
+__attribute__((deprecated("Use vkSetMoltenVKConfigurationMVK() instead.")))
+VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKDeviceConfigurationMVK(VkDevice device, MVKDeviceConfiguration* pConfiguration);
 
 #ifdef __cplusplus
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -158,7 +158,10 @@ public:
 	 */
 	VkResult getQueueFamilyProperties(uint32_t* pCount, VkQueueFamilyProperties* properties);
 
-	/** Returns a pointer to the layer manager for this device. */
+	/** Returns a pointer to the Vulkan instance. */
+	inline MVKInstance* getInstance() { return _mvkInstance; }
+
+	/** Returns a pointer to the layer manager. */
 	inline MVKLayerManager* getLayerManager() { return MVKLayerManager::globalManager(); }
 
 
@@ -251,6 +254,9 @@ class MVKDevice : public MVKDispatchableObject {
 
 public:
 
+	/** Returns a pointer to the Vulkan instance. */
+	inline MVKInstance* getInstance() { return _physicalDevice->getInstance(); }
+
 	/** Returns the physical device underlying this logical device. */
 	inline MVKPhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
 
@@ -265,12 +271,6 @@ public:
 
 	/** Block the current thread until all queues in this device are idle. */
 	VkResult waitIdle();
-
-	/** Returns a pointer to the MoltenVK configuration info for this device. */
-	const MVKDeviceConfiguration* getMoltenVKConfiguration();
-
-	/** Sets the MoltenVK configuration info for this device. */
-	void setMoltenVKConfiguration(const MVKDeviceConfiguration* pConfiguration);
 
 
 #pragma mark Object lifecycle
@@ -402,7 +402,7 @@ public:
 	 * can be used to perform this calculation.
      */
     inline uint64_t getPerformanceTimestamp() {
-		return _mvkConfig.performanceTracking ? getPerformanceTimestampImpl() : 0;
+		return _pMVKConfig->performanceTracking ? getPerformanceTimestampImpl() : 0;
 	}
 
     /**
@@ -413,7 +413,7 @@ public:
      */
     inline void addActivityPerformance(MVKPerformanceTracker& shaderCompilationEvent,
 									   uint64_t startTime, uint64_t endTime = 0) {
-		if (_mvkConfig.performanceTracking) {
+		if (_pMVKConfig->performanceTracking) {
 			addActivityPerformanceImpl(shaderCompilationEvent, startTime, endTime);
 		}
 	};
@@ -471,6 +471,9 @@ public:
 
 #pragma mark Properties directly accessible
 
+	/** The MoltenVK configuration settings. */
+	const MVKConfiguration* _pMVKConfig;
+
 	/** Pointer to the feature set of the underlying physical device. */
 	const VkPhysicalDeviceFeatures* _pFeatures;
 
@@ -482,9 +485,6 @@ public:
 
 	/** Pointer to the memory properties of the underlying physical device. */
 	const VkPhysicalDeviceMemoryProperties* _pMemoryProperties;
-
-    /** The MoltenVK configuration settings for this device. */
-    const MVKDeviceConfiguration _mvkConfig;
 
     /** Performance statistics. */
     MVKPerformanceStatistics _performanceStatistics;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -20,6 +20,7 @@
 
 #include "MVKSurface.h"
 #include "MVKBaseObject.h"
+#include "vk_mvk_moltenvk.h"
 #include <vector>
 #include <unordered_map>
 #include <string>
@@ -72,6 +73,9 @@ public:
 	void destroySurface(MVKSurface* mvkSrfc,
 						const VkAllocationCallbacks* pAllocator);
 
+	/** The MoltenVK configuration settings. */
+	MVKConfiguration _mvkConfig;
+
 
 #pragma mark Object Creation
 
@@ -96,6 +100,7 @@ public:
 
 protected:
 	void initProcAddrs();
+	void initConfig();
     void logVersions();
 
 	VkApplicationInfo _appInfo;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -241,8 +241,8 @@ void MVKInstance::initProcAddrs() {
 	ADD_PROC_ADDR(vkGetSwapchainImagesKHR);
 	ADD_PROC_ADDR(vkAcquireNextImageKHR);
 	ADD_PROC_ADDR(vkQueuePresentKHR);
-    ADD_PROC_ADDR(vkGetMoltenVKDeviceConfigurationMVK);
-    ADD_PROC_ADDR(vkSetMoltenVKDeviceConfigurationMVK);
+	ADD_PROC_ADDR(vkGetMoltenVKConfigurationMVK);
+	ADD_PROC_ADDR(vkSetMoltenVKConfigurationMVK);
     ADD_PROC_ADDR(vkGetPhysicalDeviceMetalFeaturesMVK);
     ADD_PROC_ADDR(vkGetSwapchainPerformanceMVK);
     ADD_PROC_ADDR(vkGetPerformanceStatisticsMVK);
@@ -259,6 +259,15 @@ void MVKInstance::initProcAddrs() {
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 	ADD_PROC_ADDR(vkCreateMacOSSurfaceMVK);
 #endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	// Deprecated functions
+	ADD_PROC_ADDR(vkGetMoltenVKDeviceConfigurationMVK);
+	ADD_PROC_ADDR(vkSetMoltenVKDeviceConfigurationMVK);
+#pragma clang diagnostic pop
+
+
 }
 
 void MVKInstance::logVersions() {
@@ -318,6 +327,7 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) {
 
     logVersions();          // Log the MoltenVK and Vulkan versions
 	initProcAddrs();		// Init function pointers
+	initConfig();
 
 	// Populate the array of physical GPU devices
 	NSArray<id<MTLDevice>>* mtlDevices = getAvailableMTLDevices();
@@ -333,6 +343,20 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) {
 
     setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames));
     setConfigurationResult(verifyExtensions(pCreateInfo->enabledExtensionCount, pCreateInfo->ppEnabledExtensionNames));
+}
+
+// Init config.
+void MVKInstance::initConfig() {
+	_mvkConfig.debugMode					= MVK_DEBUG;
+	_mvkConfig.shaderConversionFlipVertexY 	= MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y;
+	_mvkConfig.synchronousQueueSubmits		= MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS;
+	_mvkConfig.supportLargeQueryPools		= MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS;
+	_mvkConfig.presentWithCommandBuffer		= MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER;
+	_mvkConfig.swapchainMagFilterUseNearest	= MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST;
+	_mvkConfig.displayWatermark				= MVK_CONFIG_DISPLAY_WATERMARK;
+	_mvkConfig.performanceTracking			= MVK_DEBUG;
+	_mvkConfig.performanceLoggingFrameCount	= MVK_DEBUG ? 300 : 0;
+	_mvkConfig.metalCompileTimeout			= MVK_CONFIG_METAL_COMPILE_TIMEOUT;
 }
 
 MVKInstance::~MVKInstance() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -212,7 +212,7 @@ public:
 	/**
 	 * Returns a new (retained) MTLRenderPipelineState object compiled from the descriptor.
 	 *
-	 * If the Metal pipeline compiler does not return within MVKDeviceConfiguration::metalCompileTimeout
+	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
 	 * nanoseconds, an error will be generated and logged, and nil will be returned.
 	 */
 	id<MTLRenderPipelineState> newMTLRenderPipelineState(MTLRenderPipelineDescriptor* mtlRPLDesc);
@@ -249,7 +249,7 @@ public:
 	/**
 	 * Returns a new (retained) MTLComputePipelineState object compiled from the MTLFunction.
 	 *
-	 * If the Metal pipeline compiler does not return within MVKDeviceConfiguration::metalCompileTimeout
+	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
 	 * nanoseconds, an error will be generated and logged, and nil will be returned.
 	 */
 	id<MTLComputePipelineState> newMTLComputePipelineState(id<MTLFunction> mtlFunction);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -367,7 +367,7 @@ void MVKGraphicsPipeline::initMVKShaderConverterContext(SPIRVToMSLConverterConte
 
     shaderContext.options.isRenderingPoints = (pCreateInfo->pInputAssemblyState && (pCreateInfo->pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST));
 	shaderContext.options.isRasterizationDisabled = (pCreateInfo->pRasterizationState && (pCreateInfo->pRasterizationState->rasterizerDiscardEnable));
-    shaderContext.options.shouldFlipVertexY = _device->_mvkConfig.shaderConversionFlipVertexY;
+    shaderContext.options.shouldFlipVertexY = _device->_pMVKConfig->shaderConversionFlipVertexY;
 
     // Set the shader context vertex attribute information
     shaderContext.vertexAttributes.clear();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -204,7 +204,7 @@ void MVKOcclusionQueryPool::beginQueryAddedTo(uint32_t query, MVKCommandBuffer* 
 MVKOcclusionQueryPool::MVKOcclusionQueryPool(MVKDevice* device,
                                              const VkQueryPoolCreateInfo* pCreateInfo) : MVKQueryPool(device, pCreateInfo, 1) {
 
-    if (_device->_mvkConfig.supportLargeQueryPools) {
+    if (_device->_pMVKConfig->supportLargeQueryPools) {
         _queryIndexOffset = 0;
 
         // Ensure we don't overflow the maximum number of queries

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -127,13 +127,6 @@ public:
 	/** Constructs an instance for the device and queue family. */
 	MVKQueue(MVKDevice* device, MVKQueueFamily* queueFamily, uint32_t index, float priority);
 
-	/**
-	 * Called from MVKDevice when MVKDeviceConfiguration is updated.
-	 *
-	 * Updates the use of a dispatch queue based on the value of MVKDeviceConfiguration::synchronousQueueSubmits.
-	 */
-	void updateDeviceConfiguration();
-
 	~MVKQueue() override;
 
     /**
@@ -156,6 +149,7 @@ protected:
 	friend class MVKQueuePresentSurfaceSubmission;
 
 	void initName();
+	void initExecQueue();
 	void initMTLCommandQueue();
 	void initGPUCaptureScopes();
 	void destroyExecQueue();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -196,7 +196,7 @@ public:
 	/**
 	 * Returns a new (retained) MTLLibrary object compiled from the MSL source code.
 	 *
-	 * If the Metal library compiler does not return within MVKDeviceConfiguration::metalCompileTimeout
+	 * If the Metal library compiler does not return within MVKConfiguration::metalCompileTimeout
 	 * nanoseconds, an error will be generated and logged, and nil will be returned.
 	 */
 	id<MTLLibrary> newMTLLibrary(NSString* mslSourceCode);
@@ -234,7 +234,7 @@ public:
 	/**
 	 * Returns a new (retained) MTLFunction object compiled from the MTLLibrary and specialization constants.
 	 *
-	 * If the Metal function compiler does not return within MVKDeviceConfiguration::metalCompileTimeout
+	 * If the Metal function compiler does not return within MVKConfiguration::metalCompileTimeout
 	 * nanoseconds, an error will be generated and logged, and nil will be returned.
 	 */
 	id<MTLFunction> newMTLFunction(id<MTLLibrary> mtlLibrary, NSString* funcName, MTLFunctionConstantValues* constantValues);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -238,7 +238,7 @@ MVKMTLFunction MVKShaderModule::getMTLFunction(SPIRVToMSLConverterContext* pCont
 }
 
 bool MVKShaderModule::convert(SPIRVToMSLConverterContext* pContext) {
-	bool shouldLogCode = _device->_mvkConfig.debugMode;
+	bool shouldLogCode = _device->_pMVKConfig->debugMode;
 
 	uint64_t startTime = _device->getPerformanceTimestamp();
 	bool wasConverted = _converter.convert(*pContext, shouldLogCode, shouldLogCode, shouldLogCode);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -106,7 +106,7 @@ void MVKSwapchain::willPresentSurface(id<MTLTexture> mtlTexture, id<MTLCommandBu
 
 // If the product has not been fully licensed, renders the watermark image to the surface.
 void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffer> mtlCmdBuff) {
-    if (_device->_mvkConfig.displayWatermark) {
+    if (_device->_pMVKConfig->displayWatermark) {
         if ( !_licenseWatermark ) {
             _licenseWatermark = new MVKWatermarkRandom(getMTLDevice(),
                                                        __watermarkTextureContent,
@@ -127,7 +127,7 @@ void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffe
 
 // Calculates and remembers the time interval between frames.
 void MVKSwapchain::markFrameInterval() {
-    if ( !(_device->_mvkConfig.performanceTracking || _licenseWatermark) ) { return; }
+    if ( !(_device->_pMVKConfig->performanceTracking || _licenseWatermark) ) { return; }
 
     uint64_t prevFrameTime = _lastFrameTime;
     _lastFrameTime = mvkGetTimestamp();
@@ -145,7 +145,7 @@ void MVKSwapchain::markFrameInterval() {
 //				_performanceStatistics.averageFrameInterval,
 //				_currentPerfLogFrameCount + 1);
 
-    uint32_t perfLogCntLimit = _device->_mvkConfig.performanceLoggingFrameCount;
+    uint32_t perfLogCntLimit = _device->_pMVKConfig->performanceLoggingFrameCount;
     if ((perfLogCntLimit > 0) && (++_currentPerfLogFrameCount >= perfLogCntLimit)) {
 		_currentPerfLogFrameCount = 0;
 		MVKLogInfo("Frame interval: %.2f ms. Avg frame interval: %.2f ms. Avg FPS: %.2f. Reporting every: %d frames. Elapsed time: %.3f seconds.",
@@ -198,7 +198,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo)
 	_mtlLayer.device = getMTLDevice();
 	_mtlLayer.pixelFormat = mtlPixelFormatFromVkFormat(pCreateInfo->imageFormat);
 	_mtlLayer.displaySyncEnabledMVK = (pCreateInfo->presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
-	_mtlLayer.magnificationFilter = _device->_mvkConfig.swapchainMagFilterUseNearest ? kCAFilterNearest : kCAFilterLinear;
+	_mtlLayer.magnificationFilter = _device->_pMVKConfig->swapchainMagFilterUseNearest ? kCAFilterNearest : kCAFilterLinear;
 	_mtlLayer.framebufferOnly = !mvkIsAnyFlagEnabled(pCreateInfo->imageUsage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
 																			   VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 																			   VK_IMAGE_USAGE_SAMPLED_BIT |

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
@@ -243,7 +243,7 @@ VkResult mvkWaitForFences(uint32_t fenceCount,
 #pragma mark MVKMetalCompiler
 
 // Create a compiled object by dispatching the block to the default global dispatch queue, and waiting only as long
-// as the MVKDeviceConfiguration::metalCompileTimeout value. If the timeout is triggered, a Vulkan error is created.
+// as the MVKConfiguration::metalCompileTimeout value. If the timeout is triggered, a Vulkan error is created.
 // This approach is used to limit the lengthy time (30+ seconds!) consumed by Metal when it's internal compiler fails.
 // The thread dispatch is needed because even the sync portion of the async Metal compilation methods can take well
 // over a second to return when a compiler failure occurs!
@@ -254,7 +254,7 @@ void MVKMetalCompiler::compile(unique_lock<mutex>& lock, dispatch_block_t block)
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
 
 	// Limit timeout to avoid overflow since wait_for() uses wait_until()
-	chrono::nanoseconds nanoTimeout(min(_device->_mvkConfig.metalCompileTimeout, kMVKUndefinedLargeUInt64));
+	chrono::nanoseconds nanoTimeout(min(_device->_pMVKConfig->metalCompileTimeout, kMVKUndefinedLargeUInt64));
 	_blocker.wait_for(lock, nanoTimeout, [this]{ return _isCompileDone; });
 
 	if ( !_isCompileDone ) {

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -39,20 +39,40 @@
                                                                     VK_VERSION_MINOR(api_ver),	\
                                                                     0)
 
-/** To present surface using a command buffer, define the MVK_PRESENT_WITHOUT_COMMAND_BUFFER build setting. */
-#ifdef MVK_PRESENT_WITHOUT_COMMAND_BUFFER
-#   define MVK_PRESENT_WITH_COMMAND_BUFFER_BOOL    0
-#else
-#   define MVK_PRESENT_WITH_COMMAND_BUFFER_BOOL    1
+/** Flip the vertex coordinate in shaders. Enabled by default. */
+#ifndef MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y
+#   define MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y    1
 #endif
 
-/** To display the MoltenVK logo watermark by default, define the MVK_DISPLAY_WATERMARK build setting. */
-#ifdef MVK_DISPLAY_WATERMARK
-#   define MVK_DISPLAY_WATERMARK_BOOL    1
-#else
-#   define MVK_DISPLAY_WATERMARK_BOOL    0
+/** Process command queue submissions on the same thread on which the submission call was made. Disabled by default. */
+#ifndef MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS
+#   define MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS    0
 #endif
 
+/** Support more than 8192 occlusion queries per buffer. Enabled by default. */
+#ifndef MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS
+#   define MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS    1
+#endif
+
+/** Present surfaces using a command buffer. Enabled by default. */
+#ifndef MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER
+#   define MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER    1
+#endif
+
+/** Use nearest sampling to magnify swapchain images. Enabled by default. */
+#ifndef MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST
+#   define MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST    1
+#endif
+
+/** Display the MoltenVK logo watermark. Disabled by default. */
+#ifndef MVK_CONFIG_DISPLAY_WATERMARK
+#   define MVK_CONFIG_DISPLAY_WATERMARK    0
+#endif
+
+/** The maximum amount of time, in nanoseconds, to wait for a Metal library. Default is infinite. */
+#ifndef MVK_CONFIG_METAL_COMPILE_TIMEOUT
+#   define MVK_CONFIG_METAL_COMPILE_TIMEOUT    INT64_MAX
+#endif
 
 /**
  * IOSurfaces are supported on macOS, and on iOS starting with iOS 11.

--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -17,6 +17,7 @@
  */
 
 
+#include "MVKInstance.h"
 #include "vk_mvk_moltenvk.h"
 #include "MVKEnvironment.h"
 #include "MVKSwapchain.h"
@@ -26,20 +27,20 @@
 using namespace std;
 
 
-MVK_PUBLIC_SYMBOL void vkGetMoltenVKDeviceConfigurationMVK(
-    VkDevice                                    device,
-    MVKDeviceConfiguration*                     pConfiguration) {
+MVK_PUBLIC_SYMBOL void vkGetMoltenVKConfigurationMVK(
+    VkInstance                                  instance,
+    MVKConfiguration*                           pConfiguration) {
 
-    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-    if (pConfiguration) { *pConfiguration = *mvkDev->getMoltenVKConfiguration(); }
+	MVKInstance* mvkInst = MVKInstance::getMVKInstance(instance);
+    if (pConfiguration) { *pConfiguration = mvkInst->_mvkConfig; }
 }
 
-MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKDeviceConfigurationMVK(
-    VkDevice                                    device,
-    MVKDeviceConfiguration*                     pConfiguration) {
+MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
+    VkInstance                                  instance,
+    MVKConfiguration*                           pConfiguration) {
 
-    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-    if (pConfiguration) { mvkDev->setMoltenVKConfiguration(pConfiguration); }
+	MVKInstance* mvkInst = MVKInstance::getMVKInstance(instance);
+    if (pConfiguration) { mvkInst->_mvkConfig = *pConfiguration; }
     return VK_SUCCESS;
 }
 
@@ -133,4 +134,24 @@ MVK_PUBLIC_SYMBOL void vkGetIOSurfaceMVK(
     MVKImage* mvkImg = (MVKImage*)image;
     *pIOSurface = mvkImg->getIOSurface();
 }
+
+
+// Deprecated functions
+MVK_PUBLIC_SYMBOL void vkGetMoltenVKDeviceConfigurationMVK(
+	VkDevice                                    device,
+	MVKDeviceConfiguration*                     pConfiguration) {
+
+	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
+	if (pConfiguration) { *pConfiguration = mvkDev->getInstance()->_mvkConfig; }
+}
+
+MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKDeviceConfigurationMVK(
+	VkDevice                                    device,
+	MVKDeviceConfiguration*                     pConfiguration) {
+
+	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
+	if (pConfiguration) { mvkDev->getInstance()->_mvkConfig = *pConfiguration; }
+	return VK_SUCCESS;
+}
+
 


### PR DESCRIPTION
Add MVKConfiguration and deprecate MVKDeviceConfiguration.
Add vkGetMoltenVKConfigurationMVK() and deprecate vkGetMoltenVKDeviceConfigurationMVK().
Add vkSetMoltenVKConfigurationMVK() and deprecate vkSetMoltenVKDeviceConfigurationMVK().
Add build setting overrides for all initial MVKConfiguration member values.
Update to MoltenVK version 1.0.19.
Update to VK_MVK_moltenvk spec version 7.