### PR TITLE
MVKCommandPool: Destroy transfer images using the device.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
@@ -132,7 +132,7 @@ void MVKCommandEncodingPool::destroyMetalResources() {
     for (auto& pair : _mtlDepthStencilStates) { [pair.second release]; }
     _mtlDepthStencilStates.clear();
 
-    for (auto& pair : _transferImages) { pair.second->destroy(); }
+    for (auto& pair : _transferImages) { _device->destroyImage(pair.second, nullptr); }
     _transferImages.clear();
 
     [_cmdBlitImageLinearMTLSamplerState release];


### PR DESCRIPTION
Since we created them using the device. Otherwise, the device won't know
that it needs to stop tracking them for the purposes of generating
memory barriers.