### PR TITLE
Make PhaseScriptExecution works when SRCROOT path has whitespaces.

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -837,7 +837,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/scripts/create_dylib_macos.sh";
+			shellScript = "\"${SRCROOT}/scripts/create_dylib_macos.sh\"";
 		};
 		A9731FAD1EDDAE39006B7298 /* Create Dynamic Library */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/MoltenVKPackaging.xcodeproj/project.pbxproj
+++ b/MoltenVKPackaging.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/package_all.sh\n";
+			shellScript = "\"${SRCROOT}/Scripts/package_all.sh\"\n";
 		};
 		A975D59A2140586700D4834F /* Package MoltenVK */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -424,7 +424,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/package_all.sh";
+			shellScript = "\"${SRCROOT}/Scripts/package_all.sh\"";
 		};
 		A9FEADD61F3517480010240E /* Package MoltenVK */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -438,7 +438,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/Scripts/package_all.sh\n";
+			shellScript = "\"${SRCROOT}/Scripts/package_all.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Scripts/package_all.sh
+++ b/Scripts/package_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-${SRCROOT}/Scripts/package_moltenvk.sh
-${SRCROOT}/Scripts/package_shader_converter.sh
-${SRCROOT}/Scripts/package_docs.sh
-${SRCROOT}/Scripts/update_latest.sh
+"${SRCROOT}/Scripts/package_moltenvk.sh"
+"${SRCROOT}/Scripts/package_shader_converter.sh"
+"${SRCROOT}/Scripts/package_docs.sh"
+"${SRCROOT}/Scripts/update_latest.sh"
 


### PR DESCRIPTION
When trying to build with scheme "MoltenVK Package (Debug) (macOS only)" on my Mac, it failed at the end with error such as:

/Users/bertel/Library/Developer/Xcode/DerivedData/MoltenVKPackaging-bwwesylglieoalcjcxoqerjnfgqh/Build/Intermediates.noindex/MoltenVKPackaging.build/Debug/MoltenVK-macOS.build/Script-A975D59A2140586700D4834F.sh: line 2: /Volumes/Macintosh: Permission denied
Command PhaseScriptExecution failed with a nonzero exit code

This is because the name of my volume has a whitespace in it: "Macintosh SSD"

With this patch, this step is successful.