### PR TITLE
MVKDeviceMemory: Allow dedicated allocations to forget their resources.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -124,7 +124,6 @@ VkResult MVKDeviceMemory::addBuffer(MVKBuffer* mvkBuff) {
 
 void MVKDeviceMemory::removeBuffer(MVKBuffer* mvkBuff) {
 	lock_guard<mutex> lock(_rezLock);
-	if (_isDedicated) return;
 	mvkRemoveAllOccurances(_buffers, mvkBuff);
 }
 
@@ -145,7 +144,6 @@ VkResult MVKDeviceMemory::addImage(MVKImage* mvkImg) {
 
 void MVKDeviceMemory::removeImage(MVKImage* mvkImg) {
 	lock_guard<mutex> lock(_rezLock);
-	if (_isDedicated) return;
 	mvkRemoveAllOccurances(_images, mvkImg);
 }
 


### PR DESCRIPTION
Otherwise, if the resource is destroyed first (which it almost always
will be), then when the `VkDeviceMemory` is freed, it will access a
freed resource, at which point it will then proceed to fandango on core.