### PR TITLE
Support the VK_KHR_get_physical_device_properties2 extension.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -75,17 +75,26 @@ public:
 	/** Populates the specified structure with the features of this device. */
 	void getFeatures(VkPhysicalDeviceFeatures* features);
 
+	/** Populates the specified structure with the features of this device. */
+	void getFeatures(VkPhysicalDeviceFeatures2KHR* features);
+
 	/** Populates the specified structure with the Metal-specific features of this device. */
 	void getMetalFeatures(MVKPhysicalDeviceMetalFeatures* mtlFeatures);
 
 	/** Populates the specified structure with the properties of this device. */
 	void getProperties(VkPhysicalDeviceProperties* properties);
 
+	/** Populates the specified structure with the properties of this device. */
+	void getProperties(VkPhysicalDeviceProperties2KHR* properties);
+
 	/** Returns whether the specified format is supported on this device. */
 	bool getFormatIsSupported(VkFormat format);
 
 	/** Populates the specified structure with the format properties of this device. */
 	void getFormatProperties(VkFormat format, VkFormatProperties* pFormatProperties);
+
+	/** Populates the specified structure with the format properties of this device. */
+	void getFormatProperties(VkFormat format, VkFormatProperties2KHR* pFormatProperties);
 
     /** 
      * Populates the specified structure with the image format properties
@@ -97,6 +106,13 @@ public:
                                       VkImageUsageFlags usage,
                                       VkImageCreateFlags flags,
                                       VkImageFormatProperties* pImageFormatProperties);
+
+    /** 
+     * Populates the specified structure with the image format properties
+     * supported for the specified image characteristics on this device.
+     */
+    VkResult getImageFormatProperties(const VkPhysicalDeviceImageFormatInfo2KHR* pImageFormatInfo,
+                                      VkImageFormatProperties2KHR* pImageFormatProperties);
 
 #pragma mark Surfaces
 
@@ -158,6 +174,20 @@ public:
 	 */
 	VkResult getQueueFamilyProperties(uint32_t* pCount, VkQueueFamilyProperties* properties);
 
+	/**
+	 * If properties is null, the value of pCount is updated with the number of
+	 * queue families supported by this instance.
+	 *
+	 * If properties is not null, then pCount queue family properties are copied into the 
+	 * array. If the number of available queue families is less than pCount, the value of 
+	 * pCount is updated to indicate the number of queue families actually returned in the array.
+	 *
+	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of queue families
+	 * available in this instance is larger than the specified pCount. Returns other values if
+	 * an error occurs.
+	 */
+	VkResult getQueueFamilyProperties(uint32_t* pCount, VkQueueFamilyProperties2KHR* properties);
+
 	/** Returns a pointer to the Vulkan instance. */
 	inline MVKInstance* getInstance() { return _mvkInstance; }
 
@@ -172,6 +202,9 @@ public:
 
 	/** Populates the specified memory properties with the memory characteristics of this device. */
 	VkResult getPhysicalDeviceMemoryProperties(VkPhysicalDeviceMemoryProperties* pMemoryProperties);
+
+	/** Populates the specified memory properties with the memory characteristics of this device. */
+	VkResult getPhysicalDeviceMemoryProperties(VkPhysicalDeviceMemoryProperties2KHR* pMemoryProperties);
 
 	/**
 	 * Returns a bit mask of all memory type indices. 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -242,6 +242,13 @@ void MVKInstance::initProcAddrs() {
 	ADD_PROC_ADDR(vkAcquireNextImageKHR);
 	ADD_PROC_ADDR(vkQueuePresentKHR);
 	ADD_PROC_ADDR(vkTrimCommandPoolKHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceFeatures2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceFormatProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceImageFormatProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceQueueFamilyProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceMemoryProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
 	ADD_PROC_ADDR(vkGetMoltenVKConfigurationMVK);
 	ADD_PROC_ADDR(vkSetMoltenVKConfigurationMVK);
     ADD_PROC_ADDR(vkGetPhysicalDeviceMetalFeaturesMVK);

--- a/MoltenVK/MoltenVK/Loader/MVKLayers.mm
+++ b/MoltenVK/MoltenVK/Loader/MVKLayers.mm
@@ -102,6 +102,11 @@ MVKLayer::MVKLayer() {
     extTmplt.specVersion = VK_KHR_SHADER_DRAW_PARAMETERS_SPEC_VERSION;
     _extensions.push_back(extTmplt);
 
+    memset(extTmplt.extensionName, 0, sizeof(extTmplt.extensionName));
+    strcpy(extTmplt.extensionName, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    extTmplt.specVersion = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION;
+    _extensions.push_back(extTmplt);
+
 #if MVK_IOS
     memset(extTmplt.extensionName, 0, sizeof(extTmplt.extensionName));
 	strcpy(extTmplt.extensionName, VK_MVK_IOS_SURFACE_EXTENSION_NAME);

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1614,6 +1614,70 @@ MVK_PUBLIC_SYMBOL void vkTrimCommandPoolKHR(
 
 
 #pragma mark -
+#pragma mark VK_KHR_get_physical_device_properties2 extension
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFeatures2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceFeatures2KHR*               pFeatures) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getFeatures(pFeatures);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceProperties2KHR*             pProperties) {
+
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getProperties(pProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkFormat                                    format,
+    VkFormatProperties2KHR*                     pFormatProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getFormatProperties(format, pFormatProperties);
+}
+
+MVK_PUBLIC_SYMBOL VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceImageFormatInfo2KHR*  pImageFormatInfo,
+    VkImageFormatProperties2KHR*                pImageFormatProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    return mvkPD->getImageFormatProperties(pImageFormatInfo, pImageFormatProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pQueueFamilyPropertyCount,
+    VkQueueFamilyProperties2KHR*                pQueueFamilyProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getQueueFamilyProperties(pQueueFamilyPropertyCount, pQueueFamilyProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceMemoryProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceMemoryProperties2KHR*       pMemoryProperties) {
+
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getPhysicalDeviceMemoryProperties(pMemoryProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo,
+    uint32_t*                                   pPropertyCount,
+    VkSparseImageFormatProperties2KHR*          pProperties) {
+
+    MVKLogUnimplemented("vkGetPhysicalDeviceSparseImageFormatProperties");
+}
+
+
+#pragma mark -
 #pragma mark Loader and Layer ICD interface extension
 
 #ifdef __cplusplus


### PR DESCRIPTION
This extension is a prerequisite for multiple other extensions, the
`VK_KHR_push_descriptor` extension in particular.