### PR TITLE
Use the passed render area to set the render target extent.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -257,8 +257,8 @@ void MVKCommandEncoder::beginMetalRenderPass() {
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues, _isRenderingEntireAttachment);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 	mtlRPDesc.renderTargetArrayLengthMVK = _framebuffer->getLayerCount();
-	mtlRPDesc.renderTargetWidthMVK = _framebuffer->getExtent2D().width;
-	mtlRPDesc.renderTargetHeightMVK = _framebuffer->getExtent2D().height;
+	mtlRPDesc.renderTargetWidthMVK = min(_framebuffer->getExtent2D().width, _renderArea.extent.width);
+	mtlRPDesc.renderTargetHeightMVK = min(_framebuffer->getExtent2D().height, _renderArea.extent.height);
 
     _mtlRenderEncoder = [_mtlCmdBuffer renderCommandEncoderWithDescriptor: mtlRPDesc];     // not retained
     _mtlRenderEncoder.label = getMTLRenderCommandEncoderName();


### PR DESCRIPTION
Use the smaller of the render area and the framebuffer area.