### PR TITLE
create_dylib.sh cleanup

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -875,7 +875,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export MVK_OS=\"macosx\"\nexport MVK_ARCH=\"x86_64\"\nexport MVK_UX_FWK=\"AppKit\"\nexport MVK_MIN_OS_VERSION=${MACOSX_DEPLOYMENT_TARGET}\nexport MVK_IOSURFACE_FWK=\"-framework IOSurface\"\n\n\"${SRCROOT}/scripts/create_dylib.sh\"\n";
+			shellScript = "export MVK_OS=\"macosx\"\nexport MVK_UX_FWK=\"AppKit\"\nexport MVK_MIN_OS_VERSION=${MACOSX_DEPLOYMENT_TARGET}\nexport MVK_IOSURFACE_FWK=\"-framework IOSurface\"\n\n\"${SRCROOT}/scripts/create_dylib.sh\"\n";
 		};
 		A9731FAD1EDDAE39006B7298 /* Create Dynamic Library */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -889,7 +889,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export MVK_OS=\"ios\"\nexport MVK_ARCH=\"arm64\"\nexport MVK_UX_FWK=\"UIKit\"\nexport MVK_MIN_OS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}\nexport MVK_IOSURFACE_FWK=\"-framework IOSurface\"\n\n# Do not link to IOSurface if deploying to iOS versions below 11.0, doing so will\n# link IOSurface as a private framework, which will trigger App Store rejection.\nif [ $(echo \"${MVK_MIN_OS_VERSION} < 11.0\" | bc) -eq 1 ]; then\n    MVK_IOSURFACE_FWK=\"\"\nfi\n\n\"${SRCROOT}/scripts/create_dylib.sh\"\n";
+			shellScript = "export MVK_OS=\"ios\"\nexport MVK_UX_FWK=\"UIKit\"\nexport MVK_MIN_OS_VERSION=${IPHONEOS_DEPLOYMENT_TARGET}\nexport MVK_IOSURFACE_FWK=\"-framework IOSurface\"\n\n# Do not link to IOSurface if deploying to iOS versions below 11.0, doing so will\n# link IOSurface as a private framework, which will trigger App Store rejection.\nif [ $(echo \"${MVK_MIN_OS_VERSION} < 11.0\" | bc) -eq 1 ]; then\n    MVK_IOSURFACE_FWK=\"\"\nfi\n\n\"${SRCROOT}/scripts/create_dylib.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/MoltenVK/scripts/create_dylib.sh
+++ b/MoltenVK/scripts/create_dylib.sh
@@ -10,7 +10,7 @@ if test x"${ENABLE_THREAD_SANITIZER}" = xYES; then
 	MVK_TSAN="-fsanitize=thread"
 fi
 
-clang \
+clang++ \
 -dynamiclib ${MVK_TSAN} \
 -arch ${MVK_ARCH} \
 -m${MVK_OS}-version-min=${MVK_MIN_OS_VERSION} \
@@ -21,6 +21,6 @@ clang \
 -iframework ${MVK_SYS_FWK_DIR}  \
 -framework Metal ${MVK_IOSURFACE_FWK} -framework ${MVK_UX_FWK} -framework QuartzCore -framework IOKit -framework Foundation \
 --library-directory ${MVK_USR_LIB_DIR} \
--lSystem  -lc++ \
+-lSystem \
 -o "${BUILT_PRODUCTS_DIR}/${MVK_DYLIB_NAME}" \
 -force_load "${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a"

--- a/MoltenVK/scripts/create_dylib.sh
+++ b/MoltenVK/scripts/create_dylib.sh
@@ -11,6 +11,7 @@ if test x"${ENABLE_THREAD_SANITIZER}" = xYES; then
 fi
 
 clang++ \
+-stdlib=${CLANG_CXX_LIBRARY} \
 -dynamiclib ${MVK_TSAN} \
 -arch ${MVK_ARCH} \
 -m${MVK_OS}-version-min=${MVK_MIN_OS_VERSION} \

--- a/MoltenVK/scripts/create_dylib.sh
+++ b/MoltenVK/scripts/create_dylib.sh
@@ -13,7 +13,7 @@ fi
 clang++ \
 -stdlib=${CLANG_CXX_LIBRARY} \
 -dynamiclib ${MVK_TSAN} \
--arch ${MVK_ARCH} \
+$(printf "-arch %s " ${ARCHS}) \
 -m${MVK_OS}-version-min=${MVK_MIN_OS_VERSION} \
 -compatibility_version 1.0.0 -current_version 1.0.0  \
 -install_name "@rpath/${MVK_DYLIB_NAME}"  \

--- a/MoltenVK/scripts/create_dylib.sh
+++ b/MoltenVK/scripts/create_dylib.sh
@@ -21,6 +21,5 @@ clang++ \
 -iframework ${MVK_SYS_FWK_DIR}  \
 -framework Metal ${MVK_IOSURFACE_FWK} -framework ${MVK_UX_FWK} -framework QuartzCore -framework IOKit -framework Foundation \
 --library-directory ${MVK_USR_LIB_DIR} \
--lSystem \
 -o "${BUILT_PRODUCTS_DIR}/${MVK_DYLIB_NAME}" \
 -force_load "${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a"


### PR DESCRIPTION
Hello, here are some changes to create_dylib.sh, which I had mentioned wanting to submit in #241.

You've already implemented one of the suggestions I wanted to make, which is combining the iOS and macOS scripts into one.

You've introduced a new variable `MVK_ARCH` to tell it what architecture to build for. Xcode already has a variable for that—`ARCHS`—so this PR switches to using that. It also accommodates `ARCHS` containing more than one value, should a universal build ever become relevant.

Since it's a library of C++ code being linked here, do so using clang++ instead of clang; this makes it unnecessary to manually add `-lc++`.

As far as I know it's always unnecessary to add `-lSystem` so remove that too.

And specify which C++ library to use, using the `-stdlib` flag.

I've been using these changes in the MacPorts MoltenVK port. We only build the macOS part, but I believe these changes should be correct for the iOS part too.

I think it should be possible to remove all the other variables that were added to the Xcode project before invoking the script, and to instead detect which values to use from within the script based on environment variables Xcode already sets. But `MVK_ARCH` is the only one I've done this for so far.