### PR TITLE
Add a dummy attachment in case no attachments were specified.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -80,6 +80,7 @@ private:
 	std::vector<VkAttachmentReference> _resolveAttachments;
 	std::vector<uint32_t> _preserveAttachments;
 	VkAttachmentReference _depthStencilAttachment;
+	id<MTLTexture> _mtlDummyTex = nil;
 };
 
 


### PR DESCRIPTION
Metal currently requires at least one attachment, in order to define the
size of the render target area (and thus, how many times to run the
fragment shader). Vulkan, however, allows specifying no attachments. In
that case, the size of the render target area comes from the extent and
layer count of the framebuffer object. Since Metal doesn't let you (at
least on macOS) define the render target area without an attachment, we
have to supply a dummy attachment that will be discarded once rendering
is complete.

When possible, the render target uses the memoryless storage mode,
falling back to private when that isn't supported. It is marked as
volatile, and its load and store actions are set to "don't care." The
texture is retained for the lifetime of the subpass.