### PR TITLE
Add support for 2D multisample array textures.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -54,7 +54,7 @@ extern "C" {
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            11
+#define VK_MVK_MOLTENVK_SPEC_VERSION            12
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /**
@@ -260,6 +260,7 @@ typedef struct {
 	VkBool32 layeredRendering;                  /**< If true, layered rendering to multiple cube or texture array layers is supported. */
 	VkBool32 presentModeImmediate;              /**< If true, immediate surface present mode (VK_PRESENT_MODE_IMMEDIATE_KHR), allowing a swapchain image to be presented immediately, without waiting for the vertical sync period of the display, is supported. */
 	VkBool32 stencilViews;                      /**< If true, stencil aspect views are supported through the MTLPixelFormatX24_Stencil8 and MTLPixelFormatX32_Stencil8 formats. */
+	VkBool32 multisampleArrayTextures;          /**< If true, MTLTextureType2DMultisampleArray is supported. */
 	uint32_t maxTextureDimension; 	     	  	/**< The maximum size of each texture dimension (width, height, or depth). */
 	uint32_t maxPerStageBufferCount;            /**< The total number of per-stage Metal buffers available for shader uniform content and attributes. */
     uint32_t maxPerStageTextureCount;           /**< The total number of per-stage Metal textures available for shader uniform content. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -533,6 +533,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.texelBuffers = true;
 		_metalFeatures.presentModeImmediate = true;
     }
+
+    if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v4] ) {
+        _metalFeatures.multisampleArrayTextures = true;
+    }
+
 #endif
 
     for (uint32_t sc = VK_SAMPLE_COUNT_1_BIT; sc <= VK_SAMPLE_COUNT_64_BIT; sc <<= 1) {

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -704,6 +704,9 @@ MVK_PUBLIC_SYMBOL MTLTextureType mvkMTLTextureTypeFromVkImageType(VkImageType vk
 		case VK_IMAGE_TYPE_3D: return MTLTextureType3D;
 		case VK_IMAGE_TYPE_2D:
 		default: {
+#if !MVK_IOS  // This is marked unavailable on iOS :/
+			if (arraySize > 1 && isMultisample) { return MTLTextureType2DMultisampleArray; }
+#endif
 			if (arraySize > 1) { return MTLTextureType2DArray; }
 			if (isMultisample) { return MTLTextureType2DMultisample; }
 			return MTLTextureType2D;


### PR DESCRIPTION
Requires Metal 2.1 on Mac. Not supported at all on iOS.

I'm split as to whether or not to have
`mvkMTLTextureTypeFromVkImageType()` return
`MTLTextureType2DMultisampleArray`.