### PR TITLE
Advertise some features we already support

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -491,6 +491,10 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderInt16 = true;
 	_features.multiDrawIndirect = true;
 
+    if (_metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing) {
+        _features.drawIndirectFirstInstance = true;
+    }
+
 #if MVK_IOS
     _features.textureCompressionETC2 = true;
 
@@ -531,8 +535,8 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    sampleRateShading;
 //    VkBool32    dualSrcBlend;                                 // done
 //    VkBool32    logicOp;
-//    VkBool32    multiDrawIndirect;							// done
-//    VkBool32    drawIndirectFirstInstance;
+//    VkBool32    multiDrawIndirect;                            // done
+//    VkBool32    drawIndirectFirstInstance;                    // done
 //    VkBool32    depthClamp;                                   // done
 //    VkBool32    depthBiasClamp;                               // done
 //    VkBool32    fillModeNonSolid;                             // done

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -477,6 +477,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 void MVKPhysicalDevice::initFeatures() {
 	memset(&_features, 0, sizeof(_features));	// Start with everything cleared
 
+    _features.robustBufferAccess = true;  // XXX Required by Vulkan spec
     _features.independentBlend = true;
     _features.depthBiasClamp = true;
     _features.fillModeNonSolid = true;
@@ -520,7 +521,7 @@ void MVKPhysicalDevice::initFeatures() {
 #pragma mark VkPhysicalDeviceFeatures - List of features available on the device
 
 //typedef struct VkPhysicalDeviceFeatures {
-//    VkBool32    robustBufferAccess;
+//    VkBool32    robustBufferAccess;                           // done
 //    VkBool32    fullDrawIndexUint32;
 //    VkBool32    imageCubeArray;                               // done
 //    VkBool32    independentBlend;                             // done

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -478,6 +478,7 @@ void MVKPhysicalDevice::initFeatures() {
 	memset(&_features, 0, sizeof(_features));	// Start with everything cleared
 
     _features.robustBufferAccess = true;  // XXX Required by Vulkan spec
+    _features.fullDrawIndexUint32 = true;
     _features.independentBlend = true;
     _features.depthBiasClamp = true;
     _features.fillModeNonSolid = true;
@@ -522,7 +523,7 @@ void MVKPhysicalDevice::initFeatures() {
 
 //typedef struct VkPhysicalDeviceFeatures {
 //    VkBool32    robustBufferAccess;                           // done
-//    VkBool32    fullDrawIndexUint32;
+//    VkBool32    fullDrawIndexUint32;                          // done
 //    VkBool32    imageCubeArray;                               // done
 //    VkBool32    independentBlend;                             // done
 //    VkBool32    geometryShader;
@@ -732,7 +733,7 @@ void MVKPhysicalDevice::initProperties() {
     _properties.limits.maxComputeWorkGroupCount[1] = kMVKUndefinedLargeUInt32;
     _properties.limits.maxComputeWorkGroupCount[2] = kMVKUndefinedLargeUInt32;
 
-    _properties.limits.maxDrawIndexedIndexValue = numeric_limits<uint32_t>::max() - 1;
+    _properties.limits.maxDrawIndexedIndexValue = numeric_limits<uint32_t>::max();
     _properties.limits.maxDrawIndirectCount = kMVKUndefinedLargeUInt32;
 
     _properties.limits.minTexelOffset = -8;


### PR DESCRIPTION
Advertise a couple of features—namely `fullDrawIndexUint32`, and `drawIndirectFirstInstance`—that are already supported.

Also advertise `robustBufferAccess`; we don't really support it directly, but the spec says we have to. I haven't observed any issues with out-of-bounds accesses anyway, and I suspect that Apple wouldn't allow shaders to do crazy destabilizing things to the system, so I think we're OK here. (The feature itself does nothing in MoltenVK.)