### PR TITLE
vkCmdCopyImage: Allow copies between compatible formats.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -59,6 +59,9 @@ void MVKCmdCopyImage::setContent(VkImage srcImage,
 
     // Validate
     clearConfigurationResult();
+    if ((_srcImage->getMTLTextureType() == MTLTextureType3D) != (_dstImage->getMTLTextureType() == MTLTextureType3D)) {
+        setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdCopyImage(): Metal does not support copying to or from slices of a 3D texture."));
+    }
 }
 
 // Adds a Metal copy region structure for each layer in the specified copy region.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -59,12 +59,6 @@ void MVKCmdCopyImage::setContent(VkImage srcImage,
 
     // Validate
     clearConfigurationResult();
-    if (_srcImage->getMTLPixelFormat() != _dstImage->getMTLPixelFormat()) {
-        setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdCopyImage(): The source and destination images must have the same format."));
-    }
-	if ((_srcImage->getMTLTextureType() == MTLTextureType3D) || (_dstImage->getMTLTextureType() == MTLTextureType3D)) {
-		setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdCopyImage(): Metal does not support copying to or from slices of a 3D texture."));
-	}
 }
 
 // Adds a Metal copy region structure for each layer in the specified copy region.


### PR DESCRIPTION
The docs for the `MTLBlitCommandEncoder`'s `copyFromTexture:...` method
state that the source and destination textures must have the same
format.

This was true when it was written in the iOS 8 timeframe
for Metal 1.0. But, I suspect it was changed in Metal 1.1 when support
was added for texture views of differing formats. Like with texture
views, the two formats now need only be compatible. This is the same
behavior that Vulkan prescribes.