### PR TITLE
MVKDevice: Fix a segfault walking unknown extension structs.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -87,7 +87,7 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2KHR* properties
                 break;
             }
             default:
-                next = *(VkStructureType**)(next+1);
+                next = (VkStructureType*)((VkPhysicalDeviceProperties2KHR*)next)->pNext;
                 break;
             }
         }


### PR DESCRIPTION
The problem is that on 64-bit platforms (i.e. every platform we support)
there will be padding between the `sType` and `pNext` members of any
extensible Vulkan structure, because `sType` is only 4 bytes while
`pNext` is 8 (and needs 8-byte alignment).

Should fix a segfault running `vulkaninfo`.