### PR TITLE
Don't pass the offset to the FillBuffer compute kernel.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
@@ -80,7 +80,6 @@ kernel void cmdCopyBufferBytes(device uint8_t* src [[ buffer(0) ]],             
 };                                                                                                              \n\
                                                                                                                 \n\
 typedef struct {                                                                                                \n\
-    uint32_t dstOffset;                                                                                         \n\
     uint32_t size;                                                                                              \n\
     uint32_t data;                                                                                              \n\
 } FillInfo;                                                                                                     \n\
@@ -88,7 +87,7 @@ typedef struct {                                                                
 kernel void cmdFillBuffer(device uint32_t* dst [[ buffer(0) ]],                                                 \n\
                           constant FillInfo& info [[ buffer(1) ]]) {                                            \n\
     for (uint32_t i = 0; i < info.size; i++) {                                                                  \n\
-        dst[i + info.dstOffset] = info.data;                                                                    \n\
+        dst[i] = info.data;                                                                                     \n\
     }                                                                                                           \n\
 };                                                                                                              \n\
                                                                                                                 \n\


### PR DESCRIPTION
Just add it to the buffer offset when encoding the command. The reason
for this is that we were using it to index the buffer--which, according
to the C++ spec (on which MSL is based), causes it to be offset by that
many 32-bit words instead of bytes. This caused the buffer to be filled
incorrectly. While Metal does require the offset to be aligned to the
type size (in this case, 4 bytes), Vulkan also requires the offset to
`vkCmdFillBuffer()` to be 4-byte aligned, so this shouldn't run into the
same problem as `vkCmdCopyBuffer()`.