### PR TITLE
MVKQueryPool: Shunt copying results off to another thread.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
@@ -118,7 +118,10 @@ void MVKCmdCopyQueryPoolResults::setContent(VkQueryPool queryPool,
 
 void MVKCmdCopyQueryPoolResults::encode(MVKCommandEncoder* cmdEncoder) {
     [cmdEncoder->_mtlCmdBuffer addCompletedHandler: ^(id<MTLCommandBuffer> mtlCmdBuff) {
-        _queryPool->copyQueryPoolResults(_query, _queryCount, _destBuffer, _destOffset, _destStride, _flags);
+        // This can block, so it must not run on the Metal completion queue.
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            _queryPool->copyQueryPoolResults(_query, _queryCount, _destBuffer, _destOffset, _destStride, _flags);
+        });
     }];
 }
 


### PR DESCRIPTION
Copying the results could block if the client said to wait. If this
completion handler runs before the one that actually finishes the
queries--and it will if it's scheduled first--it will block
indefinitely, causing a deadlock. Instead, run this on a different
dispatch queue; then the query will be allowed to finish.