### PR TITLE
If user requests system default device curing vkCreateDevice, call …

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -243,7 +243,9 @@ public:
 
 	/** Returns the underlying Metal device. */
 	inline id<MTLDevice> getMTLDevice() { return _mtlDevice; }
-
+    
+    /*** Replaces the underlying Metal device .*/
+    inline void replaceMTLDevice(id<MTLDevice> mtlDevice) { [_mtlDevice autorelease]; _mtlDevice = [mtlDevice retain]; }
 
 #pragma mark Construction
 


### PR DESCRIPTION
Note.  I ensured the only call to MVKDevice constructor is through vkCreateDevice.  I wanted to do this earlier, but we cannot call the trigger method MTLCreateSystemDefaultDevice() if the user didn't want a high power device.  So deferring it until the vkCreateDevice call is the best method.  