### PR TITLE
vkCmdCopyImage: Cast source image to the destination format.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -90,6 +90,15 @@ void MVKCmdCopyImage::encode(MVKCommandEncoder* cmdEncoder) {
     id<MTLTexture> dstMTLTex = _dstImage->getMTLTexture();
     if ( !srcMTLTex || !dstMTLTex ) { return; }
 
+    if (srcMTLTex.pixelFormat != dstMTLTex.pixelFormat &&
+        mvkFormatTypeFromVkFormat(_dstImage->getVkFormat()) != kMVKFormatNone &&
+        mvkFormatTypeFromVkFormat(_srcImage->getVkFormat()) != kMVKFormatNone) {
+        // If the pixel formats don't match, Metal won't abort, but it won't
+        // do the copy either. But we can easily work around that... unless the
+        // source format is compressed.
+        srcMTLTex = [[srcMTLTex newTextureViewWithPixelFormat: dstMTLTex.pixelFormat] autorelease];
+    }
+
     id<MTLBlitCommandEncoder> mtlBlitEnc = cmdEncoder->getMTLBlitEncoder(_commandUse);
 
     for (auto& cpyRgn : _mtlTexCopyRegions) {


### PR DESCRIPTION
In which I am proved wrong again. While Metal indeed won't assert if the
pixel formats don't match, the results of attempting such a copy are...
mixed, to say the least. Sometimes, nothing is copied at all. Other
times, pixels are copied in weird ways that don't seem to conform at all
to expectation. (This is most apparent in the output of the CTS's image
copying tests.) It's best, then, to ensure that the source and
destination have the same format.

Unfortunately, in the process of writing this, my fears regarding not
being able to make uncompressed views of compressed images were
confirmed. So we can't do this for compressed images.