### PR TITLE
MVKDeviceMemory: Try creating an MTLBuffer before allocating heap memory.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -38,7 +38,7 @@ VkResult MVKDeviceMemory::map(VkDeviceSize offset, VkDeviceSize size, VkMemoryMa
 		return mvkNotifyErrorWithText(VK_ERROR_MEMORY_MAP_FAILED, "Memory is already mapped. Call vkUnmapMemory() first.");
 	}
 
-	if ( !ensureHostMemory() ) {
+	if ( !ensureMTLBuffer() && !ensureHostMemory() ) {
 		return mvkNotifyErrorWithText(VK_ERROR_OUT_OF_HOST_MEMORY, "Could not allocate %llu bytes of host-accessible device memory.", _allocationSize);
 	}
 


### PR DESCRIPTION
If the device memory is subsequently bound to a `VkBuffer` after it has
been mapped, the heap memory will be freed, leaving dangling pointers in
the client. Instead, create an `MTLBuffer` right away--it is *device*
memory after all--and use its memory.

Another option might be to use `-[MTLDevice
newBufferWithBytesNoCopy:length:options:deallocator:]`, but that
requires that the entire allocation come from a single contiguous
virtual memory mapping, a requirement that is not necessarily satisfied
by `malloc(3)` memory.

Fixes #377.