### PR TITLE
Don't use char/uchar for clearing/copying 8-bit formats.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -226,9 +226,9 @@ NSString* MVKCommandResourceFactory::getMTLFormatTypeString(MTLPixelFormat mtlPi
 	switch (mvkFormatTypeFromMTLPixelFormat(mtlPixFmt)) {
 		case kMVKFormatColorHalf:		return @"half";
 		case kMVKFormatColorFloat:		return @"float";
-		case kMVKFormatColorInt8:		return @"char";
-		case kMVKFormatColorUInt8:		return @"uchar";
+		case kMVKFormatColorInt8:
 		case kMVKFormatColorInt16:		return @"short";
+		case kMVKFormatColorUInt8:
 		case kMVKFormatColorUInt16:		return @"ushort";
 		case kMVKFormatColorInt32:		return @"int";
 		case kMVKFormatColorUInt32:		return @"uint";


### PR DESCRIPTION
Metal doesn't allow using that as a texture's sampled data type or as a
fragment shader's output type.