### PR TITLE
MVKImage: Don't say shared memory is allowed on Mac.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -218,6 +218,12 @@ public:
 	inline uint32_t getHostVisibleMemoryTypes() { return _hostVisibleMemoryTypes; }
 
 	/**
+	 * Returns a bit mask of all memory type indices that are coherent between host and device.
+	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
+	 */
+	inline uint32_t getHostCoherentMemoryTypes() { return _hostCoherentMemoryTypes; }
+
+	/**
 	 * Returns a bit mask of all memory type indices that do NOT allow host visibility to the memory.
 	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
 	 */
@@ -277,6 +283,7 @@ protected:
 	std::vector<MVKQueueFamily*> _queueFamilies;
 	uint32_t _allMemoryTypes;
 	uint32_t _hostVisibleMemoryTypes;
+	uint32_t _hostCoherentMemoryTypes;
 	uint32_t _privateMemoryTypes;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1091,15 +1091,17 @@ void MVKPhysicalDevice::initMemoryProperties() {
 
 #if MVK_MACOS
 	_memoryProperties.memoryTypeCount = 3;
-	_privateMemoryTypes		= 0x1;				// Private only
-	_hostVisibleMemoryTypes	= 0x6;				// Shared & managed
-	_allMemoryTypes			= 0x7;				// Private, shared, & managed
+	_privateMemoryTypes			= 0x1;			// Private only
+	_hostCoherentMemoryTypes 	= 0x4;			// Shared only
+	_hostVisibleMemoryTypes		= 0x6;			// Shared & managed
+	_allMemoryTypes				= 0x7;			// Private, shared, & managed
 #endif
 #if MVK_IOS
 	_memoryProperties.memoryTypeCount = 2;		// Managed storage not available on iOS
-	_privateMemoryTypes		= 0x1;				// Private only
-	_hostVisibleMemoryTypes	= 0x2;				// Shared only
-	_allMemoryTypes			= 0x3;				// Private & shared
+	_privateMemoryTypes			= 0x1;			// Private only
+	_hostCoherentMemoryTypes 	= 0x2;			// Shared only
+	_hostVisibleMemoryTypes		= 0x2;			// Shared only
+	_allMemoryTypes				= 0x3;			// Private & shared
 #endif
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -149,6 +149,11 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
 	pMemoryRequirements->memoryTypeBits = (_isDepthStencilAttachment
 										   ? _device->getPhysicalDevice()->getPrivateMemoryTypes()
 										   : _device->getPhysicalDevice()->getAllMemoryTypes());
+#if MVK_MACOS
+	if (!_isLinear) {  // XXX Linear images must support host-coherent memory
+		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+	}
+#endif
 	return VK_SUCCESS;
 }
 


### PR DESCRIPTION
It isn't. Unfortunately, we have to say it is allowed for linear images,
per the Vulkan spec.