### PR TITLE
Update shader caching for compatibility with texture swizzling.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -48,7 +48,7 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   24
+#define MVK_VERSION_PATCH   25
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
@@ -631,7 +631,7 @@ typedef uint32_t MVKMSLSPIRVHeader;
 
 #endif // VK_NO_PROTOTYPES
 
-	
+
 #ifdef __cplusplus
 }
 #endif	//  __cplusplus

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -58,6 +58,10 @@ typedef struct MVKShaderResourceBinding {
 	MVKShaderStageResourceBinding fragmentStage;
     MVKShaderStageResourceBinding computeStage;
 
+	uint32_t getMaxBufferIndex();
+	uint32_t getMaxTextureIndex();
+	uint32_t getMaxSamplerIndex();
+
 	MVKShaderResourceBinding operator+ (const MVKShaderResourceBinding& rhs);
 	MVKShaderResourceBinding& operator+= (const MVKShaderResourceBinding& rhs);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -46,6 +46,18 @@ MVK_PUBLIC_SYMBOL MVKShaderStageResourceBinding& MVKShaderStageResourceBinding::
 
 #pragma mark MVKShaderResourceBinding
 
+MVK_PUBLIC_SYMBOL uint32_t MVKShaderResourceBinding::getMaxBufferIndex() {
+	return max({vertexStage.bufferIndex, fragmentStage.bufferIndex, computeStage.bufferIndex});
+}
+
+MVK_PUBLIC_SYMBOL uint32_t MVKShaderResourceBinding::getMaxTextureIndex() {
+	return max({vertexStage.textureIndex, fragmentStage.textureIndex, computeStage.textureIndex});
+}
+
+MVK_PUBLIC_SYMBOL uint32_t MVKShaderResourceBinding::getMaxSamplerIndex() {
+	return max({vertexStage.samplerIndex, fragmentStage.samplerIndex, computeStage.samplerIndex});
+}
+
 MVK_PUBLIC_SYMBOL MVKShaderResourceBinding MVKShaderResourceBinding::operator+ (const MVKShaderResourceBinding& rhs) {
 	MVKShaderResourceBinding rslt;
 	rslt.vertexStage = this->vertexStage + rhs.vertexStage;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -75,18 +75,17 @@ public:
 	const MVKShaderAuxBufferBinding& getAuxBufferIndex() { return _auxBufferIndex; }
 
 	/** Returns the number of textures in this layout. This is used to calculate the size of the auxiliary buffer. */
-	uint32_t getNumTextures() { return _numTextures; }
+	uint32_t getMaxTextureIndex() { return _pushConstantsMTLResourceIndexes.getMaxTextureIndex(); }
 
 	/** Constructs an instance for the specified device. */
 	MVKPipelineLayout(MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo);
 
-private:
+protected:
 	std::vector<MVKDescriptorSetLayout> _descriptorSetLayouts;
 	std::vector<MVKShaderResourceBinding> _dslMTLResourceIndexOffsets;
 	std::vector<VkPushConstantRange> _pushConstants;
-	MVKShaderResourceBinding _pushConstantsMTLResourceIndexOffsets;
+	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
 	MVKShaderAuxBufferBinding _auxBufferIndex;
-	uint32_t _numTextures;
 };
 
 
@@ -107,6 +106,10 @@ public:
 	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
 	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipeline* parent) : MVKBaseDeviceObject(device),
 																						   _pipelineCache(pipelineCache) {}
+
+	~MVKPipeline() override {
+		[_auxBuffer release];
+	};
 
 protected:
 	MVKPipelineCache* _pipelineCache;

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
@@ -42,6 +42,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverterOptions::matches(const SPIRVToMSLConve
 	if (entryPointStage != other.entryPointStage) { return false; }
     if (mslVersion != other.mslVersion) { return false; }
 	if (texelBufferTextureWidth != other.texelBufferTextureWidth) { return false; }
+	if (auxBufferIndex != other.auxBufferIndex) { return false; }
     if (!!shouldFlipVertexY != !!other.shouldFlipVertexY) { return false; }
     if (!!isRenderingPoints != !!other.isRenderingPoints) { return false; }
 	if (entryPointName != other.entryPointName) { return false; }
@@ -103,6 +104,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverterContext::matches(const SPIRVToMSLConve
 MVK_PUBLIC_SYMBOL void SPIRVToMSLConverterContext::alignWith(const SPIRVToMSLConverterContext& srcContext) {
 
 	options.isRasterizationDisabled = srcContext.options.isRasterizationDisabled;
+	options.needsAuxBuffer = srcContext.options.needsAuxBuffer;
 
 	if (options.entryPointStage == spv::ExecutionModelVertex) {
 		for (auto& va : vertexAttributes) {


### PR DESCRIPTION
MVKPipelineLayout set auxiliary buffer MSL index relative to already-calculated
push constant buffer MSL index.
MVKPipeline destructor release auxiliary buffer MTLBuffer instance.
Nudge MVK_VERSION_PATCH.