### PR TITLE
Use MVKDevice::getMVKDevice() to get the real underlying device.

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1662,7 +1662,7 @@ MVK_PUBLIC_SYMBOL void vkGetDescriptorSetLayoutSupportKHR(
     VkDevice                                    device,
     const VkDescriptorSetLayoutCreateInfo*      pCreateInfo,
     VkDescriptorSetLayoutSupportKHR*            pSupport) {
-    MVKDevice* mvkDevice = (MVKDevice*)device;
+    MVKDevice* mvkDevice = MVKDevice::getMVKDevice(device);
     mvkDevice->getDescriptorSetLayoutSupport(pCreateInfo, pSupport);
 }
 


### PR DESCRIPTION
I was unaware of this method. Mea culpa.

Fixes an out-of-bounds memory access flagged by Address Sanitizer.