### PR TITLE
vkRenderPass: Set renderTargetWidth and renderTargetHeight when possible.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -257,6 +257,8 @@ void MVKCommandEncoder::beginMetalRenderPass() {
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues, _isRenderingEntireAttachment);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 	mtlRPDesc.renderTargetArrayLengthMVK = _framebuffer->getLayerCount();
+	mtlRPDesc.renderTargetWidthMVK = _framebuffer->getExtent2D().width;
+	mtlRPDesc.renderTargetHeightMVK = _framebuffer->getExtent2D().height;
 
     _mtlRenderEncoder = [_mtlCmdBuffer renderCommandEncoderWithDescriptor: mtlRPDesc];     // not retained
     _mtlRenderEncoder.label = getMTLRenderCommandEncoderName();

--- a/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.h
+++ b/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.h
@@ -31,4 +31,20 @@
  */
 @property(nonatomic, readwrite) NSUInteger renderTargetArrayLengthMVK;
 
+/**
+ * Replacement for the renderTargetWidth property.
+ *
+ * This property allows support under all OS versions. Delegates to the renderTargetWidth
+ * property if it is available. otherwise, returns 0 when read and does nothing when set.
+ */
+@property(nonatomic, readwrite) NSUInteger renderTargetWidthMVK;
+
+/**
+ * Replacement for the renderTargetHeight property.
+ *
+ * This property allows support under all OS versions. Delegates to the renderTargetHeight
+ * property if it is available. otherwise, returns 0 when read and does nothing when set.
+ */
+@property(nonatomic, readwrite) NSUInteger renderTargetHeightMVK;
+
 @end

--- a/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
@@ -41,4 +41,48 @@
 
 }
 
+-(NSUInteger) renderTargetWidthMVK {
+
+#if MVK_MACOS
+	return 0;
+#endif
+#if MVK_IOS
+	if ([self respondsToSelector: @selector(renderTargetWidth)])
+		return self.renderTargetWidth;
+	return 0;
+#endif
+
+}
+
+-(void) setRenderTargetWidthMVK: (NSUInteger) width {
+
+#if MVK_IOS
+	if ([self respondsToSelector: @selector(setRenderTargetWidth:)])
+		self.renderTargetWidth = width;
+#endif
+
+}
+
+-(NSUInteger) renderTargetHeightMVK {
+
+#if MVK_MACOS
+	return 0;
+#endif
+#if MVK_IOS
+	if ([self respondsToSelector: @selector(renderTargetHeight)])
+		return self.renderTargetHeight;
+	return 0;
+#endif
+
+}
+
+-(void) setRenderTargetHeightMVK: (NSUInteger) height {
+
+#if MVK_IOS
+	if ([self respondsToSelector: @selector(setRenderTargetHeight:)])
+		self.renderTargetHeight = height;
+#endif
+
+}
+
 @end


### PR DESCRIPTION
These properties were introduced in Metal 2.0 on iOS. (They don't exist
yet on Mac.) Currently, they are only used to constrain the size of the
render target area. Perhaps someday, they may be used to support render
passes with no render target attachments. For now, though, Metal doesn't
support that.