### PR TITLE
MVKPipeline: Set the stepRate to 0 when the attribute divisor is 0.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -399,8 +399,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
                 if (vbDesc.stepFunction == MTLVertexStepFunctionPerInstance) {
                     if (pVKVB->divisor == 0)
                         vbDesc.stepFunction = MTLVertexStepFunctionConstant;
-                    else
-                        vbDesc.stepRate = pVKVB->divisor;
+                    vbDesc.stepRate = pVKVB->divisor;
                 }
             }
         }


### PR DESCRIPTION
Otherwise, Metal asserts.