### PR TITLE
vkCmdPushDescriptorSetWithTemplate: Initialize data pointer to null.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -184,7 +184,7 @@ private:
 	MVKDescriptorUpdateTemplate* _descUpdateTemplate;
 	MVKPipelineLayout* _pipelineLayout;
 	uint32_t _set;
-	void* _pData;
+	void* _pData = nullptr;
 };
 
 


### PR DESCRIPTION
The command object assumes it is null if it hasn't been used yet. Let's
ensure this is so.