### PR TITLE
MVKPipeline: Forbid vertex attribute offsets >= stride.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -376,7 +376,11 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
         const VkVertexInputAttributeDescription* pVKVA = &pCreateInfo->pVertexInputState->pVertexAttributeDescriptions[i];
         if (shaderContext.isVertexAttributeLocationUsed(pVKVA->location)) {
             // Vulkan allows offsets to exceed the buffer stride, but Metal doesn't.
-            if (pVKVA->offset >= pCreateInfo->pVertexInputState->pVertexBindingDescriptions[pVKVA->binding].stride) {
+            const VkVertexInputBindingDescription* pVKVB = pCreateInfo->pVertexInputState->pVertexBindingDescriptions;
+            for (uint32_t j = 0; j < vbCnt; j++) {
+                if (pVKVB->binding == pVKVA->binding) { break; }
+            }
+            if (pVKVA->offset >= pVKVB->stride) {
                 setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_INITIALIZATION_FAILED, "Under Metal, vertex attribute offsets must not exceed the vertex buffer stride."));
                 return nil;
             }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -377,7 +377,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
         if (shaderContext.isVertexAttributeLocationUsed(pVKVA->location)) {
             // Vulkan allows offsets to exceed the buffer stride, but Metal doesn't.
             const VkVertexInputBindingDescription* pVKVB = pCreateInfo->pVertexInputState->pVertexBindingDescriptions;
-            for (uint32_t j = 0; j < vbCnt; j++) {
+            for (uint32_t j = 0; j < vbCnt; j++, pVKVB++) {
                 if (pVKVB->binding == pVKVA->binding) { break; }
             }
             if (pVKVA->offset >= pVKVB->stride) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -375,6 +375,11 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
     for (uint32_t i = 0; i < vaCnt; i++) {
         const VkVertexInputAttributeDescription* pVKVA = &pCreateInfo->pVertexInputState->pVertexAttributeDescriptions[i];
         if (shaderContext.isVertexAttributeLocationUsed(pVKVA->location)) {
+            // Vulkan allows offsets to exceed the buffer stride, but Metal doesn't.
+            if (pVKVA->offset >= pCreateInfo->pVertexInputState->pVertexBindingDescriptions[pVKVA->binding].stride) {
+                setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_INITIALIZATION_FAILED, "Under Metal, vertex attribute offsets must not exceed the vertex buffer stride."));
+                return nil;
+            }
             MTLVertexAttributeDescriptor* vaDesc = plDesc.vertexDescriptor.attributes[pVKVA->location];
             vaDesc.format = mvkMTLVertexFormatFromVkFormat(pVKVA->format);
             vaDesc.bufferIndex = _device->getMetalBufferIndexForVertexAttributeBinding(pVKVA->binding);


### PR DESCRIPTION
Metal validates that this is so.