### PR TITLE
Support the multiViewport feature.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -144,7 +144,7 @@ protected:
     void encodeImpl() override;
     void resetImpl() override;
 
-    MTLViewport _mtlViewport =  { 0, 0, 0, 0, 0, 0 };
+    std::vector<MTLViewport> _mtlViewports;
 };
 
 
@@ -173,7 +173,7 @@ protected:
     void encodeImpl() override;
     void resetImpl() override;
 
-    MTLScissorRect _mtlScissor =  { 0, 0, 0, 0 };
+    std::vector<MTLScissorRect> _mtlScissors;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -61,8 +61,9 @@ void MVKViewportCommandEncoderState::setViewports(vector<MTLViewport> mtlViewpor
 		(firstViewport + mtlViewports.size() <= maxViewports) &&
 		(firstViewport < maxViewports)) {
 
-		if (firstViewport + mtlViewports.size() > _mtlViewports.size())
+		if (firstViewport + mtlViewports.size() > _mtlViewports.size()) {
 			_mtlViewports.resize(firstViewport + mtlViewports.size());
+		}
 
 		std::copy(mtlViewports.begin(), mtlViewports.end(), _mtlViewports.begin() + firstViewport);
 		markDirty();
@@ -74,9 +75,12 @@ void MVKViewportCommandEncoderState::encodeImpl() {
 #if MVK_MACOS
     if (_cmdEncoder->getDevice()->_pFeatures->multiViewport) {
         [_cmdEncoder->_mtlRenderEncoder setViewports: &_mtlViewports[0] count: _mtlViewports.size()];
-    } else
-#endif
+    } else {
+        [_cmdEncoder->_mtlRenderEncoder setViewport: _mtlViewports[0]];
+    }
+#else
     [_cmdEncoder->_mtlRenderEncoder setViewport: _mtlViewports[0]];
+#endif
 }
 
 void MVKViewportCommandEncoderState::resetImpl() {
@@ -98,8 +102,9 @@ void MVKScissorCommandEncoderState::setScissors(vector<MTLScissorRect> mtlScisso
 		(firstScissor + mtlScissors.size() <= maxScissors) &&
 		(firstScissor < maxScissors)) {
 
-		if (firstScissor + mtlScissors.size() > _mtlScissors.size())
+		if (firstScissor + mtlScissors.size() > _mtlScissors.size()) {
 			_mtlScissors.resize(firstScissor + mtlScissors.size());
+		}
 
 		std::copy(mtlScissors.begin(), mtlScissors.end(), _mtlScissors.begin() + firstScissor);
 		markDirty();
@@ -115,9 +120,12 @@ void MVKScissorCommandEncoderState::encodeImpl() {
 #if MVK_MACOS
 	if (_cmdEncoder->getDevice()->_pFeatures->multiViewport) {
 		[_cmdEncoder->_mtlRenderEncoder setScissorRects: &clippedScissors[0] count: clippedScissors.size()];
-	} else
-#endif
+	} else {
+		[_cmdEncoder->_mtlRenderEncoder setScissorRect: clippedScissors[0]];
+	}
+#else
 	[_cmdEncoder->_mtlRenderEncoder setScissorRect: clippedScissors[0]];
+#endif
 }
 
 void MVKScissorCommandEncoderState::resetImpl() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -520,6 +520,10 @@ void MVKPhysicalDevice::initFeatures() {
         _features.dualSrcBlend = true;
     }
 
+    if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
+        _features.multiViewport = true;
+    }
+
 #endif
 }
 
@@ -545,7 +549,7 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    wideLines;
 //    VkBool32    largePoints;                                  // done
 //    VkBool32    alphaToOne;                                   // done
-//    VkBool32    multiViewport;
+//    VkBool32    multiViewport;                                // done
 //    VkBool32    samplerAnisotropy;                            // done
 //    VkBool32    textureCompressionETC2;                       // done
 //    VkBool32    textureCompressionASTC_LDR;                   // done
@@ -634,6 +638,12 @@ void MVKPhysicalDevice::initProperties() {
 
 	_properties.limits.maxImageDimension3D = (2 * KIBI);
 	_properties.limits.maxImageArrayLayers = (2 * KIBI);
+#if MVK_MACOS
+	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
+		_properties.limits.maxViewports = 16;
+	}
+	else
+#endif
 	_properties.limits.maxViewports = 1;
 	_properties.limits.maxSamplerAnisotropy = 16;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -641,10 +641,12 @@ void MVKPhysicalDevice::initProperties() {
 #if MVK_MACOS
 	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
 		_properties.limits.maxViewports = 16;
+	} else {
+		_properties.limits.maxViewports = 1;
 	}
-	else
-#endif
+#else
 	_properties.limits.maxViewports = 1;
+#endif
 	_properties.limits.maxSamplerAnisotropy = 16;
 
     _properties.limits.maxVertexInputAttributes = 31;


### PR DESCRIPTION
Clients can now set multiple viewports and scissor rects, but without a
geometry shader, it won't be much use. For now, however, we can support
`VK_EXT_shader_viewport_index_layer`, which will make this feature more
useful despite us not having geometry shaders.