### PR TITLE
Add a memory type for memoryless storage on iOS.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -413,6 +413,9 @@ static inline VkExtent3D mvkVkExtent3DFromMTLSize(MTLSize mtlSize) {
 /** Macro indicating the Vulkan memory type bits corresponding to Metal shared memory (host visible and coherent). */
 #define MVK_VK_MEMORY_TYPE_METAL_SHARED		(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
 
+/** Macro indicating the Vulkan memory type bits corresponding to Metal memoryless memory (not host visible and lazily allocated). */
+#define MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+
 /** Returns the Metal storage mode corresponding to the specified Vulkan memory flags. */
 MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -33,6 +33,10 @@ VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequireme
 	pMemoryRequirements->size = getByteCount();
 	pMemoryRequirements->alignment = _byteAlignment;
 	pMemoryRequirements->memoryTypeBits = _device->getPhysicalDevice()->getAllMemoryTypes();
+#if MVK_IOS
+	// Memoryless storage is not allowed for buffers
+	mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+#endif
 	return VK_SUCCESS;
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -229,6 +229,12 @@ public:
 	 */
 	inline uint32_t getPrivateMemoryTypes() { return _privateMemoryTypes; }
 
+	/**
+	 * Returns a bit mask of all memory type indices that are lazily allocated.
+	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
+	 */
+	inline uint32_t getLazilyAllocatedMemoryTypes() { return _lazilyAllocatedMemoryTypes; }
+
 	
 #pragma mark Metal
 
@@ -285,6 +291,7 @@ protected:
 	uint32_t _hostVisibleMemoryTypes;
 	uint32_t _hostCoherentMemoryTypes;
 	uint32_t _privateMemoryTypes;
+	uint32_t _lazilyAllocatedMemoryTypes;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -35,7 +35,13 @@ class MVKDeviceMemory : public MVKBaseDeviceObject {
 public:
 
 	/** Returns whether the memory is accessible from the host. */
-    inline bool isMemoryHostAccessible() { return (_mtlStorageMode != MTLStorageModePrivate); }
+    inline bool isMemoryHostAccessible() {
+#if MVK_IOS
+        if (_mtlStorageMode == MTLStorageModeMemoryless)
+            return false;
+#endif
+        return (_mtlStorageMode != MTLStorageModePrivate);
+    }
 
 	/** Returns whether the memory is automatically coherent between device and host. */
     inline bool isMemoryHostCoherent() { return (_mtlStorageMode == MTLStorageModeShared); }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -154,6 +154,12 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
 		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
 	}
 #endif
+#if MVK_IOS
+	// Only transient attachments may use memoryless storage
+	if (!mvkAreFlagsEnabled(_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ) {
+		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+	}
+#endif
 	return VK_SUCCESS;
 }
 

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -1129,6 +1129,12 @@ MVK_PUBLIC_SYMBOL MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMe
 
 	// If not visible to the host: Private
 	if ( !mvkAreFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ) {
+#if MVK_IOS
+		// iOS: If lazily allocated, Memoryless
+		if (mvkAreFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
+			return MTLStorageModeMemoryless;
+		}
+#endif
 		return MTLStorageModePrivate;
 	}
 
@@ -1175,6 +1181,11 @@ MVK_PUBLIC_SYMBOL MTLResourceOptions mvkMTLResourceOptionsFromVkMemoryPropertyFl
 #if MVK_MACOS
 		case MTLStorageModeManaged:
 			mvkEnableFlag(mtlFlags, MTLResourceStorageModeManaged);
+			break;
+#endif
+#if MVK_IOS
+		case MTLStorageModeMemoryless:
+			mvkEnableFlag(mtlFlags, MTLResourceStorageModeMemoryless);
 			break;
 #endif
 		default:		// Silence erroneous -Wswitch-enum warning on MTLResourceStorageModeManaged under iOS


### PR DESCRIPTION
This exposes `MTLStorageTypeMemoryless` on iOS as lazily allocated
device-private memory. The semantics of lazily allocated memory are
exactly those of memoryless storage: namely, it can only be used with
images, and only those used as transient attachments. This enables
Vulkan clients to take advantage of this new storage mode starting on
iOS 10.