### PR TITLE
MVKPipeline: Also create a dummy attachment if all attachments are unused.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -407,6 +407,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
     }
 
     // Color attachments
+    uint32_t caCnt = 0;
     if (pCreateInfo->pColorBlendState) {
         for (uint32_t caIdx = 0; caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {
             const VkPipelineColorBlendAttachmentState* pCA = &pCreateInfo->pColorBlendState->pAttachments[caIdx];
@@ -418,6 +419,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
             // The pixel format will be MTLPixelFormatInvalid in that case, and
             // Metal asserts if we turn on blending with that pixel format.
             if (mvkRenderSubpass->isColorAttachmentUsed(caIdx)) {
+                caCnt++;
                 colorDesc.blendingEnabled = pCA->blendEnable;
                 colorDesc.rgbBlendOperation = mvkMTLBlendOperationFromVkBlendOp(pCA->colorBlendOp);
                 colorDesc.sourceRGBBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->srcColorBlendFactor);
@@ -437,8 +439,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
     // In Vulkan, it's perfectly valid to do rasterization with no attachments.
     // Not so in Metal. If we have no attachments and rasterization is enabled,
     // then we'll have to add a dummy attachment.
-    if (plDesc.rasterizationEnabled &&
-            (!pCreateInfo->pColorBlendState || !pCreateInfo->pColorBlendState->attachmentCount) &&
+    if (plDesc.rasterizationEnabled && !caCnt &&
             !mvkMTLPixelFormatIsDepthFormat(mtlDSFormat) &&
             !mvkMTLPixelFormatIsStencilFormat(mtlDSFormat)) {
         MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[0];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -93,6 +93,8 @@ void MVKRenderSubpass::populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* 
 				mtlColorAttDesc.clearColor = mvkMTLClearColorFromVkClearValue(clearValues[clrRPAttIdx], clrMVKRPAtt->getFormat());
 			}
 
+		} else {
+			caCnt--;
 		}
 	}
 


### PR DESCRIPTION
Some clients (DXVK primarily) always set all eight color attachments,
even if they are unused. Metal will treat them as though they weren't
specified at all. If none are used, then Metal won't know how big to
make the render area, and the pipeline will fail validation. We have to
treat this case the same as if no attachments were given.