### PR TITLE
MVKDescriptorSet: Fix handling of immutable samplers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -103,6 +103,11 @@ public:
 	MVKDescriptorSetLayoutBinding(MVKDescriptorSetLayout* layout,
 								  const VkDescriptorSetLayoutBinding* pBinding);
 
+	MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding);
+
+	/** Destuctor. */
+	~MVKDescriptorSetLayoutBinding() override;
+
 protected:
 	friend class MVKDescriptorBinding;
 	friend class MVKPipelineLayout;


### PR DESCRIPTION
Null the `sampler` field of the stored `VkDescriptorImageInfo` if the
descriptor uses an immutable sampler. That way, we won't try to
double-free a sampler.

Retain immutable samplers when the set is created. Release them when the
set is destroyed.