### PR TITLE
Support the VK_KHR_maintenance1 extension.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
@@ -142,6 +142,9 @@ public:
 	void freeCommandBuffers(uint32_t commandBufferCount,
 							const VkCommandBuffer* pCommandBuffers);
 
+	/** Release any held but unused memory back to the system. */
+	void trimCommandPool();
+
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -63,6 +63,10 @@ void MVKCommandPool::freeCommandBuffers(uint32_t commandBufferCount,
 	}
 }
 
+void MVKCommandPool::trimCommandPool() {
+	// TODO: Implement.
+}
+
 void MVKCommandPool::addCommandBuffer(MVKCommandBuffer* cmdBuffer) {
 	_commandBuffers.insert(cmdBuffer);
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -611,7 +611,7 @@ VkResult MVKDescriptorPool::allocateDescriptorSets(uint32_t count,
 												   const VkDescriptorSetLayout* pSetLayouts,
 												   VkDescriptorSet* pDescriptorSets) {
 	if (_allocatedSetCount + count > _maxSets) {
-		return mvkNotifyErrorWithText(VK_ERROR_INITIALIZATION_FAILED, "The maximum number of descriptor sets that can be allocated by this descriptor pool is %d.", _maxSets);
+		return mvkNotifyErrorWithText(VK_ERROR_OUT_OF_POOL_MEMORY_KHR, "The maximum number of descriptor sets that can be allocated by this descriptor pool is %d.", _maxSets);
 	}
 
 	for (uint32_t dsIdx = 0; dsIdx < count; dsIdx++) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -241,6 +241,7 @@ void MVKInstance::initProcAddrs() {
 	ADD_PROC_ADDR(vkGetSwapchainImagesKHR);
 	ADD_PROC_ADDR(vkAcquireNextImageKHR);
 	ADD_PROC_ADDR(vkQueuePresentKHR);
+	ADD_PROC_ADDR(vkTrimCommandPoolKHR);
 	ADD_PROC_ADDR(vkGetMoltenVKConfigurationMVK);
 	ADD_PROC_ADDR(vkSetMoltenVKConfigurationMVK);
     ADD_PROC_ADDR(vkGetPhysicalDeviceMetalFeaturesMVK);

--- a/MoltenVK/MoltenVK/Loader/MVKLayers.mm
+++ b/MoltenVK/MoltenVK/Loader/MVKLayers.mm
@@ -92,6 +92,11 @@ MVKLayer::MVKLayer() {
     extTmplt.specVersion = VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_SPEC_VERSION;
     _extensions.push_back(extTmplt);
 
+    memset(extTmplt.extensionName, 0, sizeof(extTmplt.extensionName));
+    strcpy(extTmplt.extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME);
+    extTmplt.specVersion = VK_KHR_MAINTENANCE1_SPEC_VERSION;
+    _extensions.push_back(extTmplt);
+
 #if MVK_IOS
     memset(extTmplt.extensionName, 0, sizeof(extTmplt.extensionName));
 	strcpy(extTmplt.extensionName, VK_MVK_IOS_SURFACE_EXTENSION_NAME);

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1602,6 +1602,18 @@ MVK_PUBLIC_SYMBOL VkResult vkCreate_PLATFORM_SurfaceMVK(
 
 
 #pragma mark -
+#pragma mark VK_KHR_maintenace1 extension
+
+MVK_PUBLIC_SYMBOL void vkTrimCommandPoolKHR(
+    VkDevice                                    device,
+    VkCommandPool                               commandPool,
+    VkCommandPoolTrimFlagsKHR                   flags) {
+	MVKCommandPool* mvkCmdPool = (MVKCommandPool*)commandPool;
+    mvkCmdPool->trimCommandPool();
+}
+
+
+#pragma mark -
 #pragma mark Loader and Layer ICD interface extension
 
 #ifdef __cplusplus


### PR DESCRIPTION
Much of this was already supported, simply by being supported by Metal.
Of course, this support is incomplete: Metal doesn't yet allow you to
create a 2D texture view from a 3D texture.