### PR TITLE
Advertise some more features we already support.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -485,6 +485,8 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderImageGatherExtended = true;
     _features.shaderStorageImageExtendedFormats = true;
     _features.shaderStorageImageMultisample = true;
+    _features.shaderStorageImageReadWithoutFormat = true;
+    _features.shaderStorageImageWriteWithoutFormat = true;
     _features.shaderClipDistance = true;
     _features.shaderInt16 = true;
 	_features.multiDrawIndirect = true;
@@ -562,8 +564,8 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    shaderImageGatherExtended;                    // done
 //    VkBool32    shaderStorageImageExtendedFormats;            // done
 //    VkBool32    shaderStorageImageMultisample;                // done
-//    VkBool32    shaderStorageImageReadWithoutFormat;
-//    VkBool32    shaderStorageImageWriteWithoutFormat;
+//    VkBool32    shaderStorageImageReadWithoutFormat;          // done
+//    VkBool32    shaderStorageImageWriteWithoutFormat;         // done
 //    VkBool32    shaderUniformBufferArrayDynamicIndexing;
 //    VkBool32    shaderSampledImageArrayDynamicIndexing;
 //    VkBool32    shaderStorageBufferArrayDynamicIndexing;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -484,6 +484,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.samplerAnisotropy = true;
     _features.shaderImageGatherExtended = true;
     _features.shaderStorageImageExtendedFormats = true;
+    _features.shaderStorageImageMultisample = true;
     _features.shaderClipDistance = true;
     _features.shaderInt16 = true;
 	_features.multiDrawIndirect = true;
@@ -560,7 +561,7 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    shaderTessellationAndGeometryPointSize;
 //    VkBool32    shaderImageGatherExtended;                    // done
 //    VkBool32    shaderStorageImageExtendedFormats;            // done
-//    VkBool32    shaderStorageImageMultisample;
+//    VkBool32    shaderStorageImageMultisample;                // done
 //    VkBool32    shaderStorageImageReadWithoutFormat;
 //    VkBool32    shaderStorageImageWriteWithoutFormat;
 //    VkBool32    shaderUniformBufferArrayDynamicIndexing;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -487,6 +487,8 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderStorageImageMultisample = true;
     _features.shaderStorageImageReadWithoutFormat = true;
     _features.shaderStorageImageWriteWithoutFormat = true;
+    _features.shaderUniformBufferArrayDynamicIndexing = true;
+    _features.shaderStorageBufferArrayDynamicIndexing = true;
     _features.shaderClipDistance = true;
     _features.shaderInt16 = true;
 	_features.multiDrawIndirect = true;
@@ -566,9 +568,9 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    shaderStorageImageMultisample;                // done
 //    VkBool32    shaderStorageImageReadWithoutFormat;          // done
 //    VkBool32    shaderStorageImageWriteWithoutFormat;         // done
-//    VkBool32    shaderUniformBufferArrayDynamicIndexing;
+//    VkBool32    shaderUniformBufferArrayDynamicIndexing;      // done
 //    VkBool32    shaderSampledImageArrayDynamicIndexing;
-//    VkBool32    shaderStorageBufferArrayDynamicIndexing;
+//    VkBool32    shaderStorageBufferArrayDynamicIndexing;      // done
 //    VkBool32    shaderStorageImageArrayDynamicIndexing;
 //    VkBool32    shaderClipDistance;                           // done
 //    VkBool32    shaderCullDistance;


### PR DESCRIPTION
Multisample images can be used as storage images in MSL--in fact, this is the only way they are supported. Writing, however, isn't supported yet. (Multisampled array textures are supported as of Metal 2.1.)

As for storage images without formats, Metal doesn't actually care about that. There's no place in MSL to specify it.