### PR TITLE
Pull extension definitions into a common file.

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		45003E73214AD4E500E989CB /* MVKExtensions.def in Headers */ = {isa = PBXBuildFile; fileRef = 45003E6F214AD4C900E989CB /* MVKExtensions.def */; };
+		45003E74214AD4E600E989CB /* MVKExtensions.def in Headers */ = {isa = PBXBuildFile; fileRef = 45003E6F214AD4C900E989CB /* MVKExtensions.def */; };
 		A9096E5E1F81E16300DFBEA6 /* MVKCmdDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = A9096E5D1F81E16300DFBEA6 /* MVKCmdDispatch.mm */; };
 		A9096E5F1F81E16300DFBEA6 /* MVKCmdDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = A9096E5D1F81E16300DFBEA6 /* MVKCmdDispatch.mm */; };
 		A909F65F213B190700FCD6BE /* MVKExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A909F65A213B190600FCD6BE /* MVKExtensions.h */; };
@@ -258,6 +260,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		45003E6F214AD4C900E989CB /* MVKExtensions.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = MVKExtensions.def; sourceTree = "<group>"; };
 		A9096E5C1F81E16300DFBEA6 /* MVKCmdDispatch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MVKCmdDispatch.h; sourceTree = "<group>"; };
 		A9096E5D1F81E16300DFBEA6 /* MVKCmdDispatch.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MVKCmdDispatch.mm; sourceTree = "<group>"; };
 		A909F65A213B190600FCD6BE /* MVKExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKExtensions.h; sourceTree = "<group>"; };
@@ -466,6 +469,7 @@
 		A94FB79F1C7DFB4800632CA3 /* Layers */ = {
 			isa = PBXGroup;
 			children = (
+				45003E6F214AD4C900E989CB /* MVKExtensions.def */,
 				A909F65A213B190600FCD6BE /* MVKExtensions.h */,
 				A909F65E213B190700FCD6BE /* MVKExtensions.cpp */,
 				A94FB7A01C7DFB4800632CA3 /* MVKLayers.h */,
@@ -631,6 +635,7 @@
 				A98149531FB6A3F7005F00B4 /* MVKFoundation.h in Headers */,
 				A94FB7E81C7DFB4800632CA3 /* MVKDeviceMemory.h in Headers */,
 				A9E4B7891E1D8AF10046A4CE /* MVKMTLResourceBindings.h in Headers */,
+				45003E73214AD4E500E989CB /* MVKExtensions.def in Headers */,
 				A90C8DEA1F45354D009CB32C /* MVKCommandEncodingPool.h in Headers */,
 				A94FB8081C7DFB4800632CA3 /* MVKResource.h in Headers */,
 				A9E53DDD2100B197002781DD /* MTLTextureDescriptor+MoltenVK.h in Headers */,
@@ -691,6 +696,7 @@
 				A98149541FB6A3F7005F00B4 /* MVKFoundation.h in Headers */,
 				A94FB7E91C7DFB4800632CA3 /* MVKDeviceMemory.h in Headers */,
 				A9E4B78A1E1D8AF10046A4CE /* MVKMTLResourceBindings.h in Headers */,
+				45003E74214AD4E600E989CB /* MVKExtensions.def in Headers */,
 				A90C8DEB1F45354D009CB32C /* MVKCommandEncodingPool.h in Headers */,
 				A94FB8091C7DFB4800632CA3 /* MVKResource.h in Headers */,
 				A9E53DDE2100B197002781DD /* MTLTextureDescriptor+MoltenVK.h in Headers */,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -277,6 +277,19 @@ void MVKInstance::initProcAddrs() {
 	ADD_PROC_ADDR(vkCmdExecuteCommands);
 
 	// Supported extensions:
+	ADD_PROC_ADDR(vkCreateDescriptorUpdateTemplateKHR);
+	ADD_PROC_ADDR(vkDestroyDescriptorUpdateTemplateKHR);
+	ADD_PROC_ADDR(vkUpdateDescriptorSetWithTemplateKHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceFeatures2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceFormatProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceImageFormatProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceQueueFamilyProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceMemoryProperties2KHR);
+	ADD_PROC_ADDR(vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
+	ADD_PROC_ADDR(vkTrimCommandPoolKHR);
+	ADD_PROC_ADDR(vkCmdPushDescriptorSetKHR);
+	ADD_PROC_ADDR(vkCmdPushDescriptorSetWithTemplateKHR);
 	ADD_PROC_ADDR(vkDestroySurfaceKHR);
 	ADD_PROC_ADDR(vkGetPhysicalDeviceSurfaceSupportKHR);
 	ADD_PROC_ADDR(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
@@ -287,19 +300,6 @@ void MVKInstance::initProcAddrs() {
 	ADD_PROC_ADDR(vkGetSwapchainImagesKHR);
 	ADD_PROC_ADDR(vkAcquireNextImageKHR);
 	ADD_PROC_ADDR(vkQueuePresentKHR);
-	ADD_PROC_ADDR(vkTrimCommandPoolKHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceFeatures2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceProperties2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceFormatProperties2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceImageFormatProperties2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceQueueFamilyProperties2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceMemoryProperties2KHR);
-	ADD_PROC_ADDR(vkGetPhysicalDeviceSparseImageFormatProperties2KHR);
-	ADD_PROC_ADDR(vkCmdPushDescriptorSetKHR);
-	ADD_PROC_ADDR(vkCmdPushDescriptorSetWithTemplateKHR);
-	ADD_PROC_ADDR(vkCreateDescriptorUpdateTemplateKHR);
-	ADD_PROC_ADDR(vkDestroyDescriptorUpdateTemplateKHR);
-	ADD_PROC_ADDR(vkUpdateDescriptorSetWithTemplateKHR);
 	ADD_PROC_ADDR(vkGetMoltenVKConfigurationMVK);
 	ADD_PROC_ADDR(vkSetMoltenVKConfigurationMVK);
     ADD_PROC_ADDR(vkGetPhysicalDeviceMetalFeaturesMVK);

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.cpp
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.cpp
@@ -34,44 +34,15 @@ static VkExtensionProperties mvkMakeExtProps(const char* extensionName, uint32_t
 	return extProps;
 }
 
-// Declares and populates a static VkExtensionProperties variable for the extention EXT,
-// which should include the unique portion of the extension name, as uppercase.
-// For example, for the extension VK_KHR_surface, use KHR_SURFACE.
-#define MVK_MAKE_VK_EXT_PROPS(EXT) \
-static VkExtensionProperties kVkExtProps_ ##EXT = mvkMakeExtProps(VK_ ##EXT ##_EXTENSION_NAME, VK_ ##EXT ##_SPEC_VERSION)
-
 // Extension properties
-MVK_MAKE_VK_EXT_PROPS(MVK_MOLTENVK);
-MVK_MAKE_VK_EXT_PROPS(MVK_MACOS_SURFACE);
-MVK_MAKE_VK_EXT_PROPS(MVK_IOS_SURFACE);
-MVK_MAKE_VK_EXT_PROPS(KHR_SURFACE);
-MVK_MAKE_VK_EXT_PROPS(KHR_SWAPCHAIN);
-MVK_MAKE_VK_EXT_PROPS(KHR_MAINTENANCE1);
-MVK_MAKE_VK_EXT_PROPS(IMG_FORMAT_PVRTC);
-MVK_MAKE_VK_EXT_PROPS(AMD_NEGATIVE_VIEWPORT_HEIGHT);
-MVK_MAKE_VK_EXT_PROPS(KHR_SHADER_DRAW_PARAMETERS);
-MVK_MAKE_VK_EXT_PROPS(KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-MVK_MAKE_VK_EXT_PROPS(KHR_PUSH_DESCRIPTOR);
-MVK_MAKE_VK_EXT_PROPS(KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-
-// Calls the constructor for a MVKExtension member variable, using the member name and the
-// portion of the extension name, as uppercase, used in the MVK_MAKE_VK_EXT_PROPS() macro above.
-// For example, for the memeber variable vk_KHR_surface, use MVKExt_CONSTRUCT(vk_KHR_surface, KHR_SURFACE).
-#define MVKExt_CONSTRUCT(var, EXT)	var(&kVkExtProps_ ##EXT, enableForPlatform)
+#define MVK_EXTENSION(var, EXT) \
+static VkExtensionProperties kVkExtProps_ ##EXT = mvkMakeExtProps(VK_ ##EXT ##_EXTENSION_NAME, VK_ ##EXT ##_SPEC_VERSION);
+#include "MVKExtensions.def"
 
 MVKExtensionList::MVKExtensionList(bool enableForPlatform) :
-	MVKExt_CONSTRUCT(vk_MVK_moltenvk, MVK_MOLTENVK),
-	MVKExt_CONSTRUCT(vk_MVK_macos_surface, MVK_MACOS_SURFACE),
-	MVKExt_CONSTRUCT(vk_MVK_ios_surface, MVK_IOS_SURFACE),
-	MVKExt_CONSTRUCT(vk_KHR_surface, KHR_SURFACE),
-	MVKExt_CONSTRUCT(vk_KHR_swapchain, KHR_SWAPCHAIN),
-	MVKExt_CONSTRUCT(vk_KHR_maintenance1, KHR_MAINTENANCE1),
-	MVKExt_CONSTRUCT(vk_IMG_format_pvrtc, IMG_FORMAT_PVRTC),
-	MVKExt_CONSTRUCT(vk_AMD_negative_viewport_height, AMD_NEGATIVE_VIEWPORT_HEIGHT),
-	MVKExt_CONSTRUCT(vk_KHR_shader_draw_parameters, KHR_SHADER_DRAW_PARAMETERS),
-	MVKExt_CONSTRUCT(vk_KHR_get_physical_device_properties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2),
-	MVKExt_CONSTRUCT(vk_KHR_push_descriptor, KHR_PUSH_DESCRIPTOR),
-	MVKExt_CONSTRUCT(vk_KHR_descriptor_update_template, KHR_DESCRIPTOR_UPDATE_TEMPLATE)
+#define MVK_EXTENSION_LAST(var, EXT)	vk_ ##var(&kVkExtProps_ ##EXT, enableForPlatform)
+#define MVK_EXTENSION(var, EXT)			MVK_EXTENSION_LAST(var, EXT),
+#include "MVKExtensions.def"
 {}
 
 bool MVKExtensionList::isEnabled(const char* extnName) const {

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -1,0 +1,47 @@
+/*
+ * MVKExtensions.def
+ *
+ * Copyright (c) 2014-2018 The Brenwill Workshop Ltd. (http://www.brenwill.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// To use this file, define the macro MVK_EXTENSION(var, EXT), then #include this file.
+// To add a new extension, simply add an MVK_EXTENSION line below. The macro takes the
+// portion of the extension name without the leading "VK_", both in lowercase and uppercase.
+// The last line in the list must be an MVK_EXTENSION_LAST line; this is used in the MVKExtensionList
+// constructor to avoid a dangling ',' at the end of the initializer list.
+
+#ifndef MVK_EXTENSION
+#error MVK_EXTENSION must be defined before including this file
+#endif
+
+#ifndef MVK_EXTENSION_LAST
+#define MVK_EXTENSION_LAST(var, EXT) MVK_EXTENSION(var, EXT)
+#endif
+
+MVK_EXTENSION(KHR_descriptor_update_template, KHR_DESCRIPTOR_UPDATE_TEMPLATE)
+MVK_EXTENSION(KHR_get_physical_device_properties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2)
+MVK_EXTENSION(KHR_maintenance1, KHR_MAINTENANCE1)
+MVK_EXTENSION(KHR_push_descriptor, KHR_PUSH_DESCRIPTOR)
+MVK_EXTENSION(KHR_shader_draw_parameters, KHR_SHADER_DRAW_PARAMETERS)
+MVK_EXTENSION(KHR_surface, KHR_SURFACE)
+MVK_EXTENSION(KHR_swapchain, KHR_SWAPCHAIN)
+MVK_EXTENSION(MVK_ios_surface, MVK_IOS_SURFACE)
+MVK_EXTENSION(MVK_macos_surface, MVK_MACOS_SURFACE)
+MVK_EXTENSION(MVK_moltenvk, MVK_MOLTENVK)
+MVK_EXTENSION(AMD_negative_viewport_height, AMD_NEGATIVE_VIEWPORT_HEIGHT)
+MVK_EXTENSION_LAST(IMG_format_pvrtc, IMG_FORMAT_PVRTC)
+
+#undef MVK_EXTENSION
+#undef MVK_EXTENSION_LAST

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.h
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.h
@@ -38,18 +38,8 @@ struct MVKExtension {
 struct MVKExtensionList {
 	union {
 		struct {
-			MVKExtension vk_MVK_moltenvk;
-			MVKExtension vk_MVK_macos_surface;
-			MVKExtension vk_MVK_ios_surface;
-			MVKExtension vk_KHR_surface;
-			MVKExtension vk_KHR_swapchain;
-			MVKExtension vk_KHR_maintenance1;
-			MVKExtension vk_AMD_negative_viewport_height;
-			MVKExtension vk_IMG_format_pvrtc;
-			MVKExtension vk_KHR_shader_draw_parameters;
-			MVKExtension vk_KHR_get_physical_device_properties2;
-			MVKExtension vk_KHR_push_descriptor;
-			MVKExtension vk_KHR_descriptor_update_template;
+#define MVK_EXTENSION(var, EXT) MVKExtension vk_ ##var;
+#include "MVKExtensions.def"
 		};
 		MVKExtension extensionArray;
 	};

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1475,6 +1475,145 @@ MVK_PUBLIC_SYMBOL void vkCmdExecuteCommands(
 
 
 #pragma mark -
+#pragma mark VK_KHR_descriptor_update_template extension
+
+MVK_PUBLIC_SYMBOL VkResult vkCreateDescriptorUpdateTemplateKHR(
+    VkDevice                                       device,
+    const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+    const VkAllocationCallbacks*                   pAllocator,
+    VkDescriptorUpdateTemplateKHR*                 pDescriptorUpdateTemplate) {
+
+    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
+    auto *mvkDUT = mvkDev->createDescriptorUpdateTemplate(pCreateInfo,
+                                                          pAllocator);
+    *pDescriptorUpdateTemplate = (VkDescriptorUpdateTemplateKHR)mvkDUT;
+    return mvkDUT->getConfigurationResult();
+}
+
+MVK_PUBLIC_SYMBOL void vkDestroyDescriptorUpdateTemplateKHR(
+    VkDevice                                    device,
+    VkDescriptorUpdateTemplateKHR               descriptorUpdateTemplate,
+    const VkAllocationCallbacks*                pAllocator) {
+
+    if (!descriptorUpdateTemplate) { return; }
+    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
+    mvkDev->destroyDescriptorUpdateTemplate((MVKDescriptorUpdateTemplate*)descriptorUpdateTemplate, pAllocator);
+}
+
+MVK_PUBLIC_SYMBOL void vkUpdateDescriptorSetWithTemplateKHR(
+    VkDevice                                    device,
+    VkDescriptorSet                             descriptorSet,
+    VkDescriptorUpdateTemplateKHR               descriptorUpdateTemplate,
+    const void*                                 pData) {
+
+    mvkUpdateDescriptorSetWithTemplate(descriptorSet, descriptorUpdateTemplate, pData);
+}
+
+
+#pragma mark -
+#pragma mark VK_KHR_get_physical_device_properties2 extension
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFeatures2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceFeatures2KHR*               pFeatures) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getFeatures(pFeatures);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceProperties2KHR*             pProperties) {
+
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getProperties(pProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkFormat                                    format,
+    VkFormatProperties2KHR*                     pFormatProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getFormatProperties(format, pFormatProperties);
+}
+
+MVK_PUBLIC_SYMBOL VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceImageFormatInfo2KHR*  pImageFormatInfo,
+    VkImageFormatProperties2KHR*                pImageFormatProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    return mvkPD->getImageFormatProperties(pImageFormatInfo, pImageFormatProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pQueueFamilyPropertyCount,
+    VkQueueFamilyProperties2KHR*                pQueueFamilyProperties) {
+    
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getQueueFamilyProperties(pQueueFamilyPropertyCount, pQueueFamilyProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceMemoryProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    VkPhysicalDeviceMemoryProperties2KHR*       pMemoryProperties) {
+
+    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+    mvkPD->getPhysicalDeviceMemoryProperties(pMemoryProperties);
+}
+
+MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+    VkPhysicalDevice                            physicalDevice,
+    const VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo,
+    uint32_t*                                   pPropertyCount,
+    VkSparseImageFormatProperties2KHR*          pProperties) {
+
+    MVKLogUnimplemented("vkGetPhysicalDeviceSparseImageFormatProperties");
+}
+
+
+#pragma mark -
+#pragma mark VK_KHR_maintenance1 extension
+
+MVK_PUBLIC_SYMBOL void vkTrimCommandPoolKHR(
+    VkDevice                                    device,
+    VkCommandPool                               commandPool,
+    VkCommandPoolTrimFlagsKHR                   flags) {
+	MVKCommandPool* mvkCmdPool = (MVKCommandPool*)commandPool;
+    mvkCmdPool->trim();
+}
+
+
+#pragma mark -
+#pragma mark VK_KHR_push_descriptor extension
+
+MVK_PUBLIC_SYMBOL void vkCmdPushDescriptorSetKHR(
+    VkCommandBuffer                             commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    VkPipelineLayout                            layout,
+    uint32_t                                    set,
+    uint32_t                                    descriptorWriteCount,
+    const VkWriteDescriptorSet*                 pDescriptorWrites) {
+
+    MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
+    mvkCmdPushDescriptorSet(cmdBuff, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
+}
+
+MVK_PUBLIC_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
+    VkCommandBuffer                            commandBuffer,
+    VkDescriptorUpdateTemplateKHR              descriptorUpdateTemplate,
+    VkPipelineLayout                           layout,
+    uint32_t                                   set,
+    const void*                                pData) {
+
+    MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
+    mvkCmdPushDescriptorSetWithTemplate(cmdBuff, descriptorUpdateTemplate, layout, set, pData);
+}
+
+
+#pragma mark -
 #pragma mark VK_KHR_swapchain extension
 
 MVK_PUBLIC_SYMBOL VkResult vkCreateSwapchainKHR(
@@ -1600,145 +1739,6 @@ MVK_PUBLIC_SYMBOL VkResult vkCreate_PLATFORM_SurfaceMVK(
     MVKSurface* mvkSrfc = mvkInst->createSurface(pCreateInfo, pAllocator);
     *pSurface = (VkSurfaceKHR)mvkSrfc;
     return mvkSrfc->getConfigurationResult();
-}
-
-
-#pragma mark -
-#pragma mark VK_KHR_maintenace1 extension
-
-MVK_PUBLIC_SYMBOL void vkTrimCommandPoolKHR(
-    VkDevice                                    device,
-    VkCommandPool                               commandPool,
-    VkCommandPoolTrimFlagsKHR                   flags) {
-	MVKCommandPool* mvkCmdPool = (MVKCommandPool*)commandPool;
-    mvkCmdPool->trim();
-}
-
-
-#pragma mark -
-#pragma mark VK_KHR_get_physical_device_properties2 extension
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFeatures2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    VkPhysicalDeviceFeatures2KHR*               pFeatures) {
-    
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    mvkPD->getFeatures(pFeatures);
-}
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    VkPhysicalDeviceProperties2KHR*             pProperties) {
-
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    mvkPD->getProperties(pProperties);
-}
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceFormatProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    VkFormat                                    format,
-    VkFormatProperties2KHR*                     pFormatProperties) {
-    
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    mvkPD->getFormatProperties(format, pFormatProperties);
-}
-
-MVK_PUBLIC_SYMBOL VkResult vkGetPhysicalDeviceImageFormatProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    const VkPhysicalDeviceImageFormatInfo2KHR*  pImageFormatInfo,
-    VkImageFormatProperties2KHR*                pImageFormatProperties) {
-    
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    return mvkPD->getImageFormatProperties(pImageFormatInfo, pImageFormatProperties);
-}
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceQueueFamilyProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    uint32_t*                                   pQueueFamilyPropertyCount,
-    VkQueueFamilyProperties2KHR*                pQueueFamilyProperties) {
-    
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    mvkPD->getQueueFamilyProperties(pQueueFamilyPropertyCount, pQueueFamilyProperties);
-}
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceMemoryProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    VkPhysicalDeviceMemoryProperties2KHR*       pMemoryProperties) {
-
-    MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
-    mvkPD->getPhysicalDeviceMemoryProperties(pMemoryProperties);
-}
-
-MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
-    VkPhysicalDevice                            physicalDevice,
-    const VkPhysicalDeviceSparseImageFormatInfo2KHR* pFormatInfo,
-    uint32_t*                                   pPropertyCount,
-    VkSparseImageFormatProperties2KHR*          pProperties) {
-
-    MVKLogUnimplemented("vkGetPhysicalDeviceSparseImageFormatProperties");
-}
-
-
-#pragma mark -
-#pragma mark VK_KHR_push_descriptor extension
-
-MVK_PUBLIC_SYMBOL void vkCmdPushDescriptorSetKHR(
-    VkCommandBuffer                             commandBuffer,
-    VkPipelineBindPoint                         pipelineBindPoint,
-    VkPipelineLayout                            layout,
-    uint32_t                                    set,
-    uint32_t                                    descriptorWriteCount,
-    const VkWriteDescriptorSet*                 pDescriptorWrites) {
-
-    MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-    mvkCmdPushDescriptorSet(cmdBuff, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
-}
-
-MVK_PUBLIC_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
-    VkCommandBuffer                            commandBuffer,
-    VkDescriptorUpdateTemplateKHR              descriptorUpdateTemplate,
-    VkPipelineLayout                           layout,
-    uint32_t                                   set,
-    const void*                                pData) {
-
-    MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-    mvkCmdPushDescriptorSetWithTemplate(cmdBuff, descriptorUpdateTemplate, layout, set, pData);
-}
-
-
-#pragma mark -
-#pragma mark VK_KHR_descriptor_update_template extension
-
-MVK_PUBLIC_SYMBOL VkResult vkCreateDescriptorUpdateTemplateKHR(
-    VkDevice                                       device,
-    const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
-    const VkAllocationCallbacks*                   pAllocator,
-    VkDescriptorUpdateTemplateKHR*                 pDescriptorUpdateTemplate) {
-
-    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-    auto *mvkDUT = mvkDev->createDescriptorUpdateTemplate(pCreateInfo,
-                                                          pAllocator);
-    *pDescriptorUpdateTemplate = (VkDescriptorUpdateTemplateKHR)mvkDUT;
-    return mvkDUT->getConfigurationResult();
-}
-
-MVK_PUBLIC_SYMBOL void vkDestroyDescriptorUpdateTemplateKHR(
-    VkDevice                                    device,
-    VkDescriptorUpdateTemplateKHR               descriptorUpdateTemplate,
-    const VkAllocationCallbacks*                pAllocator) {
-
-    if (!descriptorUpdateTemplate) { return; }
-    MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-    mvkDev->destroyDescriptorUpdateTemplate((MVKDescriptorUpdateTemplate*)descriptorUpdateTemplate, pAllocator);
-}
-
-MVK_PUBLIC_SYMBOL void vkUpdateDescriptorSetWithTemplateKHR(
-    VkDevice                                    device,
-    VkDescriptorSet                             descriptorSet,
-    VkDescriptorUpdateTemplateKHR               descriptorUpdateTemplate,
-    const void*                                 pData) {
-
-    mvkUpdateDescriptorSetWithTemplate(descriptorSet, descriptorUpdateTemplate, pData);
 }
 
 


### PR DESCRIPTION
`#include` this file to define the various bits and pieces needed to
support an extension. Now instead of having to change three places, we
now only need change one.

Also, sort the list of extensions. This list is starting to get a little
long and unruly, so before it gets completely out of hand, let's apply a
little semblance of order to it. The extensions are now arranged in the
following order: first, the Khronos-blessed extensions; then multivendor
extensions; then our (`MVK`) extensions; and finally other vendors'
extensions. These subgroups are sorted alphabetically, as Khronos'
master list is.

I'm not happy about the `MVK_EXTENSION_LAST` kluge. But, C++ apparently
doesn't let you stick a dangling comma on a constructor's initializer
list.