### PR TITLE
 Build external dependencies into static libraries in External/build when fetched.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ cache:
     - External
 
 script:
-  - xcodebuild -scheme "MoltenVK Package"
+  - xcodebuild -project MoltenVKPackaging.xcodeproj -scheme "MoltenVK Package"
   - xcodebuild -workspace Demos/Demos.xcworkspace -scheme "Cube-macOS"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ osx_image: xcode10
 # Build dependencies
 install:
   - brew install python3
-  - ./fetchDependencies
+  - ./fetchDependencies -v
 
 # Cache built deps
 cache:

--- a/ExternalDependencies.xcodeproj/project.pbxproj
+++ b/ExternalDependencies.xcodeproj/project.pbxproj
@@ -1,0 +1,3538 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		A972A7E421CEC72F0013AB25 /* ExternalDependencies-macOS */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A972A7E721CEC72F0013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-macOS" */;
+			buildPhases = (
+			);
+			dependencies = (
+				A972A7E921CEC76A0013AB25 /* PBXTargetDependency */,
+				A972A82821CECD780013AB25 /* PBXTargetDependency */,
+				A972ABF421CED8C20013AB25 /* PBXTargetDependency */,
+			);
+			name = "ExternalDependencies-macOS";
+			productName = "ExternalLibraries-macOS";
+		};
+		A972A7EA21CEC8030013AB25 /* ExternalDependencies-iOS */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A972A7ED21CEC8030013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-iOS" */;
+			buildPhases = (
+			);
+			dependencies = (
+				A972A7F121CEC8140013AB25 /* PBXTargetDependency */,
+				A972A82621CECD6B0013AB25 /* PBXTargetDependency */,
+				A972ABF221CED8BA0013AB25 /* PBXTargetDependency */,
+			);
+			name = "ExternalDependencies-iOS";
+			productName = "ExternalLibraries-macOS";
+		};
+		A972A7F221CEC81B0013AB25 /* ExternalDependencies */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A972A7F521CEC81B0013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies" */;
+			buildPhases = (
+			);
+			dependencies = (
+				A972A7FB21CEC8540013AB25 /* PBXTargetDependency */,
+				A972A7F921CEC8500013AB25 /* PBXTargetDependency */,
+			);
+			name = ExternalDependencies;
+			productName = "ExternalLibraries-macOS";
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		A972A96821CED2730013AB25 /* spirv_target_env.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A82A21CED2720013AB25 /* spirv_target_env.cpp */; };
+		A972A96921CED2730013AB25 /* spirv_target_env.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A82A21CED2720013AB25 /* spirv_target_env.cpp */; };
+		A972A96A21CED2730013AB25 /* assembly_grammar.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A82C21CED2720013AB25 /* assembly_grammar.h */; };
+		A972A96B21CED2730013AB25 /* assembly_grammar.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A82C21CED2720013AB25 /* assembly_grammar.h */; };
+		A972A96C21CED2730013AB25 /* enum_set.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A82D21CED2720013AB25 /* enum_set.h */; };
+		A972A96D21CED2730013AB25 /* enum_set.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A82D21CED2720013AB25 /* enum_set.h */; };
+		A972A96E21CED2730013AB25 /* text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83021CED2720013AB25 /* text.cpp */; };
+		A972A96F21CED2730013AB25 /* text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83021CED2720013AB25 /* text.cpp */; };
+		A972A97021CED2730013AB25 /* assembly_grammar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83121CED2720013AB25 /* assembly_grammar.cpp */; };
+		A972A97121CED2730013AB25 /* assembly_grammar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83121CED2720013AB25 /* assembly_grammar.cpp */; };
+		A972A97221CED2730013AB25 /* text.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83221CED2720013AB25 /* text.h */; };
+		A972A97321CED2730013AB25 /* text.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83221CED2720013AB25 /* text.h */; };
+		A972A97421CED2730013AB25 /* extensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83321CED2720013AB25 /* extensions.cpp */; };
+		A972A97521CED2730013AB25 /* extensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83321CED2720013AB25 /* extensions.cpp */; };
+		A972A97621CED2730013AB25 /* pch_source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83421CED2720013AB25 /* pch_source.cpp */; };
+		A972A97721CED2730013AB25 /* pch_source.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83421CED2720013AB25 /* pch_source.cpp */; };
+		A972A97821CED2730013AB25 /* parse_number.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83621CED2720013AB25 /* parse_number.h */; };
+		A972A97921CED2730013AB25 /* parse_number.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83621CED2720013AB25 /* parse_number.h */; };
+		A972A97A21CED2730013AB25 /* ilist_node.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83721CED2720013AB25 /* ilist_node.h */; };
+		A972A97B21CED2730013AB25 /* ilist_node.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83721CED2720013AB25 /* ilist_node.h */; };
+		A972A97C21CED2730013AB25 /* make_unique.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83821CED2720013AB25 /* make_unique.h */; };
+		A972A97D21CED2730013AB25 /* make_unique.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83821CED2720013AB25 /* make_unique.h */; };
+		A972A97E21CED2730013AB25 /* string_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83921CED2720013AB25 /* string_utils.h */; };
+		A972A97F21CED2730013AB25 /* string_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83921CED2720013AB25 /* string_utils.h */; };
+		A972A98021CED2730013AB25 /* small_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83A21CED2720013AB25 /* small_vector.h */; };
+		A972A98121CED2730013AB25 /* small_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83A21CED2720013AB25 /* small_vector.h */; };
+		A972A98221CED2730013AB25 /* timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83B21CED2720013AB25 /* timer.cpp */; };
+		A972A98321CED2730013AB25 /* timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83B21CED2720013AB25 /* timer.cpp */; };
+		A972A98421CED2730013AB25 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83C21CED2720013AB25 /* timer.h */; };
+		A972A98521CED2730013AB25 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83C21CED2720013AB25 /* timer.h */; };
+		A972A98621CED2730013AB25 /* string_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83D21CED2720013AB25 /* string_utils.cpp */; };
+		A972A98721CED2730013AB25 /* string_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A83D21CED2720013AB25 /* string_utils.cpp */; };
+		A972A98821CED2730013AB25 /* bit_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83E21CED2720013AB25 /* bit_vector.h */; };
+		A972A98921CED2730013AB25 /* bit_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83E21CED2720013AB25 /* bit_vector.h */; };
+		A972A98A21CED2730013AB25 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83F21CED2720013AB25 /* bitutils.h */; };
+		A972A98B21CED2730013AB25 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A83F21CED2720013AB25 /* bitutils.h */; };
+		A972A98C21CED2730013AB25 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84021CED2720013AB25 /* hex_float.h */; };
+		A972A98D21CED2730013AB25 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84021CED2720013AB25 /* hex_float.h */; };
+		A972A98E21CED2730013AB25 /* parse_number.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84121CED2720013AB25 /* parse_number.cpp */; };
+		A972A98F21CED2730013AB25 /* parse_number.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84121CED2720013AB25 /* parse_number.cpp */; };
+		A972A99021CED2730013AB25 /* bit_vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84221CED2720013AB25 /* bit_vector.cpp */; };
+		A972A99121CED2730013AB25 /* bit_vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84221CED2720013AB25 /* bit_vector.cpp */; };
+		A972A99221CED2730013AB25 /* ilist.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84321CED2720013AB25 /* ilist.h */; };
+		A972A99321CED2730013AB25 /* ilist.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84321CED2720013AB25 /* ilist.h */; };
+		A972A99421CED2730013AB25 /* spirv_target_env.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84421CED2720013AB25 /* spirv_target_env.h */; };
+		A972A99521CED2730013AB25 /* spirv_target_env.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84421CED2720013AB25 /* spirv_target_env.h */; };
+		A972A99621CED2730013AB25 /* table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84521CED2720013AB25 /* table.cpp */; };
+		A972A99721CED2730013AB25 /* table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84521CED2720013AB25 /* table.cpp */; };
+		A972A99821CED2730013AB25 /* id_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84621CED2720013AB25 /* id_descriptor.cpp */; };
+		A972A99921CED2730013AB25 /* id_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84621CED2720013AB25 /* id_descriptor.cpp */; };
+		A972A99A21CED2730013AB25 /* latest_version_opencl_std_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84721CED2720013AB25 /* latest_version_opencl_std_header.h */; };
+		A972A99B21CED2730013AB25 /* latest_version_opencl_std_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84721CED2720013AB25 /* latest_version_opencl_std_header.h */; };
+		A972A99C21CED2730013AB25 /* spirv_optimizer_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84821CED2720013AB25 /* spirv_optimizer_options.cpp */; };
+		A972A99D21CED2730013AB25 /* spirv_optimizer_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84821CED2720013AB25 /* spirv_optimizer_options.cpp */; };
+		A972A99E21CED2730013AB25 /* cfa.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84921CED2720013AB25 /* cfa.h */; };
+		A972A99F21CED2730013AB25 /* cfa.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84921CED2720013AB25 /* cfa.h */; };
+		A972A9A021CED2730013AB25 /* pch_source.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84A21CED2720013AB25 /* pch_source.h */; };
+		A972A9A121CED2730013AB25 /* pch_source.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84A21CED2720013AB25 /* pch_source.h */; };
+		A972A9A221CED2730013AB25 /* enum_string_mapping.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84B21CED2720013AB25 /* enum_string_mapping.h */; };
+		A972A9A321CED2730013AB25 /* enum_string_mapping.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84B21CED2720013AB25 /* enum_string_mapping.h */; };
+		A972A9A421CED2730013AB25 /* spirv_validator_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84C21CED2720013AB25 /* spirv_validator_options.cpp */; };
+		A972A9A521CED2730013AB25 /* spirv_validator_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84C21CED2720013AB25 /* spirv_validator_options.cpp */; };
+		A972A9A621CED2730013AB25 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84E21CED2720013AB25 /* print.cpp */; };
+		A972A9A721CED2730013AB25 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A84E21CED2720013AB25 /* print.cpp */; };
+		A972A9A821CED2730013AB25 /* spirv_definition.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84F21CED2720013AB25 /* spirv_definition.h */; };
+		A972A9A921CED2730013AB25 /* spirv_definition.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A84F21CED2720013AB25 /* spirv_definition.h */; };
+		A972A9AA21CED2730013AB25 /* operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85021CED2720013AB25 /* operand.h */; };
+		A972A9AB21CED2730013AB25 /* operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85021CED2720013AB25 /* operand.h */; };
+		A972A9AC21CED2730013AB25 /* spirv_endian.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85121CED2720013AB25 /* spirv_endian.cpp */; };
+		A972A9AD21CED2730013AB25 /* spirv_endian.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85121CED2720013AB25 /* spirv_endian.cpp */; };
+		A972A9AE21CED2730013AB25 /* macro.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85221CED2720013AB25 /* macro.h */; };
+		A972A9AF21CED2730013AB25 /* macro.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85221CED2720013AB25 /* macro.h */; };
+		A972A9B021CED2730013AB25 /* spirv_constant.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85321CED2720013AB25 /* spirv_constant.h */; };
+		A972A9B121CED2730013AB25 /* spirv_constant.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85321CED2720013AB25 /* spirv_constant.h */; };
+		A972A9B221CED2730013AB25 /* binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85521CED2720013AB25 /* binary.cpp */; };
+		A972A9B321CED2730013AB25 /* binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85521CED2720013AB25 /* binary.cpp */; };
+		A972A9B421CED2730013AB25 /* spirv_validator_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85621CED2720013AB25 /* spirv_validator_options.h */; };
+		A972A9B521CED2730013AB25 /* spirv_validator_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85621CED2720013AB25 /* spirv_validator_options.h */; };
+		A972A9B621CED2730013AB25 /* markv_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85821CED2720013AB25 /* markv_codec.cpp */; };
+		A972A9B721CED2730013AB25 /* markv_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85821CED2720013AB25 /* markv_codec.cpp */; };
+		A972A9B821CED2730013AB25 /* markv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85921CED2720013AB25 /* markv.cpp */; };
+		A972A9B921CED2730013AB25 /* markv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85921CED2720013AB25 /* markv.cpp */; };
+		A972A9BA21CED2730013AB25 /* huffman_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85A21CED2720013AB25 /* huffman_codec.h */; };
+		A972A9BB21CED2730013AB25 /* huffman_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85A21CED2720013AB25 /* huffman_codec.h */; };
+		A972A9BC21CED2730013AB25 /* bit_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85C21CED2720013AB25 /* bit_stream.h */; };
+		A972A9BD21CED2730013AB25 /* bit_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85C21CED2720013AB25 /* bit_stream.h */; };
+		A972A9BE21CED2730013AB25 /* move_to_front.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85D21CED2720013AB25 /* move_to_front.cpp */; };
+		A972A9BF21CED2730013AB25 /* move_to_front.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A85D21CED2720013AB25 /* move_to_front.cpp */; };
+		A972A9C021CED2730013AB25 /* markv_encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85E21CED2720013AB25 /* markv_encoder.h */; };
+		A972A9C121CED2730013AB25 /* markv_encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85E21CED2720013AB25 /* markv_encoder.h */; };
+		A972A9C221CED2730013AB25 /* markv_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85F21CED2720013AB25 /* markv_decoder.h */; };
+		A972A9C321CED2730013AB25 /* markv_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A85F21CED2720013AB25 /* markv_decoder.h */; };
+		A972A9C421CED2730013AB25 /* markv.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86021CED2720013AB25 /* markv.h */; };
+		A972A9C521CED2730013AB25 /* markv.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86021CED2720013AB25 /* markv.h */; };
+		A972A9C621CED2730013AB25 /* markv_model.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86121CED2720013AB25 /* markv_model.h */; };
+		A972A9C721CED2730013AB25 /* markv_model.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86121CED2720013AB25 /* markv_model.h */; };
+		A972A9C821CED2730013AB25 /* markv_decoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86221CED2720013AB25 /* markv_decoder.cpp */; };
+		A972A9C921CED2730013AB25 /* markv_decoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86221CED2720013AB25 /* markv_decoder.cpp */; };
+		A972A9CA21CED2730013AB25 /* move_to_front.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86321CED2720013AB25 /* move_to_front.h */; };
+		A972A9CB21CED2730013AB25 /* move_to_front.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86321CED2720013AB25 /* move_to_front.h */; };
+		A972A9CC21CED2730013AB25 /* markv_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86421CED2720013AB25 /* markv_codec.h */; };
+		A972A9CD21CED2730013AB25 /* markv_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86421CED2720013AB25 /* markv_codec.h */; };
+		A972A9CE21CED2730013AB25 /* markv_logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86521CED2720013AB25 /* markv_logger.h */; };
+		A972A9CF21CED2730013AB25 /* markv_logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86521CED2720013AB25 /* markv_logger.h */; };
+		A972A9D021CED2730013AB25 /* bit_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86621CED2720013AB25 /* bit_stream.cpp */; };
+		A972A9D121CED2730013AB25 /* bit_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86621CED2720013AB25 /* bit_stream.cpp */; };
+		A972A9D221CED2730013AB25 /* markv_encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86721CED2720013AB25 /* markv_encoder.cpp */; };
+		A972A9D321CED2730013AB25 /* markv_encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86721CED2720013AB25 /* markv_encoder.cpp */; };
+		A972A9D421CED2730013AB25 /* enum_string_mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86821CED2720013AB25 /* enum_string_mapping.cpp */; };
+		A972A9D521CED2730013AB25 /* enum_string_mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86821CED2720013AB25 /* enum_string_mapping.cpp */; };
+		A972A9D621CED2730013AB25 /* text_handler.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86921CED2720013AB25 /* text_handler.h */; };
+		A972A9D721CED2730013AB25 /* text_handler.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86921CED2720013AB25 /* text_handler.h */; };
+		A972A9D821CED2730013AB25 /* parsed_operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86A21CED2720013AB25 /* parsed_operand.h */; };
+		A972A9D921CED2730013AB25 /* parsed_operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86A21CED2720013AB25 /* parsed_operand.h */; };
+		A972A9DA21CED2730013AB25 /* name_mapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86B21CED2720013AB25 /* name_mapper.h */; };
+		A972A9DB21CED2730013AB25 /* name_mapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86B21CED2720013AB25 /* name_mapper.h */; };
+		A972A9DC21CED2730013AB25 /* parsed_operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86C21CED2720013AB25 /* parsed_operand.cpp */; };
+		A972A9DD21CED2730013AB25 /* parsed_operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86C21CED2720013AB25 /* parsed_operand.cpp */; };
+		A972A9DE21CED2730013AB25 /* diagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86D21CED2720013AB25 /* diagnostic.h */; };
+		A972A9DF21CED2730013AB25 /* diagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86D21CED2720013AB25 /* diagnostic.h */; };
+		A972A9E021CED2730013AB25 /* spirv_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86E21CED2720013AB25 /* spirv_endian.h */; };
+		A972A9E121CED2730013AB25 /* spirv_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A86E21CED2720013AB25 /* spirv_endian.h */; };
+		A972A9E221CED2730013AB25 /* name_mapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86F21CED2720013AB25 /* name_mapper.cpp */; };
+		A972A9E321CED2730013AB25 /* name_mapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A86F21CED2720013AB25 /* name_mapper.cpp */; };
+		A972A9E421CED2730013AB25 /* linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87321CED2720013AB25 /* linker.cpp */; };
+		A972A9E521CED2730013AB25 /* linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87321CED2720013AB25 /* linker.cpp */; };
+		A972A9E621CED2730013AB25 /* software_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87421CED2720013AB25 /* software_version.cpp */; };
+		A972A9E721CED2730013AB25 /* software_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87421CED2720013AB25 /* software_version.cpp */; };
+		A972A9E821CED2730013AB25 /* opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87521CED2720013AB25 /* opcode.cpp */; };
+		A972A9E921CED2730013AB25 /* opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87521CED2720013AB25 /* opcode.cpp */; };
+		A972A9EA21CED2730013AB25 /* print.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87621CED2720013AB25 /* print.h */; };
+		A972A9EB21CED2730013AB25 /* print.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87621CED2720013AB25 /* print.h */; };
+		A972A9EC21CED2730013AB25 /* ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87721CED2720013AB25 /* ext_inst.cpp */; };
+		A972A9ED21CED2730013AB25 /* ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87721CED2720013AB25 /* ext_inst.cpp */; };
+		A972A9EE21CED2730013AB25 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87821CED2720013AB25 /* disassemble.h */; };
+		A972A9EF21CED2730013AB25 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87821CED2720013AB25 /* disassemble.h */; };
+		A972A9F021CED2730013AB25 /* optimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87A21CED2720013AB25 /* optimizer.cpp */; };
+		A972A9F121CED2730013AB25 /* optimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87A21CED2720013AB25 /* optimizer.cpp */; };
+		A972A9F221CED2730013AB25 /* if_conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87B21CED2720013AB25 /* if_conversion.h */; };
+		A972A9F321CED2730013AB25 /* if_conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87B21CED2720013AB25 /* if_conversion.h */; };
+		A972A9F421CED2730013AB25 /* register_pressure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87C21CED2720013AB25 /* register_pressure.cpp */; };
+		A972A9F521CED2730013AB25 /* register_pressure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87C21CED2720013AB25 /* register_pressure.cpp */; };
+		A972A9F621CED2730013AB25 /* loop_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87D21CED2720013AB25 /* loop_utils.cpp */; };
+		A972A9F721CED2730013AB25 /* loop_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A87D21CED2720013AB25 /* loop_utils.cpp */; };
+		A972A9F821CED2730013AB25 /* merge_return_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87E21CED2720013AB25 /* merge_return_pass.h */; };
+		A972A9F921CED2730013AB25 /* merge_return_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87E21CED2720013AB25 /* merge_return_pass.h */; };
+		A972A9FA21CED2730013AB25 /* inline_opaque_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87F21CED2720013AB25 /* inline_opaque_pass.h */; };
+		A972A9FB21CED2730013AB25 /* inline_opaque_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A87F21CED2720013AB25 /* inline_opaque_pass.h */; };
+		A972A9FC21CED2730013AB25 /* loop_fusion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88021CED2720013AB25 /* loop_fusion.h */; };
+		A972A9FD21CED2730013AB25 /* loop_fusion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88021CED2720013AB25 /* loop_fusion.h */; };
+		A972A9FE21CED2730013AB25 /* combine_access_chains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88121CED2720013AB25 /* combine_access_chains.cpp */; };
+		A972A9FF21CED2730013AB25 /* combine_access_chains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88121CED2720013AB25 /* combine_access_chains.cpp */; };
+		A972AA0021CED2730013AB25 /* build_module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88221CED2720013AB25 /* build_module.cpp */; };
+		A972AA0121CED2730013AB25 /* build_module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88221CED2720013AB25 /* build_module.cpp */; };
+		A972AA0221CED2730013AB25 /* composite.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88321CED2720013AB25 /* composite.h */; };
+		A972AA0321CED2730013AB25 /* composite.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88321CED2720013AB25 /* composite.h */; };
+		A972AA0421CED2730013AB25 /* compact_ids_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88421CED2720013AB25 /* compact_ids_pass.h */; };
+		A972AA0521CED2730013AB25 /* compact_ids_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88421CED2720013AB25 /* compact_ids_pass.h */; };
+		A972AA0621CED2730013AB25 /* register_pressure.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88521CED2720013AB25 /* register_pressure.h */; };
+		A972AA0721CED2730013AB25 /* register_pressure.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88521CED2720013AB25 /* register_pressure.h */; };
+		A972AA0821CED2730013AB25 /* tree_iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88621CED2720013AB25 /* tree_iterator.h */; };
+		A972AA0921CED2730013AB25 /* tree_iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88621CED2720013AB25 /* tree_iterator.h */; };
+		A972AA0A21CED2730013AB25 /* local_single_store_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88721CED2720013AB25 /* local_single_store_elim_pass.h */; };
+		A972AA0B21CED2730013AB25 /* local_single_store_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88721CED2720013AB25 /* local_single_store_elim_pass.h */; };
+		A972AA0C21CED2730013AB25 /* reduce_load_size.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88821CED2720013AB25 /* reduce_load_size.h */; };
+		A972AA0D21CED2730013AB25 /* reduce_load_size.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88821CED2720013AB25 /* reduce_load_size.h */; };
+		A972AA0E21CED2730013AB25 /* types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88921CED2720013AB25 /* types.cpp */; };
+		A972AA0F21CED2730013AB25 /* types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88921CED2720013AB25 /* types.cpp */; };
+		A972AA1021CED2730013AB25 /* scalar_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88A21CED2720013AB25 /* scalar_analysis.h */; };
+		A972AA1121CED2730013AB25 /* scalar_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88A21CED2720013AB25 /* scalar_analysis.h */; };
+		A972AA1221CED2730013AB25 /* strip_debug_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88B21CED2720013AB25 /* strip_debug_info_pass.h */; };
+		A972AA1321CED2730013AB25 /* strip_debug_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A88B21CED2720013AB25 /* strip_debug_info_pass.h */; };
+		A972AA1421CED2730013AB25 /* cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88C21CED2720013AB25 /* cfg.cpp */; };
+		A972AA1521CED2730013AB25 /* cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88C21CED2720013AB25 /* cfg.cpp */; };
+		A972AA1621CED2730013AB25 /* decoration_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88D21CED2720013AB25 /* decoration_manager.cpp */; };
+		A972AA1721CED2730013AB25 /* decoration_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88D21CED2720013AB25 /* decoration_manager.cpp */; };
+		A972AA1821CED2730013AB25 /* local_single_block_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88E21CED2720013AB25 /* local_single_block_elim_pass.cpp */; };
+		A972AA1921CED2730013AB25 /* local_single_block_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88E21CED2720013AB25 /* local_single_block_elim_pass.cpp */; };
+		A972AA1A21CED2730013AB25 /* freeze_spec_constant_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88F21CED2720013AB25 /* freeze_spec_constant_value_pass.cpp */; };
+		A972AA1B21CED2730013AB25 /* freeze_spec_constant_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A88F21CED2720013AB25 /* freeze_spec_constant_value_pass.cpp */; };
+		A972AA1C21CED2730013AB25 /* replace_invalid_opc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89021CED2720013AB25 /* replace_invalid_opc.h */; };
+		A972AA1D21CED2730013AB25 /* replace_invalid_opc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89021CED2720013AB25 /* replace_invalid_opc.h */; };
+		A972AA1E21CED2730013AB25 /* local_access_chain_convert_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89121CED2720013AB25 /* local_access_chain_convert_pass.h */; };
+		A972AA1F21CED2730013AB25 /* local_access_chain_convert_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89121CED2720013AB25 /* local_access_chain_convert_pass.h */; };
+		A972AA2021CED2730013AB25 /* inst_bindless_check_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89221CED2720013AB25 /* inst_bindless_check_pass.cpp */; };
+		A972AA2121CED2730013AB25 /* inst_bindless_check_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89221CED2720013AB25 /* inst_bindless_check_pass.cpp */; };
+		A972AA2221CED2730013AB25 /* local_redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89321CED2720013AB25 /* local_redundancy_elimination.cpp */; };
+		A972AA2321CED2730013AB25 /* local_redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89321CED2720013AB25 /* local_redundancy_elimination.cpp */; };
+		A972AA2421CED2730013AB25 /* instrument_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89521CED2720013AB25 /* instrument_pass.cpp */; };
+		A972AA2521CED2730013AB25 /* instrument_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89521CED2720013AB25 /* instrument_pass.cpp */; };
+		A972AA2621CED2730013AB25 /* propagator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89621CED2720013AB25 /* propagator.h */; };
+		A972AA2721CED2730013AB25 /* propagator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89621CED2720013AB25 /* propagator.h */; };
+		A972AA2821CED2730013AB25 /* instruction_list.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89721CED2720013AB25 /* instruction_list.h */; };
+		A972AA2921CED2730013AB25 /* instruction_list.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89721CED2720013AB25 /* instruction_list.h */; };
+		A972AA2A21CED2730013AB25 /* feature_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89821CED2720013AB25 /* feature_manager.cpp */; };
+		A972AA2B21CED2730013AB25 /* feature_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89821CED2720013AB25 /* feature_manager.cpp */; };
+		A972AA2C21CED2730013AB25 /* pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89921CED2720013AB25 /* pass.cpp */; };
+		A972AA2D21CED2730013AB25 /* pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89921CED2720013AB25 /* pass.cpp */; };
+		A972AA2E21CED2730013AB25 /* loop_fission.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89A21CED2720013AB25 /* loop_fission.cpp */; };
+		A972AA2F21CED2730013AB25 /* loop_fission.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89A21CED2720013AB25 /* loop_fission.cpp */; };
+		A972AA3021CED2730013AB25 /* dominator_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89B21CED2720013AB25 /* dominator_tree.cpp */; };
+		A972AA3121CED2730013AB25 /* dominator_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89B21CED2720013AB25 /* dominator_tree.cpp */; };
+		A972AA3221CED2730013AB25 /* merge_return_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89C21CED2720013AB25 /* merge_return_pass.cpp */; };
+		A972AA3321CED2730013AB25 /* merge_return_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89C21CED2720013AB25 /* merge_return_pass.cpp */; };
+		A972AA3421CED2730013AB25 /* ir_context.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89D21CED2720013AB25 /* ir_context.h */; };
+		A972AA3521CED2730013AB25 /* ir_context.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A89D21CED2720013AB25 /* ir_context.h */; };
+		A972AA3621CED2730013AB25 /* eliminate_dead_constant_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89E21CED2720013AB25 /* eliminate_dead_constant_pass.cpp */; };
+		A972AA3721CED2730013AB25 /* eliminate_dead_constant_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89E21CED2720013AB25 /* eliminate_dead_constant_pass.cpp */; };
+		A972AA3821CED2730013AB25 /* cfg_cleanup_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89F21CED2720013AB25 /* cfg_cleanup_pass.cpp */; };
+		A972AA3921CED2730013AB25 /* cfg_cleanup_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A89F21CED2720013AB25 /* cfg_cleanup_pass.cpp */; };
+		A972AA3A21CED2730013AB25 /* const_folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A021CED2720013AB25 /* const_folding_rules.cpp */; };
+		A972AA3B21CED2730013AB25 /* const_folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A021CED2720013AB25 /* const_folding_rules.cpp */; };
+		A972AA3C21CED2730013AB25 /* loop_unroller.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A121CED2720013AB25 /* loop_unroller.h */; };
+		A972AA3D21CED2730013AB25 /* loop_unroller.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A121CED2720013AB25 /* loop_unroller.h */; };
+		A972AA3E21CED2730013AB25 /* strip_debug_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A221CED2720013AB25 /* strip_debug_info_pass.cpp */; };
+		A972AA3F21CED2730013AB25 /* strip_debug_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A221CED2720013AB25 /* strip_debug_info_pass.cpp */; };
+		A972AA4021CED2730013AB25 /* ssa_rewrite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A321CED2720013AB25 /* ssa_rewrite_pass.cpp */; };
+		A972AA4121CED2730013AB25 /* ssa_rewrite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A321CED2720013AB25 /* ssa_rewrite_pass.cpp */; };
+		A972AA4221CED2730013AB25 /* loop_dependence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A421CED2720013AB25 /* loop_dependence.cpp */; };
+		A972AA4321CED2730013AB25 /* loop_dependence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A421CED2720013AB25 /* loop_dependence.cpp */; };
+		A972AA4421CED2730013AB25 /* unify_const_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A521CED2720013AB25 /* unify_const_pass.h */; };
+		A972AA4521CED2730013AB25 /* unify_const_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A521CED2720013AB25 /* unify_const_pass.h */; };
+		A972AA4621CED2730013AB25 /* ir_loader.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A621CED2720013AB25 /* ir_loader.h */; };
+		A972AA4721CED2730013AB25 /* ir_loader.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A621CED2720013AB25 /* ir_loader.h */; };
+		A972AA4821CED2730013AB25 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A721CED2720013AB25 /* types.h */; };
+		A972AA4921CED2730013AB25 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A721CED2720013AB25 /* types.h */; };
+		A972AA4A21CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A821CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.h */; };
+		A972AA4B21CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8A821CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.h */; };
+		A972AA4C21CED2730013AB25 /* mem_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A921CED2720013AB25 /* mem_pass.cpp */; };
+		A972AA4D21CED2730013AB25 /* mem_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8A921CED2720013AB25 /* mem_pass.cpp */; };
+		A972AA4E21CED2730013AB25 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8AA21CED2720013AB25 /* basic_block.h */; };
+		A972AA4F21CED2730013AB25 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8AA21CED2720013AB25 /* basic_block.h */; };
+		A972AA5021CED2730013AB25 /* remove_duplicates_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AB21CED2720013AB25 /* remove_duplicates_pass.cpp */; };
+		A972AA5121CED2730013AB25 /* remove_duplicates_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AB21CED2720013AB25 /* remove_duplicates_pass.cpp */; };
+		A972AA5221CED2730013AB25 /* dead_variable_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AC21CED2720013AB25 /* dead_variable_elimination.cpp */; };
+		A972AA5321CED2730013AB25 /* dead_variable_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AC21CED2720013AB25 /* dead_variable_elimination.cpp */; };
+		A972AA5421CED2730013AB25 /* block_merge_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8AD21CED2720013AB25 /* block_merge_pass.h */; };
+		A972AA5521CED2730013AB25 /* block_merge_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8AD21CED2720013AB25 /* block_merge_pass.h */; };
+		A972AA5621CED2730013AB25 /* module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AE21CED2720013AB25 /* module.cpp */; };
+		A972AA5721CED2730013AB25 /* module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AE21CED2720013AB25 /* module.cpp */; };
+		A972AA5821CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AF21CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.cpp */; };
+		A972AA5921CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8AF21CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.cpp */; };
+		A972AA5A21CED2730013AB25 /* loop_unswitch_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B021CED2720013AB25 /* loop_unswitch_pass.cpp */; };
+		A972AA5B21CED2730013AB25 /* loop_unswitch_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B021CED2720013AB25 /* loop_unswitch_pass.cpp */; };
+		A972AA5C21CED2730013AB25 /* unify_const_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B121CED2720013AB25 /* unify_const_pass.cpp */; };
+		A972AA5D21CED2730013AB25 /* unify_const_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B121CED2720013AB25 /* unify_const_pass.cpp */; };
+		A972AA5E21CED2730013AB25 /* type_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B221CED2720013AB25 /* type_manager.cpp */; };
+		A972AA5F21CED2730013AB25 /* type_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B221CED2720013AB25 /* type_manager.cpp */; };
+		A972AA6021CED2730013AB25 /* private_to_local_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B321CED2720013AB25 /* private_to_local_pass.h */; };
+		A972AA6121CED2730013AB25 /* private_to_local_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B321CED2720013AB25 /* private_to_local_pass.h */; };
+		A972AA6221CED2730013AB25 /* inline_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B421CED2720013AB25 /* inline_pass.cpp */; };
+		A972AA6321CED2730013AB25 /* inline_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B421CED2720013AB25 /* inline_pass.cpp */; };
+		A972AA6421CED2730013AB25 /* def_use_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B521CED2720013AB25 /* def_use_manager.h */; };
+		A972AA6521CED2730013AB25 /* def_use_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B521CED2720013AB25 /* def_use_manager.h */; };
+		A972AA6621CED2730013AB25 /* ir_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B621CED2720013AB25 /* ir_loader.cpp */; };
+		A972AA6721CED2730013AB25 /* ir_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B621CED2720013AB25 /* ir_loader.cpp */; };
+		A972AA6821CED2730013AB25 /* cfg_cleanup_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B721CED2720013AB25 /* cfg_cleanup_pass.h */; };
+		A972AA6921CED2730013AB25 /* cfg_cleanup_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8B721CED2720013AB25 /* cfg_cleanup_pass.h */; };
+		A972AA6A21CED2730013AB25 /* licm_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B821CED2720013AB25 /* licm_pass.cpp */; };
+		A972AA6B21CED2730013AB25 /* licm_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B821CED2720013AB25 /* licm_pass.cpp */; };
+		A972AA6C21CED2730013AB25 /* eliminate_dead_functions_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B921CED2720013AB25 /* eliminate_dead_functions_pass.cpp */; };
+		A972AA6D21CED2730013AB25 /* eliminate_dead_functions_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8B921CED2720013AB25 /* eliminate_dead_functions_pass.cpp */; };
+		A972AA6E21CED2730013AB25 /* local_redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BA21CED2720013AB25 /* local_redundancy_elimination.h */; };
+		A972AA6F21CED2730013AB25 /* local_redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BA21CED2720013AB25 /* local_redundancy_elimination.h */; };
+		A972AA7021CED2730013AB25 /* loop_peeling.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BB21CED2720013AB25 /* loop_peeling.h */; };
+		A972AA7121CED2730013AB25 /* loop_peeling.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BB21CED2720013AB25 /* loop_peeling.h */; };
+		A972AA7221CED2730013AB25 /* vector_dce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BC21CED2720013AB25 /* vector_dce.cpp */; };
+		A972AA7321CED2730013AB25 /* vector_dce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BC21CED2720013AB25 /* vector_dce.cpp */; };
+		A972AA7421CED2730013AB25 /* loop_unroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BD21CED2720013AB25 /* loop_unroller.cpp */; };
+		A972AA7521CED2730013AB25 /* loop_unroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BD21CED2720013AB25 /* loop_unroller.cpp */; };
+		A972AA7621CED2730013AB25 /* constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BE21CED2720013AB25 /* constants.cpp */; };
+		A972AA7721CED2730013AB25 /* constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8BE21CED2720013AB25 /* constants.cpp */; };
+		A972AA7821CED2730013AB25 /* loop_fusion_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BF21CED2720013AB25 /* loop_fusion_pass.h */; };
+		A972AA7921CED2730013AB25 /* loop_fusion_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8BF21CED2720013AB25 /* loop_fusion_pass.h */; };
+		A972AA7A21CED2730013AB25 /* struct_cfg_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C021CED2720013AB25 /* struct_cfg_analysis.h */; };
+		A972AA7B21CED2730013AB25 /* struct_cfg_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C021CED2720013AB25 /* struct_cfg_analysis.h */; };
+		A972AA7C21CED2730013AB25 /* common_uniform_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C121CED2720013AB25 /* common_uniform_elim_pass.cpp */; };
+		A972AA7D21CED2730013AB25 /* common_uniform_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C121CED2720013AB25 /* common_uniform_elim_pass.cpp */; };
+		A972AA7E21CED2730013AB25 /* def_use_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C221CED2720013AB25 /* def_use_manager.cpp */; };
+		A972AA7F21CED2730013AB25 /* def_use_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C221CED2720013AB25 /* def_use_manager.cpp */; };
+		A972AA8021CED2730013AB25 /* strip_reflect_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C321CED2720013AB25 /* strip_reflect_info_pass.cpp */; };
+		A972AA8121CED2730013AB25 /* strip_reflect_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C321CED2720013AB25 /* strip_reflect_info_pass.cpp */; };
+		A972AA8221CED2730013AB25 /* decoration_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C421CED2720013AB25 /* decoration_manager.h */; };
+		A972AA8321CED2730013AB25 /* decoration_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C421CED2720013AB25 /* decoration_manager.h */; };
+		A972AA8421CED2730013AB25 /* ccp_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C521CED2720013AB25 /* ccp_pass.cpp */; };
+		A972AA8521CED2730013AB25 /* ccp_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C521CED2720013AB25 /* ccp_pass.cpp */; };
+		A972AA8621CED2730013AB25 /* local_single_block_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C621CED2720013AB25 /* local_single_block_elim_pass.h */; };
+		A972AA8721CED2730013AB25 /* local_single_block_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C621CED2720013AB25 /* local_single_block_elim_pass.h */; };
+		A972AA8821CED2730013AB25 /* pch_source_opt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C721CED2720013AB25 /* pch_source_opt.cpp */; };
+		A972AA8921CED2730013AB25 /* pch_source_opt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C721CED2720013AB25 /* pch_source_opt.cpp */; };
+		A972AA8A21CED2730013AB25 /* strength_reduction_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C821CED2720013AB25 /* strength_reduction_pass.h */; };
+		A972AA8B21CED2730013AB25 /* strength_reduction_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8C821CED2720013AB25 /* strength_reduction_pass.h */; };
+		A972AA8C21CED2730013AB25 /* aggressive_dead_code_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C921CED2720013AB25 /* aggressive_dead_code_elim_pass.cpp */; };
+		A972AA8D21CED2730013AB25 /* aggressive_dead_code_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8C921CED2720013AB25 /* aggressive_dead_code_elim_pass.cpp */; };
+		A972AA8E21CED2730013AB25 /* simplification_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CA21CED2720013AB25 /* simplification_pass.cpp */; };
+		A972AA8F21CED2730013AB25 /* simplification_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CA21CED2720013AB25 /* simplification_pass.cpp */; };
+		A972AA9021CED2730013AB25 /* dead_branch_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CB21CED2720013AB25 /* dead_branch_elim_pass.cpp */; };
+		A972AA9121CED2730013AB25 /* dead_branch_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CB21CED2720013AB25 /* dead_branch_elim_pass.cpp */; };
+		A972AA9221CED2730013AB25 /* flatten_decoration_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CC21CED2720013AB25 /* flatten_decoration_pass.cpp */; };
+		A972AA9321CED2730013AB25 /* flatten_decoration_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CC21CED2720013AB25 /* flatten_decoration_pass.cpp */; };
+		A972AA9421CED2730013AB25 /* dead_insert_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8CD21CED2720013AB25 /* dead_insert_elim_pass.h */; };
+		A972AA9521CED2730013AB25 /* dead_insert_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8CD21CED2720013AB25 /* dead_insert_elim_pass.h */; };
+		A972AA9621CED2730013AB25 /* folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CE21CED2720013AB25 /* folding_rules.cpp */; };
+		A972AA9721CED2730013AB25 /* folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8CE21CED2720013AB25 /* folding_rules.cpp */; };
+		A972AA9821CED2730013AB25 /* freeze_spec_constant_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8CF21CED2720013AB25 /* freeze_spec_constant_value_pass.h */; };
+		A972AA9921CED2730013AB25 /* freeze_spec_constant_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8CF21CED2720013AB25 /* freeze_spec_constant_value_pass.h */; };
+		A972AA9A21CED2730013AB25 /* ir_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D021CED2720013AB25 /* ir_context.cpp */; };
+		A972AA9B21CED2730013AB25 /* ir_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D021CED2720013AB25 /* ir_context.cpp */; };
+		A972AA9C21CED2730013AB25 /* instrument_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D121CED2720013AB25 /* instrument_pass.h */; };
+		A972AA9D21CED2730013AB25 /* instrument_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D121CED2720013AB25 /* instrument_pass.h */; };
+		A972AA9E21CED2730013AB25 /* mem_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D221CED2720013AB25 /* mem_pass.h */; };
+		A972AA9F21CED2730013AB25 /* mem_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D221CED2720013AB25 /* mem_pass.h */; };
+		A972AAA021CED2730013AB25 /* loop_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D321CED2720013AB25 /* loop_descriptor.cpp */; };
+		A972AAA121CED2730013AB25 /* loop_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D321CED2720013AB25 /* loop_descriptor.cpp */; };
+		A972AAA221CED2730013AB25 /* local_ssa_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D421CED2720013AB25 /* local_ssa_elim_pass.cpp */; };
+		A972AAA321CED2730013AB25 /* local_ssa_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D421CED2720013AB25 /* local_ssa_elim_pass.cpp */; };
+		A972AAA421CED2730013AB25 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D521CED2720013AB25 /* function.cpp */; };
+		A972AAA521CED2730013AB25 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D521CED2720013AB25 /* function.cpp */; };
+		A972AAA621CED2730013AB25 /* instruction_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D621CED2720013AB25 /* instruction_list.cpp */; };
+		A972AAA721CED2730013AB25 /* instruction_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D621CED2720013AB25 /* instruction_list.cpp */; };
+		A972AAA821CED2730013AB25 /* composite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D721CED2720013AB25 /* composite.cpp */; };
+		A972AAA921CED2730013AB25 /* composite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8D721CED2720013AB25 /* composite.cpp */; };
+		A972AAAA21CED2730013AB25 /* inline_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D821CED2720013AB25 /* inline_pass.h */; };
+		A972AAAB21CED2730013AB25 /* inline_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D821CED2720013AB25 /* inline_pass.h */; };
+		A972AAAC21CED2730013AB25 /* loop_dependence.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D921CED2720013AB25 /* loop_dependence.h */; };
+		A972AAAD21CED2730013AB25 /* loop_dependence.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8D921CED2720013AB25 /* loop_dependence.h */; };
+		A972AAAE21CED2730013AB25 /* value_number_table.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DA21CED2720013AB25 /* value_number_table.h */; };
+		A972AAAF21CED2730013AB25 /* value_number_table.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DA21CED2720013AB25 /* value_number_table.h */; };
+		A972AAB021CED2730013AB25 /* flatten_decoration_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DB21CED2720013AB25 /* flatten_decoration_pass.h */; };
+		A972AAB121CED2730013AB25 /* flatten_decoration_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DB21CED2720013AB25 /* flatten_decoration_pass.h */; };
+		A972AAB221CED2730013AB25 /* if_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8DC21CED2720013AB25 /* if_conversion.cpp */; };
+		A972AAB321CED2730013AB25 /* if_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8DC21CED2720013AB25 /* if_conversion.cpp */; };
+		A972AAB421CED2730013AB25 /* inline_exhaustive_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DD21CED2720013AB25 /* inline_exhaustive_pass.h */; };
+		A972AAB521CED2730013AB25 /* inline_exhaustive_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DD21CED2720013AB25 /* inline_exhaustive_pass.h */; };
+		A972AAB621CED2730013AB25 /* constants.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DE21CED2720013AB25 /* constants.h */; };
+		A972AAB721CED2730013AB25 /* constants.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8DE21CED2720013AB25 /* constants.h */; };
+		A972AAB821CED2730013AB25 /* strength_reduction_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8DF21CED2720013AB25 /* strength_reduction_pass.cpp */; };
+		A972AAB921CED2730013AB25 /* strength_reduction_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8DF21CED2720013AB25 /* strength_reduction_pass.cpp */; };
+		A972AABA21CED2730013AB25 /* copy_prop_arrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E021CED2720013AB25 /* copy_prop_arrays.cpp */; };
+		A972AABB21CED2730013AB25 /* copy_prop_arrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E021CED2720013AB25 /* copy_prop_arrays.cpp */; };
+		A972AABC21CED2730013AB25 /* pass_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E121CED2720013AB25 /* pass_manager.cpp */; };
+		A972AABD21CED2730013AB25 /* pass_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E121CED2720013AB25 /* pass_manager.cpp */; };
+		A972AABE21CED2730013AB25 /* inline_exhaustive_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E221CED2720013AB25 /* inline_exhaustive_pass.cpp */; };
+		A972AABF21CED2730013AB25 /* inline_exhaustive_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E221CED2720013AB25 /* inline_exhaustive_pass.cpp */; };
+		A972AAC021CED2730013AB25 /* loop_fission.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E321CED2720013AB25 /* loop_fission.h */; };
+		A972AAC121CED2730013AB25 /* loop_fission.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E321CED2720013AB25 /* loop_fission.h */; };
+		A972AAC221CED2730013AB25 /* workaround1209.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E421CED2720013AB25 /* workaround1209.h */; };
+		A972AAC321CED2730013AB25 /* workaround1209.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E421CED2720013AB25 /* workaround1209.h */; };
+		A972AAC421CED2730013AB25 /* loop_fusion_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E521CED2720013AB25 /* loop_fusion_pass.cpp */; };
+		A972AAC521CED2730013AB25 /* loop_fusion_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E521CED2720013AB25 /* loop_fusion_pass.cpp */; };
+		A972AAC621CED2730013AB25 /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E621CED2720013AB25 /* log.h */; };
+		A972AAC721CED2730013AB25 /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E621CED2720013AB25 /* log.h */; };
+		A972AAC821CED2730013AB25 /* copy_prop_arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E721CED2720013AB25 /* copy_prop_arrays.h */; };
+		A972AAC921CED2730013AB25 /* copy_prop_arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E721CED2720013AB25 /* copy_prop_arrays.h */; };
+		A972AACA21CED2730013AB25 /* eliminate_dead_constant_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E821CED2720013AB25 /* eliminate_dead_constant_pass.h */; };
+		A972AACB21CED2730013AB25 /* eliminate_dead_constant_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8E821CED2720013AB25 /* eliminate_dead_constant_pass.h */; };
+		A972AACC21CED2730013AB25 /* dead_insert_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E921CED2720013AB25 /* dead_insert_elim_pass.cpp */; };
+		A972AACD21CED2730013AB25 /* dead_insert_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8E921CED2720013AB25 /* dead_insert_elim_pass.cpp */; };
+		A972AACE21CED2730013AB25 /* ssa_rewrite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EA21CED2720013AB25 /* ssa_rewrite_pass.h */; };
+		A972AACF21CED2730013AB25 /* ssa_rewrite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EA21CED2720013AB25 /* ssa_rewrite_pass.h */; };
+		A972AAD021CED2730013AB25 /* scalar_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8EB21CED2720013AB25 /* scalar_analysis.cpp */; };
+		A972AAD121CED2730013AB25 /* scalar_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8EB21CED2720013AB25 /* scalar_analysis.cpp */; };
+		A972AAD221CED2730013AB25 /* dead_variable_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EC21CED2720013AB25 /* dead_variable_elimination.h */; };
+		A972AAD321CED2730013AB25 /* dead_variable_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EC21CED2720013AB25 /* dead_variable_elimination.h */; };
+		A972AAD421CED2730013AB25 /* block_merge_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8ED21CED2720013AB25 /* block_merge_pass.cpp */; };
+		A972AAD521CED2730013AB25 /* block_merge_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8ED21CED2720013AB25 /* block_merge_pass.cpp */; };
+		A972AAD621CED2730013AB25 /* dominator_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EE21CED2720013AB25 /* dominator_analysis.h */; };
+		A972AAD721CED2730013AB25 /* dominator_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EE21CED2720013AB25 /* dominator_analysis.h */; };
+		A972AAD821CED2730013AB25 /* pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EF21CED2720013AB25 /* pass.h */; };
+		A972AAD921CED2730013AB25 /* pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8EF21CED2720013AB25 /* pass.h */; };
+		A972AADA21CED2730013AB25 /* folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F021CED2720013AB25 /* folding_rules.h */; };
+		A972AADB21CED2730013AB25 /* folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F021CED2720013AB25 /* folding_rules.h */; };
+		A972AADC21CED2730013AB25 /* eliminate_dead_functions_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F121CED2720013AB25 /* eliminate_dead_functions_pass.h */; };
+		A972AADD21CED2730013AB25 /* eliminate_dead_functions_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F121CED2720013AB25 /* eliminate_dead_functions_pass.h */; };
+		A972AADE21CED2730013AB25 /* common_uniform_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F221CED2720013AB25 /* common_uniform_elim_pass.h */; };
+		A972AADF21CED2730013AB25 /* common_uniform_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F221CED2720013AB25 /* common_uniform_elim_pass.h */; };
+		A972AAE021CED2730013AB25 /* fold.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F321CED2720013AB25 /* fold.h */; };
+		A972AAE121CED2730013AB25 /* fold.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F321CED2720013AB25 /* fold.h */; };
+		A972AAE221CED2730013AB25 /* local_single_store_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F421CED2720013AB25 /* local_single_store_elim_pass.cpp */; };
+		A972AAE321CED2730013AB25 /* local_single_store_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F421CED2720013AB25 /* local_single_store_elim_pass.cpp */; };
+		A972AAE421CED2730013AB25 /* dead_branch_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F521CED2720013AB25 /* dead_branch_elim_pass.h */; };
+		A972AAE521CED2730013AB25 /* dead_branch_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F521CED2720013AB25 /* dead_branch_elim_pass.h */; };
+		A972AAE621CED2730013AB25 /* private_to_local_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F621CED2720013AB25 /* private_to_local_pass.cpp */; };
+		A972AAE721CED2730013AB25 /* private_to_local_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F621CED2720013AB25 /* private_to_local_pass.cpp */; };
+		A972AAE821CED2730013AB25 /* scalar_analysis_nodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F721CED2720013AB25 /* scalar_analysis_nodes.h */; };
+		A972AAE921CED2730013AB25 /* scalar_analysis_nodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8F721CED2720013AB25 /* scalar_analysis_nodes.h */; };
+		A972AAEA21CED2730013AB25 /* propagator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F821CED2720013AB25 /* propagator.cpp */; };
+		A972AAEB21CED2730013AB25 /* propagator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F821CED2720013AB25 /* propagator.cpp */; };
+		A972AAEC21CED2730013AB25 /* loop_dependence_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F921CED2720013AB25 /* loop_dependence_helpers.cpp */; };
+		A972AAED21CED2730013AB25 /* loop_dependence_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8F921CED2720013AB25 /* loop_dependence_helpers.cpp */; };
+		A972AAEE21CED2730013AB25 /* set_spec_constant_default_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FA21CED2720013AB25 /* set_spec_constant_default_value_pass.cpp */; };
+		A972AAEF21CED2730013AB25 /* set_spec_constant_default_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FA21CED2720013AB25 /* set_spec_constant_default_value_pass.cpp */; };
+		A972AAF021CED2730013AB25 /* passes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FB21CED2720013AB25 /* passes.h */; };
+		A972AAF121CED2730013AB25 /* passes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FB21CED2720013AB25 /* passes.h */; };
+		A972AAF221CED2730013AB25 /* fold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FC21CED2720013AB25 /* fold.cpp */; };
+		A972AAF321CED2730013AB25 /* fold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FC21CED2720013AB25 /* fold.cpp */; };
+		A972AAF421CED2730013AB25 /* strip_reflect_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FD21CED2720013AB25 /* strip_reflect_info_pass.h */; };
+		A972AAF521CED2730013AB25 /* strip_reflect_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FD21CED2720013AB25 /* strip_reflect_info_pass.h */; };
+		A972AAF621CED2730013AB25 /* scalar_replacement_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FE21CED2720013AB25 /* scalar_replacement_pass.cpp */; };
+		A972AAF721CED2730013AB25 /* scalar_replacement_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A8FE21CED2720013AB25 /* scalar_replacement_pass.cpp */; };
+		A972AAF821CED2730013AB25 /* simplification_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FF21CED2720013AB25 /* simplification_pass.h */; };
+		A972AAF921CED2730013AB25 /* simplification_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A8FF21CED2720013AB25 /* simplification_pass.h */; };
+		A972AAFA21CED2730013AB25 /* remove_duplicates_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90021CED2720013AB25 /* remove_duplicates_pass.h */; };
+		A972AAFB21CED2730013AB25 /* remove_duplicates_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90021CED2720013AB25 /* remove_duplicates_pass.h */; };
+		A972AAFC21CED2730013AB25 /* redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90121CED2720013AB25 /* redundancy_elimination.cpp */; };
+		A972AAFD21CED2730013AB25 /* redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90121CED2720013AB25 /* redundancy_elimination.cpp */; };
+		A972AAFE21CED2730013AB25 /* reflect.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90221CED2720013AB25 /* reflect.h */; };
+		A972AAFF21CED2730013AB25 /* reflect.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90221CED2720013AB25 /* reflect.h */; };
+		A972AB0021CED2730013AB25 /* workaround1209.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90321CED2720013AB25 /* workaround1209.cpp */; };
+		A972AB0121CED2730013AB25 /* workaround1209.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90321CED2720013AB25 /* workaround1209.cpp */; };
+		A972AB0221CED2730013AB25 /* null_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90421CED2720013AB25 /* null_pass.h */; };
+		A972AB0321CED2730013AB25 /* null_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90421CED2720013AB25 /* null_pass.h */; };
+		A972AB0421CED2730013AB25 /* const_folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90521CED2720013AB25 /* const_folding_rules.h */; };
+		A972AB0521CED2730013AB25 /* const_folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90521CED2720013AB25 /* const_folding_rules.h */; };
+		A972AB0621CED2730013AB25 /* scalar_replacement_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90621CED2720013AB25 /* scalar_replacement_pass.h */; };
+		A972AB0721CED2730013AB25 /* scalar_replacement_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90621CED2720013AB25 /* scalar_replacement_pass.h */; };
+		A972AB0821CED2730013AB25 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90721CED2720013AB25 /* instruction.cpp */; };
+		A972AB0921CED2730013AB25 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90721CED2720013AB25 /* instruction.cpp */; };
+		A972AB0A21CED2730013AB25 /* pch_source_opt.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90821CED2720013AB25 /* pch_source_opt.h */; };
+		A972AB0B21CED2730013AB25 /* pch_source_opt.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90821CED2720013AB25 /* pch_source_opt.h */; };
+		A972AB0C21CED2730013AB25 /* reduce_load_size.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90921CED2720013AB25 /* reduce_load_size.cpp */; };
+		A972AB0D21CED2730013AB25 /* reduce_load_size.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90921CED2720013AB25 /* reduce_load_size.cpp */; };
+		A972AB0E21CED2730013AB25 /* redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90A21CED2720013AB25 /* redundancy_elimination.h */; };
+		A972AB0F21CED2730013AB25 /* redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90A21CED2720013AB25 /* redundancy_elimination.h */; };
+		A972AB1021CED2730013AB25 /* value_number_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90B21CED2720013AB25 /* value_number_table.cpp */; };
+		A972AB1121CED2730013AB25 /* value_number_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90B21CED2720013AB25 /* value_number_table.cpp */; };
+		A972AB1221CED2730013AB25 /* local_ssa_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90C21CED2720013AB25 /* local_ssa_elim_pass.h */; };
+		A972AB1321CED2730013AB25 /* local_ssa_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90C21CED2720013AB25 /* local_ssa_elim_pass.h */; };
+		A972AB1421CED2730013AB25 /* inline_opaque_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90D21CED2720013AB25 /* inline_opaque_pass.cpp */; };
+		A972AB1521CED2730013AB25 /* inline_opaque_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90D21CED2720013AB25 /* inline_opaque_pass.cpp */; };
+		A972AB1621CED2730013AB25 /* replace_invalid_opc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90E21CED2720013AB25 /* replace_invalid_opc.cpp */; };
+		A972AB1721CED2730013AB25 /* replace_invalid_opc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A90E21CED2720013AB25 /* replace_invalid_opc.cpp */; };
+		A972AB1821CED2730013AB25 /* loop_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90F21CED2720013AB25 /* loop_utils.h */; };
+		A972AB1921CED2730013AB25 /* loop_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A90F21CED2720013AB25 /* loop_utils.h */; };
+		A972AB1A21CED2730013AB25 /* module.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91021CED2720013AB25 /* module.h */; };
+		A972AB1B21CED2730013AB25 /* module.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91021CED2720013AB25 /* module.h */; };
+		A972AB1C21CED2730013AB25 /* dominator_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91121CED2720013AB25 /* dominator_analysis.cpp */; };
+		A972AB1D21CED2730013AB25 /* dominator_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91121CED2720013AB25 /* dominator_analysis.cpp */; };
+		A972AB1E21CED2730013AB25 /* ir_builder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91221CED2720013AB25 /* ir_builder.h */; };
+		A972AB1F21CED2730013AB25 /* ir_builder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91221CED2720013AB25 /* ir_builder.h */; };
+		A972AB2021CED2730013AB25 /* loop_unswitch_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91321CED2720013AB25 /* loop_unswitch_pass.h */; };
+		A972AB2121CED2730013AB25 /* loop_unswitch_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91321CED2720013AB25 /* loop_unswitch_pass.h */; };
+		A972AB2221CED2730013AB25 /* cfg.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91421CED2720013AB25 /* cfg.h */; };
+		A972AB2321CED2730013AB25 /* cfg.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91421CED2720013AB25 /* cfg.h */; };
+		A972AB2421CED2730013AB25 /* loop_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91521CED2720013AB25 /* loop_descriptor.h */; };
+		A972AB2521CED2730013AB25 /* loop_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91521CED2720013AB25 /* loop_descriptor.h */; };
+		A972AB2621CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91621CED2730013AB25 /* instruction.h */; };
+		A972AB2721CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91621CED2730013AB25 /* instruction.h */; };
+		A972AB2821CED2730013AB25 /* aggressive_dead_code_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91721CED2730013AB25 /* aggressive_dead_code_elim_pass.h */; };
+		A972AB2921CED2730013AB25 /* aggressive_dead_code_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91721CED2730013AB25 /* aggressive_dead_code_elim_pass.h */; };
+		A972AB2A21CED2730013AB25 /* struct_cfg_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91821CED2730013AB25 /* struct_cfg_analysis.cpp */; };
+		A972AB2B21CED2730013AB25 /* struct_cfg_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91821CED2730013AB25 /* struct_cfg_analysis.cpp */; };
+		A972AB2C21CED2730013AB25 /* vector_dce.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91921CED2730013AB25 /* vector_dce.h */; };
+		A972AB2D21CED2730013AB25 /* vector_dce.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91921CED2730013AB25 /* vector_dce.h */; };
+		A972AB2E21CED2730013AB25 /* combine_access_chains.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91A21CED2730013AB25 /* combine_access_chains.h */; };
+		A972AB2F21CED2730013AB25 /* combine_access_chains.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91A21CED2730013AB25 /* combine_access_chains.h */; };
+		A972AB3021CED2730013AB25 /* pass_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91B21CED2730013AB25 /* pass_manager.h */; };
+		A972AB3121CED2730013AB25 /* pass_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91B21CED2730013AB25 /* pass_manager.h */; };
+		A972AB3221CED2730013AB25 /* local_access_chain_convert_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91C21CED2730013AB25 /* local_access_chain_convert_pass.cpp */; };
+		A972AB3321CED2730013AB25 /* local_access_chain_convert_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91C21CED2730013AB25 /* local_access_chain_convert_pass.cpp */; };
+		A972AB3421CED2730013AB25 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91D21CED2730013AB25 /* basic_block.cpp */; };
+		A972AB3521CED2730013AB25 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A91D21CED2730013AB25 /* basic_block.cpp */; };
+		A972AB3621CED2730013AB25 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91E21CED2730013AB25 /* iterator.h */; };
+		A972AB3721CED2730013AB25 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91E21CED2730013AB25 /* iterator.h */; };
+		A972AB3821CED2730013AB25 /* licm_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91F21CED2730013AB25 /* licm_pass.h */; };
+		A972AB3921CED2730013AB25 /* licm_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A91F21CED2730013AB25 /* licm_pass.h */; };
+		A972AB3A21CED2730013AB25 /* build_module.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92021CED2730013AB25 /* build_module.h */; };
+		A972AB3B21CED2730013AB25 /* build_module.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92021CED2730013AB25 /* build_module.h */; };
+		A972AB3C21CED2730013AB25 /* ccp_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92121CED2730013AB25 /* ccp_pass.h */; };
+		A972AB3D21CED2730013AB25 /* ccp_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92121CED2730013AB25 /* ccp_pass.h */; };
+		A972AB3E21CED2730013AB25 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92221CED2730013AB25 /* function.h */; };
+		A972AB3F21CED2730013AB25 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92221CED2730013AB25 /* function.h */; };
+		A972AB4021CED2730013AB25 /* loop_fusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92321CED2730013AB25 /* loop_fusion.cpp */; };
+		A972AB4121CED2730013AB25 /* loop_fusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92321CED2730013AB25 /* loop_fusion.cpp */; };
+		A972AB4221CED2730013AB25 /* feature_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92421CED2730013AB25 /* feature_manager.h */; };
+		A972AB4321CED2730013AB25 /* feature_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92421CED2730013AB25 /* feature_manager.h */; };
+		A972AB4421CED2730013AB25 /* inst_bindless_check_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92521CED2730013AB25 /* inst_bindless_check_pass.h */; };
+		A972AB4521CED2730013AB25 /* inst_bindless_check_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92521CED2730013AB25 /* inst_bindless_check_pass.h */; };
+		A972AB4621CED2730013AB25 /* scalar_analysis_simplification.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92621CED2730013AB25 /* scalar_analysis_simplification.cpp */; };
+		A972AB4721CED2730013AB25 /* scalar_analysis_simplification.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92621CED2730013AB25 /* scalar_analysis_simplification.cpp */; };
+		A972AB4821CED2730013AB25 /* set_spec_constant_default_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92721CED2730013AB25 /* set_spec_constant_default_value_pass.h */; };
+		A972AB4921CED2730013AB25 /* set_spec_constant_default_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92721CED2730013AB25 /* set_spec_constant_default_value_pass.h */; };
+		A972AB4A21CED2730013AB25 /* dominator_tree.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92821CED2730013AB25 /* dominator_tree.h */; };
+		A972AB4B21CED2730013AB25 /* dominator_tree.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92821CED2730013AB25 /* dominator_tree.h */; };
+		A972AB4C21CED2730013AB25 /* type_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92921CED2730013AB25 /* type_manager.h */; };
+		A972AB4D21CED2730013AB25 /* type_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92921CED2730013AB25 /* type_manager.h */; };
+		A972AB4E21CED2730013AB25 /* compact_ids_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92A21CED2730013AB25 /* compact_ids_pass.cpp */; };
+		A972AB4F21CED2730013AB25 /* compact_ids_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92A21CED2730013AB25 /* compact_ids_pass.cpp */; };
+		A972AB5021CED2730013AB25 /* loop_peeling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92B21CED2730013AB25 /* loop_peeling.cpp */; };
+		A972AB5121CED2730013AB25 /* loop_peeling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92B21CED2730013AB25 /* loop_peeling.cpp */; };
+		A972AB5221CED2730013AB25 /* table.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92C21CED2730013AB25 /* table.h */; };
+		A972AB5321CED2730013AB25 /* table.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92C21CED2730013AB25 /* table.h */; };
+		A972AB5421CED2730013AB25 /* ext_inst.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92D21CED2730013AB25 /* ext_inst.h */; };
+		A972AB5521CED2730013AB25 /* ext_inst.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92D21CED2730013AB25 /* ext_inst.h */; };
+		A972AB5621CED2730013AB25 /* diagnostic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92E21CED2730013AB25 /* diagnostic.cpp */; };
+		A972AB5721CED2730013AB25 /* diagnostic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A92E21CED2730013AB25 /* diagnostic.cpp */; };
+		A972AB5821CED2730013AB25 /* latest_version_spirv_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92F21CED2730013AB25 /* latest_version_spirv_header.h */; };
+		A972AB5921CED2730013AB25 /* latest_version_spirv_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A92F21CED2730013AB25 /* latest_version_spirv_header.h */; };
+		A972AB5A21CED2730013AB25 /* libspirv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93021CED2730013AB25 /* libspirv.cpp */; };
+		A972AB5B21CED2730013AB25 /* libspirv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93021CED2730013AB25 /* libspirv.cpp */; };
+		A972AB5C21CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93121CED2730013AB25 /* instruction.h */; };
+		A972AB5D21CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93121CED2730013AB25 /* instruction.h */; };
+		A972AB5E21CED2730013AB25 /* id_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93221CED2730013AB25 /* id_descriptor.h */; };
+		A972AB5F21CED2730013AB25 /* id_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93221CED2730013AB25 /* id_descriptor.h */; };
+		A972AB6021CED2730013AB25 /* spirv_optimizer_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93321CED2730013AB25 /* spirv_optimizer_options.h */; };
+		A972AB6121CED2730013AB25 /* spirv_optimizer_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93321CED2730013AB25 /* spirv_optimizer_options.h */; };
+		A972AB6221CED2730013AB25 /* opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93421CED2730013AB25 /* opcode.h */; };
+		A972AB6321CED2730013AB25 /* opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93421CED2730013AB25 /* opcode.h */; };
+		A972AB6421CED2730013AB25 /* operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93521CED2730013AB25 /* operand.cpp */; };
+		A972AB6521CED2730013AB25 /* operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93521CED2730013AB25 /* operand.cpp */; };
+		A972AB6621CED2730013AB25 /* latest_version_glsl_std_450_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93621CED2730013AB25 /* latest_version_glsl_std_450_header.h */; };
+		A972AB6721CED2730013AB25 /* latest_version_glsl_std_450_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93621CED2730013AB25 /* latest_version_glsl_std_450_header.h */; };
+		A972AB6821CED2730013AB25 /* extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93721CED2730013AB25 /* extensions.h */; };
+		A972AB6921CED2730013AB25 /* extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93721CED2730013AB25 /* extensions.h */; };
+		A972AB6A21CED2730013AB25 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93821CED2730013AB25 /* disassemble.cpp */; };
+		A972AB6B21CED2730013AB25 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93821CED2730013AB25 /* disassemble.cpp */; };
+		A972AB6C21CED2730013AB25 /* binary.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93921CED2730013AB25 /* binary.h */; };
+		A972AB6D21CED2730013AB25 /* binary.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93921CED2730013AB25 /* binary.h */; };
+		A972AB6E21CED2730013AB25 /* text_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93A21CED2730013AB25 /* text_handler.cpp */; };
+		A972AB6F21CED2730013AB25 /* text_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93A21CED2730013AB25 /* text_handler.cpp */; };
+		A972AB7021CED2730013AB25 /* validate_annotation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93C21CED2730013AB25 /* validate_annotation.cpp */; };
+		A972AB7121CED2730013AB25 /* validate_annotation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93C21CED2730013AB25 /* validate_annotation.cpp */; };
+		A972AB7221CED2730013AB25 /* validate_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93D21CED2730013AB25 /* validate_cfg.cpp */; };
+		A972AB7321CED2730013AB25 /* validate_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93D21CED2730013AB25 /* validate_cfg.cpp */; };
+		A972AB7421CED2730013AB25 /* validate_capability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93E21CED2730013AB25 /* validate_capability.cpp */; };
+		A972AB7521CED2730013AB25 /* validate_capability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A93E21CED2730013AB25 /* validate_capability.cpp */; };
+		A972AB7621CED2730013AB25 /* construct.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93F21CED2730013AB25 /* construct.h */; };
+		A972AB7721CED2730013AB25 /* construct.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A93F21CED2730013AB25 /* construct.h */; };
+		A972AB7821CED2730013AB25 /* validate_barriers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94021CED2730013AB25 /* validate_barriers.cpp */; };
+		A972AB7921CED2730013AB25 /* validate_barriers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94021CED2730013AB25 /* validate_barriers.cpp */; };
+		A972AB7A21CED2730013AB25 /* validate_non_uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94121CED2730013AB25 /* validate_non_uniform.cpp */; };
+		A972AB7B21CED2730013AB25 /* validate_non_uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94121CED2730013AB25 /* validate_non_uniform.cpp */; };
+		A972AB7C21CED2730013AB25 /* validate_atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94221CED2730013AB25 /* validate_atomics.cpp */; };
+		A972AB7D21CED2730013AB25 /* validate_atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94221CED2730013AB25 /* validate_atomics.cpp */; };
+		A972AB7E21CED2730013AB25 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94321CED2730013AB25 /* basic_block.h */; };
+		A972AB7F21CED2730013AB25 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94321CED2730013AB25 /* basic_block.h */; };
+		A972AB8021CED2730013AB25 /* validate_instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94421CED2730013AB25 /* validate_instruction.cpp */; };
+		A972AB8121CED2730013AB25 /* validate_instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94421CED2730013AB25 /* validate_instruction.cpp */; };
+		A972AB8221CED2730013AB25 /* validate_decorations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94521CED2730013AB25 /* validate_decorations.cpp */; };
+		A972AB8321CED2730013AB25 /* validate_decorations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94521CED2730013AB25 /* validate_decorations.cpp */; };
+		A972AB8421CED2730013AB25 /* validate_debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94621CED2730013AB25 /* validate_debug.cpp */; };
+		A972AB8521CED2730013AB25 /* validate_debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94621CED2730013AB25 /* validate_debug.cpp */; };
+		A972AB8621CED2730013AB25 /* validate_builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94721CED2730013AB25 /* validate_builtins.cpp */; };
+		A972AB8721CED2730013AB25 /* validate_builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94721CED2730013AB25 /* validate_builtins.cpp */; };
+		A972AB8821CED2730013AB25 /* validate_interfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94821CED2730013AB25 /* validate_interfaces.cpp */; };
+		A972AB8921CED2730013AB25 /* validate_interfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94821CED2730013AB25 /* validate_interfaces.cpp */; };
+		A972AB8A21CED2730013AB25 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94921CED2730013AB25 /* validate.cpp */; };
+		A972AB8B21CED2730013AB25 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94921CED2730013AB25 /* validate.cpp */; };
+		A972AB8C21CED2730013AB25 /* validation_state.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94A21CED2730013AB25 /* validation_state.h */; };
+		A972AB8D21CED2730013AB25 /* validation_state.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94A21CED2730013AB25 /* validation_state.h */; };
+		A972AB8E21CED2730013AB25 /* validate_constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94B21CED2730013AB25 /* validate_constants.cpp */; };
+		A972AB8F21CED2730013AB25 /* validate_constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94B21CED2730013AB25 /* validate_constants.cpp */; };
+		A972AB9021CED2730013AB25 /* validate_bitwise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94C21CED2730013AB25 /* validate_bitwise.cpp */; };
+		A972AB9121CED2730013AB25 /* validate_bitwise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94C21CED2730013AB25 /* validate_bitwise.cpp */; };
+		A972AB9221CED2730013AB25 /* construct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94D21CED2730013AB25 /* construct.cpp */; };
+		A972AB9321CED2730013AB25 /* construct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94D21CED2730013AB25 /* construct.cpp */; };
+		A972AB9421CED2730013AB25 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94E21CED2730013AB25 /* function.cpp */; };
+		A972AB9521CED2730013AB25 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A94E21CED2730013AB25 /* function.cpp */; };
+		A972AB9621CED2730013AB25 /* validate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94F21CED2730013AB25 /* validate.h */; };
+		A972AB9721CED2730013AB25 /* validate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A94F21CED2730013AB25 /* validate.h */; };
+		A972AB9821CED2730013AB25 /* validate_adjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95021CED2730013AB25 /* validate_adjacency.cpp */; };
+		A972AB9921CED2730013AB25 /* validate_adjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95021CED2730013AB25 /* validate_adjacency.cpp */; };
+		A972AB9A21CED2730013AB25 /* validate_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95121CED2730013AB25 /* validate_conversion.cpp */; };
+		A972AB9B21CED2730013AB25 /* validate_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95121CED2730013AB25 /* validate_conversion.cpp */; };
+		A972AB9C21CED2730013AB25 /* validate_datarules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95221CED2730013AB25 /* validate_datarules.cpp */; };
+		A972AB9D21CED2730013AB25 /* validate_datarules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95221CED2730013AB25 /* validate_datarules.cpp */; };
+		A972AB9E21CED2730013AB25 /* validate_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95321CED2730013AB25 /* validate_id.cpp */; };
+		A972AB9F21CED2730013AB25 /* validate_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95321CED2730013AB25 /* validate_id.cpp */; };
+		A972ABA021CED2730013AB25 /* validate_arithmetics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95421CED2730013AB25 /* validate_arithmetics.cpp */; };
+		A972ABA121CED2730013AB25 /* validate_arithmetics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95421CED2730013AB25 /* validate_arithmetics.cpp */; };
+		A972ABA221CED2730013AB25 /* validate_mode_setting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95521CED2730013AB25 /* validate_mode_setting.cpp */; };
+		A972ABA321CED2730013AB25 /* validate_mode_setting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95521CED2730013AB25 /* validate_mode_setting.cpp */; };
+		A972ABA421CED2730013AB25 /* validate_logicals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95621CED2730013AB25 /* validate_logicals.cpp */; };
+		A972ABA521CED2730013AB25 /* validate_logicals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95621CED2730013AB25 /* validate_logicals.cpp */; };
+		A972ABA621CED2730013AB25 /* validate_derivatives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95721CED2730013AB25 /* validate_derivatives.cpp */; };
+		A972ABA721CED2730013AB25 /* validate_derivatives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95721CED2730013AB25 /* validate_derivatives.cpp */; };
+		A972ABA821CED2730013AB25 /* validate_memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95821CED2730013AB25 /* validate_memory.cpp */; };
+		A972ABA921CED2730013AB25 /* validate_memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95821CED2730013AB25 /* validate_memory.cpp */; };
+		A972ABAA21CED2730013AB25 /* validate_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95921CED2730013AB25 /* validate_image.cpp */; };
+		A972ABAB21CED2730013AB25 /* validate_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95921CED2730013AB25 /* validate_image.cpp */; };
+		A972ABAC21CED2730013AB25 /* validate_literals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95A21CED2730013AB25 /* validate_literals.cpp */; };
+		A972ABAD21CED2730013AB25 /* validate_literals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95A21CED2730013AB25 /* validate_literals.cpp */; };
+		A972ABAE21CED2730013AB25 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95B21CED2730013AB25 /* instruction.cpp */; };
+		A972ABAF21CED2730013AB25 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95B21CED2730013AB25 /* instruction.cpp */; };
+		A972ABB021CED2730013AB25 /* validate_type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95C21CED2730013AB25 /* validate_type.cpp */; };
+		A972ABB121CED2730013AB25 /* validate_type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95C21CED2730013AB25 /* validate_type.cpp */; };
+		A972ABB221CED2730013AB25 /* validate_ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95D21CED2730013AB25 /* validate_ext_inst.cpp */; };
+		A972ABB321CED2730013AB25 /* validate_ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95D21CED2730013AB25 /* validate_ext_inst.cpp */; };
+		A972ABB421CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A95E21CED2730013AB25 /* instruction.h */; };
+		A972ABB521CED2730013AB25 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A95E21CED2730013AB25 /* instruction.h */; };
+		A972ABB621CED2730013AB25 /* validate_execution_limitations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95F21CED2730013AB25 /* validate_execution_limitations.cpp */; };
+		A972ABB721CED2730013AB25 /* validate_execution_limitations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A95F21CED2730013AB25 /* validate_execution_limitations.cpp */; };
+		A972ABB821CED2730013AB25 /* validate_layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96021CED2730013AB25 /* validate_layout.cpp */; };
+		A972ABB921CED2730013AB25 /* validate_layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96021CED2730013AB25 /* validate_layout.cpp */; };
+		A972ABBA21CED2730013AB25 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96121CED2730013AB25 /* basic_block.cpp */; };
+		A972ABBB21CED2730013AB25 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96121CED2730013AB25 /* basic_block.cpp */; };
+		A972ABBC21CED2730013AB25 /* validate_function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96221CED2730013AB25 /* validate_function.cpp */; };
+		A972ABBD21CED2730013AB25 /* validate_function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96221CED2730013AB25 /* validate_function.cpp */; };
+		A972ABBE21CED2730013AB25 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A96321CED2730013AB25 /* function.h */; };
+		A972ABBF21CED2730013AB25 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A96321CED2730013AB25 /* function.h */; };
+		A972ABC021CED2730013AB25 /* validate_composites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96421CED2730013AB25 /* validate_composites.cpp */; };
+		A972ABC121CED2730013AB25 /* validate_composites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96421CED2730013AB25 /* validate_composites.cpp */; };
+		A972ABC221CED2730013AB25 /* validation_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96521CED2730013AB25 /* validation_state.cpp */; };
+		A972ABC321CED2730013AB25 /* validation_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96521CED2730013AB25 /* validation_state.cpp */; };
+		A972ABC421CED2730013AB25 /* validate_primitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96621CED2730013AB25 /* validate_primitives.cpp */; };
+		A972ABC521CED2730013AB25 /* validate_primitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972A96621CED2730013AB25 /* validate_primitives.cpp */; };
+		A972ABC621CED2730013AB25 /* decoration.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A96721CED2730013AB25 /* decoration.h */; };
+		A972ABC721CED2730013AB25 /* decoration.h in Headers */ = {isa = PBXBuildFile; fileRef = A972A96721CED2730013AB25 /* decoration.h */; };
+		A972ABCB21CED7BC0013AB25 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290921CC60BC00B52A68 /* spirv_cfg.hpp */; };
+		A972ABCC21CED7BC0013AB25 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */; };
+		A972ABCD21CED7BC0013AB25 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290721CC60BC00B52A68 /* spirv_common.hpp */; };
+		A972ABCE21CED7BC0013AB25 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */; };
+		A972ABCF21CED7BC0013AB25 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290C21CC60BC00B52A68 /* spirv_parser.hpp */; };
+		A972ABD021CED7BC0013AB25 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290321CC60BC00B52A68 /* spirv_cross.hpp */; };
+		A972ABD121CED7BC0013AB25 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290221CC60BC00B52A68 /* spirv_msl.hpp */; };
+		A972ABD321CED7BC0013AB25 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290D21CC60BC00B52A68 /* spirv_msl.cpp */; };
+		A972ABD421CED7BC0013AB25 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290421CC60BC00B52A68 /* spirv_parser.cpp */; };
+		A972ABD521CED7BC0013AB25 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */; };
+		A972ABD621CED7BC0013AB25 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290521CC60BC00B52A68 /* spirv_cross.cpp */; };
+		A972ABD721CED7BC0013AB25 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290621CC60BC00B52A68 /* spirv_glsl.cpp */; };
+		A972ABD821CED7BC0013AB25 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */; };
+		A972ABDF21CED7CB0013AB25 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290921CC60BC00B52A68 /* spirv_cfg.hpp */; };
+		A972ABE021CED7CB0013AB25 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */; };
+		A972ABE121CED7CB0013AB25 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290721CC60BC00B52A68 /* spirv_common.hpp */; };
+		A972ABE221CED7CB0013AB25 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */; };
+		A972ABE321CED7CB0013AB25 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290C21CC60BC00B52A68 /* spirv_parser.hpp */; };
+		A972ABE421CED7CB0013AB25 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290321CC60BC00B52A68 /* spirv_cross.hpp */; };
+		A972ABE521CED7CB0013AB25 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290221CC60BC00B52A68 /* spirv_msl.hpp */; };
+		A972ABE721CED7CB0013AB25 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290D21CC60BC00B52A68 /* spirv_msl.cpp */; };
+		A972ABE821CED7CB0013AB25 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290421CC60BC00B52A68 /* spirv_parser.cpp */; };
+		A972ABE921CED7CB0013AB25 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */; };
+		A972ABEA21CED7CB0013AB25 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290521CC60BC00B52A68 /* spirv_cross.cpp */; };
+		A972ABEB21CED7CB0013AB25 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290621CC60BC00B52A68 /* spirv_glsl.cpp */; };
+		A972ABEC21CED7CB0013AB25 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */; };
+		A972AC6521CED9060013AB25 /* InitializeDll.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABF721CED9060013AB25 /* InitializeDll.h */; };
+		A972AC6621CED9060013AB25 /* InitializeDll.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABF721CED9060013AB25 /* InitializeDll.h */; };
+		A972AC6721CED9060013AB25 /* InitializeDll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABF821CED9060013AB25 /* InitializeDll.cpp */; };
+		A972AC6821CED9060013AB25 /* InitializeDll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABF821CED9060013AB25 /* InitializeDll.cpp */; };
+		A972AC6921CED9060013AB25 /* SPVRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFA21CED9060013AB25 /* SPVRemapper.h */; };
+		A972AC6A21CED9060013AB25 /* SPVRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFA21CED9060013AB25 /* SPVRemapper.h */; };
+		A972AC6B21CED9060013AB25 /* SpvBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFB21CED9060013AB25 /* SpvBuilder.h */; };
+		A972AC6C21CED9060013AB25 /* SpvBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFB21CED9060013AB25 /* SpvBuilder.h */; };
+		A972AC6D21CED9060013AB25 /* SpvPostProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABFD21CED9060013AB25 /* SpvPostProcess.cpp */; };
+		A972AC6E21CED9060013AB25 /* SpvPostProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABFD21CED9060013AB25 /* SpvPostProcess.cpp */; };
+		A972AC6F21CED9060013AB25 /* SpvTools.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFE21CED9060013AB25 /* SpvTools.h */; };
+		A972AC7021CED9060013AB25 /* SpvTools.h in Headers */ = {isa = PBXBuildFile; fileRef = A972ABFE21CED9060013AB25 /* SpvTools.h */; };
+		A972AC7121CED9060013AB25 /* SpvTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABFF21CED9060013AB25 /* SpvTools.cpp */; };
+		A972AC7221CED9060013AB25 /* SpvTools.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972ABFF21CED9060013AB25 /* SpvTools.cpp */; };
+		A972AC7321CED9060013AB25 /* InReadableOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0021CED9060013AB25 /* InReadableOrder.cpp */; };
+		A972AC7421CED9060013AB25 /* InReadableOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0021CED9060013AB25 /* InReadableOrder.cpp */; };
+		A972AC7521CED9060013AB25 /* GLSL.ext.AMD.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0121CED9060013AB25 /* GLSL.ext.AMD.h */; };
+		A972AC7621CED9060013AB25 /* GLSL.ext.AMD.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0121CED9060013AB25 /* GLSL.ext.AMD.h */; };
+		A972AC7721CED9060013AB25 /* doc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0221CED9060013AB25 /* doc.h */; };
+		A972AC7821CED9060013AB25 /* doc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0221CED9060013AB25 /* doc.h */; };
+		A972AC7921CED9060013AB25 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0321CED9060013AB25 /* spirv.hpp */; };
+		A972AC7A21CED9060013AB25 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0321CED9060013AB25 /* spirv.hpp */; };
+		A972AC7B21CED9060013AB25 /* SpvBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0421CED9060013AB25 /* SpvBuilder.cpp */; };
+		A972AC7C21CED9060013AB25 /* SpvBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0421CED9060013AB25 /* SpvBuilder.cpp */; };
+		A972AC7D21CED9060013AB25 /* GLSL.ext.EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0521CED9060013AB25 /* GLSL.ext.EXT.h */; };
+		A972AC7E21CED9060013AB25 /* GLSL.ext.EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0521CED9060013AB25 /* GLSL.ext.EXT.h */; };
+		A972AC7F21CED9060013AB25 /* GLSL.ext.KHR.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0621CED9060013AB25 /* GLSL.ext.KHR.h */; };
+		A972AC8021CED9060013AB25 /* GLSL.ext.KHR.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0621CED9060013AB25 /* GLSL.ext.KHR.h */; };
+		A972AC8121CED9060013AB25 /* GLSL.ext.NV.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0721CED9060013AB25 /* GLSL.ext.NV.h */; };
+		A972AC8221CED9060013AB25 /* GLSL.ext.NV.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0721CED9060013AB25 /* GLSL.ext.NV.h */; };
+		A972AC8321CED9060013AB25 /* GlslangToSpv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0821CED9060013AB25 /* GlslangToSpv.cpp */; };
+		A972AC8421CED9060013AB25 /* GlslangToSpv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0821CED9060013AB25 /* GlslangToSpv.cpp */; };
+		A972AC8521CED9060013AB25 /* spvIR.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0921CED9060013AB25 /* spvIR.h */; };
+		A972AC8621CED9060013AB25 /* spvIR.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0921CED9060013AB25 /* spvIR.h */; };
+		A972AC8721CED9060013AB25 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0A21CED9060013AB25 /* bitutils.h */; };
+		A972AC8821CED9060013AB25 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0A21CED9060013AB25 /* bitutils.h */; };
+		A972AC8921CED9060013AB25 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0B21CED9060013AB25 /* disassemble.h */; };
+		A972AC8A21CED9060013AB25 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0B21CED9060013AB25 /* disassemble.h */; };
+		A972AC8B21CED9060013AB25 /* GlslangToSpv.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0C21CED9060013AB25 /* GlslangToSpv.h */; };
+		A972AC8C21CED9060013AB25 /* GlslangToSpv.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0C21CED9060013AB25 /* GlslangToSpv.h */; };
+		A972AC8D21CED9060013AB25 /* GLSL.std.450.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0D21CED9060013AB25 /* GLSL.std.450.h */; };
+		A972AC8E21CED9060013AB25 /* GLSL.std.450.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC0D21CED9060013AB25 /* GLSL.std.450.h */; };
+		A972AC8F21CED9060013AB25 /* SPVRemapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0E21CED9060013AB25 /* SPVRemapper.cpp */; };
+		A972AC9021CED9060013AB25 /* SPVRemapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0E21CED9060013AB25 /* SPVRemapper.cpp */; };
+		A972AC9121CED9060013AB25 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0F21CED9060013AB25 /* Logger.cpp */; };
+		A972AC9221CED9060013AB25 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC0F21CED9060013AB25 /* Logger.cpp */; };
+		A972AC9321CED9060013AB25 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1021CED9060013AB25 /* hex_float.h */; };
+		A972AC9421CED9060013AB25 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1021CED9060013AB25 /* hex_float.h */; };
+		A972AC9521CED9060013AB25 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1121CED9060013AB25 /* Logger.h */; };
+		A972AC9621CED9060013AB25 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1121CED9060013AB25 /* Logger.h */; };
+		A972AC9721CED9060013AB25 /* doc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1221CED9060013AB25 /* doc.cpp */; };
+		A972AC9821CED9060013AB25 /* doc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1221CED9060013AB25 /* doc.cpp */; };
+		A972AC9921CED9060013AB25 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1321CED9060013AB25 /* disassemble.cpp */; };
+		A972AC9A21CED9060013AB25 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1321CED9060013AB25 /* disassemble.cpp */; };
+		A972AC9B21CED9060013AB25 /* ossource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1821CED9060013AB25 /* ossource.cpp */; };
+		A972AC9C21CED9060013AB25 /* ossource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC1821CED9060013AB25 /* ossource.cpp */; };
+		A972AC9D21CED9060013AB25 /* osinclude.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1A21CED9060013AB25 /* osinclude.h */; };
+		A972AC9E21CED9060013AB25 /* osinclude.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC1A21CED9060013AB25 /* osinclude.h */; };
+		A972ACA321CED9060013AB25 /* ResourceLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2021CED9060013AB25 /* ResourceLimits.h */; };
+		A972ACA421CED9060013AB25 /* ResourceLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2021CED9060013AB25 /* ResourceLimits.h */; };
+		A972ACA521CED9060013AB25 /* Types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2121CED9060013AB25 /* Types.h */; };
+		A972ACA621CED9060013AB25 /* Types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2121CED9060013AB25 /* Types.h */; };
+		A972ACA721CED9060013AB25 /* intermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2221CED9060013AB25 /* intermediate.h */; };
+		A972ACA821CED9060013AB25 /* intermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2221CED9060013AB25 /* intermediate.h */; };
+		A972ACA921CED9060013AB25 /* BaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2321CED9060013AB25 /* BaseTypes.h */; };
+		A972ACAA21CED9060013AB25 /* BaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2321CED9060013AB25 /* BaseTypes.h */; };
+		A972ACAB21CED9060013AB25 /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2421CED9060013AB25 /* revision.h */; };
+		A972ACAC21CED9060013AB25 /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2421CED9060013AB25 /* revision.h */; };
+		A972ACAD21CED9060013AB25 /* InitializeGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2521CED9060013AB25 /* InitializeGlobals.h */; };
+		A972ACAE21CED9060013AB25 /* InitializeGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2521CED9060013AB25 /* InitializeGlobals.h */; };
+		A972ACAF21CED9060013AB25 /* ShHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2621CED9060013AB25 /* ShHandle.h */; };
+		A972ACB021CED9060013AB25 /* ShHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2621CED9060013AB25 /* ShHandle.h */; };
+		A972ACB121CED9060013AB25 /* arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2721CED9060013AB25 /* arrays.h */; };
+		A972ACB221CED9060013AB25 /* arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2721CED9060013AB25 /* arrays.h */; };
+		A972ACB321CED9060013AB25 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2821CED9060013AB25 /* Common.h */; };
+		A972ACB421CED9060013AB25 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2821CED9060013AB25 /* Common.h */; };
+		A972ACB521CED9060013AB25 /* ConstantUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2A21CED9060013AB25 /* ConstantUnion.h */; };
+		A972ACB621CED9060013AB25 /* ConstantUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2A21CED9060013AB25 /* ConstantUnion.h */; };
+		A972ACB721CED9060013AB25 /* InfoSink.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2B21CED9060013AB25 /* InfoSink.h */; };
+		A972ACB821CED9060013AB25 /* InfoSink.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2B21CED9060013AB25 /* InfoSink.h */; };
+		A972ACB921CED9060013AB25 /* PoolAlloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2C21CED9060013AB25 /* PoolAlloc.h */; };
+		A972ACBA21CED9060013AB25 /* PoolAlloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC2C21CED9060013AB25 /* PoolAlloc.h */; };
+		A972ACBB21CED9060013AB25 /* ParseHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC2F21CED9060013AB25 /* ParseHelper.cpp */; };
+		A972ACBC21CED9060013AB25 /* ParseHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC2F21CED9060013AB25 /* ParseHelper.cpp */; };
+		A972ACBD21CED9060013AB25 /* parseVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3021CED9060013AB25 /* parseVersions.h */; };
+		A972ACBE21CED9060013AB25 /* parseVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3021CED9060013AB25 /* parseVersions.h */; };
+		A972ACBF21CED9060013AB25 /* gl_types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3121CED9060013AB25 /* gl_types.h */; };
+		A972ACC021CED9060013AB25 /* gl_types.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3121CED9060013AB25 /* gl_types.h */; };
+		A972ACC121CED9060013AB25 /* propagateNoContraction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3221CED9060013AB25 /* propagateNoContraction.cpp */; };
+		A972ACC221CED9060013AB25 /* propagateNoContraction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3221CED9060013AB25 /* propagateNoContraction.cpp */; };
+		A972ACC321CED9060013AB25 /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3321CED9060013AB25 /* pch.h */; };
+		A972ACC421CED9060013AB25 /* pch.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3321CED9060013AB25 /* pch.h */; };
+		A972ACC521CED9060013AB25 /* ScanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3421CED9060013AB25 /* ScanContext.h */; };
+		A972ACC621CED9060013AB25 /* ScanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3421CED9060013AB25 /* ScanContext.h */; };
+		A972ACC721CED9060013AB25 /* iomapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3521CED9060013AB25 /* iomapper.h */; };
+		A972ACC821CED9060013AB25 /* iomapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3521CED9060013AB25 /* iomapper.h */; };
+		A972ACC921CED9060013AB25 /* localintermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3621CED9060013AB25 /* localintermediate.h */; };
+		A972ACCA21CED9060013AB25 /* localintermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3621CED9060013AB25 /* localintermediate.h */; };
+		A972ACCB21CED9060013AB25 /* Scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3721CED9060013AB25 /* Scan.cpp */; };
+		A972ACCC21CED9060013AB25 /* Scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3721CED9060013AB25 /* Scan.cpp */; };
+		A972ACCF21CED9060013AB25 /* RemoveTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3921CED9060013AB25 /* RemoveTree.h */; };
+		A972ACD021CED9060013AB25 /* RemoveTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3921CED9060013AB25 /* RemoveTree.h */; };
+		A972ACD121CED9060013AB25 /* Initialize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3A21CED9060013AB25 /* Initialize.cpp */; };
+		A972ACD221CED9060013AB25 /* Initialize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3A21CED9060013AB25 /* Initialize.cpp */; };
+		A972ACD321CED9060013AB25 /* glslang_tab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3B21CED9060013AB25 /* glslang_tab.cpp */; };
+		A972ACD421CED9060013AB25 /* glslang_tab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3B21CED9060013AB25 /* glslang_tab.cpp */; };
+		A972ACD521CED9060013AB25 /* limits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3C21CED9060013AB25 /* limits.cpp */; };
+		A972ACD621CED9060013AB25 /* limits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3C21CED9060013AB25 /* limits.cpp */; };
+		A972ACD721CED9060013AB25 /* parseConst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3D21CED9060013AB25 /* parseConst.cpp */; };
+		A972ACD821CED9060013AB25 /* parseConst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC3D21CED9060013AB25 /* parseConst.cpp */; };
+		A972ACD921CED9060013AB25 /* propagateNoContraction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3E21CED9060013AB25 /* propagateNoContraction.h */; };
+		A972ACDA21CED9060013AB25 /* propagateNoContraction.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3E21CED9060013AB25 /* propagateNoContraction.h */; };
+		A972ACDB21CED9060013AB25 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3F21CED9060013AB25 /* Versions.h */; };
+		A972ACDC21CED9060013AB25 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC3F21CED9060013AB25 /* Versions.h */; };
+		A972ACDD21CED9060013AB25 /* IntermTraverse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4021CED9060013AB25 /* IntermTraverse.cpp */; };
+		A972ACDE21CED9060013AB25 /* IntermTraverse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4021CED9060013AB25 /* IntermTraverse.cpp */; };
+		A972ACDF21CED9060013AB25 /* intermOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4121CED9060013AB25 /* intermOut.cpp */; };
+		A972ACE021CED9060013AB25 /* intermOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4121CED9060013AB25 /* intermOut.cpp */; };
+		A972ACE121CED9060013AB25 /* iomapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4221CED9060013AB25 /* iomapper.cpp */; };
+		A972ACE221CED9060013AB25 /* iomapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4221CED9060013AB25 /* iomapper.cpp */; };
+		A972ACE321CED9060013AB25 /* PoolAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4321CED9060013AB25 /* PoolAlloc.cpp */; };
+		A972ACE421CED9060013AB25 /* PoolAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4321CED9060013AB25 /* PoolAlloc.cpp */; };
+		A972ACE521CED9060013AB25 /* ShaderLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4421CED9060013AB25 /* ShaderLang.cpp */; };
+		A972ACE621CED9060013AB25 /* ShaderLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4421CED9060013AB25 /* ShaderLang.cpp */; };
+		A972ACE721CED9060013AB25 /* SymbolTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4521CED9060013AB25 /* SymbolTable.h */; };
+		A972ACE821CED9060013AB25 /* SymbolTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4521CED9060013AB25 /* SymbolTable.h */; };
+		A972ACE921CED9060013AB25 /* InfoSink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4621CED9060013AB25 /* InfoSink.cpp */; };
+		A972ACEA21CED9060013AB25 /* InfoSink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4621CED9060013AB25 /* InfoSink.cpp */; };
+		A972ACEB21CED9060013AB25 /* Intermediate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4721CED9060013AB25 /* Intermediate.cpp */; };
+		A972ACEC21CED9060013AB25 /* Intermediate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4721CED9060013AB25 /* Intermediate.cpp */; };
+		A972ACED21CED9060013AB25 /* pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4821CED9060013AB25 /* pch.cpp */; };
+		A972ACEE21CED9060013AB25 /* pch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4821CED9060013AB25 /* pch.cpp */; };
+		A972ACEF21CED9060013AB25 /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4921CED9060013AB25 /* SymbolTable.cpp */; };
+		A972ACF021CED9060013AB25 /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4921CED9060013AB25 /* SymbolTable.cpp */; };
+		A972ACF121CED9060013AB25 /* glslang_tab.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4A21CED9060013AB25 /* glslang_tab.cpp.h */; };
+		A972ACF221CED9060013AB25 /* glslang_tab.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4A21CED9060013AB25 /* glslang_tab.cpp.h */; };
+		A972ACF321CED9060013AB25 /* LiveTraverser.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4B21CED9060013AB25 /* LiveTraverser.h */; };
+		A972ACF421CED9060013AB25 /* LiveTraverser.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4B21CED9060013AB25 /* LiveTraverser.h */; };
+		A972ACF521CED9060013AB25 /* Initialize.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4C21CED9060013AB25 /* Initialize.h */; };
+		A972ACF621CED9060013AB25 /* Initialize.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC4C21CED9060013AB25 /* Initialize.h */; };
+		A972ACF721CED9060013AB25 /* attribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4D21CED9060013AB25 /* attribute.cpp */; };
+		A972ACF821CED9060013AB25 /* attribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4D21CED9060013AB25 /* attribute.cpp */; };
+		A972ACF921CED9060013AB25 /* reflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4E21CED9060013AB25 /* reflection.cpp */; };
+		A972ACFA21CED9060013AB25 /* reflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4E21CED9060013AB25 /* reflection.cpp */; };
+		A972ACFB21CED9060013AB25 /* RemoveTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4F21CED9060013AB25 /* RemoveTree.cpp */; };
+		A972ACFC21CED9060013AB25 /* RemoveTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC4F21CED9060013AB25 /* RemoveTree.cpp */; };
+		A972ACFD21CED9060013AB25 /* attribute.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5021CED9060013AB25 /* attribute.h */; };
+		A972ACFE21CED9060013AB25 /* attribute.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5021CED9060013AB25 /* attribute.h */; };
+		A972ACFF21CED9060013AB25 /* Versions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5121CED9060013AB25 /* Versions.cpp */; };
+		A972AD0021CED9060013AB25 /* Versions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5121CED9060013AB25 /* Versions.cpp */; };
+		A972AD0121CED9060013AB25 /* Constant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5221CED9060013AB25 /* Constant.cpp */; };
+		A972AD0221CED9060013AB25 /* Constant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5221CED9060013AB25 /* Constant.cpp */; };
+		A972AD0321CED9060013AB25 /* linkValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5321CED9060013AB25 /* linkValidate.cpp */; };
+		A972AD0421CED9060013AB25 /* linkValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5321CED9060013AB25 /* linkValidate.cpp */; };
+		A972AD0521CED9060013AB25 /* ParseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5421CED9060013AB25 /* ParseHelper.h */; };
+		A972AD0621CED9060013AB25 /* ParseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5421CED9060013AB25 /* ParseHelper.h */; };
+		A972AD0721CED9060013AB25 /* PpAtom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5621CED9060013AB25 /* PpAtom.cpp */; };
+		A972AD0821CED9060013AB25 /* PpAtom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5621CED9060013AB25 /* PpAtom.cpp */; };
+		A972AD0921CED9060013AB25 /* PpTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5721CED9060013AB25 /* PpTokens.h */; };
+		A972AD0A21CED9060013AB25 /* PpTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5721CED9060013AB25 /* PpTokens.h */; };
+		A972AD0B21CED9060013AB25 /* Pp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5821CED9060013AB25 /* Pp.cpp */; };
+		A972AD0C21CED9060013AB25 /* Pp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5821CED9060013AB25 /* Pp.cpp */; };
+		A972AD0D21CED9060013AB25 /* PpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5921CED9060013AB25 /* PpContext.h */; };
+		A972AD0E21CED9060013AB25 /* PpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5921CED9060013AB25 /* PpContext.h */; };
+		A972AD0F21CED9060013AB25 /* PpTokens.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5A21CED9060013AB25 /* PpTokens.cpp */; };
+		A972AD1021CED9060013AB25 /* PpTokens.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5A21CED9060013AB25 /* PpTokens.cpp */; };
+		A972AD1121CED9060013AB25 /* PpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5B21CED9060013AB25 /* PpContext.cpp */; };
+		A972AD1221CED9060013AB25 /* PpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5B21CED9060013AB25 /* PpContext.cpp */; };
+		A972AD1321CED9060013AB25 /* PpScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5C21CED9060013AB25 /* PpScanner.cpp */; };
+		A972AD1421CED9060013AB25 /* PpScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5C21CED9060013AB25 /* PpScanner.cpp */; };
+		A972AD1521CED9060013AB25 /* ParseContextBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5D21CED9060013AB25 /* ParseContextBase.cpp */; };
+		A972AD1621CED9060013AB25 /* ParseContextBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC5D21CED9060013AB25 /* ParseContextBase.cpp */; };
+		A972AD1721CED9060013AB25 /* reflection.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5E21CED9060013AB25 /* reflection.h */; };
+		A972AD1821CED9060013AB25 /* reflection.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5E21CED9060013AB25 /* reflection.h */; };
+		A972AD1921CED9060013AB25 /* Scan.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5F21CED9060013AB25 /* Scan.h */; };
+		A972AD1A21CED9060013AB25 /* Scan.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC5F21CED9060013AB25 /* Scan.h */; };
+		A972AD1B21CED9060013AB25 /* ShaderLang.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC6121CED9060013AB25 /* ShaderLang.h */; };
+		A972AD1C21CED9060013AB25 /* ShaderLang.h in Headers */ = {isa = PBXBuildFile; fileRef = A972AC6121CED9060013AB25 /* ShaderLang.h */; };
+		A972AD1D21CED9060013AB25 /* CodeGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC6321CED9060013AB25 /* CodeGen.cpp */; };
+		A972AD1E21CED9060013AB25 /* CodeGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC6321CED9060013AB25 /* CodeGen.cpp */; };
+		A972AD1F21CED9060013AB25 /* Link.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC6421CED9060013AB25 /* Link.cpp */; };
+		A972AD2021CED9060013AB25 /* Link.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A972AC6421CED9060013AB25 /* Link.cpp */; };
+		A976290F21CC60BC00B52A68 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290221CC60BC00B52A68 /* spirv_msl.hpp */; };
+		A976291021CC60BC00B52A68 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290221CC60BC00B52A68 /* spirv_msl.hpp */; };
+		A976291121CC60BC00B52A68 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290321CC60BC00B52A68 /* spirv_cross.hpp */; };
+		A976291221CC60BC00B52A68 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290321CC60BC00B52A68 /* spirv_cross.hpp */; };
+		A976291321CC60BC00B52A68 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290421CC60BC00B52A68 /* spirv_parser.cpp */; };
+		A976291421CC60BC00B52A68 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290421CC60BC00B52A68 /* spirv_parser.cpp */; };
+		A976291521CC60BC00B52A68 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290521CC60BC00B52A68 /* spirv_cross.cpp */; };
+		A976291621CC60BC00B52A68 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290521CC60BC00B52A68 /* spirv_cross.cpp */; };
+		A976291721CC60BC00B52A68 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290621CC60BC00B52A68 /* spirv_glsl.cpp */; };
+		A976291821CC60BC00B52A68 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290621CC60BC00B52A68 /* spirv_glsl.cpp */; };
+		A976291921CC60BC00B52A68 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290721CC60BC00B52A68 /* spirv_common.hpp */; };
+		A976291A21CC60BC00B52A68 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290721CC60BC00B52A68 /* spirv_common.hpp */; };
+		A976291B21CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */; };
+		A976291C21CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */; };
+		A976291D21CC60BC00B52A68 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290921CC60BC00B52A68 /* spirv_cfg.hpp */; };
+		A976291E21CC60BC00B52A68 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290921CC60BC00B52A68 /* spirv_cfg.hpp */; };
+		A976291F21CC60BC00B52A68 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */; };
+		A976292021CC60BC00B52A68 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */; };
+		A976292121CC60BC00B52A68 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */; };
+		A976292221CC60BC00B52A68 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */; };
+		A976292321CC60BC00B52A68 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290C21CC60BC00B52A68 /* spirv_parser.hpp */; };
+		A976292421CC60BC00B52A68 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A976290C21CC60BC00B52A68 /* spirv_parser.hpp */; };
+		A976292521CC60BC00B52A68 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290D21CC60BC00B52A68 /* spirv_msl.cpp */; };
+		A976292621CC60BC00B52A68 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290D21CC60BC00B52A68 /* spirv_msl.cpp */; };
+		A976292721CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */; };
+		A976292821CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A972A7E821CEC76A0013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A90FD8A021CC4EB900B92BB2;
+			remoteInfo = "SPIRV-Cross-macOS";
+		};
+		A972A7F021CEC8140013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A90FD75B21CC4EAB00B92BB2;
+			remoteInfo = "SPIRV-Cross-iOS";
+		};
+		A972A7F821CEC8500013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972A7E421CEC72F0013AB25;
+			remoteInfo = "ExternalLibraries-macOS";
+		};
+		A972A7FA21CEC8540013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972A7EA21CEC8030013AB25;
+			remoteInfo = "ExternalLibraries-iOS";
+		};
+		A972A82521CECD6B0013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972A7FC21CECBBF0013AB25;
+			remoteInfo = "SPIRV-Tools-iOS";
+		};
+		A972A82721CECD780013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972A81021CECBE90013AB25;
+			remoteInfo = "SPIRV-Tools-macOS";
+		};
+		A972ABF121CED8BA0013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972ABC921CED7BC0013AB25;
+			remoteInfo = "glslang-iOS";
+		};
+		A972ABF321CED8C20013AB25 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9F55D25198BE6A7004EC31B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A972ABDD21CED7CB0013AB25;
+			remoteInfo = "glslang-macOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A90FD89F21CC4EAB00B92BB2 /* libSPIRVCross.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVCross.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A90FD9E421CC4EB900B92BB2 /* libSPIRVCross.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVCross.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A972A80F21CECBBF0013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVTools.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A972A82321CECBE90013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVTools.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A972A82A21CED2720013AB25 /* spirv_target_env.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_target_env.cpp; sourceTree = "<group>"; };
+		A972A82B21CED2720013AB25 /* extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json"; sourceTree = "<group>"; };
+		A972A82C21CED2720013AB25 /* assembly_grammar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assembly_grammar.h; sourceTree = "<group>"; };
+		A972A82D21CED2720013AB25 /* enum_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_set.h; sourceTree = "<group>"; };
+		A972A82E21CED2720013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972A82F21CED2720013AB25 /* extinst.spv-amd-shader-ballot.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-ballot.grammar.json"; sourceTree = "<group>"; };
+		A972A83021CED2720013AB25 /* text.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = text.cpp; sourceTree = "<group>"; };
+		A972A83121CED2720013AB25 /* assembly_grammar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = assembly_grammar.cpp; sourceTree = "<group>"; };
+		A972A83221CED2720013AB25 /* text.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = text.h; sourceTree = "<group>"; };
+		A972A83321CED2720013AB25 /* extensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = extensions.cpp; sourceTree = "<group>"; };
+		A972A83421CED2720013AB25 /* pch_source.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pch_source.cpp; sourceTree = "<group>"; };
+		A972A83621CED2720013AB25 /* parse_number.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parse_number.h; sourceTree = "<group>"; };
+		A972A83721CED2720013AB25 /* ilist_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ilist_node.h; sourceTree = "<group>"; };
+		A972A83821CED2720013AB25 /* make_unique.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = make_unique.h; sourceTree = "<group>"; };
+		A972A83921CED2720013AB25 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_utils.h; sourceTree = "<group>"; };
+		A972A83A21CED2720013AB25 /* small_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = small_vector.h; sourceTree = "<group>"; };
+		A972A83B21CED2720013AB25 /* timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = timer.cpp; sourceTree = "<group>"; };
+		A972A83C21CED2720013AB25 /* timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timer.h; sourceTree = "<group>"; };
+		A972A83D21CED2720013AB25 /* string_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_utils.cpp; sourceTree = "<group>"; };
+		A972A83E21CED2720013AB25 /* bit_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_vector.h; sourceTree = "<group>"; };
+		A972A83F21CED2720013AB25 /* bitutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitutils.h; sourceTree = "<group>"; };
+		A972A84021CED2720013AB25 /* hex_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hex_float.h; sourceTree = "<group>"; };
+		A972A84121CED2720013AB25 /* parse_number.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parse_number.cpp; sourceTree = "<group>"; };
+		A972A84221CED2720013AB25 /* bit_vector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bit_vector.cpp; sourceTree = "<group>"; };
+		A972A84321CED2720013AB25 /* ilist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ilist.h; sourceTree = "<group>"; };
+		A972A84421CED2720013AB25 /* spirv_target_env.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_target_env.h; sourceTree = "<group>"; };
+		A972A84521CED2720013AB25 /* table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = table.cpp; sourceTree = "<group>"; };
+		A972A84621CED2720013AB25 /* id_descriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = id_descriptor.cpp; sourceTree = "<group>"; };
+		A972A84721CED2720013AB25 /* latest_version_opencl_std_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_opencl_std_header.h; sourceTree = "<group>"; };
+		A972A84821CED2720013AB25 /* spirv_optimizer_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_optimizer_options.cpp; sourceTree = "<group>"; };
+		A972A84921CED2720013AB25 /* cfa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfa.h; sourceTree = "<group>"; };
+		A972A84A21CED2720013AB25 /* pch_source.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pch_source.h; sourceTree = "<group>"; };
+		A972A84B21CED2720013AB25 /* enum_string_mapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_string_mapping.h; sourceTree = "<group>"; };
+		A972A84C21CED2720013AB25 /* spirv_validator_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_validator_options.cpp; sourceTree = "<group>"; };
+		A972A84D21CED2720013AB25 /* extinst.spv-amd-shader-trinary-minmax.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-trinary-minmax.grammar.json"; sourceTree = "<group>"; };
+		A972A84E21CED2720013AB25 /* print.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = print.cpp; sourceTree = "<group>"; };
+		A972A84F21CED2720013AB25 /* spirv_definition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_definition.h; sourceTree = "<group>"; };
+		A972A85021CED2720013AB25 /* operand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operand.h; sourceTree = "<group>"; };
+		A972A85121CED2720013AB25 /* spirv_endian.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_endian.cpp; sourceTree = "<group>"; };
+		A972A85221CED2720013AB25 /* macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macro.h; sourceTree = "<group>"; };
+		A972A85321CED2720013AB25 /* spirv_constant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_constant.h; sourceTree = "<group>"; };
+		A972A85421CED2720013AB25 /* extinst.spv-amd-gcn-shader.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-gcn-shader.grammar.json"; sourceTree = "<group>"; };
+		A972A85521CED2720013AB25 /* binary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = binary.cpp; sourceTree = "<group>"; };
+		A972A85621CED2720013AB25 /* spirv_validator_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_validator_options.h; sourceTree = "<group>"; };
+		A972A85821CED2720013AB25 /* markv_codec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_codec.cpp; sourceTree = "<group>"; };
+		A972A85921CED2720013AB25 /* markv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv.cpp; sourceTree = "<group>"; };
+		A972A85A21CED2720013AB25 /* huffman_codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman_codec.h; sourceTree = "<group>"; };
+		A972A85B21CED2720013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972A85C21CED2720013AB25 /* bit_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_stream.h; sourceTree = "<group>"; };
+		A972A85D21CED2720013AB25 /* move_to_front.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = move_to_front.cpp; sourceTree = "<group>"; };
+		A972A85E21CED2720013AB25 /* markv_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_encoder.h; sourceTree = "<group>"; };
+		A972A85F21CED2720013AB25 /* markv_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_decoder.h; sourceTree = "<group>"; };
+		A972A86021CED2720013AB25 /* markv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv.h; sourceTree = "<group>"; };
+		A972A86121CED2720013AB25 /* markv_model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_model.h; sourceTree = "<group>"; };
+		A972A86221CED2720013AB25 /* markv_decoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_decoder.cpp; sourceTree = "<group>"; };
+		A972A86321CED2720013AB25 /* move_to_front.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = move_to_front.h; sourceTree = "<group>"; };
+		A972A86421CED2720013AB25 /* markv_codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_codec.h; sourceTree = "<group>"; };
+		A972A86521CED2720013AB25 /* markv_logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_logger.h; sourceTree = "<group>"; };
+		A972A86621CED2720013AB25 /* bit_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bit_stream.cpp; sourceTree = "<group>"; };
+		A972A86721CED2720013AB25 /* markv_encoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_encoder.cpp; sourceTree = "<group>"; };
+		A972A86821CED2720013AB25 /* enum_string_mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = enum_string_mapping.cpp; sourceTree = "<group>"; };
+		A972A86921CED2720013AB25 /* text_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = text_handler.h; sourceTree = "<group>"; };
+		A972A86A21CED2720013AB25 /* parsed_operand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parsed_operand.h; sourceTree = "<group>"; };
+		A972A86B21CED2720013AB25 /* name_mapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = name_mapper.h; sourceTree = "<group>"; };
+		A972A86C21CED2720013AB25 /* parsed_operand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parsed_operand.cpp; sourceTree = "<group>"; };
+		A972A86D21CED2720013AB25 /* diagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = diagnostic.h; sourceTree = "<group>"; };
+		A972A86E21CED2720013AB25 /* spirv_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_endian.h; sourceTree = "<group>"; };
+		A972A86F21CED2720013AB25 /* name_mapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = name_mapper.cpp; sourceTree = "<group>"; };
+		A972A87021CED2720013AB25 /* extinst.debuginfo.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = extinst.debuginfo.grammar.json; sourceTree = "<group>"; };
+		A972A87221CED2720013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972A87321CED2720013AB25 /* linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = linker.cpp; sourceTree = "<group>"; };
+		A972A87421CED2720013AB25 /* software_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = software_version.cpp; sourceTree = "<group>"; };
+		A972A87521CED2720013AB25 /* opcode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = opcode.cpp; sourceTree = "<group>"; };
+		A972A87621CED2720013AB25 /* print.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = print.h; sourceTree = "<group>"; };
+		A972A87721CED2720013AB25 /* ext_inst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ext_inst.cpp; sourceTree = "<group>"; };
+		A972A87821CED2720013AB25 /* disassemble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disassemble.h; sourceTree = "<group>"; };
+		A972A87A21CED2720013AB25 /* optimizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = optimizer.cpp; sourceTree = "<group>"; };
+		A972A87B21CED2720013AB25 /* if_conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = if_conversion.h; sourceTree = "<group>"; };
+		A972A87C21CED2720013AB25 /* register_pressure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = register_pressure.cpp; sourceTree = "<group>"; };
+		A972A87D21CED2720013AB25 /* loop_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_utils.cpp; sourceTree = "<group>"; };
+		A972A87E21CED2720013AB25 /* merge_return_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = merge_return_pass.h; sourceTree = "<group>"; };
+		A972A87F21CED2720013AB25 /* inline_opaque_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_opaque_pass.h; sourceTree = "<group>"; };
+		A972A88021CED2720013AB25 /* loop_fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fusion.h; sourceTree = "<group>"; };
+		A972A88121CED2720013AB25 /* combine_access_chains.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = combine_access_chains.cpp; sourceTree = "<group>"; };
+		A972A88221CED2720013AB25 /* build_module.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = build_module.cpp; sourceTree = "<group>"; };
+		A972A88321CED2720013AB25 /* composite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = composite.h; sourceTree = "<group>"; };
+		A972A88421CED2720013AB25 /* compact_ids_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compact_ids_pass.h; sourceTree = "<group>"; };
+		A972A88521CED2720013AB25 /* register_pressure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = register_pressure.h; sourceTree = "<group>"; };
+		A972A88621CED2720013AB25 /* tree_iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree_iterator.h; sourceTree = "<group>"; };
+		A972A88721CED2720013AB25 /* local_single_store_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_single_store_elim_pass.h; sourceTree = "<group>"; };
+		A972A88821CED2720013AB25 /* reduce_load_size.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_load_size.h; sourceTree = "<group>"; };
+		A972A88921CED2720013AB25 /* types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = types.cpp; sourceTree = "<group>"; };
+		A972A88A21CED2720013AB25 /* scalar_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_analysis.h; sourceTree = "<group>"; };
+		A972A88B21CED2720013AB25 /* strip_debug_info_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strip_debug_info_pass.h; sourceTree = "<group>"; };
+		A972A88C21CED2720013AB25 /* cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cfg.cpp; sourceTree = "<group>"; };
+		A972A88D21CED2720013AB25 /* decoration_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = decoration_manager.cpp; sourceTree = "<group>"; };
+		A972A88E21CED2720013AB25 /* local_single_block_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_single_block_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A88F21CED2720013AB25 /* freeze_spec_constant_value_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = freeze_spec_constant_value_pass.cpp; sourceTree = "<group>"; };
+		A972A89021CED2720013AB25 /* replace_invalid_opc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = replace_invalid_opc.h; sourceTree = "<group>"; };
+		A972A89121CED2720013AB25 /* local_access_chain_convert_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_access_chain_convert_pass.h; sourceTree = "<group>"; };
+		A972A89221CED2720013AB25 /* inst_bindless_check_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inst_bindless_check_pass.cpp; sourceTree = "<group>"; };
+		A972A89321CED2720013AB25 /* local_redundancy_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_redundancy_elimination.cpp; sourceTree = "<group>"; };
+		A972A89421CED2720013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972A89521CED2720013AB25 /* instrument_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instrument_pass.cpp; sourceTree = "<group>"; };
+		A972A89621CED2720013AB25 /* propagator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagator.h; sourceTree = "<group>"; };
+		A972A89721CED2720013AB25 /* instruction_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction_list.h; sourceTree = "<group>"; };
+		A972A89821CED2720013AB25 /* feature_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = feature_manager.cpp; sourceTree = "<group>"; };
+		A972A89921CED2720013AB25 /* pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass.cpp; sourceTree = "<group>"; };
+		A972A89A21CED2720013AB25 /* loop_fission.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fission.cpp; sourceTree = "<group>"; };
+		A972A89B21CED2720013AB25 /* dominator_tree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dominator_tree.cpp; sourceTree = "<group>"; };
+		A972A89C21CED2720013AB25 /* merge_return_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = merge_return_pass.cpp; sourceTree = "<group>"; };
+		A972A89D21CED2720013AB25 /* ir_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_context.h; sourceTree = "<group>"; };
+		A972A89E21CED2720013AB25 /* eliminate_dead_constant_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = eliminate_dead_constant_pass.cpp; sourceTree = "<group>"; };
+		A972A89F21CED2720013AB25 /* cfg_cleanup_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cfg_cleanup_pass.cpp; sourceTree = "<group>"; };
+		A972A8A021CED2720013AB25 /* const_folding_rules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = const_folding_rules.cpp; sourceTree = "<group>"; };
+		A972A8A121CED2720013AB25 /* loop_unroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_unroller.h; sourceTree = "<group>"; };
+		A972A8A221CED2720013AB25 /* strip_debug_info_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strip_debug_info_pass.cpp; sourceTree = "<group>"; };
+		A972A8A321CED2720013AB25 /* ssa_rewrite_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssa_rewrite_pass.cpp; sourceTree = "<group>"; };
+		A972A8A421CED2720013AB25 /* loop_dependence.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_dependence.cpp; sourceTree = "<group>"; };
+		A972A8A521CED2720013AB25 /* unify_const_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unify_const_pass.h; sourceTree = "<group>"; };
+		A972A8A621CED2720013AB25 /* ir_loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_loader.h; sourceTree = "<group>"; };
+		A972A8A721CED2720013AB25 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		A972A8A821CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold_spec_constant_op_and_composite_pass.h; sourceTree = "<group>"; };
+		A972A8A921CED2720013AB25 /* mem_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mem_pass.cpp; sourceTree = "<group>"; };
+		A972A8AA21CED2720013AB25 /* basic_block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_block.h; sourceTree = "<group>"; };
+		A972A8AB21CED2720013AB25 /* remove_duplicates_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remove_duplicates_pass.cpp; sourceTree = "<group>"; };
+		A972A8AC21CED2720013AB25 /* dead_variable_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_variable_elimination.cpp; sourceTree = "<group>"; };
+		A972A8AD21CED2720013AB25 /* block_merge_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = block_merge_pass.h; sourceTree = "<group>"; };
+		A972A8AE21CED2720013AB25 /* module.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = module.cpp; sourceTree = "<group>"; };
+		A972A8AF21CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fold_spec_constant_op_and_composite_pass.cpp; sourceTree = "<group>"; };
+		A972A8B021CED2720013AB25 /* loop_unswitch_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_unswitch_pass.cpp; sourceTree = "<group>"; };
+		A972A8B121CED2720013AB25 /* unify_const_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unify_const_pass.cpp; sourceTree = "<group>"; };
+		A972A8B221CED2720013AB25 /* type_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = type_manager.cpp; sourceTree = "<group>"; };
+		A972A8B321CED2720013AB25 /* private_to_local_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = private_to_local_pass.h; sourceTree = "<group>"; };
+		A972A8B421CED2720013AB25 /* inline_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_pass.cpp; sourceTree = "<group>"; };
+		A972A8B521CED2720013AB25 /* def_use_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = def_use_manager.h; sourceTree = "<group>"; };
+		A972A8B621CED2720013AB25 /* ir_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ir_loader.cpp; sourceTree = "<group>"; };
+		A972A8B721CED2720013AB25 /* cfg_cleanup_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfg_cleanup_pass.h; sourceTree = "<group>"; };
+		A972A8B821CED2720013AB25 /* licm_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = licm_pass.cpp; sourceTree = "<group>"; };
+		A972A8B921CED2720013AB25 /* eliminate_dead_functions_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = eliminate_dead_functions_pass.cpp; sourceTree = "<group>"; };
+		A972A8BA21CED2720013AB25 /* local_redundancy_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_redundancy_elimination.h; sourceTree = "<group>"; };
+		A972A8BB21CED2720013AB25 /* loop_peeling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_peeling.h; sourceTree = "<group>"; };
+		A972A8BC21CED2720013AB25 /* vector_dce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vector_dce.cpp; sourceTree = "<group>"; };
+		A972A8BD21CED2720013AB25 /* loop_unroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_unroller.cpp; sourceTree = "<group>"; };
+		A972A8BE21CED2720013AB25 /* constants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = constants.cpp; sourceTree = "<group>"; };
+		A972A8BF21CED2720013AB25 /* loop_fusion_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fusion_pass.h; sourceTree = "<group>"; };
+		A972A8C021CED2720013AB25 /* struct_cfg_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = struct_cfg_analysis.h; sourceTree = "<group>"; };
+		A972A8C121CED2720013AB25 /* common_uniform_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common_uniform_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8C221CED2720013AB25 /* def_use_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = def_use_manager.cpp; sourceTree = "<group>"; };
+		A972A8C321CED2720013AB25 /* strip_reflect_info_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strip_reflect_info_pass.cpp; sourceTree = "<group>"; };
+		A972A8C421CED2720013AB25 /* decoration_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoration_manager.h; sourceTree = "<group>"; };
+		A972A8C521CED2720013AB25 /* ccp_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ccp_pass.cpp; sourceTree = "<group>"; };
+		A972A8C621CED2720013AB25 /* local_single_block_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_single_block_elim_pass.h; sourceTree = "<group>"; };
+		A972A8C721CED2720013AB25 /* pch_source_opt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pch_source_opt.cpp; sourceTree = "<group>"; };
+		A972A8C821CED2720013AB25 /* strength_reduction_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strength_reduction_pass.h; sourceTree = "<group>"; };
+		A972A8C921CED2720013AB25 /* aggressive_dead_code_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aggressive_dead_code_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8CA21CED2720013AB25 /* simplification_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simplification_pass.cpp; sourceTree = "<group>"; };
+		A972A8CB21CED2720013AB25 /* dead_branch_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_branch_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8CC21CED2720013AB25 /* flatten_decoration_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flatten_decoration_pass.cpp; sourceTree = "<group>"; };
+		A972A8CD21CED2720013AB25 /* dead_insert_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_insert_elim_pass.h; sourceTree = "<group>"; };
+		A972A8CE21CED2720013AB25 /* folding_rules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = folding_rules.cpp; sourceTree = "<group>"; };
+		A972A8CF21CED2720013AB25 /* freeze_spec_constant_value_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = freeze_spec_constant_value_pass.h; sourceTree = "<group>"; };
+		A972A8D021CED2720013AB25 /* ir_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ir_context.cpp; sourceTree = "<group>"; };
+		A972A8D121CED2720013AB25 /* instrument_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instrument_pass.h; sourceTree = "<group>"; };
+		A972A8D221CED2720013AB25 /* mem_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem_pass.h; sourceTree = "<group>"; };
+		A972A8D321CED2720013AB25 /* loop_descriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_descriptor.cpp; sourceTree = "<group>"; };
+		A972A8D421CED2720013AB25 /* local_ssa_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_ssa_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8D521CED2720013AB25 /* function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = function.cpp; sourceTree = "<group>"; };
+		A972A8D621CED2720013AB25 /* instruction_list.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction_list.cpp; sourceTree = "<group>"; };
+		A972A8D721CED2720013AB25 /* composite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = composite.cpp; sourceTree = "<group>"; };
+		A972A8D821CED2720013AB25 /* inline_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_pass.h; sourceTree = "<group>"; };
+		A972A8D921CED2720013AB25 /* loop_dependence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_dependence.h; sourceTree = "<group>"; };
+		A972A8DA21CED2720013AB25 /* value_number_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = value_number_table.h; sourceTree = "<group>"; };
+		A972A8DB21CED2720013AB25 /* flatten_decoration_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flatten_decoration_pass.h; sourceTree = "<group>"; };
+		A972A8DC21CED2720013AB25 /* if_conversion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = if_conversion.cpp; sourceTree = "<group>"; };
+		A972A8DD21CED2720013AB25 /* inline_exhaustive_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_exhaustive_pass.h; sourceTree = "<group>"; };
+		A972A8DE21CED2720013AB25 /* constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
+		A972A8DF21CED2720013AB25 /* strength_reduction_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strength_reduction_pass.cpp; sourceTree = "<group>"; };
+		A972A8E021CED2720013AB25 /* copy_prop_arrays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = copy_prop_arrays.cpp; sourceTree = "<group>"; };
+		A972A8E121CED2720013AB25 /* pass_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass_manager.cpp; sourceTree = "<group>"; };
+		A972A8E221CED2720013AB25 /* inline_exhaustive_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_exhaustive_pass.cpp; sourceTree = "<group>"; };
+		A972A8E321CED2720013AB25 /* loop_fission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fission.h; sourceTree = "<group>"; };
+		A972A8E421CED2720013AB25 /* workaround1209.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = workaround1209.h; sourceTree = "<group>"; };
+		A972A8E521CED2720013AB25 /* loop_fusion_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fusion_pass.cpp; sourceTree = "<group>"; };
+		A972A8E621CED2720013AB25 /* log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log.h; sourceTree = "<group>"; };
+		A972A8E721CED2720013AB25 /* copy_prop_arrays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_prop_arrays.h; sourceTree = "<group>"; };
+		A972A8E821CED2720013AB25 /* eliminate_dead_constant_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eliminate_dead_constant_pass.h; sourceTree = "<group>"; };
+		A972A8E921CED2720013AB25 /* dead_insert_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_insert_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8EA21CED2720013AB25 /* ssa_rewrite_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssa_rewrite_pass.h; sourceTree = "<group>"; };
+		A972A8EB21CED2720013AB25 /* scalar_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_analysis.cpp; sourceTree = "<group>"; };
+		A972A8EC21CED2720013AB25 /* dead_variable_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_variable_elimination.h; sourceTree = "<group>"; };
+		A972A8ED21CED2720013AB25 /* block_merge_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = block_merge_pass.cpp; sourceTree = "<group>"; };
+		A972A8EE21CED2720013AB25 /* dominator_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dominator_analysis.h; sourceTree = "<group>"; };
+		A972A8EF21CED2720013AB25 /* pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pass.h; sourceTree = "<group>"; };
+		A972A8F021CED2720013AB25 /* folding_rules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = folding_rules.h; sourceTree = "<group>"; };
+		A972A8F121CED2720013AB25 /* eliminate_dead_functions_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eliminate_dead_functions_pass.h; sourceTree = "<group>"; };
+		A972A8F221CED2720013AB25 /* common_uniform_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_uniform_elim_pass.h; sourceTree = "<group>"; };
+		A972A8F321CED2720013AB25 /* fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold.h; sourceTree = "<group>"; };
+		A972A8F421CED2720013AB25 /* local_single_store_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_single_store_elim_pass.cpp; sourceTree = "<group>"; };
+		A972A8F521CED2720013AB25 /* dead_branch_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_branch_elim_pass.h; sourceTree = "<group>"; };
+		A972A8F621CED2720013AB25 /* private_to_local_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = private_to_local_pass.cpp; sourceTree = "<group>"; };
+		A972A8F721CED2720013AB25 /* scalar_analysis_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_analysis_nodes.h; sourceTree = "<group>"; };
+		A972A8F821CED2720013AB25 /* propagator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = propagator.cpp; sourceTree = "<group>"; };
+		A972A8F921CED2720013AB25 /* loop_dependence_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_dependence_helpers.cpp; sourceTree = "<group>"; };
+		A972A8FA21CED2720013AB25 /* set_spec_constant_default_value_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = set_spec_constant_default_value_pass.cpp; sourceTree = "<group>"; };
+		A972A8FB21CED2720013AB25 /* passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passes.h; sourceTree = "<group>"; };
+		A972A8FC21CED2720013AB25 /* fold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fold.cpp; sourceTree = "<group>"; };
+		A972A8FD21CED2720013AB25 /* strip_reflect_info_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strip_reflect_info_pass.h; sourceTree = "<group>"; };
+		A972A8FE21CED2720013AB25 /* scalar_replacement_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_replacement_pass.cpp; sourceTree = "<group>"; };
+		A972A8FF21CED2720013AB25 /* simplification_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simplification_pass.h; sourceTree = "<group>"; };
+		A972A90021CED2720013AB25 /* remove_duplicates_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_duplicates_pass.h; sourceTree = "<group>"; };
+		A972A90121CED2720013AB25 /* redundancy_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = redundancy_elimination.cpp; sourceTree = "<group>"; };
+		A972A90221CED2720013AB25 /* reflect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reflect.h; sourceTree = "<group>"; };
+		A972A90321CED2720013AB25 /* workaround1209.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = workaround1209.cpp; sourceTree = "<group>"; };
+		A972A90421CED2720013AB25 /* null_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = null_pass.h; sourceTree = "<group>"; };
+		A972A90521CED2720013AB25 /* const_folding_rules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = const_folding_rules.h; sourceTree = "<group>"; };
+		A972A90621CED2720013AB25 /* scalar_replacement_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_replacement_pass.h; sourceTree = "<group>"; };
+		A972A90721CED2720013AB25 /* instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction.cpp; sourceTree = "<group>"; };
+		A972A90821CED2720013AB25 /* pch_source_opt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pch_source_opt.h; sourceTree = "<group>"; };
+		A972A90921CED2720013AB25 /* reduce_load_size.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reduce_load_size.cpp; sourceTree = "<group>"; };
+		A972A90A21CED2720013AB25 /* redundancy_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = redundancy_elimination.h; sourceTree = "<group>"; };
+		A972A90B21CED2720013AB25 /* value_number_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = value_number_table.cpp; sourceTree = "<group>"; };
+		A972A90C21CED2720013AB25 /* local_ssa_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_ssa_elim_pass.h; sourceTree = "<group>"; };
+		A972A90D21CED2720013AB25 /* inline_opaque_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_opaque_pass.cpp; sourceTree = "<group>"; };
+		A972A90E21CED2720013AB25 /* replace_invalid_opc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = replace_invalid_opc.cpp; sourceTree = "<group>"; };
+		A972A90F21CED2720013AB25 /* loop_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_utils.h; sourceTree = "<group>"; };
+		A972A91021CED2720013AB25 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
+		A972A91121CED2720013AB25 /* dominator_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dominator_analysis.cpp; sourceTree = "<group>"; };
+		A972A91221CED2720013AB25 /* ir_builder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_builder.h; sourceTree = "<group>"; };
+		A972A91321CED2720013AB25 /* loop_unswitch_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_unswitch_pass.h; sourceTree = "<group>"; };
+		A972A91421CED2720013AB25 /* cfg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfg.h; sourceTree = "<group>"; };
+		A972A91521CED2720013AB25 /* loop_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_descriptor.h; sourceTree = "<group>"; };
+		A972A91621CED2730013AB25 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
+		A972A91721CED2730013AB25 /* aggressive_dead_code_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aggressive_dead_code_elim_pass.h; sourceTree = "<group>"; };
+		A972A91821CED2730013AB25 /* struct_cfg_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = struct_cfg_analysis.cpp; sourceTree = "<group>"; };
+		A972A91921CED2730013AB25 /* vector_dce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector_dce.h; sourceTree = "<group>"; };
+		A972A91A21CED2730013AB25 /* combine_access_chains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = combine_access_chains.h; sourceTree = "<group>"; };
+		A972A91B21CED2730013AB25 /* pass_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pass_manager.h; sourceTree = "<group>"; };
+		A972A91C21CED2730013AB25 /* local_access_chain_convert_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_access_chain_convert_pass.cpp; sourceTree = "<group>"; };
+		A972A91D21CED2730013AB25 /* basic_block.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = basic_block.cpp; sourceTree = "<group>"; };
+		A972A91E21CED2730013AB25 /* iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iterator.h; sourceTree = "<group>"; };
+		A972A91F21CED2730013AB25 /* licm_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = licm_pass.h; sourceTree = "<group>"; };
+		A972A92021CED2730013AB25 /* build_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = build_module.h; sourceTree = "<group>"; };
+		A972A92121CED2730013AB25 /* ccp_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccp_pass.h; sourceTree = "<group>"; };
+		A972A92221CED2730013AB25 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
+		A972A92321CED2730013AB25 /* loop_fusion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fusion.cpp; sourceTree = "<group>"; };
+		A972A92421CED2730013AB25 /* feature_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = feature_manager.h; sourceTree = "<group>"; };
+		A972A92521CED2730013AB25 /* inst_bindless_check_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inst_bindless_check_pass.h; sourceTree = "<group>"; };
+		A972A92621CED2730013AB25 /* scalar_analysis_simplification.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_analysis_simplification.cpp; sourceTree = "<group>"; };
+		A972A92721CED2730013AB25 /* set_spec_constant_default_value_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = set_spec_constant_default_value_pass.h; sourceTree = "<group>"; };
+		A972A92821CED2730013AB25 /* dominator_tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dominator_tree.h; sourceTree = "<group>"; };
+		A972A92921CED2730013AB25 /* type_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_manager.h; sourceTree = "<group>"; };
+		A972A92A21CED2730013AB25 /* compact_ids_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compact_ids_pass.cpp; sourceTree = "<group>"; };
+		A972A92B21CED2730013AB25 /* loop_peeling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_peeling.cpp; sourceTree = "<group>"; };
+		A972A92C21CED2730013AB25 /* table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = table.h; sourceTree = "<group>"; };
+		A972A92D21CED2730013AB25 /* ext_inst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ext_inst.h; sourceTree = "<group>"; };
+		A972A92E21CED2730013AB25 /* diagnostic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = diagnostic.cpp; sourceTree = "<group>"; };
+		A972A92F21CED2730013AB25 /* latest_version_spirv_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_spirv_header.h; sourceTree = "<group>"; };
+		A972A93021CED2730013AB25 /* libspirv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libspirv.cpp; sourceTree = "<group>"; };
+		A972A93121CED2730013AB25 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
+		A972A93221CED2730013AB25 /* id_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = id_descriptor.h; sourceTree = "<group>"; };
+		A972A93321CED2730013AB25 /* spirv_optimizer_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_optimizer_options.h; sourceTree = "<group>"; };
+		A972A93421CED2730013AB25 /* opcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opcode.h; sourceTree = "<group>"; };
+		A972A93521CED2730013AB25 /* operand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = operand.cpp; sourceTree = "<group>"; };
+		A972A93621CED2730013AB25 /* latest_version_glsl_std_450_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_glsl_std_450_header.h; sourceTree = "<group>"; };
+		A972A93721CED2730013AB25 /* extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = extensions.h; sourceTree = "<group>"; };
+		A972A93821CED2730013AB25 /* disassemble.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = disassemble.cpp; sourceTree = "<group>"; };
+		A972A93921CED2730013AB25 /* binary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = binary.h; sourceTree = "<group>"; };
+		A972A93A21CED2730013AB25 /* text_handler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = text_handler.cpp; sourceTree = "<group>"; };
+		A972A93C21CED2730013AB25 /* validate_annotation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_annotation.cpp; sourceTree = "<group>"; };
+		A972A93D21CED2730013AB25 /* validate_cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_cfg.cpp; sourceTree = "<group>"; };
+		A972A93E21CED2730013AB25 /* validate_capability.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_capability.cpp; sourceTree = "<group>"; };
+		A972A93F21CED2730013AB25 /* construct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = construct.h; sourceTree = "<group>"; };
+		A972A94021CED2730013AB25 /* validate_barriers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_barriers.cpp; sourceTree = "<group>"; };
+		A972A94121CED2730013AB25 /* validate_non_uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_non_uniform.cpp; sourceTree = "<group>"; };
+		A972A94221CED2730013AB25 /* validate_atomics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_atomics.cpp; sourceTree = "<group>"; };
+		A972A94321CED2730013AB25 /* basic_block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_block.h; sourceTree = "<group>"; };
+		A972A94421CED2730013AB25 /* validate_instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_instruction.cpp; sourceTree = "<group>"; };
+		A972A94521CED2730013AB25 /* validate_decorations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_decorations.cpp; sourceTree = "<group>"; };
+		A972A94621CED2730013AB25 /* validate_debug.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_debug.cpp; sourceTree = "<group>"; };
+		A972A94721CED2730013AB25 /* validate_builtins.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_builtins.cpp; sourceTree = "<group>"; };
+		A972A94821CED2730013AB25 /* validate_interfaces.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_interfaces.cpp; sourceTree = "<group>"; };
+		A972A94921CED2730013AB25 /* validate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate.cpp; sourceTree = "<group>"; };
+		A972A94A21CED2730013AB25 /* validation_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = validation_state.h; sourceTree = "<group>"; };
+		A972A94B21CED2730013AB25 /* validate_constants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_constants.cpp; sourceTree = "<group>"; };
+		A972A94C21CED2730013AB25 /* validate_bitwise.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_bitwise.cpp; sourceTree = "<group>"; };
+		A972A94D21CED2730013AB25 /* construct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = construct.cpp; sourceTree = "<group>"; };
+		A972A94E21CED2730013AB25 /* function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = function.cpp; sourceTree = "<group>"; };
+		A972A94F21CED2730013AB25 /* validate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = validate.h; sourceTree = "<group>"; };
+		A972A95021CED2730013AB25 /* validate_adjacency.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_adjacency.cpp; sourceTree = "<group>"; };
+		A972A95121CED2730013AB25 /* validate_conversion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_conversion.cpp; sourceTree = "<group>"; };
+		A972A95221CED2730013AB25 /* validate_datarules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_datarules.cpp; sourceTree = "<group>"; };
+		A972A95321CED2730013AB25 /* validate_id.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_id.cpp; sourceTree = "<group>"; };
+		A972A95421CED2730013AB25 /* validate_arithmetics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_arithmetics.cpp; sourceTree = "<group>"; };
+		A972A95521CED2730013AB25 /* validate_mode_setting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_mode_setting.cpp; sourceTree = "<group>"; };
+		A972A95621CED2730013AB25 /* validate_logicals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_logicals.cpp; sourceTree = "<group>"; };
+		A972A95721CED2730013AB25 /* validate_derivatives.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_derivatives.cpp; sourceTree = "<group>"; };
+		A972A95821CED2730013AB25 /* validate_memory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_memory.cpp; sourceTree = "<group>"; };
+		A972A95921CED2730013AB25 /* validate_image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_image.cpp; sourceTree = "<group>"; };
+		A972A95A21CED2730013AB25 /* validate_literals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_literals.cpp; sourceTree = "<group>"; };
+		A972A95B21CED2730013AB25 /* instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction.cpp; sourceTree = "<group>"; };
+		A972A95C21CED2730013AB25 /* validate_type.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_type.cpp; sourceTree = "<group>"; };
+		A972A95D21CED2730013AB25 /* validate_ext_inst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_ext_inst.cpp; sourceTree = "<group>"; };
+		A972A95E21CED2730013AB25 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
+		A972A95F21CED2730013AB25 /* validate_execution_limitations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_execution_limitations.cpp; sourceTree = "<group>"; };
+		A972A96021CED2730013AB25 /* validate_layout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_layout.cpp; sourceTree = "<group>"; };
+		A972A96121CED2730013AB25 /* basic_block.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = basic_block.cpp; sourceTree = "<group>"; };
+		A972A96221CED2730013AB25 /* validate_function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_function.cpp; sourceTree = "<group>"; };
+		A972A96321CED2730013AB25 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
+		A972A96421CED2730013AB25 /* validate_composites.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_composites.cpp; sourceTree = "<group>"; };
+		A972A96521CED2730013AB25 /* validation_state.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validation_state.cpp; sourceTree = "<group>"; };
+		A972A96621CED2730013AB25 /* validate_primitives.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_primitives.cpp; sourceTree = "<group>"; };
+		A972A96721CED2730013AB25 /* decoration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoration.h; sourceTree = "<group>"; };
+		A972ABDC21CED7BC0013AB25 /* libglslang.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libglslang.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A972ABF021CED7CB0013AB25 /* libglslang.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libglslang.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A972ABF621CED9060013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972ABF721CED9060013AB25 /* InitializeDll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitializeDll.h; sourceTree = "<group>"; };
+		A972ABF821CED9060013AB25 /* InitializeDll.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InitializeDll.cpp; sourceTree = "<group>"; };
+		A972ABFA21CED9060013AB25 /* SPVRemapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPVRemapper.h; sourceTree = "<group>"; };
+		A972ABFB21CED9060013AB25 /* SpvBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpvBuilder.h; sourceTree = "<group>"; };
+		A972ABFC21CED9060013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972ABFD21CED9060013AB25 /* SpvPostProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpvPostProcess.cpp; sourceTree = "<group>"; };
+		A972ABFE21CED9060013AB25 /* SpvTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpvTools.h; sourceTree = "<group>"; };
+		A972ABFF21CED9060013AB25 /* SpvTools.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpvTools.cpp; sourceTree = "<group>"; };
+		A972AC0021CED9060013AB25 /* InReadableOrder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InReadableOrder.cpp; sourceTree = "<group>"; };
+		A972AC0121CED9060013AB25 /* GLSL.ext.AMD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.AMD.h; sourceTree = "<group>"; };
+		A972AC0221CED9060013AB25 /* doc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = doc.h; sourceTree = "<group>"; };
+		A972AC0321CED9060013AB25 /* spirv.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv.hpp; sourceTree = "<group>"; };
+		A972AC0421CED9060013AB25 /* SpvBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpvBuilder.cpp; sourceTree = "<group>"; };
+		A972AC0521CED9060013AB25 /* GLSL.ext.EXT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.EXT.h; sourceTree = "<group>"; };
+		A972AC0621CED9060013AB25 /* GLSL.ext.KHR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.KHR.h; sourceTree = "<group>"; };
+		A972AC0721CED9060013AB25 /* GLSL.ext.NV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.NV.h; sourceTree = "<group>"; };
+		A972AC0821CED9060013AB25 /* GlslangToSpv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlslangToSpv.cpp; sourceTree = "<group>"; };
+		A972AC0921CED9060013AB25 /* spvIR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spvIR.h; sourceTree = "<group>"; };
+		A972AC0A21CED9060013AB25 /* bitutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitutils.h; sourceTree = "<group>"; };
+		A972AC0B21CED9060013AB25 /* disassemble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disassemble.h; sourceTree = "<group>"; };
+		A972AC0C21CED9060013AB25 /* GlslangToSpv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlslangToSpv.h; sourceTree = "<group>"; };
+		A972AC0D21CED9060013AB25 /* GLSL.std.450.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.std.450.h; sourceTree = "<group>"; };
+		A972AC0E21CED9060013AB25 /* SPVRemapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SPVRemapper.cpp; sourceTree = "<group>"; };
+		A972AC0F21CED9060013AB25 /* Logger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logger.cpp; sourceTree = "<group>"; };
+		A972AC1021CED9060013AB25 /* hex_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hex_float.h; sourceTree = "<group>"; };
+		A972AC1121CED9060013AB25 /* Logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logger.h; sourceTree = "<group>"; };
+		A972AC1221CED9060013AB25 /* doc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = doc.cpp; sourceTree = "<group>"; };
+		A972AC1321CED9060013AB25 /* disassemble.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = disassemble.cpp; sourceTree = "<group>"; };
+		A972AC1521CED9060013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972AC1821CED9060013AB25 /* ossource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ossource.cpp; sourceTree = "<group>"; };
+		A972AC1921CED9060013AB25 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
+		A972AC1A21CED9060013AB25 /* osinclude.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = osinclude.h; sourceTree = "<group>"; };
+		A972AC2021CED9060013AB25 /* ResourceLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLimits.h; sourceTree = "<group>"; };
+		A972AC2121CED9060013AB25 /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Types.h; sourceTree = "<group>"; };
+		A972AC2221CED9060013AB25 /* intermediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intermediate.h; sourceTree = "<group>"; };
+		A972AC2321CED9060013AB25 /* BaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseTypes.h; sourceTree = "<group>"; };
+		A972AC2421CED9060013AB25 /* revision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = revision.h; sourceTree = "<group>"; };
+		A972AC2521CED9060013AB25 /* InitializeGlobals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitializeGlobals.h; sourceTree = "<group>"; };
+		A972AC2621CED9060013AB25 /* ShHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShHandle.h; sourceTree = "<group>"; };
+		A972AC2721CED9060013AB25 /* arrays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arrays.h; sourceTree = "<group>"; };
+		A972AC2821CED9060013AB25 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
+		A972AC2921CED9060013AB25 /* revision.template */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = revision.template; sourceTree = "<group>"; };
+		A972AC2A21CED9060013AB25 /* ConstantUnion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantUnion.h; sourceTree = "<group>"; };
+		A972AC2B21CED9060013AB25 /* InfoSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoSink.h; sourceTree = "<group>"; };
+		A972AC2C21CED9060013AB25 /* PoolAlloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PoolAlloc.h; sourceTree = "<group>"; };
+		A972AC2D21CED9060013AB25 /* updateGrammar */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = updateGrammar; sourceTree = "<group>"; };
+		A972AC2F21CED9060013AB25 /* ParseHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParseHelper.cpp; sourceTree = "<group>"; };
+		A972AC3021CED9060013AB25 /* parseVersions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parseVersions.h; sourceTree = "<group>"; };
+		A972AC3121CED9060013AB25 /* gl_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_types.h; sourceTree = "<group>"; };
+		A972AC3221CED9060013AB25 /* propagateNoContraction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = propagateNoContraction.cpp; sourceTree = "<group>"; };
+		A972AC3321CED9060013AB25 /* pch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pch.h; sourceTree = "<group>"; };
+		A972AC3421CED9060013AB25 /* ScanContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScanContext.h; sourceTree = "<group>"; };
+		A972AC3521CED9060013AB25 /* iomapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iomapper.h; sourceTree = "<group>"; };
+		A972AC3621CED9060013AB25 /* localintermediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = localintermediate.h; sourceTree = "<group>"; };
+		A972AC3721CED9060013AB25 /* Scan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scan.cpp; sourceTree = "<group>"; };
+		A972AC3921CED9060013AB25 /* RemoveTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveTree.h; sourceTree = "<group>"; };
+		A972AC3A21CED9060013AB25 /* Initialize.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Initialize.cpp; sourceTree = "<group>"; };
+		A972AC3B21CED9060013AB25 /* glslang_tab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = glslang_tab.cpp; sourceTree = "<group>"; };
+		A972AC3C21CED9060013AB25 /* limits.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = limits.cpp; sourceTree = "<group>"; };
+		A972AC3D21CED9060013AB25 /* parseConst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parseConst.cpp; sourceTree = "<group>"; };
+		A972AC3E21CED9060013AB25 /* propagateNoContraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagateNoContraction.h; sourceTree = "<group>"; };
+		A972AC3F21CED9060013AB25 /* Versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Versions.h; sourceTree = "<group>"; };
+		A972AC4021CED9060013AB25 /* IntermTraverse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntermTraverse.cpp; sourceTree = "<group>"; };
+		A972AC4121CED9060013AB25 /* intermOut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = intermOut.cpp; sourceTree = "<group>"; };
+		A972AC4221CED9060013AB25 /* iomapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = iomapper.cpp; sourceTree = "<group>"; };
+		A972AC4321CED9060013AB25 /* PoolAlloc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PoolAlloc.cpp; sourceTree = "<group>"; };
+		A972AC4421CED9060013AB25 /* ShaderLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShaderLang.cpp; sourceTree = "<group>"; };
+		A972AC4521CED9060013AB25 /* SymbolTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolTable.h; sourceTree = "<group>"; };
+		A972AC4621CED9060013AB25 /* InfoSink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InfoSink.cpp; sourceTree = "<group>"; };
+		A972AC4721CED9060013AB25 /* Intermediate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Intermediate.cpp; sourceTree = "<group>"; };
+		A972AC4821CED9060013AB25 /* pch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pch.cpp; sourceTree = "<group>"; };
+		A972AC4921CED9060013AB25 /* SymbolTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolTable.cpp; sourceTree = "<group>"; };
+		A972AC4A21CED9060013AB25 /* glslang_tab.cpp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = glslang_tab.cpp.h; sourceTree = "<group>"; };
+		A972AC4B21CED9060013AB25 /* LiveTraverser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LiveTraverser.h; sourceTree = "<group>"; };
+		A972AC4C21CED9060013AB25 /* Initialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Initialize.h; sourceTree = "<group>"; };
+		A972AC4D21CED9060013AB25 /* attribute.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = attribute.cpp; sourceTree = "<group>"; };
+		A972AC4E21CED9060013AB25 /* reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reflection.cpp; sourceTree = "<group>"; };
+		A972AC4F21CED9060013AB25 /* RemoveTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveTree.cpp; sourceTree = "<group>"; };
+		A972AC5021CED9060013AB25 /* attribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attribute.h; sourceTree = "<group>"; };
+		A972AC5121CED9060013AB25 /* Versions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Versions.cpp; sourceTree = "<group>"; };
+		A972AC5221CED9060013AB25 /* Constant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constant.cpp; sourceTree = "<group>"; };
+		A972AC5321CED9060013AB25 /* linkValidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = linkValidate.cpp; sourceTree = "<group>"; };
+		A972AC5421CED9060013AB25 /* ParseHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseHelper.h; sourceTree = "<group>"; };
+		A972AC5621CED9060013AB25 /* PpAtom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpAtom.cpp; sourceTree = "<group>"; };
+		A972AC5721CED9060013AB25 /* PpTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PpTokens.h; sourceTree = "<group>"; };
+		A972AC5821CED9060013AB25 /* Pp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pp.cpp; sourceTree = "<group>"; };
+		A972AC5921CED9060013AB25 /* PpContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PpContext.h; sourceTree = "<group>"; };
+		A972AC5A21CED9060013AB25 /* PpTokens.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpTokens.cpp; sourceTree = "<group>"; };
+		A972AC5B21CED9060013AB25 /* PpContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpContext.cpp; sourceTree = "<group>"; };
+		A972AC5C21CED9060013AB25 /* PpScanner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpScanner.cpp; sourceTree = "<group>"; };
+		A972AC5D21CED9060013AB25 /* ParseContextBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParseContextBase.cpp; sourceTree = "<group>"; };
+		A972AC5E21CED9060013AB25 /* reflection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reflection.h; sourceTree = "<group>"; };
+		A972AC5F21CED9060013AB25 /* Scan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scan.h; sourceTree = "<group>"; };
+		A972AC6121CED9060013AB25 /* ShaderLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShaderLang.h; sourceTree = "<group>"; };
+		A972AC6321CED9060013AB25 /* CodeGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CodeGen.cpp; sourceTree = "<group>"; };
+		A972AC6421CED9060013AB25 /* Link.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Link.cpp; sourceTree = "<group>"; };
+		A976290221CC60BC00B52A68 /* spirv_msl.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_msl.hpp; sourceTree = "<group>"; };
+		A976290321CC60BC00B52A68 /* spirv_cross.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cross.hpp; sourceTree = "<group>"; };
+		A976290421CC60BC00B52A68 /* spirv_parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_parser.cpp; sourceTree = "<group>"; };
+		A976290521CC60BC00B52A68 /* spirv_cross.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cross.cpp; sourceTree = "<group>"; };
+		A976290621CC60BC00B52A68 /* spirv_glsl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_glsl.cpp; sourceTree = "<group>"; };
+		A976290721CC60BC00B52A68 /* spirv_common.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_common.hpp; sourceTree = "<group>"; };
+		A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cross_parsed_ir.hpp; sourceTree = "<group>"; };
+		A976290921CC60BC00B52A68 /* spirv_cfg.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cfg.hpp; sourceTree = "<group>"; };
+		A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_glsl.hpp; sourceTree = "<group>"; };
+		A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cfg.cpp; sourceTree = "<group>"; };
+		A976290C21CC60BC00B52A68 /* spirv_parser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_parser.hpp; sourceTree = "<group>"; };
+		A976290D21CC60BC00B52A68 /* spirv_msl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_msl.cpp; sourceTree = "<group>"; };
+		A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cross_parsed_ir.cpp; sourceTree = "<group>"; };
+		A9C2104521D14FD7006BA2D3 /* fetchDependencies */ = {isa = PBXFileReference; lastKnownFileType = text; path = fetchDependencies; sourceTree = "<group>"; };
+		A9C2104721D15843006BA2D3 /* ExternalRevisions */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ExternalRevisions; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		A90FD9E921CC519E00B92BB2 /* External */ = {
+			isa = PBXGroup;
+			children = (
+				A97628F021CC5DA700B52A68 /* SPIRV-Cross */,
+				A972A82421CECC410013AB25 /* SPIRV-Tools */,
+				A972ABC821CED6F90013AB25 /* glslang */,
+			);
+			path = External;
+			sourceTree = "<group>";
+		};
+		A972A82421CECC410013AB25 /* SPIRV-Tools */ = {
+			isa = PBXGroup;
+			children = (
+				A972A82921CED2720013AB25 /* source */,
+			);
+			name = "SPIRV-Tools";
+			path = "glslang/External/spirv-tools";
+			sourceTree = "<group>";
+		};
+		A972A82921CED2720013AB25 /* source */ = {
+			isa = PBXGroup;
+			children = (
+				A972A82A21CED2720013AB25 /* spirv_target_env.cpp */,
+				A972A82B21CED2720013AB25 /* extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json */,
+				A972A82C21CED2720013AB25 /* assembly_grammar.h */,
+				A972A82D21CED2720013AB25 /* enum_set.h */,
+				A972A82E21CED2720013AB25 /* CMakeLists.txt */,
+				A972A82F21CED2720013AB25 /* extinst.spv-amd-shader-ballot.grammar.json */,
+				A972A83021CED2720013AB25 /* text.cpp */,
+				A972A83121CED2720013AB25 /* assembly_grammar.cpp */,
+				A972A83221CED2720013AB25 /* text.h */,
+				A972A83321CED2720013AB25 /* extensions.cpp */,
+				A972A83421CED2720013AB25 /* pch_source.cpp */,
+				A972A83521CED2720013AB25 /* util */,
+				A972A84421CED2720013AB25 /* spirv_target_env.h */,
+				A972A84521CED2720013AB25 /* table.cpp */,
+				A972A84621CED2720013AB25 /* id_descriptor.cpp */,
+				A972A84721CED2720013AB25 /* latest_version_opencl_std_header.h */,
+				A972A84821CED2720013AB25 /* spirv_optimizer_options.cpp */,
+				A972A84921CED2720013AB25 /* cfa.h */,
+				A972A84A21CED2720013AB25 /* pch_source.h */,
+				A972A84B21CED2720013AB25 /* enum_string_mapping.h */,
+				A972A84C21CED2720013AB25 /* spirv_validator_options.cpp */,
+				A972A84D21CED2720013AB25 /* extinst.spv-amd-shader-trinary-minmax.grammar.json */,
+				A972A84E21CED2720013AB25 /* print.cpp */,
+				A972A84F21CED2720013AB25 /* spirv_definition.h */,
+				A972A85021CED2720013AB25 /* operand.h */,
+				A972A85121CED2720013AB25 /* spirv_endian.cpp */,
+				A972A85221CED2720013AB25 /* macro.h */,
+				A972A85321CED2720013AB25 /* spirv_constant.h */,
+				A972A85421CED2720013AB25 /* extinst.spv-amd-gcn-shader.grammar.json */,
+				A972A85521CED2720013AB25 /* binary.cpp */,
+				A972A85621CED2720013AB25 /* spirv_validator_options.h */,
+				A972A85721CED2720013AB25 /* comp */,
+				A972A86821CED2720013AB25 /* enum_string_mapping.cpp */,
+				A972A86921CED2720013AB25 /* text_handler.h */,
+				A972A86A21CED2720013AB25 /* parsed_operand.h */,
+				A972A86B21CED2720013AB25 /* name_mapper.h */,
+				A972A86C21CED2720013AB25 /* parsed_operand.cpp */,
+				A972A86D21CED2720013AB25 /* diagnostic.h */,
+				A972A86E21CED2720013AB25 /* spirv_endian.h */,
+				A972A86F21CED2720013AB25 /* name_mapper.cpp */,
+				A972A87021CED2720013AB25 /* extinst.debuginfo.grammar.json */,
+				A972A87121CED2720013AB25 /* link */,
+				A972A87421CED2720013AB25 /* software_version.cpp */,
+				A972A87521CED2720013AB25 /* opcode.cpp */,
+				A972A87621CED2720013AB25 /* print.h */,
+				A972A87721CED2720013AB25 /* ext_inst.cpp */,
+				A972A87821CED2720013AB25 /* disassemble.h */,
+				A972A87921CED2720013AB25 /* opt */,
+				A972A92C21CED2730013AB25 /* table.h */,
+				A972A92D21CED2730013AB25 /* ext_inst.h */,
+				A972A92E21CED2730013AB25 /* diagnostic.cpp */,
+				A972A92F21CED2730013AB25 /* latest_version_spirv_header.h */,
+				A972A93021CED2730013AB25 /* libspirv.cpp */,
+				A972A93121CED2730013AB25 /* instruction.h */,
+				A972A93221CED2730013AB25 /* id_descriptor.h */,
+				A972A93321CED2730013AB25 /* spirv_optimizer_options.h */,
+				A972A93421CED2730013AB25 /* opcode.h */,
+				A972A93521CED2730013AB25 /* operand.cpp */,
+				A972A93621CED2730013AB25 /* latest_version_glsl_std_450_header.h */,
+				A972A93721CED2730013AB25 /* extensions.h */,
+				A972A93821CED2730013AB25 /* disassemble.cpp */,
+				A972A93921CED2730013AB25 /* binary.h */,
+				A972A93A21CED2730013AB25 /* text_handler.cpp */,
+				A972A93B21CED2730013AB25 /* val */,
+			);
+			path = source;
+			sourceTree = "<group>";
+		};
+		A972A83521CED2720013AB25 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				A972A83621CED2720013AB25 /* parse_number.h */,
+				A972A83721CED2720013AB25 /* ilist_node.h */,
+				A972A83821CED2720013AB25 /* make_unique.h */,
+				A972A83921CED2720013AB25 /* string_utils.h */,
+				A972A83A21CED2720013AB25 /* small_vector.h */,
+				A972A83B21CED2720013AB25 /* timer.cpp */,
+				A972A83C21CED2720013AB25 /* timer.h */,
+				A972A83D21CED2720013AB25 /* string_utils.cpp */,
+				A972A83E21CED2720013AB25 /* bit_vector.h */,
+				A972A83F21CED2720013AB25 /* bitutils.h */,
+				A972A84021CED2720013AB25 /* hex_float.h */,
+				A972A84121CED2720013AB25 /* parse_number.cpp */,
+				A972A84221CED2720013AB25 /* bit_vector.cpp */,
+				A972A84321CED2720013AB25 /* ilist.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		A972A85721CED2720013AB25 /* comp */ = {
+			isa = PBXGroup;
+			children = (
+				A972A85821CED2720013AB25 /* markv_codec.cpp */,
+				A972A85921CED2720013AB25 /* markv.cpp */,
+				A972A85A21CED2720013AB25 /* huffman_codec.h */,
+				A972A85B21CED2720013AB25 /* CMakeLists.txt */,
+				A972A85C21CED2720013AB25 /* bit_stream.h */,
+				A972A85D21CED2720013AB25 /* move_to_front.cpp */,
+				A972A85E21CED2720013AB25 /* markv_encoder.h */,
+				A972A85F21CED2720013AB25 /* markv_decoder.h */,
+				A972A86021CED2720013AB25 /* markv.h */,
+				A972A86121CED2720013AB25 /* markv_model.h */,
+				A972A86221CED2720013AB25 /* markv_decoder.cpp */,
+				A972A86321CED2720013AB25 /* move_to_front.h */,
+				A972A86421CED2720013AB25 /* markv_codec.h */,
+				A972A86521CED2720013AB25 /* markv_logger.h */,
+				A972A86621CED2720013AB25 /* bit_stream.cpp */,
+				A972A86721CED2720013AB25 /* markv_encoder.cpp */,
+			);
+			path = comp;
+			sourceTree = "<group>";
+		};
+		A972A87121CED2720013AB25 /* link */ = {
+			isa = PBXGroup;
+			children = (
+				A972A87221CED2720013AB25 /* CMakeLists.txt */,
+				A972A87321CED2720013AB25 /* linker.cpp */,
+			);
+			path = link;
+			sourceTree = "<group>";
+		};
+		A972A87921CED2720013AB25 /* opt */ = {
+			isa = PBXGroup;
+			children = (
+				A972A87A21CED2720013AB25 /* optimizer.cpp */,
+				A972A87B21CED2720013AB25 /* if_conversion.h */,
+				A972A87C21CED2720013AB25 /* register_pressure.cpp */,
+				A972A87D21CED2720013AB25 /* loop_utils.cpp */,
+				A972A87E21CED2720013AB25 /* merge_return_pass.h */,
+				A972A87F21CED2720013AB25 /* inline_opaque_pass.h */,
+				A972A88021CED2720013AB25 /* loop_fusion.h */,
+				A972A88121CED2720013AB25 /* combine_access_chains.cpp */,
+				A972A88221CED2720013AB25 /* build_module.cpp */,
+				A972A88321CED2720013AB25 /* composite.h */,
+				A972A88421CED2720013AB25 /* compact_ids_pass.h */,
+				A972A88521CED2720013AB25 /* register_pressure.h */,
+				A972A88621CED2720013AB25 /* tree_iterator.h */,
+				A972A88721CED2720013AB25 /* local_single_store_elim_pass.h */,
+				A972A88821CED2720013AB25 /* reduce_load_size.h */,
+				A972A88921CED2720013AB25 /* types.cpp */,
+				A972A88A21CED2720013AB25 /* scalar_analysis.h */,
+				A972A88B21CED2720013AB25 /* strip_debug_info_pass.h */,
+				A972A88C21CED2720013AB25 /* cfg.cpp */,
+				A972A88D21CED2720013AB25 /* decoration_manager.cpp */,
+				A972A88E21CED2720013AB25 /* local_single_block_elim_pass.cpp */,
+				A972A88F21CED2720013AB25 /* freeze_spec_constant_value_pass.cpp */,
+				A972A89021CED2720013AB25 /* replace_invalid_opc.h */,
+				A972A89121CED2720013AB25 /* local_access_chain_convert_pass.h */,
+				A972A89221CED2720013AB25 /* inst_bindless_check_pass.cpp */,
+				A972A89321CED2720013AB25 /* local_redundancy_elimination.cpp */,
+				A972A89421CED2720013AB25 /* CMakeLists.txt */,
+				A972A89521CED2720013AB25 /* instrument_pass.cpp */,
+				A972A89621CED2720013AB25 /* propagator.h */,
+				A972A89721CED2720013AB25 /* instruction_list.h */,
+				A972A89821CED2720013AB25 /* feature_manager.cpp */,
+				A972A89921CED2720013AB25 /* pass.cpp */,
+				A972A89A21CED2720013AB25 /* loop_fission.cpp */,
+				A972A89B21CED2720013AB25 /* dominator_tree.cpp */,
+				A972A89C21CED2720013AB25 /* merge_return_pass.cpp */,
+				A972A89D21CED2720013AB25 /* ir_context.h */,
+				A972A89E21CED2720013AB25 /* eliminate_dead_constant_pass.cpp */,
+				A972A89F21CED2720013AB25 /* cfg_cleanup_pass.cpp */,
+				A972A8A021CED2720013AB25 /* const_folding_rules.cpp */,
+				A972A8A121CED2720013AB25 /* loop_unroller.h */,
+				A972A8A221CED2720013AB25 /* strip_debug_info_pass.cpp */,
+				A972A8A321CED2720013AB25 /* ssa_rewrite_pass.cpp */,
+				A972A8A421CED2720013AB25 /* loop_dependence.cpp */,
+				A972A8A521CED2720013AB25 /* unify_const_pass.h */,
+				A972A8A621CED2720013AB25 /* ir_loader.h */,
+				A972A8A721CED2720013AB25 /* types.h */,
+				A972A8A821CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.h */,
+				A972A8A921CED2720013AB25 /* mem_pass.cpp */,
+				A972A8AA21CED2720013AB25 /* basic_block.h */,
+				A972A8AB21CED2720013AB25 /* remove_duplicates_pass.cpp */,
+				A972A8AC21CED2720013AB25 /* dead_variable_elimination.cpp */,
+				A972A8AD21CED2720013AB25 /* block_merge_pass.h */,
+				A972A8AE21CED2720013AB25 /* module.cpp */,
+				A972A8AF21CED2720013AB25 /* fold_spec_constant_op_and_composite_pass.cpp */,
+				A972A8B021CED2720013AB25 /* loop_unswitch_pass.cpp */,
+				A972A8B121CED2720013AB25 /* unify_const_pass.cpp */,
+				A972A8B221CED2720013AB25 /* type_manager.cpp */,
+				A972A8B321CED2720013AB25 /* private_to_local_pass.h */,
+				A972A8B421CED2720013AB25 /* inline_pass.cpp */,
+				A972A8B521CED2720013AB25 /* def_use_manager.h */,
+				A972A8B621CED2720013AB25 /* ir_loader.cpp */,
+				A972A8B721CED2720013AB25 /* cfg_cleanup_pass.h */,
+				A972A8B821CED2720013AB25 /* licm_pass.cpp */,
+				A972A8B921CED2720013AB25 /* eliminate_dead_functions_pass.cpp */,
+				A972A8BA21CED2720013AB25 /* local_redundancy_elimination.h */,
+				A972A8BB21CED2720013AB25 /* loop_peeling.h */,
+				A972A8BC21CED2720013AB25 /* vector_dce.cpp */,
+				A972A8BD21CED2720013AB25 /* loop_unroller.cpp */,
+				A972A8BE21CED2720013AB25 /* constants.cpp */,
+				A972A8BF21CED2720013AB25 /* loop_fusion_pass.h */,
+				A972A8C021CED2720013AB25 /* struct_cfg_analysis.h */,
+				A972A8C121CED2720013AB25 /* common_uniform_elim_pass.cpp */,
+				A972A8C221CED2720013AB25 /* def_use_manager.cpp */,
+				A972A8C321CED2720013AB25 /* strip_reflect_info_pass.cpp */,
+				A972A8C421CED2720013AB25 /* decoration_manager.h */,
+				A972A8C521CED2720013AB25 /* ccp_pass.cpp */,
+				A972A8C621CED2720013AB25 /* local_single_block_elim_pass.h */,
+				A972A8C721CED2720013AB25 /* pch_source_opt.cpp */,
+				A972A8C821CED2720013AB25 /* strength_reduction_pass.h */,
+				A972A8C921CED2720013AB25 /* aggressive_dead_code_elim_pass.cpp */,
+				A972A8CA21CED2720013AB25 /* simplification_pass.cpp */,
+				A972A8CB21CED2720013AB25 /* dead_branch_elim_pass.cpp */,
+				A972A8CC21CED2720013AB25 /* flatten_decoration_pass.cpp */,
+				A972A8CD21CED2720013AB25 /* dead_insert_elim_pass.h */,
+				A972A8CE21CED2720013AB25 /* folding_rules.cpp */,
+				A972A8CF21CED2720013AB25 /* freeze_spec_constant_value_pass.h */,
+				A972A8D021CED2720013AB25 /* ir_context.cpp */,
+				A972A8D121CED2720013AB25 /* instrument_pass.h */,
+				A972A8D221CED2720013AB25 /* mem_pass.h */,
+				A972A8D321CED2720013AB25 /* loop_descriptor.cpp */,
+				A972A8D421CED2720013AB25 /* local_ssa_elim_pass.cpp */,
+				A972A8D521CED2720013AB25 /* function.cpp */,
+				A972A8D621CED2720013AB25 /* instruction_list.cpp */,
+				A972A8D721CED2720013AB25 /* composite.cpp */,
+				A972A8D821CED2720013AB25 /* inline_pass.h */,
+				A972A8D921CED2720013AB25 /* loop_dependence.h */,
+				A972A8DA21CED2720013AB25 /* value_number_table.h */,
+				A972A8DB21CED2720013AB25 /* flatten_decoration_pass.h */,
+				A972A8DC21CED2720013AB25 /* if_conversion.cpp */,
+				A972A8DD21CED2720013AB25 /* inline_exhaustive_pass.h */,
+				A972A8DE21CED2720013AB25 /* constants.h */,
+				A972A8DF21CED2720013AB25 /* strength_reduction_pass.cpp */,
+				A972A8E021CED2720013AB25 /* copy_prop_arrays.cpp */,
+				A972A8E121CED2720013AB25 /* pass_manager.cpp */,
+				A972A8E221CED2720013AB25 /* inline_exhaustive_pass.cpp */,
+				A972A8E321CED2720013AB25 /* loop_fission.h */,
+				A972A8E421CED2720013AB25 /* workaround1209.h */,
+				A972A8E521CED2720013AB25 /* loop_fusion_pass.cpp */,
+				A972A8E621CED2720013AB25 /* log.h */,
+				A972A8E721CED2720013AB25 /* copy_prop_arrays.h */,
+				A972A8E821CED2720013AB25 /* eliminate_dead_constant_pass.h */,
+				A972A8E921CED2720013AB25 /* dead_insert_elim_pass.cpp */,
+				A972A8EA21CED2720013AB25 /* ssa_rewrite_pass.h */,
+				A972A8EB21CED2720013AB25 /* scalar_analysis.cpp */,
+				A972A8EC21CED2720013AB25 /* dead_variable_elimination.h */,
+				A972A8ED21CED2720013AB25 /* block_merge_pass.cpp */,
+				A972A8EE21CED2720013AB25 /* dominator_analysis.h */,
+				A972A8EF21CED2720013AB25 /* pass.h */,
+				A972A8F021CED2720013AB25 /* folding_rules.h */,
+				A972A8F121CED2720013AB25 /* eliminate_dead_functions_pass.h */,
+				A972A8F221CED2720013AB25 /* common_uniform_elim_pass.h */,
+				A972A8F321CED2720013AB25 /* fold.h */,
+				A972A8F421CED2720013AB25 /* local_single_store_elim_pass.cpp */,
+				A972A8F521CED2720013AB25 /* dead_branch_elim_pass.h */,
+				A972A8F621CED2720013AB25 /* private_to_local_pass.cpp */,
+				A972A8F721CED2720013AB25 /* scalar_analysis_nodes.h */,
+				A972A8F821CED2720013AB25 /* propagator.cpp */,
+				A972A8F921CED2720013AB25 /* loop_dependence_helpers.cpp */,
+				A972A8FA21CED2720013AB25 /* set_spec_constant_default_value_pass.cpp */,
+				A972A8FB21CED2720013AB25 /* passes.h */,
+				A972A8FC21CED2720013AB25 /* fold.cpp */,
+				A972A8FD21CED2720013AB25 /* strip_reflect_info_pass.h */,
+				A972A8FE21CED2720013AB25 /* scalar_replacement_pass.cpp */,
+				A972A8FF21CED2720013AB25 /* simplification_pass.h */,
+				A972A90021CED2720013AB25 /* remove_duplicates_pass.h */,
+				A972A90121CED2720013AB25 /* redundancy_elimination.cpp */,
+				A972A90221CED2720013AB25 /* reflect.h */,
+				A972A90321CED2720013AB25 /* workaround1209.cpp */,
+				A972A90421CED2720013AB25 /* null_pass.h */,
+				A972A90521CED2720013AB25 /* const_folding_rules.h */,
+				A972A90621CED2720013AB25 /* scalar_replacement_pass.h */,
+				A972A90721CED2720013AB25 /* instruction.cpp */,
+				A972A90821CED2720013AB25 /* pch_source_opt.h */,
+				A972A90921CED2720013AB25 /* reduce_load_size.cpp */,
+				A972A90A21CED2720013AB25 /* redundancy_elimination.h */,
+				A972A90B21CED2720013AB25 /* value_number_table.cpp */,
+				A972A90C21CED2720013AB25 /* local_ssa_elim_pass.h */,
+				A972A90D21CED2720013AB25 /* inline_opaque_pass.cpp */,
+				A972A90E21CED2720013AB25 /* replace_invalid_opc.cpp */,
+				A972A90F21CED2720013AB25 /* loop_utils.h */,
+				A972A91021CED2720013AB25 /* module.h */,
+				A972A91121CED2720013AB25 /* dominator_analysis.cpp */,
+				A972A91221CED2720013AB25 /* ir_builder.h */,
+				A972A91321CED2720013AB25 /* loop_unswitch_pass.h */,
+				A972A91421CED2720013AB25 /* cfg.h */,
+				A972A91521CED2720013AB25 /* loop_descriptor.h */,
+				A972A91621CED2730013AB25 /* instruction.h */,
+				A972A91721CED2730013AB25 /* aggressive_dead_code_elim_pass.h */,
+				A972A91821CED2730013AB25 /* struct_cfg_analysis.cpp */,
+				A972A91921CED2730013AB25 /* vector_dce.h */,
+				A972A91A21CED2730013AB25 /* combine_access_chains.h */,
+				A972A91B21CED2730013AB25 /* pass_manager.h */,
+				A972A91C21CED2730013AB25 /* local_access_chain_convert_pass.cpp */,
+				A972A91D21CED2730013AB25 /* basic_block.cpp */,
+				A972A91E21CED2730013AB25 /* iterator.h */,
+				A972A91F21CED2730013AB25 /* licm_pass.h */,
+				A972A92021CED2730013AB25 /* build_module.h */,
+				A972A92121CED2730013AB25 /* ccp_pass.h */,
+				A972A92221CED2730013AB25 /* function.h */,
+				A972A92321CED2730013AB25 /* loop_fusion.cpp */,
+				A972A92421CED2730013AB25 /* feature_manager.h */,
+				A972A92521CED2730013AB25 /* inst_bindless_check_pass.h */,
+				A972A92621CED2730013AB25 /* scalar_analysis_simplification.cpp */,
+				A972A92721CED2730013AB25 /* set_spec_constant_default_value_pass.h */,
+				A972A92821CED2730013AB25 /* dominator_tree.h */,
+				A972A92921CED2730013AB25 /* type_manager.h */,
+				A972A92A21CED2730013AB25 /* compact_ids_pass.cpp */,
+				A972A92B21CED2730013AB25 /* loop_peeling.cpp */,
+			);
+			path = opt;
+			sourceTree = "<group>";
+		};
+		A972A93B21CED2730013AB25 /* val */ = {
+			isa = PBXGroup;
+			children = (
+				A972A93C21CED2730013AB25 /* validate_annotation.cpp */,
+				A972A93D21CED2730013AB25 /* validate_cfg.cpp */,
+				A972A93E21CED2730013AB25 /* validate_capability.cpp */,
+				A972A93F21CED2730013AB25 /* construct.h */,
+				A972A94021CED2730013AB25 /* validate_barriers.cpp */,
+				A972A94121CED2730013AB25 /* validate_non_uniform.cpp */,
+				A972A94221CED2730013AB25 /* validate_atomics.cpp */,
+				A972A94321CED2730013AB25 /* basic_block.h */,
+				A972A94421CED2730013AB25 /* validate_instruction.cpp */,
+				A972A94521CED2730013AB25 /* validate_decorations.cpp */,
+				A972A94621CED2730013AB25 /* validate_debug.cpp */,
+				A972A94721CED2730013AB25 /* validate_builtins.cpp */,
+				A972A94821CED2730013AB25 /* validate_interfaces.cpp */,
+				A972A94921CED2730013AB25 /* validate.cpp */,
+				A972A94A21CED2730013AB25 /* validation_state.h */,
+				A972A94B21CED2730013AB25 /* validate_constants.cpp */,
+				A972A94C21CED2730013AB25 /* validate_bitwise.cpp */,
+				A972A94D21CED2730013AB25 /* construct.cpp */,
+				A972A94E21CED2730013AB25 /* function.cpp */,
+				A972A94F21CED2730013AB25 /* validate.h */,
+				A972A95021CED2730013AB25 /* validate_adjacency.cpp */,
+				A972A95121CED2730013AB25 /* validate_conversion.cpp */,
+				A972A95221CED2730013AB25 /* validate_datarules.cpp */,
+				A972A95321CED2730013AB25 /* validate_id.cpp */,
+				A972A95421CED2730013AB25 /* validate_arithmetics.cpp */,
+				A972A95521CED2730013AB25 /* validate_mode_setting.cpp */,
+				A972A95621CED2730013AB25 /* validate_logicals.cpp */,
+				A972A95721CED2730013AB25 /* validate_derivatives.cpp */,
+				A972A95821CED2730013AB25 /* validate_memory.cpp */,
+				A972A95921CED2730013AB25 /* validate_image.cpp */,
+				A972A95A21CED2730013AB25 /* validate_literals.cpp */,
+				A972A95B21CED2730013AB25 /* instruction.cpp */,
+				A972A95C21CED2730013AB25 /* validate_type.cpp */,
+				A972A95D21CED2730013AB25 /* validate_ext_inst.cpp */,
+				A972A95E21CED2730013AB25 /* instruction.h */,
+				A972A95F21CED2730013AB25 /* validate_execution_limitations.cpp */,
+				A972A96021CED2730013AB25 /* validate_layout.cpp */,
+				A972A96121CED2730013AB25 /* basic_block.cpp */,
+				A972A96221CED2730013AB25 /* validate_function.cpp */,
+				A972A96321CED2730013AB25 /* function.h */,
+				A972A96421CED2730013AB25 /* validate_composites.cpp */,
+				A972A96521CED2730013AB25 /* validation_state.cpp */,
+				A972A96621CED2730013AB25 /* validate_primitives.cpp */,
+				A972A96721CED2730013AB25 /* decoration.h */,
+			);
+			path = val;
+			sourceTree = "<group>";
+		};
+		A972ABC821CED6F90013AB25 /* glslang */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC1421CED9060013AB25 /* glslang */,
+				A972ABF521CED9060013AB25 /* OGLCompilersDLL */,
+				A972ABF921CED9060013AB25 /* SPIRV */,
+			);
+			path = glslang;
+			sourceTree = "<group>";
+		};
+		A972ABF521CED9060013AB25 /* OGLCompilersDLL */ = {
+			isa = PBXGroup;
+			children = (
+				A972ABF621CED9060013AB25 /* CMakeLists.txt */,
+				A972ABF721CED9060013AB25 /* InitializeDll.h */,
+				A972ABF821CED9060013AB25 /* InitializeDll.cpp */,
+			);
+			path = OGLCompilersDLL;
+			sourceTree = "<group>";
+		};
+		A972ABF921CED9060013AB25 /* SPIRV */ = {
+			isa = PBXGroup;
+			children = (
+				A972ABFA21CED9060013AB25 /* SPVRemapper.h */,
+				A972ABFB21CED9060013AB25 /* SpvBuilder.h */,
+				A972ABFC21CED9060013AB25 /* CMakeLists.txt */,
+				A972ABFD21CED9060013AB25 /* SpvPostProcess.cpp */,
+				A972ABFE21CED9060013AB25 /* SpvTools.h */,
+				A972ABFF21CED9060013AB25 /* SpvTools.cpp */,
+				A972AC0021CED9060013AB25 /* InReadableOrder.cpp */,
+				A972AC0121CED9060013AB25 /* GLSL.ext.AMD.h */,
+				A972AC0221CED9060013AB25 /* doc.h */,
+				A972AC0321CED9060013AB25 /* spirv.hpp */,
+				A972AC0421CED9060013AB25 /* SpvBuilder.cpp */,
+				A972AC0521CED9060013AB25 /* GLSL.ext.EXT.h */,
+				A972AC0621CED9060013AB25 /* GLSL.ext.KHR.h */,
+				A972AC0721CED9060013AB25 /* GLSL.ext.NV.h */,
+				A972AC0821CED9060013AB25 /* GlslangToSpv.cpp */,
+				A972AC0921CED9060013AB25 /* spvIR.h */,
+				A972AC0A21CED9060013AB25 /* bitutils.h */,
+				A972AC0B21CED9060013AB25 /* disassemble.h */,
+				A972AC0C21CED9060013AB25 /* GlslangToSpv.h */,
+				A972AC0D21CED9060013AB25 /* GLSL.std.450.h */,
+				A972AC0E21CED9060013AB25 /* SPVRemapper.cpp */,
+				A972AC0F21CED9060013AB25 /* Logger.cpp */,
+				A972AC1021CED9060013AB25 /* hex_float.h */,
+				A972AC1121CED9060013AB25 /* Logger.h */,
+				A972AC1221CED9060013AB25 /* doc.cpp */,
+				A972AC1321CED9060013AB25 /* disassemble.cpp */,
+			);
+			path = SPIRV;
+			sourceTree = "<group>";
+		};
+		A972AC1421CED9060013AB25 /* glslang */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC1521CED9060013AB25 /* CMakeLists.txt */,
+				A972AC1621CED9060013AB25 /* OSDependent */,
+				A972AC1F21CED9060013AB25 /* Include */,
+				A972AC2D21CED9060013AB25 /* updateGrammar */,
+				A972AC2E21CED9060013AB25 /* MachineIndependent */,
+				A972AC6021CED9060013AB25 /* Public */,
+				A972AC6221CED9060013AB25 /* GenericCodeGen */,
+			);
+			path = glslang;
+			sourceTree = "<group>";
+		};
+		A972AC1621CED9060013AB25 /* OSDependent */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC1721CED9060013AB25 /* Unix */,
+				A972AC1A21CED9060013AB25 /* osinclude.h */,
+			);
+			path = OSDependent;
+			sourceTree = "<group>";
+		};
+		A972AC1721CED9060013AB25 /* Unix */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC1821CED9060013AB25 /* ossource.cpp */,
+				A972AC1921CED9060013AB25 /* CMakeLists.txt */,
+			);
+			path = Unix;
+			sourceTree = "<group>";
+		};
+		A972AC1F21CED9060013AB25 /* Include */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC2021CED9060013AB25 /* ResourceLimits.h */,
+				A972AC2121CED9060013AB25 /* Types.h */,
+				A972AC2221CED9060013AB25 /* intermediate.h */,
+				A972AC2321CED9060013AB25 /* BaseTypes.h */,
+				A972AC2421CED9060013AB25 /* revision.h */,
+				A972AC2521CED9060013AB25 /* InitializeGlobals.h */,
+				A972AC2621CED9060013AB25 /* ShHandle.h */,
+				A972AC2721CED9060013AB25 /* arrays.h */,
+				A972AC2821CED9060013AB25 /* Common.h */,
+				A972AC2921CED9060013AB25 /* revision.template */,
+				A972AC2A21CED9060013AB25 /* ConstantUnion.h */,
+				A972AC2B21CED9060013AB25 /* InfoSink.h */,
+				A972AC2C21CED9060013AB25 /* PoolAlloc.h */,
+			);
+			path = Include;
+			sourceTree = "<group>";
+		};
+		A972AC2E21CED9060013AB25 /* MachineIndependent */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC2F21CED9060013AB25 /* ParseHelper.cpp */,
+				A972AC3021CED9060013AB25 /* parseVersions.h */,
+				A972AC3121CED9060013AB25 /* gl_types.h */,
+				A972AC3221CED9060013AB25 /* propagateNoContraction.cpp */,
+				A972AC3321CED9060013AB25 /* pch.h */,
+				A972AC3421CED9060013AB25 /* ScanContext.h */,
+				A972AC3521CED9060013AB25 /* iomapper.h */,
+				A972AC3621CED9060013AB25 /* localintermediate.h */,
+				A972AC3721CED9060013AB25 /* Scan.cpp */,
+				A972AC3921CED9060013AB25 /* RemoveTree.h */,
+				A972AC3A21CED9060013AB25 /* Initialize.cpp */,
+				A972AC3B21CED9060013AB25 /* glslang_tab.cpp */,
+				A972AC3C21CED9060013AB25 /* limits.cpp */,
+				A972AC3D21CED9060013AB25 /* parseConst.cpp */,
+				A972AC3E21CED9060013AB25 /* propagateNoContraction.h */,
+				A972AC3F21CED9060013AB25 /* Versions.h */,
+				A972AC4021CED9060013AB25 /* IntermTraverse.cpp */,
+				A972AC4121CED9060013AB25 /* intermOut.cpp */,
+				A972AC4221CED9060013AB25 /* iomapper.cpp */,
+				A972AC4321CED9060013AB25 /* PoolAlloc.cpp */,
+				A972AC4421CED9060013AB25 /* ShaderLang.cpp */,
+				A972AC4521CED9060013AB25 /* SymbolTable.h */,
+				A972AC4621CED9060013AB25 /* InfoSink.cpp */,
+				A972AC4721CED9060013AB25 /* Intermediate.cpp */,
+				A972AC4821CED9060013AB25 /* pch.cpp */,
+				A972AC4921CED9060013AB25 /* SymbolTable.cpp */,
+				A972AC4A21CED9060013AB25 /* glslang_tab.cpp.h */,
+				A972AC4B21CED9060013AB25 /* LiveTraverser.h */,
+				A972AC4C21CED9060013AB25 /* Initialize.h */,
+				A972AC4D21CED9060013AB25 /* attribute.cpp */,
+				A972AC4E21CED9060013AB25 /* reflection.cpp */,
+				A972AC4F21CED9060013AB25 /* RemoveTree.cpp */,
+				A972AC5021CED9060013AB25 /* attribute.h */,
+				A972AC5121CED9060013AB25 /* Versions.cpp */,
+				A972AC5221CED9060013AB25 /* Constant.cpp */,
+				A972AC5321CED9060013AB25 /* linkValidate.cpp */,
+				A972AC5421CED9060013AB25 /* ParseHelper.h */,
+				A972AC5521CED9060013AB25 /* preprocessor */,
+				A972AC5D21CED9060013AB25 /* ParseContextBase.cpp */,
+				A972AC5E21CED9060013AB25 /* reflection.h */,
+				A972AC5F21CED9060013AB25 /* Scan.h */,
+			);
+			path = MachineIndependent;
+			sourceTree = "<group>";
+		};
+		A972AC5521CED9060013AB25 /* preprocessor */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC5621CED9060013AB25 /* PpAtom.cpp */,
+				A972AC5721CED9060013AB25 /* PpTokens.h */,
+				A972AC5821CED9060013AB25 /* Pp.cpp */,
+				A972AC5921CED9060013AB25 /* PpContext.h */,
+				A972AC5A21CED9060013AB25 /* PpTokens.cpp */,
+				A972AC5B21CED9060013AB25 /* PpContext.cpp */,
+				A972AC5C21CED9060013AB25 /* PpScanner.cpp */,
+			);
+			path = preprocessor;
+			sourceTree = "<group>";
+		};
+		A972AC6021CED9060013AB25 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC6121CED9060013AB25 /* ShaderLang.h */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		A972AC6221CED9060013AB25 /* GenericCodeGen */ = {
+			isa = PBXGroup;
+			children = (
+				A972AC6321CED9060013AB25 /* CodeGen.cpp */,
+				A972AC6421CED9060013AB25 /* Link.cpp */,
+			);
+			path = GenericCodeGen;
+			sourceTree = "<group>";
+		};
+		A972AD2421CEE30F0013AB25 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A90FD89F21CC4EAB00B92BB2 /* libSPIRVCross.a */,
+				A90FD9E421CC4EB900B92BB2 /* libSPIRVCross.a */,
+				A972A80F21CECBBF0013AB25 /* libSPIRVTools.a */,
+				A972A82321CECBE90013AB25 /* libSPIRVTools.a */,
+				A972ABDC21CED7BC0013AB25 /* libglslang.a */,
+				A972ABF021CED7CB0013AB25 /* libglslang.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A97628F021CC5DA700B52A68 /* SPIRV-Cross */ = {
+			isa = PBXGroup;
+			children = (
+				A976290B21CC60BC00B52A68 /* spirv_cfg.cpp */,
+				A976290921CC60BC00B52A68 /* spirv_cfg.hpp */,
+				A976290721CC60BC00B52A68 /* spirv_common.hpp */,
+				A976290E21CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp */,
+				A976290821CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp */,
+				A976290521CC60BC00B52A68 /* spirv_cross.cpp */,
+				A976290321CC60BC00B52A68 /* spirv_cross.hpp */,
+				A976290621CC60BC00B52A68 /* spirv_glsl.cpp */,
+				A976290A21CC60BC00B52A68 /* spirv_glsl.hpp */,
+				A976290D21CC60BC00B52A68 /* spirv_msl.cpp */,
+				A976290221CC60BC00B52A68 /* spirv_msl.hpp */,
+				A976290421CC60BC00B52A68 /* spirv_parser.cpp */,
+				A976290C21CC60BC00B52A68 /* spirv_parser.hpp */,
+			);
+			path = "SPIRV-Cross";
+			sourceTree = "<group>";
+		};
+		A9F55D24198BE6A7004EC31B = {
+			isa = PBXGroup;
+			children = (
+				A9C2104521D14FD7006BA2D3 /* fetchDependencies */,
+				A9C2104721D15843006BA2D3 /* ExternalRevisions */,
+				A90FD9E921CC519E00B92BB2 /* External */,
+				A972AD2421CEE30F0013AB25 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		A972A7FD21CECBBF0013AB25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972A9EE21CED2730013AB25 /* disassemble.h in Headers */,
+				A972AAE021CED2730013AB25 /* fold.h in Headers */,
+				A972AB5421CED2730013AB25 /* ext_inst.h in Headers */,
+				A972A97E21CED2730013AB25 /* string_utils.h in Headers */,
+				A972AB0E21CED2730013AB25 /* redundancy_elimination.h in Headers */,
+				A972AA0821CED2730013AB25 /* tree_iterator.h in Headers */,
+				A972A97221CED2730013AB25 /* text.h in Headers */,
+				A972AAC021CED2730013AB25 /* loop_fission.h in Headers */,
+				A972AA9821CED2730013AB25 /* freeze_spec_constant_value_pass.h in Headers */,
+				A972AAB621CED2730013AB25 /* constants.h in Headers */,
+				A972AA8221CED2730013AB25 /* decoration_manager.h in Headers */,
+				A972AA4621CED2730013AB25 /* ir_loader.h in Headers */,
+				A972A97C21CED2730013AB25 /* make_unique.h in Headers */,
+				A972AA0621CED2730013AB25 /* register_pressure.h in Headers */,
+				A972AB2E21CED2730013AB25 /* combine_access_chains.h in Headers */,
+				A972A98C21CED2730013AB25 /* hex_float.h in Headers */,
+				A972AB2C21CED2730013AB25 /* vector_dce.h in Headers */,
+				A972AA9C21CED2730013AB25 /* instrument_pass.h in Headers */,
+				A972AA1221CED2730013AB25 /* strip_debug_info_pass.h in Headers */,
+				A972AA5421CED2730013AB25 /* block_merge_pass.h in Headers */,
+				A972A9CE21CED2730013AB25 /* markv_logger.h in Headers */,
+				A972AA0A21CED2730013AB25 /* local_single_store_elim_pass.h in Headers */,
+				A972AA8A21CED2730013AB25 /* strength_reduction_pass.h in Headers */,
+				A972A9CA21CED2730013AB25 /* move_to_front.h in Headers */,
+				A972AB0621CED2730013AB25 /* scalar_replacement_pass.h in Headers */,
+				A972AAD821CED2730013AB25 /* pass.h in Headers */,
+				A972AB9621CED2730013AB25 /* validate.h in Headers */,
+				A972A9AA21CED2730013AB25 /* operand.h in Headers */,
+				A972AB6C21CED2730013AB25 /* binary.h in Headers */,
+				A972AB2021CED2730013AB25 /* loop_unswitch_pass.h in Headers */,
+				A972A99A21CED2730013AB25 /* latest_version_opencl_std_header.h in Headers */,
+				A972AB0421CED2730013AB25 /* const_folding_rules.h in Headers */,
+				A972AB4221CED2730013AB25 /* feature_manager.h in Headers */,
+				A972AB6621CED2730013AB25 /* latest_version_glsl_std_450_header.h in Headers */,
+				A972A9F221CED2730013AB25 /* if_conversion.h in Headers */,
+				A972AB6021CED2730013AB25 /* spirv_optimizer_options.h in Headers */,
+				A972A9F821CED2730013AB25 /* merge_return_pass.h in Headers */,
+				A972AB1821CED2730013AB25 /* loop_utils.h in Headers */,
+				A972AADA21CED2730013AB25 /* folding_rules.h in Headers */,
+				A972AB6221CED2730013AB25 /* opcode.h in Headers */,
+				A972ABB421CED2730013AB25 /* instruction.h in Headers */,
+				A972AB7E21CED2730013AB25 /* basic_block.h in Headers */,
+				A972AB4421CED2730013AB25 /* inst_bindless_check_pass.h in Headers */,
+				A972A9AE21CED2730013AB25 /* macro.h in Headers */,
+				A972A99E21CED2730013AB25 /* cfa.h in Headers */,
+				A972AA4821CED2730013AB25 /* types.h in Headers */,
+				A972AA2821CED2730013AB25 /* instruction_list.h in Headers */,
+				A972A9FA21CED2730013AB25 /* inline_opaque_pass.h in Headers */,
+				A972A9DA21CED2730013AB25 /* name_mapper.h in Headers */,
+				A972AA3C21CED2730013AB25 /* loop_unroller.h in Headers */,
+				A972A9C621CED2730013AB25 /* markv_model.h in Headers */,
+				A972A97A21CED2730013AB25 /* ilist_node.h in Headers */,
+				A972AA4E21CED2730013AB25 /* basic_block.h in Headers */,
+				A972AACE21CED2730013AB25 /* ssa_rewrite_pass.h in Headers */,
+				A972AAF021CED2730013AB25 /* passes.h in Headers */,
+				A972AAAC21CED2730013AB25 /* loop_dependence.h in Headers */,
+				A972A99221CED2730013AB25 /* ilist.h in Headers */,
+				A972AAC621CED2730013AB25 /* log.h in Headers */,
+				A972AB2421CED2730013AB25 /* loop_descriptor.h in Headers */,
+				A972A9C221CED2730013AB25 /* markv_decoder.h in Headers */,
+				A972AA7021CED2730013AB25 /* loop_peeling.h in Headers */,
+				A972AAC821CED2730013AB25 /* copy_prop_arrays.h in Headers */,
+				A972AB5C21CED2730013AB25 /* instruction.h in Headers */,
+				A972AB5E21CED2730013AB25 /* id_descriptor.h in Headers */,
+				A972A9D621CED2730013AB25 /* text_handler.h in Headers */,
+				A972AB3021CED2730013AB25 /* pass_manager.h in Headers */,
+				A972AACA21CED2730013AB25 /* eliminate_dead_constant_pass.h in Headers */,
+				A972A96C21CED2730013AB25 /* enum_set.h in Headers */,
+				A972AB1E21CED2730013AB25 /* ir_builder.h in Headers */,
+				A972AB6821CED2730013AB25 /* extensions.h in Headers */,
+				A972A9C021CED2730013AB25 /* markv_encoder.h in Headers */,
+				A972AA1C21CED2730013AB25 /* replace_invalid_opc.h in Headers */,
+				A972A9A221CED2730013AB25 /* enum_string_mapping.h in Headers */,
+				A972AB3821CED2730013AB25 /* licm_pass.h in Headers */,
+				A972A9CC21CED2730013AB25 /* markv_codec.h in Headers */,
+				A972A9BC21CED2730013AB25 /* bit_stream.h in Headers */,
+				A972AAB021CED2730013AB25 /* flatten_decoration_pass.h in Headers */,
+				A972AA1021CED2730013AB25 /* scalar_analysis.h in Headers */,
+				A972A98821CED2730013AB25 /* bit_vector.h in Headers */,
+				A972AAFA21CED2730013AB25 /* remove_duplicates_pass.h in Headers */,
+				A972A96A21CED2730013AB25 /* assembly_grammar.h in Headers */,
+				A972AAD621CED2730013AB25 /* dominator_analysis.h in Headers */,
+				A972AB0221CED2730013AB25 /* null_pass.h in Headers */,
+				A972A9DE21CED2730013AB25 /* diagnostic.h in Headers */,
+				A972AA0221CED2730013AB25 /* composite.h in Headers */,
+				A972A9EA21CED2730013AB25 /* print.h in Headers */,
+				A972AB2621CED2730013AB25 /* instruction.h in Headers */,
+				A972AA6021CED2730013AB25 /* private_to_local_pass.h in Headers */,
+				A972AB2221CED2730013AB25 /* cfg.h in Headers */,
+				A972AAD221CED2730013AB25 /* dead_variable_elimination.h in Headers */,
+				A972A98421CED2730013AB25 /* timer.h in Headers */,
+				A972AB2821CED2730013AB25 /* aggressive_dead_code_elim_pass.h in Headers */,
+				A972AA8621CED2730013AB25 /* local_single_block_elim_pass.h in Headers */,
+				A972AAE421CED2730013AB25 /* dead_branch_elim_pass.h in Headers */,
+				A972AA6E21CED2730013AB25 /* local_redundancy_elimination.h in Headers */,
+				A972AB4C21CED2730013AB25 /* type_manager.h in Headers */,
+				A972AADE21CED2730013AB25 /* common_uniform_elim_pass.h in Headers */,
+				A972AB0A21CED2730013AB25 /* pch_source_opt.h in Headers */,
+				A972A9E021CED2730013AB25 /* spirv_endian.h in Headers */,
+				A972AB3E21CED2730013AB25 /* function.h in Headers */,
+				A972ABC621CED2730013AB25 /* decoration.h in Headers */,
+				A972AB5821CED2730013AB25 /* latest_version_spirv_header.h in Headers */,
+				A972AB8C21CED2730013AB25 /* validation_state.h in Headers */,
+				A972A9B421CED2730013AB25 /* spirv_validator_options.h in Headers */,
+				A972AB3A21CED2730013AB25 /* build_module.h in Headers */,
+				A972AAF821CED2730013AB25 /* simplification_pass.h in Headers */,
+				A972AB3C21CED2730013AB25 /* ccp_pass.h in Headers */,
+				A972AAAE21CED2730013AB25 /* value_number_table.h in Headers */,
+				A972AAC221CED2730013AB25 /* workaround1209.h in Headers */,
+				A972AB1A21CED2730013AB25 /* module.h in Headers */,
+				A972AB5221CED2730013AB25 /* table.h in Headers */,
+				A972AA4421CED2730013AB25 /* unify_const_pass.h in Headers */,
+				A972A99421CED2730013AB25 /* spirv_target_env.h in Headers */,
+				A972AAFE21CED2730013AB25 /* reflect.h in Headers */,
+				A972AA6421CED2730013AB25 /* def_use_manager.h in Headers */,
+				A972AB1221CED2730013AB25 /* local_ssa_elim_pass.h in Headers */,
+				A972AAAA21CED2730013AB25 /* inline_pass.h in Headers */,
+				A972AAE821CED2730013AB25 /* scalar_analysis_nodes.h in Headers */,
+				A972A9A021CED2730013AB25 /* pch_source.h in Headers */,
+				A972AA7821CED2730013AB25 /* loop_fusion_pass.h in Headers */,
+				A972AA0421CED2730013AB25 /* compact_ids_pass.h in Headers */,
+				A972AA9E21CED2730013AB25 /* mem_pass.h in Headers */,
+				A972AA4A21CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.h in Headers */,
+				A972A9A821CED2730013AB25 /* spirv_definition.h in Headers */,
+				A972A9D821CED2730013AB25 /* parsed_operand.h in Headers */,
+				A972A98A21CED2730013AB25 /* bitutils.h in Headers */,
+				A972AAB421CED2730013AB25 /* inline_exhaustive_pass.h in Headers */,
+				A972AADC21CED2730013AB25 /* eliminate_dead_functions_pass.h in Headers */,
+				A972AAF421CED2730013AB25 /* strip_reflect_info_pass.h in Headers */,
+				A972AB4821CED2730013AB25 /* set_spec_constant_default_value_pass.h in Headers */,
+				A972A9FC21CED2730013AB25 /* loop_fusion.h in Headers */,
+				A972AB7621CED2730013AB25 /* construct.h in Headers */,
+				A972A97821CED2730013AB25 /* parse_number.h in Headers */,
+				A972AA0C21CED2730013AB25 /* reduce_load_size.h in Headers */,
+				A972AA3421CED2730013AB25 /* ir_context.h in Headers */,
+				A972AA7A21CED2730013AB25 /* struct_cfg_analysis.h in Headers */,
+				A972A98021CED2730013AB25 /* small_vector.h in Headers */,
+				A972AA9421CED2730013AB25 /* dead_insert_elim_pass.h in Headers */,
+				A972AB4A21CED2730013AB25 /* dominator_tree.h in Headers */,
+				A972A9B021CED2730013AB25 /* spirv_constant.h in Headers */,
+				A972AA6821CED2730013AB25 /* cfg_cleanup_pass.h in Headers */,
+				A972ABBE21CED2730013AB25 /* function.h in Headers */,
+				A972AA1E21CED2730013AB25 /* local_access_chain_convert_pass.h in Headers */,
+				A972A9C421CED2730013AB25 /* markv.h in Headers */,
+				A972A9BA21CED2730013AB25 /* huffman_codec.h in Headers */,
+				A972AA2621CED2730013AB25 /* propagator.h in Headers */,
+				A972AB3621CED2730013AB25 /* iterator.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972A81121CECBE90013AB25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972A9EF21CED2730013AB25 /* disassemble.h in Headers */,
+				A972AAE121CED2730013AB25 /* fold.h in Headers */,
+				A972AB5521CED2730013AB25 /* ext_inst.h in Headers */,
+				A972A97F21CED2730013AB25 /* string_utils.h in Headers */,
+				A972AB0F21CED2730013AB25 /* redundancy_elimination.h in Headers */,
+				A972AA0921CED2730013AB25 /* tree_iterator.h in Headers */,
+				A972A97321CED2730013AB25 /* text.h in Headers */,
+				A972AAC121CED2730013AB25 /* loop_fission.h in Headers */,
+				A972AA9921CED2730013AB25 /* freeze_spec_constant_value_pass.h in Headers */,
+				A972AAB721CED2730013AB25 /* constants.h in Headers */,
+				A972AA8321CED2730013AB25 /* decoration_manager.h in Headers */,
+				A972AA4721CED2730013AB25 /* ir_loader.h in Headers */,
+				A972A97D21CED2730013AB25 /* make_unique.h in Headers */,
+				A972AA0721CED2730013AB25 /* register_pressure.h in Headers */,
+				A972AB2F21CED2730013AB25 /* combine_access_chains.h in Headers */,
+				A972A98D21CED2730013AB25 /* hex_float.h in Headers */,
+				A972AB2D21CED2730013AB25 /* vector_dce.h in Headers */,
+				A972AA9D21CED2730013AB25 /* instrument_pass.h in Headers */,
+				A972AA1321CED2730013AB25 /* strip_debug_info_pass.h in Headers */,
+				A972AA5521CED2730013AB25 /* block_merge_pass.h in Headers */,
+				A972A9CF21CED2730013AB25 /* markv_logger.h in Headers */,
+				A972AA0B21CED2730013AB25 /* local_single_store_elim_pass.h in Headers */,
+				A972AA8B21CED2730013AB25 /* strength_reduction_pass.h in Headers */,
+				A972A9CB21CED2730013AB25 /* move_to_front.h in Headers */,
+				A972AB0721CED2730013AB25 /* scalar_replacement_pass.h in Headers */,
+				A972AAD921CED2730013AB25 /* pass.h in Headers */,
+				A972AB9721CED2730013AB25 /* validate.h in Headers */,
+				A972A9AB21CED2730013AB25 /* operand.h in Headers */,
+				A972AB6D21CED2730013AB25 /* binary.h in Headers */,
+				A972AB2121CED2730013AB25 /* loop_unswitch_pass.h in Headers */,
+				A972A99B21CED2730013AB25 /* latest_version_opencl_std_header.h in Headers */,
+				A972AB0521CED2730013AB25 /* const_folding_rules.h in Headers */,
+				A972AB4321CED2730013AB25 /* feature_manager.h in Headers */,
+				A972AB6721CED2730013AB25 /* latest_version_glsl_std_450_header.h in Headers */,
+				A972A9F321CED2730013AB25 /* if_conversion.h in Headers */,
+				A972AB6121CED2730013AB25 /* spirv_optimizer_options.h in Headers */,
+				A972A9F921CED2730013AB25 /* merge_return_pass.h in Headers */,
+				A972AB1921CED2730013AB25 /* loop_utils.h in Headers */,
+				A972AADB21CED2730013AB25 /* folding_rules.h in Headers */,
+				A972AB6321CED2730013AB25 /* opcode.h in Headers */,
+				A972ABB521CED2730013AB25 /* instruction.h in Headers */,
+				A972AB7F21CED2730013AB25 /* basic_block.h in Headers */,
+				A972AB4521CED2730013AB25 /* inst_bindless_check_pass.h in Headers */,
+				A972A9AF21CED2730013AB25 /* macro.h in Headers */,
+				A972A99F21CED2730013AB25 /* cfa.h in Headers */,
+				A972AA4921CED2730013AB25 /* types.h in Headers */,
+				A972AA2921CED2730013AB25 /* instruction_list.h in Headers */,
+				A972A9FB21CED2730013AB25 /* inline_opaque_pass.h in Headers */,
+				A972A9DB21CED2730013AB25 /* name_mapper.h in Headers */,
+				A972AA3D21CED2730013AB25 /* loop_unroller.h in Headers */,
+				A972A9C721CED2730013AB25 /* markv_model.h in Headers */,
+				A972A97B21CED2730013AB25 /* ilist_node.h in Headers */,
+				A972AA4F21CED2730013AB25 /* basic_block.h in Headers */,
+				A972AACF21CED2730013AB25 /* ssa_rewrite_pass.h in Headers */,
+				A972AAF121CED2730013AB25 /* passes.h in Headers */,
+				A972AAAD21CED2730013AB25 /* loop_dependence.h in Headers */,
+				A972A99321CED2730013AB25 /* ilist.h in Headers */,
+				A972AAC721CED2730013AB25 /* log.h in Headers */,
+				A972AB2521CED2730013AB25 /* loop_descriptor.h in Headers */,
+				A972A9C321CED2730013AB25 /* markv_decoder.h in Headers */,
+				A972AA7121CED2730013AB25 /* loop_peeling.h in Headers */,
+				A972AAC921CED2730013AB25 /* copy_prop_arrays.h in Headers */,
+				A972AB5D21CED2730013AB25 /* instruction.h in Headers */,
+				A972AB5F21CED2730013AB25 /* id_descriptor.h in Headers */,
+				A972A9D721CED2730013AB25 /* text_handler.h in Headers */,
+				A972AB3121CED2730013AB25 /* pass_manager.h in Headers */,
+				A972AACB21CED2730013AB25 /* eliminate_dead_constant_pass.h in Headers */,
+				A972A96D21CED2730013AB25 /* enum_set.h in Headers */,
+				A972AB1F21CED2730013AB25 /* ir_builder.h in Headers */,
+				A972AB6921CED2730013AB25 /* extensions.h in Headers */,
+				A972A9C121CED2730013AB25 /* markv_encoder.h in Headers */,
+				A972AA1D21CED2730013AB25 /* replace_invalid_opc.h in Headers */,
+				A972A9A321CED2730013AB25 /* enum_string_mapping.h in Headers */,
+				A972AB3921CED2730013AB25 /* licm_pass.h in Headers */,
+				A972A9CD21CED2730013AB25 /* markv_codec.h in Headers */,
+				A972A9BD21CED2730013AB25 /* bit_stream.h in Headers */,
+				A972AAB121CED2730013AB25 /* flatten_decoration_pass.h in Headers */,
+				A972AA1121CED2730013AB25 /* scalar_analysis.h in Headers */,
+				A972A98921CED2730013AB25 /* bit_vector.h in Headers */,
+				A972AAFB21CED2730013AB25 /* remove_duplicates_pass.h in Headers */,
+				A972A96B21CED2730013AB25 /* assembly_grammar.h in Headers */,
+				A972AAD721CED2730013AB25 /* dominator_analysis.h in Headers */,
+				A972AB0321CED2730013AB25 /* null_pass.h in Headers */,
+				A972A9DF21CED2730013AB25 /* diagnostic.h in Headers */,
+				A972AA0321CED2730013AB25 /* composite.h in Headers */,
+				A972A9EB21CED2730013AB25 /* print.h in Headers */,
+				A972AB2721CED2730013AB25 /* instruction.h in Headers */,
+				A972AA6121CED2730013AB25 /* private_to_local_pass.h in Headers */,
+				A972AB2321CED2730013AB25 /* cfg.h in Headers */,
+				A972AAD321CED2730013AB25 /* dead_variable_elimination.h in Headers */,
+				A972A98521CED2730013AB25 /* timer.h in Headers */,
+				A972AB2921CED2730013AB25 /* aggressive_dead_code_elim_pass.h in Headers */,
+				A972AA8721CED2730013AB25 /* local_single_block_elim_pass.h in Headers */,
+				A972AAE521CED2730013AB25 /* dead_branch_elim_pass.h in Headers */,
+				A972AA6F21CED2730013AB25 /* local_redundancy_elimination.h in Headers */,
+				A972AB4D21CED2730013AB25 /* type_manager.h in Headers */,
+				A972AADF21CED2730013AB25 /* common_uniform_elim_pass.h in Headers */,
+				A972AB0B21CED2730013AB25 /* pch_source_opt.h in Headers */,
+				A972A9E121CED2730013AB25 /* spirv_endian.h in Headers */,
+				A972AB3F21CED2730013AB25 /* function.h in Headers */,
+				A972ABC721CED2730013AB25 /* decoration.h in Headers */,
+				A972AB5921CED2730013AB25 /* latest_version_spirv_header.h in Headers */,
+				A972AB8D21CED2730013AB25 /* validation_state.h in Headers */,
+				A972A9B521CED2730013AB25 /* spirv_validator_options.h in Headers */,
+				A972AB3B21CED2730013AB25 /* build_module.h in Headers */,
+				A972AAF921CED2730013AB25 /* simplification_pass.h in Headers */,
+				A972AB3D21CED2730013AB25 /* ccp_pass.h in Headers */,
+				A972AAAF21CED2730013AB25 /* value_number_table.h in Headers */,
+				A972AAC321CED2730013AB25 /* workaround1209.h in Headers */,
+				A972AB1B21CED2730013AB25 /* module.h in Headers */,
+				A972AB5321CED2730013AB25 /* table.h in Headers */,
+				A972AA4521CED2730013AB25 /* unify_const_pass.h in Headers */,
+				A972A99521CED2730013AB25 /* spirv_target_env.h in Headers */,
+				A972AAFF21CED2730013AB25 /* reflect.h in Headers */,
+				A972AA6521CED2730013AB25 /* def_use_manager.h in Headers */,
+				A972AB1321CED2730013AB25 /* local_ssa_elim_pass.h in Headers */,
+				A972AAAB21CED2730013AB25 /* inline_pass.h in Headers */,
+				A972AAE921CED2730013AB25 /* scalar_analysis_nodes.h in Headers */,
+				A972A9A121CED2730013AB25 /* pch_source.h in Headers */,
+				A972AA7921CED2730013AB25 /* loop_fusion_pass.h in Headers */,
+				A972AA0521CED2730013AB25 /* compact_ids_pass.h in Headers */,
+				A972AA9F21CED2730013AB25 /* mem_pass.h in Headers */,
+				A972AA4B21CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.h in Headers */,
+				A972A9A921CED2730013AB25 /* spirv_definition.h in Headers */,
+				A972A9D921CED2730013AB25 /* parsed_operand.h in Headers */,
+				A972A98B21CED2730013AB25 /* bitutils.h in Headers */,
+				A972AAB521CED2730013AB25 /* inline_exhaustive_pass.h in Headers */,
+				A972AADD21CED2730013AB25 /* eliminate_dead_functions_pass.h in Headers */,
+				A972AAF521CED2730013AB25 /* strip_reflect_info_pass.h in Headers */,
+				A972AB4921CED2730013AB25 /* set_spec_constant_default_value_pass.h in Headers */,
+				A972A9FD21CED2730013AB25 /* loop_fusion.h in Headers */,
+				A972AB7721CED2730013AB25 /* construct.h in Headers */,
+				A972A97921CED2730013AB25 /* parse_number.h in Headers */,
+				A972AA0D21CED2730013AB25 /* reduce_load_size.h in Headers */,
+				A972AA3521CED2730013AB25 /* ir_context.h in Headers */,
+				A972AA7B21CED2730013AB25 /* struct_cfg_analysis.h in Headers */,
+				A972A98121CED2730013AB25 /* small_vector.h in Headers */,
+				A972AA9521CED2730013AB25 /* dead_insert_elim_pass.h in Headers */,
+				A972AB4B21CED2730013AB25 /* dominator_tree.h in Headers */,
+				A972A9B121CED2730013AB25 /* spirv_constant.h in Headers */,
+				A972AA6921CED2730013AB25 /* cfg_cleanup_pass.h in Headers */,
+				A972ABBF21CED2730013AB25 /* function.h in Headers */,
+				A972AA1F21CED2730013AB25 /* local_access_chain_convert_pass.h in Headers */,
+				A972A9C521CED2730013AB25 /* markv.h in Headers */,
+				A972A9BB21CED2730013AB25 /* huffman_codec.h in Headers */,
+				A972AA2721CED2730013AB25 /* propagator.h in Headers */,
+				A972AB3721CED2730013AB25 /* iterator.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972ABCA21CED7BC0013AB25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972ACB521CED9060013AB25 /* ConstantUnion.h in Headers */,
+				A972ACB121CED9060013AB25 /* arrays.h in Headers */,
+				A972AC6B21CED9060013AB25 /* SpvBuilder.h in Headers */,
+				A972AC7D21CED9060013AB25 /* GLSL.ext.EXT.h in Headers */,
+				A972ACBF21CED9060013AB25 /* gl_types.h in Headers */,
+				A972ACDB21CED9060013AB25 /* Versions.h in Headers */,
+				A972AC9D21CED9060013AB25 /* osinclude.h in Headers */,
+				A972AD0921CED9060013AB25 /* PpTokens.h in Headers */,
+				A972AC7521CED9060013AB25 /* GLSL.ext.AMD.h in Headers */,
+				A972AC8921CED9060013AB25 /* disassemble.h in Headers */,
+				A972ACCF21CED9060013AB25 /* RemoveTree.h in Headers */,
+				A972ABCB21CED7BC0013AB25 /* spirv_cfg.hpp in Headers */,
+				A972ACB921CED9060013AB25 /* PoolAlloc.h in Headers */,
+				A972AC6F21CED9060013AB25 /* SpvTools.h in Headers */,
+				A972ACAF21CED9060013AB25 /* ShHandle.h in Headers */,
+				A972ACF321CED9060013AB25 /* LiveTraverser.h in Headers */,
+				A972AC9521CED9060013AB25 /* Logger.h in Headers */,
+				A972AD1921CED9060013AB25 /* Scan.h in Headers */,
+				A972ABCC21CED7BC0013AB25 /* spirv_cross_parsed_ir.hpp in Headers */,
+				A972ACAD21CED9060013AB25 /* InitializeGlobals.h in Headers */,
+				A972ACB721CED9060013AB25 /* InfoSink.h in Headers */,
+				A972ACA521CED9060013AB25 /* Types.h in Headers */,
+				A972AC7921CED9060013AB25 /* spirv.hpp in Headers */,
+				A972ABCD21CED7BC0013AB25 /* spirv_common.hpp in Headers */,
+				A972ACC921CED9060013AB25 /* localintermediate.h in Headers */,
+				A972ACE721CED9060013AB25 /* SymbolTable.h in Headers */,
+				A972AC7F21CED9060013AB25 /* GLSL.ext.KHR.h in Headers */,
+				A972ACBD21CED9060013AB25 /* parseVersions.h in Headers */,
+				A972ACF521CED9060013AB25 /* Initialize.h in Headers */,
+				A972AC8121CED9060013AB25 /* GLSL.ext.NV.h in Headers */,
+				A972AC6521CED9060013AB25 /* InitializeDll.h in Headers */,
+				A972ACC721CED9060013AB25 /* iomapper.h in Headers */,
+				A972AC8B21CED9060013AB25 /* GlslangToSpv.h in Headers */,
+				A972ACD921CED9060013AB25 /* propagateNoContraction.h in Headers */,
+				A972AC6921CED9060013AB25 /* SPVRemapper.h in Headers */,
+				A972ABCE21CED7BC0013AB25 /* spirv_glsl.hpp in Headers */,
+				A972ACC521CED9060013AB25 /* ScanContext.h in Headers */,
+				A972AC7721CED9060013AB25 /* doc.h in Headers */,
+				A972AD1B21CED9060013AB25 /* ShaderLang.h in Headers */,
+				A972ACAB21CED9060013AB25 /* revision.h in Headers */,
+				A972AC8D21CED9060013AB25 /* GLSL.std.450.h in Headers */,
+				A972ACA921CED9060013AB25 /* BaseTypes.h in Headers */,
+				A972ACB321CED9060013AB25 /* Common.h in Headers */,
+				A972ACF121CED9060013AB25 /* glslang_tab.cpp.h in Headers */,
+				A972ABCF21CED7BC0013AB25 /* spirv_parser.hpp in Headers */,
+				A972AC8521CED9060013AB25 /* spvIR.h in Headers */,
+				A972AC9321CED9060013AB25 /* hex_float.h in Headers */,
+				A972ACA721CED9060013AB25 /* intermediate.h in Headers */,
+				A972ACA321CED9060013AB25 /* ResourceLimits.h in Headers */,
+				A972AD0521CED9060013AB25 /* ParseHelper.h in Headers */,
+				A972ABD021CED7BC0013AB25 /* spirv_cross.hpp in Headers */,
+				A972ABD121CED7BC0013AB25 /* spirv_msl.hpp in Headers */,
+				A972AD0D21CED9060013AB25 /* PpContext.h in Headers */,
+				A972ACC321CED9060013AB25 /* pch.h in Headers */,
+				A972AC8721CED9060013AB25 /* bitutils.h in Headers */,
+				A972AD1721CED9060013AB25 /* reflection.h in Headers */,
+				A972ACFD21CED9060013AB25 /* attribute.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972ABDE21CED7CB0013AB25 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972ACB621CED9060013AB25 /* ConstantUnion.h in Headers */,
+				A972ACB221CED9060013AB25 /* arrays.h in Headers */,
+				A972AC6C21CED9060013AB25 /* SpvBuilder.h in Headers */,
+				A972AC7E21CED9060013AB25 /* GLSL.ext.EXT.h in Headers */,
+				A972ACC021CED9060013AB25 /* gl_types.h in Headers */,
+				A972ACDC21CED9060013AB25 /* Versions.h in Headers */,
+				A972AC9E21CED9060013AB25 /* osinclude.h in Headers */,
+				A972AD0A21CED9060013AB25 /* PpTokens.h in Headers */,
+				A972AC7621CED9060013AB25 /* GLSL.ext.AMD.h in Headers */,
+				A972AC8A21CED9060013AB25 /* disassemble.h in Headers */,
+				A972ACD021CED9060013AB25 /* RemoveTree.h in Headers */,
+				A972ABDF21CED7CB0013AB25 /* spirv_cfg.hpp in Headers */,
+				A972ACBA21CED9060013AB25 /* PoolAlloc.h in Headers */,
+				A972AC7021CED9060013AB25 /* SpvTools.h in Headers */,
+				A972ACB021CED9060013AB25 /* ShHandle.h in Headers */,
+				A972ACF421CED9060013AB25 /* LiveTraverser.h in Headers */,
+				A972AC9621CED9060013AB25 /* Logger.h in Headers */,
+				A972AD1A21CED9060013AB25 /* Scan.h in Headers */,
+				A972ABE021CED7CB0013AB25 /* spirv_cross_parsed_ir.hpp in Headers */,
+				A972ACAE21CED9060013AB25 /* InitializeGlobals.h in Headers */,
+				A972ACB821CED9060013AB25 /* InfoSink.h in Headers */,
+				A972ACA621CED9060013AB25 /* Types.h in Headers */,
+				A972AC7A21CED9060013AB25 /* spirv.hpp in Headers */,
+				A972ABE121CED7CB0013AB25 /* spirv_common.hpp in Headers */,
+				A972ACCA21CED9060013AB25 /* localintermediate.h in Headers */,
+				A972ACE821CED9060013AB25 /* SymbolTable.h in Headers */,
+				A972AC8021CED9060013AB25 /* GLSL.ext.KHR.h in Headers */,
+				A972ACBE21CED9060013AB25 /* parseVersions.h in Headers */,
+				A972ACF621CED9060013AB25 /* Initialize.h in Headers */,
+				A972AC8221CED9060013AB25 /* GLSL.ext.NV.h in Headers */,
+				A972AC6621CED9060013AB25 /* InitializeDll.h in Headers */,
+				A972ACC821CED9060013AB25 /* iomapper.h in Headers */,
+				A972AC8C21CED9060013AB25 /* GlslangToSpv.h in Headers */,
+				A972ACDA21CED9060013AB25 /* propagateNoContraction.h in Headers */,
+				A972AC6A21CED9060013AB25 /* SPVRemapper.h in Headers */,
+				A972ABE221CED7CB0013AB25 /* spirv_glsl.hpp in Headers */,
+				A972ACC621CED9060013AB25 /* ScanContext.h in Headers */,
+				A972AC7821CED9060013AB25 /* doc.h in Headers */,
+				A972AD1C21CED9060013AB25 /* ShaderLang.h in Headers */,
+				A972ACAC21CED9060013AB25 /* revision.h in Headers */,
+				A972AC8E21CED9060013AB25 /* GLSL.std.450.h in Headers */,
+				A972ACAA21CED9060013AB25 /* BaseTypes.h in Headers */,
+				A972ACB421CED9060013AB25 /* Common.h in Headers */,
+				A972ACF221CED9060013AB25 /* glslang_tab.cpp.h in Headers */,
+				A972ABE321CED7CB0013AB25 /* spirv_parser.hpp in Headers */,
+				A972AC8621CED9060013AB25 /* spvIR.h in Headers */,
+				A972AC9421CED9060013AB25 /* hex_float.h in Headers */,
+				A972ACA821CED9060013AB25 /* intermediate.h in Headers */,
+				A972ACA421CED9060013AB25 /* ResourceLimits.h in Headers */,
+				A972AD0621CED9060013AB25 /* ParseHelper.h in Headers */,
+				A972ABE421CED7CB0013AB25 /* spirv_cross.hpp in Headers */,
+				A972ABE521CED7CB0013AB25 /* spirv_msl.hpp in Headers */,
+				A972AD0E21CED9060013AB25 /* PpContext.h in Headers */,
+				A972ACC421CED9060013AB25 /* pch.h in Headers */,
+				A972AC8821CED9060013AB25 /* bitutils.h in Headers */,
+				A972AD1821CED9060013AB25 /* reflection.h in Headers */,
+				A972ACFE21CED9060013AB25 /* attribute.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A97628FF21CC608900B52A68 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A976291E21CC60BC00B52A68 /* spirv_cfg.hpp in Headers */,
+				A976291C21CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp in Headers */,
+				A976291A21CC60BC00B52A68 /* spirv_common.hpp in Headers */,
+				A976292021CC60BC00B52A68 /* spirv_glsl.hpp in Headers */,
+				A976292421CC60BC00B52A68 /* spirv_parser.hpp in Headers */,
+				A976291221CC60BC00B52A68 /* spirv_cross.hpp in Headers */,
+				A976291021CC60BC00B52A68 /* spirv_msl.hpp in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A976290021CC608E00B52A68 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A976291D21CC60BC00B52A68 /* spirv_cfg.hpp in Headers */,
+				A976291B21CC60BC00B52A68 /* spirv_cross_parsed_ir.hpp in Headers */,
+				A976291921CC60BC00B52A68 /* spirv_common.hpp in Headers */,
+				A976291F21CC60BC00B52A68 /* spirv_glsl.hpp in Headers */,
+				A976292321CC60BC00B52A68 /* spirv_parser.hpp in Headers */,
+				A976291121CC60BC00B52A68 /* spirv_cross.hpp in Headers */,
+				A976290F21CC60BC00B52A68 /* spirv_msl.hpp in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		A90FD75B21CC4EAB00B92BB2 /* SPIRV-Cross-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A90FD89C21CC4EAB00B92BB2 /* Build configuration list for PBXNativeTarget "SPIRV-Cross-iOS" */;
+			buildPhases = (
+				A976290021CC608E00B52A68 /* Headers */,
+				A976290121CC609100B52A68 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SPIRV-Cross-iOS";
+			productName = "SPIRV-Cross-iOS";
+			productReference = A90FD89F21CC4EAB00B92BB2 /* libSPIRVCross.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A90FD8A021CC4EB900B92BB2 /* SPIRV-Cross-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A90FD9E121CC4EB900B92BB2 /* Build configuration list for PBXNativeTarget "SPIRV-Cross-macOS" */;
+			buildPhases = (
+				A97628FF21CC608900B52A68 /* Headers */,
+				A97628FE21CC608400B52A68 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SPIRV-Cross-macOS";
+			productName = "SPIRV-Cross-macOS";
+			productReference = A90FD9E421CC4EB900B92BB2 /* libSPIRVCross.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A972A7FC21CECBBF0013AB25 /* SPIRV-Tools-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A972A80C21CECBBF0013AB25 /* Build configuration list for PBXNativeTarget "SPIRV-Tools-iOS" */;
+			buildPhases = (
+				A972A7FD21CECBBF0013AB25 /* Headers */,
+				A972A80521CECBBF0013AB25 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SPIRV-Tools-iOS";
+			productName = "SPIRV-Cross-iOS";
+			productReference = A972A80F21CECBBF0013AB25 /* libSPIRVTools.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A972A81021CECBE90013AB25 /* SPIRV-Tools-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A972A82021CECBE90013AB25 /* Build configuration list for PBXNativeTarget "SPIRV-Tools-macOS" */;
+			buildPhases = (
+				A972A81121CECBE90013AB25 /* Headers */,
+				A972A81921CECBE90013AB25 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SPIRV-Tools-macOS";
+			productName = "SPIRV-Cross-macOS";
+			productReference = A972A82321CECBE90013AB25 /* libSPIRVTools.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A972ABC921CED7BC0013AB25 /* glslang-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A972ABD921CED7BC0013AB25 /* Build configuration list for PBXNativeTarget "glslang-iOS" */;
+			buildPhases = (
+				A972ABCA21CED7BC0013AB25 /* Headers */,
+				A972ABD221CED7BC0013AB25 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "glslang-iOS";
+			productName = "SPIRV-Cross-iOS";
+			productReference = A972ABDC21CED7BC0013AB25 /* libglslang.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A972ABDD21CED7CB0013AB25 /* glslang-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A972ABED21CED7CB0013AB25 /* Build configuration list for PBXNativeTarget "glslang-macOS" */;
+			buildPhases = (
+				A972ABDE21CED7CB0013AB25 /* Headers */,
+				A972ABE621CED7CB0013AB25 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "glslang-macOS";
+			productName = "SPIRV-Cross-macOS";
+			productReference = A972ABF021CED7CB0013AB25 /* libglslang.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A9F55D25198BE6A7004EC31B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "The Brenwill Workshop Ltd.";
+				TargetAttributes = {
+					A972A7E421CEC72F0013AB25 = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
+					A972A7EA21CEC8030013AB25 = {
+						ProvisioningStyle = Automatic;
+					};
+					A972A7F221CEC81B0013AB25 = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = A9F55D28198BE6A7004EC31B /* Build configuration list for PBXProject "ExternalDependencies" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = A9F55D24198BE6A7004EC31B;
+			productRefGroup = A9F55D24198BE6A7004EC31B;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A972A7F221CEC81B0013AB25 /* ExternalDependencies */,
+				A972A7EA21CEC8030013AB25 /* ExternalDependencies-iOS */,
+				A972A7E421CEC72F0013AB25 /* ExternalDependencies-macOS */,
+				A90FD75B21CC4EAB00B92BB2 /* SPIRV-Cross-iOS */,
+				A90FD8A021CC4EB900B92BB2 /* SPIRV-Cross-macOS */,
+				A972A7FC21CECBBF0013AB25 /* SPIRV-Tools-iOS */,
+				A972A81021CECBE90013AB25 /* SPIRV-Tools-macOS */,
+				A972ABC921CED7BC0013AB25 /* glslang-iOS */,
+				A972ABDD21CED7CB0013AB25 /* glslang-macOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A972A80521CECBBF0013AB25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AB8421CED2730013AB25 /* validate_debug.cpp in Sources */,
+				A972AA4C21CED2730013AB25 /* mem_pass.cpp in Sources */,
+				A972AB4621CED2730013AB25 /* scalar_analysis_simplification.cpp in Sources */,
+				A972AA1621CED2730013AB25 /* decoration_manager.cpp in Sources */,
+				A972AA3E21CED2730013AB25 /* strip_debug_info_pass.cpp in Sources */,
+				A972AA6221CED2730013AB25 /* inline_pass.cpp in Sources */,
+				A972ABC021CED2730013AB25 /* validate_composites.cpp in Sources */,
+				A972AA5621CED2730013AB25 /* module.cpp in Sources */,
+				A972AA2A21CED2730013AB25 /* feature_manager.cpp in Sources */,
+				A972AB1021CED2730013AB25 /* value_number_table.cpp in Sources */,
+				A972AA7421CED2730013AB25 /* loop_unroller.cpp in Sources */,
+				A972AA1421CED2730013AB25 /* cfg.cpp in Sources */,
+				A972A9D221CED2730013AB25 /* markv_encoder.cpp in Sources */,
+				A972AA8E21CED2730013AB25 /* simplification_pass.cpp in Sources */,
+				A972AB2A21CED2730013AB25 /* struct_cfg_analysis.cpp in Sources */,
+				A972A9FE21CED2730013AB25 /* combine_access_chains.cpp in Sources */,
+				A972AB9A21CED2730013AB25 /* validate_conversion.cpp in Sources */,
+				A972A9F421CED2730013AB25 /* register_pressure.cpp in Sources */,
+				A972AA4021CED2730013AB25 /* ssa_rewrite_pass.cpp in Sources */,
+				A972AA9A21CED2730013AB25 /* ir_context.cpp in Sources */,
+				A972AAC421CED2730013AB25 /* loop_fusion_pass.cpp in Sources */,
+				A972AAD421CED2730013AB25 /* block_merge_pass.cpp in Sources */,
+				A972AB4E21CED2730013AB25 /* compact_ids_pass.cpp in Sources */,
+				A972AB8621CED2730013AB25 /* validate_builtins.cpp in Sources */,
+				A972ABC221CED2730013AB25 /* validation_state.cpp in Sources */,
+				A972AAB221CED2730013AB25 /* if_conversion.cpp in Sources */,
+				A972AA2421CED2730013AB25 /* instrument_pass.cpp in Sources */,
+				A972ABAA21CED2730013AB25 /* validate_image.cpp in Sources */,
+				A972ABA021CED2730013AB25 /* validate_arithmetics.cpp in Sources */,
+				A972AB0821CED2730013AB25 /* instruction.cpp in Sources */,
+				A972A9B221CED2730013AB25 /* binary.cpp in Sources */,
+				A972AB9C21CED2730013AB25 /* validate_datarules.cpp in Sources */,
+				A972AAE621CED2730013AB25 /* private_to_local_pass.cpp in Sources */,
+				A972AA5A21CED2730013AB25 /* loop_unswitch_pass.cpp in Sources */,
+				A972AB7C21CED2730013AB25 /* validate_atomics.cpp in Sources */,
+				A972A96E21CED2730013AB25 /* text.cpp in Sources */,
+				A972A99C21CED2730013AB25 /* spirv_optimizer_options.cpp in Sources */,
+				A972AAD021CED2730013AB25 /* scalar_analysis.cpp in Sources */,
+				A972A9E621CED2730013AB25 /* software_version.cpp in Sources */,
+				A972AAA221CED2730013AB25 /* local_ssa_elim_pass.cpp in Sources */,
+				A972AA2021CED2730013AB25 /* inst_bindless_check_pass.cpp in Sources */,
+				A972A9D421CED2730013AB25 /* enum_string_mapping.cpp in Sources */,
+				A972AB3421CED2730013AB25 /* basic_block.cpp in Sources */,
+				A972AA8C21CED2730013AB25 /* aggressive_dead_code_elim_pass.cpp in Sources */,
+				A972AB0021CED2730013AB25 /* workaround1209.cpp in Sources */,
+				A972AB1621CED2730013AB25 /* replace_invalid_opc.cpp in Sources */,
+				A972AB1421CED2730013AB25 /* inline_opaque_pass.cpp in Sources */,
+				A972A97621CED2730013AB25 /* pch_source.cpp in Sources */,
+				A972AA3821CED2730013AB25 /* cfg_cleanup_pass.cpp in Sources */,
+				A972AA5C21CED2730013AB25 /* unify_const_pass.cpp in Sources */,
+				A972AA6621CED2730013AB25 /* ir_loader.cpp in Sources */,
+				A972AA5021CED2730013AB25 /* remove_duplicates_pass.cpp in Sources */,
+				A972AA7C21CED2730013AB25 /* common_uniform_elim_pass.cpp in Sources */,
+				A972AABE21CED2730013AB25 /* inline_exhaustive_pass.cpp in Sources */,
+				A972A9C821CED2730013AB25 /* markv_decoder.cpp in Sources */,
+				A972AA7221CED2730013AB25 /* vector_dce.cpp in Sources */,
+				A972AB1C21CED2730013AB25 /* dominator_analysis.cpp in Sources */,
+				A972A9F621CED2730013AB25 /* loop_utils.cpp in Sources */,
+				A972AABC21CED2730013AB25 /* pass_manager.cpp in Sources */,
+				A972A99821CED2730013AB25 /* id_descriptor.cpp in Sources */,
+				A972A99621CED2730013AB25 /* table.cpp in Sources */,
+				A972AAA421CED2730013AB25 /* function.cpp in Sources */,
+				A972A9AC21CED2730013AB25 /* spirv_endian.cpp in Sources */,
+				A972AA5821CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */,
+				A972AA8421CED2730013AB25 /* ccp_pass.cpp in Sources */,
+				A972A9EC21CED2730013AB25 /* ext_inst.cpp in Sources */,
+				A972AAE221CED2730013AB25 /* local_single_store_elim_pass.cpp in Sources */,
+				A972AA5221CED2730013AB25 /* dead_variable_elimination.cpp in Sources */,
+				A972AB3221CED2730013AB25 /* local_access_chain_convert_pass.cpp in Sources */,
+				A972A96821CED2730013AB25 /* spirv_target_env.cpp in Sources */,
+				A972AA0021CED2730013AB25 /* build_module.cpp in Sources */,
+				A972A98621CED2730013AB25 /* string_utils.cpp in Sources */,
+				A972A9B821CED2730013AB25 /* markv.cpp in Sources */,
+				A972AB5621CED2730013AB25 /* diagnostic.cpp in Sources */,
+				A972AB9E21CED2730013AB25 /* validate_id.cpp in Sources */,
+				A972AACC21CED2730013AB25 /* dead_insert_elim_pass.cpp in Sources */,
+				A972ABAE21CED2730013AB25 /* instruction.cpp in Sources */,
+				A972AB6A21CED2730013AB25 /* disassemble.cpp in Sources */,
+				A972AA2C21CED2730013AB25 /* pass.cpp in Sources */,
+				A972ABC421CED2730013AB25 /* validate_primitives.cpp in Sources */,
+				A972ABA221CED2730013AB25 /* validate_mode_setting.cpp in Sources */,
+				A972AA2221CED2730013AB25 /* local_redundancy_elimination.cpp in Sources */,
+				A972AAF221CED2730013AB25 /* fold.cpp in Sources */,
+				A972AA3621CED2730013AB25 /* eliminate_dead_constant_pass.cpp in Sources */,
+				A972AA8021CED2730013AB25 /* strip_reflect_info_pass.cpp in Sources */,
+				A972AA2E21CED2730013AB25 /* loop_fission.cpp in Sources */,
+				A972ABA421CED2730013AB25 /* validate_logicals.cpp in Sources */,
+				A972AB0C21CED2730013AB25 /* reduce_load_size.cpp in Sources */,
+				A972AB8021CED2730013AB25 /* validate_instruction.cpp in Sources */,
+				A972AB9821CED2730013AB25 /* validate_adjacency.cpp in Sources */,
+				A972ABB621CED2730013AB25 /* validate_execution_limitations.cpp in Sources */,
+				A972AB9221CED2730013AB25 /* construct.cpp in Sources */,
+				A972AA3A21CED2730013AB25 /* const_folding_rules.cpp in Sources */,
+				A972AB8221CED2730013AB25 /* validate_decorations.cpp in Sources */,
+				A972A9F021CED2730013AB25 /* optimizer.cpp in Sources */,
+				A972ABAC21CED2730013AB25 /* validate_literals.cpp in Sources */,
+				A972AA6C21CED2730013AB25 /* eliminate_dead_functions_pass.cpp in Sources */,
+				A972AAEA21CED2730013AB25 /* propagator.cpp in Sources */,
+				A972A9A621CED2730013AB25 /* print.cpp in Sources */,
+				A972ABB221CED2730013AB25 /* validate_ext_inst.cpp in Sources */,
+				A972AB7421CED2730013AB25 /* validate_capability.cpp in Sources */,
+				A972AA9621CED2730013AB25 /* folding_rules.cpp in Sources */,
+				A972AB7821CED2730013AB25 /* validate_barriers.cpp in Sources */,
+				A972AA3021CED2730013AB25 /* dominator_tree.cpp in Sources */,
+				A972AB7021CED2730013AB25 /* validate_annotation.cpp in Sources */,
+				A972A9E421CED2730013AB25 /* linker.cpp in Sources */,
+				A972AA9021CED2730013AB25 /* dead_branch_elim_pass.cpp in Sources */,
+				A972AB8E21CED2730013AB25 /* validate_constants.cpp in Sources */,
+				A972AA1A21CED2730013AB25 /* freeze_spec_constant_value_pass.cpp in Sources */,
+				A972ABBA21CED2730013AB25 /* basic_block.cpp in Sources */,
+				A972AA9221CED2730013AB25 /* flatten_decoration_pass.cpp in Sources */,
+				A972A98E21CED2730013AB25 /* parse_number.cpp in Sources */,
+				A972A9BE21CED2730013AB25 /* move_to_front.cpp in Sources */,
+				A972ABA621CED2730013AB25 /* validate_derivatives.cpp in Sources */,
+				A972AB5A21CED2730013AB25 /* libspirv.cpp in Sources */,
+				A972AB6421CED2730013AB25 /* operand.cpp in Sources */,
+				A972AA7621CED2730013AB25 /* constants.cpp in Sources */,
+				A972AB5021CED2730013AB25 /* loop_peeling.cpp in Sources */,
+				A972ABA821CED2730013AB25 /* validate_memory.cpp in Sources */,
+				A972AA1821CED2730013AB25 /* local_single_block_elim_pass.cpp in Sources */,
+				A972AAF621CED2730013AB25 /* scalar_replacement_pass.cpp in Sources */,
+				A972A97021CED2730013AB25 /* assembly_grammar.cpp in Sources */,
+				A972AAA821CED2730013AB25 /* composite.cpp in Sources */,
+				A972A99021CED2730013AB25 /* bit_vector.cpp in Sources */,
+				A972ABB021CED2730013AB25 /* validate_type.cpp in Sources */,
+				A972AB9021CED2730013AB25 /* validate_bitwise.cpp in Sources */,
+				A972AB9421CED2730013AB25 /* function.cpp in Sources */,
+				A972AAEC21CED2730013AB25 /* loop_dependence_helpers.cpp in Sources */,
+				A972AB7A21CED2730013AB25 /* validate_non_uniform.cpp in Sources */,
+				A972AA5E21CED2730013AB25 /* type_manager.cpp in Sources */,
+				A972A9DC21CED2730013AB25 /* parsed_operand.cpp in Sources */,
+				A972A9E821CED2730013AB25 /* opcode.cpp in Sources */,
+				A972A97421CED2730013AB25 /* extensions.cpp in Sources */,
+				A972AA0E21CED2730013AB25 /* types.cpp in Sources */,
+				A972AA8821CED2730013AB25 /* pch_source_opt.cpp in Sources */,
+				A972AA3221CED2730013AB25 /* merge_return_pass.cpp in Sources */,
+				A972AA6A21CED2730013AB25 /* licm_pass.cpp in Sources */,
+				A972AAA621CED2730013AB25 /* instruction_list.cpp in Sources */,
+				A972AB8A21CED2730013AB25 /* validate.cpp in Sources */,
+				A972A9E221CED2730013AB25 /* name_mapper.cpp in Sources */,
+				A972AAEE21CED2730013AB25 /* set_spec_constant_default_value_pass.cpp in Sources */,
+				A972AABA21CED2730013AB25 /* copy_prop_arrays.cpp in Sources */,
+				A972AA4221CED2730013AB25 /* loop_dependence.cpp in Sources */,
+				A972A98221CED2730013AB25 /* timer.cpp in Sources */,
+				A972A9B621CED2730013AB25 /* markv_codec.cpp in Sources */,
+				A972AAA021CED2730013AB25 /* loop_descriptor.cpp in Sources */,
+				A972AB8821CED2730013AB25 /* validate_interfaces.cpp in Sources */,
+				A972AAFC21CED2730013AB25 /* redundancy_elimination.cpp in Sources */,
+				A972A9A421CED2730013AB25 /* spirv_validator_options.cpp in Sources */,
+				A972AB6E21CED2730013AB25 /* text_handler.cpp in Sources */,
+				A972AAB821CED2730013AB25 /* strength_reduction_pass.cpp in Sources */,
+				A972ABB821CED2730013AB25 /* validate_layout.cpp in Sources */,
+				A972AB4021CED2730013AB25 /* loop_fusion.cpp in Sources */,
+				A972A9D021CED2730013AB25 /* bit_stream.cpp in Sources */,
+				A972AB7221CED2730013AB25 /* validate_cfg.cpp in Sources */,
+				A972AA7E21CED2730013AB25 /* def_use_manager.cpp in Sources */,
+				A972ABBC21CED2730013AB25 /* validate_function.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972A81921CECBE90013AB25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AB8521CED2730013AB25 /* validate_debug.cpp in Sources */,
+				A972AA4D21CED2730013AB25 /* mem_pass.cpp in Sources */,
+				A972AB4721CED2730013AB25 /* scalar_analysis_simplification.cpp in Sources */,
+				A972AA1721CED2730013AB25 /* decoration_manager.cpp in Sources */,
+				A972AA3F21CED2730013AB25 /* strip_debug_info_pass.cpp in Sources */,
+				A972AA6321CED2730013AB25 /* inline_pass.cpp in Sources */,
+				A972ABC121CED2730013AB25 /* validate_composites.cpp in Sources */,
+				A972AA5721CED2730013AB25 /* module.cpp in Sources */,
+				A972AA2B21CED2730013AB25 /* feature_manager.cpp in Sources */,
+				A972AB1121CED2730013AB25 /* value_number_table.cpp in Sources */,
+				A972AA7521CED2730013AB25 /* loop_unroller.cpp in Sources */,
+				A972AA1521CED2730013AB25 /* cfg.cpp in Sources */,
+				A972A9D321CED2730013AB25 /* markv_encoder.cpp in Sources */,
+				A972AA8F21CED2730013AB25 /* simplification_pass.cpp in Sources */,
+				A972AB2B21CED2730013AB25 /* struct_cfg_analysis.cpp in Sources */,
+				A972A9FF21CED2730013AB25 /* combine_access_chains.cpp in Sources */,
+				A972AB9B21CED2730013AB25 /* validate_conversion.cpp in Sources */,
+				A972A9F521CED2730013AB25 /* register_pressure.cpp in Sources */,
+				A972AA4121CED2730013AB25 /* ssa_rewrite_pass.cpp in Sources */,
+				A972AA9B21CED2730013AB25 /* ir_context.cpp in Sources */,
+				A972AAC521CED2730013AB25 /* loop_fusion_pass.cpp in Sources */,
+				A972AAD521CED2730013AB25 /* block_merge_pass.cpp in Sources */,
+				A972AB4F21CED2730013AB25 /* compact_ids_pass.cpp in Sources */,
+				A972AB8721CED2730013AB25 /* validate_builtins.cpp in Sources */,
+				A972ABC321CED2730013AB25 /* validation_state.cpp in Sources */,
+				A972AAB321CED2730013AB25 /* if_conversion.cpp in Sources */,
+				A972AA2521CED2730013AB25 /* instrument_pass.cpp in Sources */,
+				A972ABAB21CED2730013AB25 /* validate_image.cpp in Sources */,
+				A972ABA121CED2730013AB25 /* validate_arithmetics.cpp in Sources */,
+				A972AB0921CED2730013AB25 /* instruction.cpp in Sources */,
+				A972A9B321CED2730013AB25 /* binary.cpp in Sources */,
+				A972AB9D21CED2730013AB25 /* validate_datarules.cpp in Sources */,
+				A972AAE721CED2730013AB25 /* private_to_local_pass.cpp in Sources */,
+				A972AA5B21CED2730013AB25 /* loop_unswitch_pass.cpp in Sources */,
+				A972AB7D21CED2730013AB25 /* validate_atomics.cpp in Sources */,
+				A972A96F21CED2730013AB25 /* text.cpp in Sources */,
+				A972A99D21CED2730013AB25 /* spirv_optimizer_options.cpp in Sources */,
+				A972AAD121CED2730013AB25 /* scalar_analysis.cpp in Sources */,
+				A972A9E721CED2730013AB25 /* software_version.cpp in Sources */,
+				A972AAA321CED2730013AB25 /* local_ssa_elim_pass.cpp in Sources */,
+				A972AA2121CED2730013AB25 /* inst_bindless_check_pass.cpp in Sources */,
+				A972A9D521CED2730013AB25 /* enum_string_mapping.cpp in Sources */,
+				A972AB3521CED2730013AB25 /* basic_block.cpp in Sources */,
+				A972AA8D21CED2730013AB25 /* aggressive_dead_code_elim_pass.cpp in Sources */,
+				A972AB0121CED2730013AB25 /* workaround1209.cpp in Sources */,
+				A972AB1721CED2730013AB25 /* replace_invalid_opc.cpp in Sources */,
+				A972AB1521CED2730013AB25 /* inline_opaque_pass.cpp in Sources */,
+				A972A97721CED2730013AB25 /* pch_source.cpp in Sources */,
+				A972AA3921CED2730013AB25 /* cfg_cleanup_pass.cpp in Sources */,
+				A972AA5D21CED2730013AB25 /* unify_const_pass.cpp in Sources */,
+				A972AA6721CED2730013AB25 /* ir_loader.cpp in Sources */,
+				A972AA5121CED2730013AB25 /* remove_duplicates_pass.cpp in Sources */,
+				A972AA7D21CED2730013AB25 /* common_uniform_elim_pass.cpp in Sources */,
+				A972AABF21CED2730013AB25 /* inline_exhaustive_pass.cpp in Sources */,
+				A972A9C921CED2730013AB25 /* markv_decoder.cpp in Sources */,
+				A972AA7321CED2730013AB25 /* vector_dce.cpp in Sources */,
+				A972AB1D21CED2730013AB25 /* dominator_analysis.cpp in Sources */,
+				A972A9F721CED2730013AB25 /* loop_utils.cpp in Sources */,
+				A972AABD21CED2730013AB25 /* pass_manager.cpp in Sources */,
+				A972A99921CED2730013AB25 /* id_descriptor.cpp in Sources */,
+				A972A99721CED2730013AB25 /* table.cpp in Sources */,
+				A972AAA521CED2730013AB25 /* function.cpp in Sources */,
+				A972A9AD21CED2730013AB25 /* spirv_endian.cpp in Sources */,
+				A972AA5921CED2730013AB25 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */,
+				A972AA8521CED2730013AB25 /* ccp_pass.cpp in Sources */,
+				A972A9ED21CED2730013AB25 /* ext_inst.cpp in Sources */,
+				A972AAE321CED2730013AB25 /* local_single_store_elim_pass.cpp in Sources */,
+				A972AA5321CED2730013AB25 /* dead_variable_elimination.cpp in Sources */,
+				A972AB3321CED2730013AB25 /* local_access_chain_convert_pass.cpp in Sources */,
+				A972A96921CED2730013AB25 /* spirv_target_env.cpp in Sources */,
+				A972AA0121CED2730013AB25 /* build_module.cpp in Sources */,
+				A972A98721CED2730013AB25 /* string_utils.cpp in Sources */,
+				A972A9B921CED2730013AB25 /* markv.cpp in Sources */,
+				A972AB5721CED2730013AB25 /* diagnostic.cpp in Sources */,
+				A972AB9F21CED2730013AB25 /* validate_id.cpp in Sources */,
+				A972AACD21CED2730013AB25 /* dead_insert_elim_pass.cpp in Sources */,
+				A972ABAF21CED2730013AB25 /* instruction.cpp in Sources */,
+				A972AB6B21CED2730013AB25 /* disassemble.cpp in Sources */,
+				A972AA2D21CED2730013AB25 /* pass.cpp in Sources */,
+				A972ABC521CED2730013AB25 /* validate_primitives.cpp in Sources */,
+				A972ABA321CED2730013AB25 /* validate_mode_setting.cpp in Sources */,
+				A972AA2321CED2730013AB25 /* local_redundancy_elimination.cpp in Sources */,
+				A972AAF321CED2730013AB25 /* fold.cpp in Sources */,
+				A972AA3721CED2730013AB25 /* eliminate_dead_constant_pass.cpp in Sources */,
+				A972AA8121CED2730013AB25 /* strip_reflect_info_pass.cpp in Sources */,
+				A972AA2F21CED2730013AB25 /* loop_fission.cpp in Sources */,
+				A972ABA521CED2730013AB25 /* validate_logicals.cpp in Sources */,
+				A972AB0D21CED2730013AB25 /* reduce_load_size.cpp in Sources */,
+				A972AB8121CED2730013AB25 /* validate_instruction.cpp in Sources */,
+				A972AB9921CED2730013AB25 /* validate_adjacency.cpp in Sources */,
+				A972ABB721CED2730013AB25 /* validate_execution_limitations.cpp in Sources */,
+				A972AB9321CED2730013AB25 /* construct.cpp in Sources */,
+				A972AA3B21CED2730013AB25 /* const_folding_rules.cpp in Sources */,
+				A972AB8321CED2730013AB25 /* validate_decorations.cpp in Sources */,
+				A972A9F121CED2730013AB25 /* optimizer.cpp in Sources */,
+				A972ABAD21CED2730013AB25 /* validate_literals.cpp in Sources */,
+				A972AA6D21CED2730013AB25 /* eliminate_dead_functions_pass.cpp in Sources */,
+				A972AAEB21CED2730013AB25 /* propagator.cpp in Sources */,
+				A972A9A721CED2730013AB25 /* print.cpp in Sources */,
+				A972ABB321CED2730013AB25 /* validate_ext_inst.cpp in Sources */,
+				A972AB7521CED2730013AB25 /* validate_capability.cpp in Sources */,
+				A972AA9721CED2730013AB25 /* folding_rules.cpp in Sources */,
+				A972AB7921CED2730013AB25 /* validate_barriers.cpp in Sources */,
+				A972AA3121CED2730013AB25 /* dominator_tree.cpp in Sources */,
+				A972AB7121CED2730013AB25 /* validate_annotation.cpp in Sources */,
+				A972A9E521CED2730013AB25 /* linker.cpp in Sources */,
+				A972AA9121CED2730013AB25 /* dead_branch_elim_pass.cpp in Sources */,
+				A972AB8F21CED2730013AB25 /* validate_constants.cpp in Sources */,
+				A972AA1B21CED2730013AB25 /* freeze_spec_constant_value_pass.cpp in Sources */,
+				A972ABBB21CED2730013AB25 /* basic_block.cpp in Sources */,
+				A972AA9321CED2730013AB25 /* flatten_decoration_pass.cpp in Sources */,
+				A972A98F21CED2730013AB25 /* parse_number.cpp in Sources */,
+				A972A9BF21CED2730013AB25 /* move_to_front.cpp in Sources */,
+				A972ABA721CED2730013AB25 /* validate_derivatives.cpp in Sources */,
+				A972AB5B21CED2730013AB25 /* libspirv.cpp in Sources */,
+				A972AB6521CED2730013AB25 /* operand.cpp in Sources */,
+				A972AA7721CED2730013AB25 /* constants.cpp in Sources */,
+				A972AB5121CED2730013AB25 /* loop_peeling.cpp in Sources */,
+				A972ABA921CED2730013AB25 /* validate_memory.cpp in Sources */,
+				A972AA1921CED2730013AB25 /* local_single_block_elim_pass.cpp in Sources */,
+				A972AAF721CED2730013AB25 /* scalar_replacement_pass.cpp in Sources */,
+				A972A97121CED2730013AB25 /* assembly_grammar.cpp in Sources */,
+				A972AAA921CED2730013AB25 /* composite.cpp in Sources */,
+				A972A99121CED2730013AB25 /* bit_vector.cpp in Sources */,
+				A972ABB121CED2730013AB25 /* validate_type.cpp in Sources */,
+				A972AB9121CED2730013AB25 /* validate_bitwise.cpp in Sources */,
+				A972AB9521CED2730013AB25 /* function.cpp in Sources */,
+				A972AAED21CED2730013AB25 /* loop_dependence_helpers.cpp in Sources */,
+				A972AB7B21CED2730013AB25 /* validate_non_uniform.cpp in Sources */,
+				A972AA5F21CED2730013AB25 /* type_manager.cpp in Sources */,
+				A972A9DD21CED2730013AB25 /* parsed_operand.cpp in Sources */,
+				A972A9E921CED2730013AB25 /* opcode.cpp in Sources */,
+				A972A97521CED2730013AB25 /* extensions.cpp in Sources */,
+				A972AA0F21CED2730013AB25 /* types.cpp in Sources */,
+				A972AA8921CED2730013AB25 /* pch_source_opt.cpp in Sources */,
+				A972AA3321CED2730013AB25 /* merge_return_pass.cpp in Sources */,
+				A972AA6B21CED2730013AB25 /* licm_pass.cpp in Sources */,
+				A972AAA721CED2730013AB25 /* instruction_list.cpp in Sources */,
+				A972AB8B21CED2730013AB25 /* validate.cpp in Sources */,
+				A972A9E321CED2730013AB25 /* name_mapper.cpp in Sources */,
+				A972AAEF21CED2730013AB25 /* set_spec_constant_default_value_pass.cpp in Sources */,
+				A972AABB21CED2730013AB25 /* copy_prop_arrays.cpp in Sources */,
+				A972AA4321CED2730013AB25 /* loop_dependence.cpp in Sources */,
+				A972A98321CED2730013AB25 /* timer.cpp in Sources */,
+				A972A9B721CED2730013AB25 /* markv_codec.cpp in Sources */,
+				A972AAA121CED2730013AB25 /* loop_descriptor.cpp in Sources */,
+				A972AB8921CED2730013AB25 /* validate_interfaces.cpp in Sources */,
+				A972AAFD21CED2730013AB25 /* redundancy_elimination.cpp in Sources */,
+				A972A9A521CED2730013AB25 /* spirv_validator_options.cpp in Sources */,
+				A972AB6F21CED2730013AB25 /* text_handler.cpp in Sources */,
+				A972AAB921CED2730013AB25 /* strength_reduction_pass.cpp in Sources */,
+				A972ABB921CED2730013AB25 /* validate_layout.cpp in Sources */,
+				A972AB4121CED2730013AB25 /* loop_fusion.cpp in Sources */,
+				A972A9D121CED2730013AB25 /* bit_stream.cpp in Sources */,
+				A972AB7321CED2730013AB25 /* validate_cfg.cpp in Sources */,
+				A972AA7F21CED2730013AB25 /* def_use_manager.cpp in Sources */,
+				A972ABBD21CED2730013AB25 /* validate_function.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972ABD221CED7BC0013AB25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AC8F21CED9060013AB25 /* SPVRemapper.cpp in Sources */,
+				A972AC9121CED9060013AB25 /* Logger.cpp in Sources */,
+				A972ACD721CED9060013AB25 /* parseConst.cpp in Sources */,
+				A972ACE121CED9060013AB25 /* iomapper.cpp in Sources */,
+				A972ABD321CED7BC0013AB25 /* spirv_msl.cpp in Sources */,
+				A972ACD321CED9060013AB25 /* glslang_tab.cpp in Sources */,
+				A972AC9B21CED9060013AB25 /* ossource.cpp in Sources */,
+				A972AC6D21CED9060013AB25 /* SpvPostProcess.cpp in Sources */,
+				A972AD1F21CED9060013AB25 /* Link.cpp in Sources */,
+				A972AD0721CED9060013AB25 /* PpAtom.cpp in Sources */,
+				A972ACF721CED9060013AB25 /* attribute.cpp in Sources */,
+				A972ABD421CED7BC0013AB25 /* spirv_parser.cpp in Sources */,
+				A972ACED21CED9060013AB25 /* pch.cpp in Sources */,
+				A972AC6721CED9060013AB25 /* InitializeDll.cpp in Sources */,
+				A972ACD521CED9060013AB25 /* limits.cpp in Sources */,
+				A972AD0B21CED9060013AB25 /* Pp.cpp in Sources */,
+				A972AD1521CED9060013AB25 /* ParseContextBase.cpp in Sources */,
+				A972ACFF21CED9060013AB25 /* Versions.cpp in Sources */,
+				A972ACF921CED9060013AB25 /* reflection.cpp in Sources */,
+				A972AC7B21CED9060013AB25 /* SpvBuilder.cpp in Sources */,
+				A972ACFB21CED9060013AB25 /* RemoveTree.cpp in Sources */,
+				A972ACEF21CED9060013AB25 /* SymbolTable.cpp in Sources */,
+				A972AC7121CED9060013AB25 /* SpvTools.cpp in Sources */,
+				A972ACEB21CED9060013AB25 /* Intermediate.cpp in Sources */,
+				A972ABD521CED7BC0013AB25 /* spirv_cfg.cpp in Sources */,
+				A972ACCB21CED9060013AB25 /* Scan.cpp in Sources */,
+				A972AD1121CED9060013AB25 /* PpContext.cpp in Sources */,
+				A972AC9721CED9060013AB25 /* doc.cpp in Sources */,
+				A972ACBB21CED9060013AB25 /* ParseHelper.cpp in Sources */,
+				A972ACC121CED9060013AB25 /* propagateNoContraction.cpp in Sources */,
+				A972ABD621CED7BC0013AB25 /* spirv_cross.cpp in Sources */,
+				A972AD0F21CED9060013AB25 /* PpTokens.cpp in Sources */,
+				A972AD1321CED9060013AB25 /* PpScanner.cpp in Sources */,
+				A972ABD721CED7BC0013AB25 /* spirv_glsl.cpp in Sources */,
+				A972ACD121CED9060013AB25 /* Initialize.cpp in Sources */,
+				A972ACDD21CED9060013AB25 /* IntermTraverse.cpp in Sources */,
+				A972ACE521CED9060013AB25 /* ShaderLang.cpp in Sources */,
+				A972AC9921CED9060013AB25 /* disassemble.cpp in Sources */,
+				A972AD0121CED9060013AB25 /* Constant.cpp in Sources */,
+				A972AC8321CED9060013AB25 /* GlslangToSpv.cpp in Sources */,
+				A972ACDF21CED9060013AB25 /* intermOut.cpp in Sources */,
+				A972ABD821CED7BC0013AB25 /* spirv_cross_parsed_ir.cpp in Sources */,
+				A972AD0321CED9060013AB25 /* linkValidate.cpp in Sources */,
+				A972ACE921CED9060013AB25 /* InfoSink.cpp in Sources */,
+				A972AD1D21CED9060013AB25 /* CodeGen.cpp in Sources */,
+				A972AC7321CED9060013AB25 /* InReadableOrder.cpp in Sources */,
+				A972ACE321CED9060013AB25 /* PoolAlloc.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972ABE621CED7CB0013AB25 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AC9021CED9060013AB25 /* SPVRemapper.cpp in Sources */,
+				A972AC9221CED9060013AB25 /* Logger.cpp in Sources */,
+				A972ACD821CED9060013AB25 /* parseConst.cpp in Sources */,
+				A972ACE221CED9060013AB25 /* iomapper.cpp in Sources */,
+				A972ABE721CED7CB0013AB25 /* spirv_msl.cpp in Sources */,
+				A972ACD421CED9060013AB25 /* glslang_tab.cpp in Sources */,
+				A972AC9C21CED9060013AB25 /* ossource.cpp in Sources */,
+				A972AC6E21CED9060013AB25 /* SpvPostProcess.cpp in Sources */,
+				A972AD2021CED9060013AB25 /* Link.cpp in Sources */,
+				A972AD0821CED9060013AB25 /* PpAtom.cpp in Sources */,
+				A972ACF821CED9060013AB25 /* attribute.cpp in Sources */,
+				A972ABE821CED7CB0013AB25 /* spirv_parser.cpp in Sources */,
+				A972ACEE21CED9060013AB25 /* pch.cpp in Sources */,
+				A972AC6821CED9060013AB25 /* InitializeDll.cpp in Sources */,
+				A972ACD621CED9060013AB25 /* limits.cpp in Sources */,
+				A972AD0C21CED9060013AB25 /* Pp.cpp in Sources */,
+				A972AD1621CED9060013AB25 /* ParseContextBase.cpp in Sources */,
+				A972AD0021CED9060013AB25 /* Versions.cpp in Sources */,
+				A972ACFA21CED9060013AB25 /* reflection.cpp in Sources */,
+				A972AC7C21CED9060013AB25 /* SpvBuilder.cpp in Sources */,
+				A972ACFC21CED9060013AB25 /* RemoveTree.cpp in Sources */,
+				A972ACF021CED9060013AB25 /* SymbolTable.cpp in Sources */,
+				A972AC7221CED9060013AB25 /* SpvTools.cpp in Sources */,
+				A972ACEC21CED9060013AB25 /* Intermediate.cpp in Sources */,
+				A972ABE921CED7CB0013AB25 /* spirv_cfg.cpp in Sources */,
+				A972ACCC21CED9060013AB25 /* Scan.cpp in Sources */,
+				A972AD1221CED9060013AB25 /* PpContext.cpp in Sources */,
+				A972AC9821CED9060013AB25 /* doc.cpp in Sources */,
+				A972ACBC21CED9060013AB25 /* ParseHelper.cpp in Sources */,
+				A972ACC221CED9060013AB25 /* propagateNoContraction.cpp in Sources */,
+				A972ABEA21CED7CB0013AB25 /* spirv_cross.cpp in Sources */,
+				A972AD1021CED9060013AB25 /* PpTokens.cpp in Sources */,
+				A972AD1421CED9060013AB25 /* PpScanner.cpp in Sources */,
+				A972ABEB21CED7CB0013AB25 /* spirv_glsl.cpp in Sources */,
+				A972ACD221CED9060013AB25 /* Initialize.cpp in Sources */,
+				A972ACDE21CED9060013AB25 /* IntermTraverse.cpp in Sources */,
+				A972ACE621CED9060013AB25 /* ShaderLang.cpp in Sources */,
+				A972AC9A21CED9060013AB25 /* disassemble.cpp in Sources */,
+				A972AD0221CED9060013AB25 /* Constant.cpp in Sources */,
+				A972AC8421CED9060013AB25 /* GlslangToSpv.cpp in Sources */,
+				A972ACE021CED9060013AB25 /* intermOut.cpp in Sources */,
+				A972ABEC21CED7CB0013AB25 /* spirv_cross_parsed_ir.cpp in Sources */,
+				A972AD0421CED9060013AB25 /* linkValidate.cpp in Sources */,
+				A972ACEA21CED9060013AB25 /* InfoSink.cpp in Sources */,
+				A972AD1E21CED9060013AB25 /* CodeGen.cpp in Sources */,
+				A972AC7421CED9060013AB25 /* InReadableOrder.cpp in Sources */,
+				A972ACE421CED9060013AB25 /* PoolAlloc.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A97628FE21CC608400B52A68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A976292621CC60BC00B52A68 /* spirv_msl.cpp in Sources */,
+				A976291421CC60BC00B52A68 /* spirv_parser.cpp in Sources */,
+				A976292221CC60BC00B52A68 /* spirv_cfg.cpp in Sources */,
+				A976291621CC60BC00B52A68 /* spirv_cross.cpp in Sources */,
+				A976291821CC60BC00B52A68 /* spirv_glsl.cpp in Sources */,
+				A976292821CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A976290121CC609100B52A68 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A976292521CC60BC00B52A68 /* spirv_msl.cpp in Sources */,
+				A976291321CC60BC00B52A68 /* spirv_parser.cpp in Sources */,
+				A976292121CC60BC00B52A68 /* spirv_cfg.cpp in Sources */,
+				A976291521CC60BC00B52A68 /* spirv_cross.cpp in Sources */,
+				A976291721CC60BC00B52A68 /* spirv_glsl.cpp in Sources */,
+				A976292721CC60BC00B52A68 /* spirv_cross_parsed_ir.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A972A7E921CEC76A0013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A90FD8A021CC4EB900B92BB2 /* SPIRV-Cross-macOS */;
+			targetProxy = A972A7E821CEC76A0013AB25 /* PBXContainerItemProxy */;
+		};
+		A972A7F121CEC8140013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A90FD75B21CC4EAB00B92BB2 /* SPIRV-Cross-iOS */;
+			targetProxy = A972A7F021CEC8140013AB25 /* PBXContainerItemProxy */;
+		};
+		A972A7F921CEC8500013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972A7E421CEC72F0013AB25 /* ExternalDependencies-macOS */;
+			targetProxy = A972A7F821CEC8500013AB25 /* PBXContainerItemProxy */;
+		};
+		A972A7FB21CEC8540013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972A7EA21CEC8030013AB25 /* ExternalDependencies-iOS */;
+			targetProxy = A972A7FA21CEC8540013AB25 /* PBXContainerItemProxy */;
+		};
+		A972A82621CECD6B0013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972A7FC21CECBBF0013AB25 /* SPIRV-Tools-iOS */;
+			targetProxy = A972A82521CECD6B0013AB25 /* PBXContainerItemProxy */;
+		};
+		A972A82821CECD780013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972A81021CECBE90013AB25 /* SPIRV-Tools-macOS */;
+			targetProxy = A972A82721CECD780013AB25 /* PBXContainerItemProxy */;
+		};
+		A972ABF221CED8BA0013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972ABC921CED7BC0013AB25 /* glslang-iOS */;
+			targetProxy = A972ABF121CED8BA0013AB25 /* PBXContainerItemProxy */;
+		};
+		A972ABF421CED8C20013AB25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A972ABDD21CED7CB0013AB25 /* glslang-macOS */;
+			targetProxy = A972ABF321CED8C20013AB25 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A90FD89D21CC4EAB00B92BB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPIRV_CROSS_FLT_FMT=\\\"%.6g\\\"",
+				);
+				PRODUCT_NAME = SPIRVCross;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Debug;
+		};
+		A90FD89E21CC4EAB00B92BB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPIRV_CROSS_FLT_FMT=\\\"%.6g\\\"",
+				);
+				PRODUCT_NAME = SPIRVCross;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Release;
+		};
+		A90FD9E221CC4EB900B92BB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPIRV_CROSS_FLT_FMT=\\\"%.6g\\\"",
+				);
+				PRODUCT_NAME = SPIRVCross;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		A90FD9E321CC4EB900B92BB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPIRV_CROSS_FLT_FMT=\\\"%.6g\\\"",
+				);
+				PRODUCT_NAME = SPIRVCross;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		A972A7E521CEC72F0013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		A972A7E621CEC72F0013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		A972A7EE21CEC8030013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		A972A7EF21CEC8030013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		A972A7F621CEC81B0013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		A972A7F721CEC81B0013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		A972A80D21CECBBF0013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/external/spirv-headers/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/build\"",
+				);
+				PRODUCT_NAME = SPIRVTools;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Debug;
+		};
+		A972A80E21CECBBF0013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/external/spirv-headers/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/build\"",
+				);
+				PRODUCT_NAME = SPIRVTools;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Release;
+		};
+		A972A82121CECBE90013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/external/spirv-headers/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/build\"",
+				);
+				PRODUCT_NAME = SPIRVTools;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		A972A82221CECBE90013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/external/spirv-headers/include\"",
+					"\"$(SRCROOT)/External/glslang/External/spirv-tools/build\"",
+				);
+				PRODUCT_NAME = SPIRVTools;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		A972ABDA21CED7BC0013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				PRODUCT_NAME = glslang;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Debug;
+		};
+		A972ABDB21CED7BC0013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				PRODUCT_NAME = glslang;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Release;
+		};
+		A972ABEE21CED7CB0013AB25 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				PRODUCT_NAME = glslang;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		A972ABEF21CED7CB0013AB25 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				PRODUCT_NAME = glslang;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		A9F55D3F198BE6A8004EC31B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_PARAMETER = YES;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				ONLY_ACTIVE_ARCH = YES;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A9F55D40198BE6A8004EC31B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_CXX0X_EXTENSIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = fast;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_NON_VIRTUAL_DESTRUCTOR = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_PARAMETER = YES;
+				GCC_WARN_UNUSED_VARIABLE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A90FD89C21CC4EAB00B92BB2 /* Build configuration list for PBXNativeTarget "SPIRV-Cross-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A90FD89D21CC4EAB00B92BB2 /* Debug */,
+				A90FD89E21CC4EAB00B92BB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A90FD9E121CC4EB900B92BB2 /* Build configuration list for PBXNativeTarget "SPIRV-Cross-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A90FD9E221CC4EB900B92BB2 /* Debug */,
+				A90FD9E321CC4EB900B92BB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972A7E721CEC72F0013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972A7E521CEC72F0013AB25 /* Debug */,
+				A972A7E621CEC72F0013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972A7ED21CEC8030013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972A7EE21CEC8030013AB25 /* Debug */,
+				A972A7EF21CEC8030013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972A7F521CEC81B0013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972A7F621CEC81B0013AB25 /* Debug */,
+				A972A7F721CEC81B0013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972A80C21CECBBF0013AB25 /* Build configuration list for PBXNativeTarget "SPIRV-Tools-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972A80D21CECBBF0013AB25 /* Debug */,
+				A972A80E21CECBBF0013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972A82021CECBE90013AB25 /* Build configuration list for PBXNativeTarget "SPIRV-Tools-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972A82121CECBE90013AB25 /* Debug */,
+				A972A82221CECBE90013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972ABD921CED7BC0013AB25 /* Build configuration list for PBXNativeTarget "glslang-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972ABDA21CED7BC0013AB25 /* Debug */,
+				A972ABDB21CED7BC0013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A972ABED21CED7CB0013AB25 /* Build configuration list for PBXNativeTarget "glslang-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A972ABEE21CED7CB0013AB25 /* Debug */,
+				A972ABEF21CED7CB0013AB25 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A9F55D28198BE6A7004EC31B /* Build configuration list for PBXProject "ExternalDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A9F55D3F198BE6A8004EC31B /* Debug */,
+				A9F55D40198BE6A8004EC31B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A9F55D25198BE6A7004EC31B /* Project object */;
+}

--- a/ExternalDependencies.xcodeproj/project.pbxproj
+++ b/ExternalDependencies.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = A972A7E721CEC72F0013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-macOS" */;
 			buildPhases = (
+				A9679AB021D26C7000856BF7 /* Package External Libraries */,
 			);
 			dependencies = (
 				A972A7E921CEC76A0013AB25 /* PBXTargetDependency */,
@@ -24,6 +25,7 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = A972A7ED21CEC8030013AB25 /* Build configuration list for PBXAggregateTarget "ExternalDependencies-iOS" */;
 			buildPhases = (
+				A9679AAF21D26C1400856BF7 /* Package External Libraries */,
 			);
 			dependencies = (
 				A972A7F121CEC8140013AB25 /* PBXTargetDependency */,
@@ -954,6 +956,9 @@
 /* Begin PBXFileReference section */
 		A90FD89F21CC4EAB00B92BB2 /* libSPIRVCross.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVCross.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A90FD9E421CC4EB900B92BB2 /* libSPIRVCross.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVCross.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9679AAC21D269D900856BF7 /* package_ext_libs_macos.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_ext_libs_macos.sh; sourceTree = "<group>"; };
+		A9679AAD21D269D900856BF7 /* package_ext_libs_ios.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_ext_libs_ios.sh; sourceTree = "<group>"; };
+		A9679AAE21D269D900856BF7 /* package_ext_libs.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_ext_libs.sh; sourceTree = "<group>"; };
 		A972A80F21CECBBF0013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVTools.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A972A82321CECBE90013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSPIRVTools.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A972A82A21CED2720013AB25 /* spirv_target_env.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_target_env.cpp; sourceTree = "<group>"; };
@@ -1394,6 +1399,16 @@
 				A972ABC821CED6F90013AB25 /* glslang */,
 			);
 			path = External;
+			sourceTree = "<group>";
+		};
+		A9679AAB21D2699800856BF7 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				A9679AAD21D269D900856BF7 /* package_ext_libs_ios.sh */,
+				A9679AAC21D269D900856BF7 /* package_ext_libs_macos.sh */,
+				A9679AAE21D269D900856BF7 /* package_ext_libs.sh */,
+			);
+			path = Scripts;
 			sourceTree = "<group>";
 		};
 		A972A82421CECC410013AB25 /* SPIRV-Tools */ = {
@@ -1988,6 +2003,7 @@
 				A9C2104521D14FD7006BA2D3 /* fetchDependencies */,
 				A9C2104721D15843006BA2D3 /* ExternalRevisions */,
 				A90FD9E921CC519E00B92BB2 /* External */,
+				A9679AAB21D2699800856BF7 /* Scripts */,
 				A972AD2421CEE30F0013AB25 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -2603,6 +2619,45 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A9679AAF21D26C1400856BF7 /* Package External Libraries */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Package External Libraries";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/package_ext_libs_ios.sh\"\n";
+		};
+		A9679AB021D26C7000856BF7 /* Package External Libraries */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Package External Libraries";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/package_ext_libs_macos.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A972A80521CECBBF0013AB25 /* Sources */ = {

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-iOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972A7EA21CEC8030013AB25"
+               BuildableName = "ExternalDependencies-iOS"
+               BlueprintName = "ExternalDependencies-iOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7EA21CEC8030013AB25"
+            BuildableName = "ExternalDependencies-iOS"
+            BlueprintName = "ExternalDependencies-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7EA21CEC8030013AB25"
+            BuildableName = "ExternalDependencies-iOS"
+            BlueprintName = "ExternalDependencies-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-macOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972A7E421CEC72F0013AB25"
+               BuildableName = "ExternalDependencies-macOS"
+               BlueprintName = "ExternalDependencies-macOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7E421CEC72F0013AB25"
+            BuildableName = "ExternalDependencies-macOS"
+            BlueprintName = "ExternalDependencies-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7E421CEC72F0013AB25"
+            BuildableName = "ExternalDependencies-macOS"
+            BlueprintName = "ExternalDependencies-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972A7F221CEC81B0013AB25"
+               BuildableName = "ExternalDependencies"
+               BlueprintName = "ExternalDependencies"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7F221CEC81B0013AB25"
+            BuildableName = "ExternalDependencies"
+            BlueprintName = "ExternalDependencies"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7F221CEC81B0013AB25"
+            BuildableName = "ExternalDependencies"
+            BlueprintName = "ExternalDependencies"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-iOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A90FD75B21CC4EAB00B92BB2"
+               BuildableName = "libSPIRVCross.a"
+               BlueprintName = "SPIRV-Cross-iOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A90FD75B21CC4EAB00B92BB2"
+            BuildableName = "libSPIRVCross.a"
+            BlueprintName = "SPIRV-Cross-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A90FD75B21CC4EAB00B92BB2"
+            BuildableName = "libSPIRVCross.a"
+            BlueprintName = "SPIRV-Cross-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-macOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A90FD8A021CC4EB900B92BB2"
+               BuildableName = "libSPIRVCross.a"
+               BlueprintName = "SPIRV-Cross-macOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A90FD8A021CC4EB900B92BB2"
+            BuildableName = "libSPIRVCross.a"
+            BlueprintName = "SPIRV-Cross-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A90FD8A021CC4EB900B92BB2"
+            BuildableName = "libSPIRVCross.a"
+            BlueprintName = "SPIRV-Cross-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-iOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972A7FC21CECBBF0013AB25"
+               BuildableName = "libSPIRVTools.a"
+               BlueprintName = "SPIRV-Tools-iOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7FC21CECBBF0013AB25"
+            BuildableName = "libSPIRVTools.a"
+            BlueprintName = "SPIRV-Tools-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A7FC21CECBBF0013AB25"
+            BuildableName = "libSPIRVTools.a"
+            BlueprintName = "SPIRV-Tools-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-macOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972A81021CECBE90013AB25"
+               BuildableName = "libSPIRVTools.a"
+               BlueprintName = "SPIRV-Tools-macOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A81021CECBE90013AB25"
+            BuildableName = "libSPIRVTools.a"
+            BlueprintName = "SPIRV-Tools-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972A81021CECBE90013AB25"
+            BuildableName = "libSPIRVTools.a"
+            BlueprintName = "SPIRV-Tools-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-iOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972ABC921CED7BC0013AB25"
+               BuildableName = "libglslang.a"
+               BlueprintName = "glslang-iOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972ABC921CED7BC0013AB25"
+            BuildableName = "libglslang.a"
+            BlueprintName = "glslang-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972ABC921CED7BC0013AB25"
+            BuildableName = "libglslang.a"
+            BlueprintName = "glslang-iOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-macOS.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A972ABDD21CED7CB0013AB25"
+               BuildableName = "libglslang.a"
+               BlueprintName = "glslang-macOS"
+               ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "NO"
+      debugXPCServices = "NO"
+      debugServiceExtension = "internal"
+      enableGPUFrameCaptureMode = "3"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "NO"
+      queueDebuggingEnabled = "No">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972ABDD21CED7CB0013AB25"
+            BuildableName = "libglslang.a"
+            BlueprintName = "glslang-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A972ABDD21CED7CB0013AB25"
+            BuildableName = "libglslang.a"
+            BlueprintName = "glslang-macOS"
+            ReferencedContainer = "container:ExternalDependencies.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExternalRevisions/README.md
+++ b/ExternalRevisions/README.md
@@ -15,18 +15,18 @@ For best results, use a Markdown reader.*
 Table of Contents
 -----------------
 
-- [Fetching External Libraries](#fetching)
+- [Fetching and Building External Libraries](#fetching)
 - [Updating External Library Versions](#updating)
 - [Adding the *cereal* Library to the *MoltenVK Xcode* Project](#add_cereal)
-- [Adding the *SPIRV-Cross* Library to the *MoltenVKShaderConverter Xcode* Project](#add_spirv-cross)
-- [Adding the *glslang* Library to the *MoltenVKShaderConverter Xcode* Project](#add_glslang)
-- [Adding the *SPIRV-Tools* Library to the *MoltenVKShaderConverter Xcode* Project](#add_spirv-tools)
+- [Adding the *SPIRV-Cross* Library to the *ExternalDependencies Xcode* Project](#add_spirv-cross)
+- [Adding the *SPIRV-Tools* Library to the *ExternalDependencies Xcode* Project](#add_spirv-tools)
+- [Adding the *glslang* Library to the *ExternalDependencies Xcode* Project](#add_glslang)
 
 
 
 <a name="fetching"></a>
-Fetching External Libraries
----------------------------
+Fetching and Building External Libraries
+----------------------------------------
 
 **MoltenVK** uses technology from the following external open-source libraries:
 
@@ -40,8 +40,8 @@ Fetching External Libraries
 - [*VulkanSamples*](https://github.com/LunarG/VulkanSamples)
 
 These external open-source libraries are maintained in the `External` directory.
-To retrieve these libraries from their sources, run the `fetchDependencies`  script
-in the main repository directory:
+To retrieve and build these libraries from their sources, run the `fetchDependencies`
+script in the main repository directory:
 
 	./fetchDependencies
 
@@ -84,8 +84,8 @@ the value held in the corresponding `*_repo_revision` file listed above.
 The version of the *SPIRV-Tools* and *SPIRV-Headers* libraries is automatically 
 determined by the version of the *glslang* library you have retrieved.
 
-Once you have made changes to the `*_repo_revision` files, you can retrieve the 
-updated library versions by running the `fetchDependencies` script again.
+Once you have made changes to the `*_repo_revision` files, you can retrieve the updated 
+library versions by running the `fetchDependencies` script, as described above, again.
 
 >***Note:*** If, after updating to new versions of the external libraries, you encounter 
 >build errors when building **MoltenVK**, review the instructions in the sections below 
@@ -109,18 +109,18 @@ errors, you may need to re-add the *cereal* library to the `MoltenVK` *Xcode* pr
 
 
 <a name="add_spirv-cross"></a>
-Adding the *SPIRV-Cross* Library to the *MoltenVKShaderConverter Xcode* Project
--------------------------------------------------------------------------------
+Adding the *SPIRV-Cross* Library to the *ExternalDependencies Xcode* Project
+----------------------------------------------------------------------------
 
-The `MoltenVKShaderConverter` *Xcode* project is already configured to use the *SPIRV-Cross*
+The `ExternalDependencies` *Xcode* project is already configured to use the *SPIRV-Cross*
 library. However, after updating the version of *SPIRV-Cross*, as described [above](#updating),
 if you encounter any building errors, you may need to re-add the *SPIRV-Cross* library to the
-`MoltenVKShaderConverter` *Xcode* project as follows:
+`ExternalDependencies` *Xcode* project as follows:
 
 1. In the *Project Navigator*, remove all of the files under the *Group* named 
-   `MoltenVKSPIRVToMSLConverter/SPIRV-Cross`.
+   `External/SPIRV-Cross`.
 
-2. Drag the following files from the `External/SPIRV-Cross` directory to the `SPIRV-Cross` 
+2. Drag the following files from the `External/SPIRV-Cross` directory to the `External/SPIRV-Cross` 
    group in the *Project Navigator* panel:
 
 		spirv_cfg.cpp
@@ -137,24 +137,15 @@ if you encounter any building errors, you may need to re-add the *SPIRV-Cross* l
 		spirv_parser.cpp
 		spirv_parser.hpp
 
-   In the ***Choose options for adding these files*** dialog that opens, select the 
-   ***Create groups*** option, add the files to *both* the `MoltenVKSPIRVToMSLConverter-iOS` 
-   and `MoltenVKSPIRVToMSLConverter-macOS` targets, and click the ***Finish*** button.
-
-3. ***(Optional)*** To simplify the paths used within *Xcode* to reference the added files,
-   perform the following steps:
-   
-   1. **Create a backup of your project!** This is an intrusive and dangerous operation!
-   2. In the *Finder*, right-click your `MoltenVKShaderConverter.xcodeproj` file and select 
-      **_Show Package Contents_**.
-   3. Open the `project.pbxproj` file in a text editor.
-   4. Remove all occurrences of `path-to-SPIRV-Cross-repo-folder` from the paths to the files added above.
+   In the ***Choose options for adding these files*** dialog that opens, select the ***Create groups*** option, 
+   add the files to *both* the `SPIRV-Cross-macOS` and `SPIRV-Cross-iOS` targets, and click the ***Finish*** button.
 
 
 ### Regression Testing Your Changes to *SPIRV-Cross*
 
-If you make changes to the `SPIRV-Cross` repository, you can regression test your changes
- using the following steps:
+The *SPIRV-Cross* library plays an important part in providing features for **_MoltenVK_**, and if you are 
+developing features for **_MoltenVK_**, you may end up making changes to *SPIRV-Cross*. If you make changes 
+to the `SPIRV-Cross` repository, you can regression test your changes using the following steps:
 
 1. Load and build the versions of `SPRIV-Tools` and `glslang` that are used by the `SPIRV-Cross` tests:
 
@@ -170,88 +161,62 @@ If you make changes to the `SPIRV-Cross` repository, you can regression test you
 
 		./test_shaders.sh
 
-4. If your changes result in different expected output for a reference shader, and the new results
-   are correct, you can update the reference shader for a particular regression test by deleting
-   that reference shader, in either `External/SPIRV-Cross/reference/shaders-msl` or 
-   `External/SPIRV-Cross/reference/opt/shaders-msl`, and running the test again. The test will
-   replace the deleted reference shader.
+
+
+<a name="add_spirv-tools"></a>
+Adding the *SPIRV-Tools* Library to the *ExternalDependencies Xcode* Project
+----------------------------------------------------------------------------
+
+The `ExternalDependencies` *Xcode* project is already configured to use the *SPIRV-Tools*
+library. However, after updating the version of *glslang* (which adds *SPIRV-Tools*), 
+as described [above](#updating), if you encounter any building errors, you may need to re-add 
+the *SPIRV-Tools* library to the `ExternalDependencies` *Xcode* project as follows:
+
+1. In the *Project Navigator*, remove the *Group* named `source` from under the *Group* named
+   `External/SPIRV-Tools`.
+
+2. Drag the `External/glslang/Extermal/spirv-tools/source` file folder to the `External/SPIRV-Tools` 
+   group in the *Project Navigator* panel. In the _**Choose options for adding these files**_ dialog 
+   that opens, select the _**Create groups**_ option, add the files to *both* the `SPIRV-Tools-macOS` 
+   and `SPIRV-Tools-iOS` targets, and click the ***Finish*** button.
+
+3. In the *Project Navigator* panel, select the `ExternalDependencies` *Xcode* project, then 
+   select the `SPIRV-Tools-macOS` target, and open the *Build Settings* tab. Locate the build 
+   setting entry **Header Search Paths** (`HEADER_SEARCH_PATHS`) and add the following paths:
+
+		$(inherited) 
+		"$(SRCROOT)/External/glslang/External/spirv-tools/"
+		"$(SRCROOT)/External/glslang/External/spirv-tools/include"
+		"$(SRCROOT)/External/glslang/External/spirv-tools/external/spirv-headers/include"
+		"$(SRCROOT)/External/glslang/External/spirv-tools/build"
+
+4. Repeat *Step 3* for the `SPIRV-Tools-iOS` target within the `ExternalDependencies` *Xcode* project
 
 
 
 <a name="add_glslang"></a>
-Adding the *glslang* Library to the *MoltenVKShaderConverter Xcode* Project
----------------------------------------------------------------------------
+Adding the *glslang* Library to the *ExternalDependencies Xcode* Project
+------------------------------------------------------------------------
 
-The `MoltenVKShaderConverter` *Xcode* project is already configured to use the *glslang*
+The `ExternalDependencies` *Xcode* project is already configured to use the *glslang*
 library. However, after updating the version of *glslang*, as described [above](#updating),
 if you encounter any building errors, you may need to re-add the *glslang* library to the
-`MoltenVKShaderConverter` *Xcode* project as follows:
+`ExternalDependencies` *Xcode* project as follows:
 
 1. In the *Project Navigator*, remove all *Groups* from under the *Group* named
-   `MoltenVKGLSLToSPIRVConverter/glslang`.
+   `External/glslang`.
 
-2. Drag the following folders from the `External/glslang` file folder to the `glslang` *Group* in
-   the *Project Navigator* panel:
+2. Drag the following folders from the `External/glslang` file folder to the `External/glslang` 
+   *Group* in the *Project Navigator* panel:
 
 		glslang
 		OGLCompilersDLL
 		SPIRV
 
-   In the ***Choose options for adding these files*** dialog that opens, select the 
-   ***Create groups*** option, add the files to *both* the `MoltenVKGLSLToSPIRVConverter-iOS` 
-   and `MoltenVKGLSLToSPIRVConverter-macOS` targets, and click the ***Finish*** button.
+   In the ***Choose options for adding these files*** dialog that opens, select the ***Create groups*** option, 
+   add the files to *both* the `glslang-macOS` and `glslang-iOS` targets, and click the ***Finish*** button.
 
 3. In the *Project Navigator* panel, remove the references to the following files and folders:
 
-		glslang/glslang/MachineIndependant/glslang.y
-		glslang/glslang/OSDependent/Windows
-
-4. ***(Optional)*** To simplify the paths used within *Xcode* to reference the added files,
-   perform the following steps:
-   
-   1. **Create a backup of your project!** This is an intrusive and dangerous operation!
-   2. In the *Finder*, right-click your `MoltenVKShaderConverter.xcodeproj` file and select 
-      **_Show Package Contents_**.
-   3. Open the `project.pbxproj` file in a text editor.
-   4. Remove all occurrences of `path-to-glslang-repo-folder` from the paths to the 
-      `glslang`, `OGLCompilersDLL`, and `SPIRV` directories added above.
-
-
-
-<a name="add_spirv-tools"></a>
-Adding the *SPIRV-Tools* Library to the *MoltenVKShaderConverter Xcode* Project
--------------------------------------------------------------------------------
-
-The `MoltenVKShaderConverter` *Xcode* project is already configured to use the *SPIRV-Tools*
-library. However, after updating the version of *SPIRV-Tools*, as described [above](#updating),
-if you encounter any building errors, you may need to re-add the *SPIRV-Tools* library to the
-`MoltenVKShaderConverter` *Xcode* project as follows:
-
-1. In the *Project Navigator*, remove the *Group* named `source` from under the *Group* named
-   `MoltenVKSPIRVToMSLConverter/SPIRV-Tools`.
-
-2. Drag the `External/glslang/Extermal/spirv-tools/source` file folder to the `SPIRV-Tools` group in the *Project Navigator* panel.
-   In the _**Choose options for adding these files**_ dialog that opens, select the 
-   _**Create groups**_ option, add the files to *both* the `MoltenVKSPIRVToMSLConverter-iOS` 
-   and `MoltenVKSPIRVToMSLConverter-macOS` targets, and click the ***Finish*** button.
-
-3. In the *Project Navigator* panel, select the `MoltenVKShaderConverter` *Xcode* project, then select the 
-   `MoltenVKSPIRVToMSLConverter-macOS` target, and open the *Build Settings* tab. Locate the build setting 
-   entry **Header Search Paths** (`HEADER_SEARCH_PATHS`) and add the following paths:
-   
-		"$(SRCROOT)/glslang/External/spirv-tools"
-		"$(SRCROOT)/glslang/External/spirv-tools/include"
-		"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include"
-		"$(SRCROOT)/glslang/build/External/spirv-tools"
-
-4. Repeat *Step 3* for the `MoltenVKSPIRVToMSLConverter-iOS` target within the `MoltenVKShaderConverter` *Xcode* project
-
-5. ***(Optional)*** To simplify the paths used within *Xcode* to reference the added files,
-   perform the following steps:
-   
-   1. **Create a backup of your project!** This is an intrusive and dangerous operation!
-   2. In the *Finder*, right-click your `MoltenVKShaderConverter.xcodeproj` file and select 
-      **_Show Package Contents_**.
-   3. Open the `project.pbxproj` file in a text editor.
-   4. Remove all occurrences of `path-to-SPIRV-Tools-repo-folder` from the paths to the 
-      `source` directory added above.
+		External/glslang/glslang/MachineIndependant/glslang.y
+		External/glslang/glslang/OSDependent/Windows

--- a/ExternalRevisions/README.md
+++ b/ExternalRevisions/README.md
@@ -143,9 +143,14 @@ if you encounter any building errors, you may need to re-add the *SPIRV-Cross* l
 
 ### Regression Testing Your Changes to *SPIRV-Cross*
 
-The *SPIRV-Cross* library plays an important part in providing features for **_MoltenVK_**, and if you are 
-developing features for **_MoltenVK_**, you may end up making changes to *SPIRV-Cross*. If you make changes 
-to the `SPIRV-Cross` repository, you can regression test your changes using the following steps:
+The *SPIRV-Cross* library plays an important part in providing features for **_MoltenVK_**, and if 
+you are developing features for **_MoltenVK_**, you may end up making changes to *SPIRV-Cross*. 
+
+If you make changes to the `SPIRV-Cross` repository, you can build a new version of the `libSPIRVCross.a`
+static library by opening the `ExternalDependencies.xcodeproj` *Xcode* project, and running the **_ExternalDependencies_** *Xcode* scheme. You can then rebuild **MoltenVK** to include the new library.
+
+While makng changes to the `SPIRV-Cross` repository, you can regression test your changes using the
+following steps:
 
 1. Load and build the versions of `SPRIV-Tools` and `glslang` that are used by the `SPIRV-Cross` tests:
 

--- a/MoltenVKPackaging.xcodeproj/project.pbxproj
+++ b/MoltenVKPackaging.xcodeproj/project.pbxproj
@@ -179,19 +179,11 @@
 		A92EF7CA21856EA200C8B91B /* package_update_latest.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_update_latest.sh; sourceTree = "<group>"; };
 		A92EF7CB21856EA300C8B91B /* package_shader_converter.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_shader_converter.sh; sourceTree = "<group>"; };
 		A92EF7DE2186451700C8B91B /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; name = Makefile; path = ../Makefile; sourceTree = "<group>"; };
-		A943100220546CDD00F5CF87 /* fetchDependencies */ = {isa = PBXFileReference; lastKnownFileType = text; name = fetchDependencies; path = ../fetchDependencies; sourceTree = "<group>"; };
 		A975D55C213F25D700D4834F /* create_dylib.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = create_dylib.sh; path = ../MoltenVK/scripts/create_dylib.sh; sourceTree = "<group>"; };
 		A98149E51FB78829005F00B4 /* MoltenVK_Runtime_UserGuide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = MoltenVK_Runtime_UserGuide.md; path = Docs/MoltenVK_Runtime_UserGuide.md; sourceTree = "<group>"; };
 		A99A760321852584000A8E2A /* create_framework.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = create_framework.sh; path = ../MoltenVK/scripts/create_framework.sh; sourceTree = "<group>"; };
-		A9AD67D12054E2D700ED3C08 /* VulkanSamples_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = VulkanSamples_repo_revision; sourceTree = "<group>"; };
-		A9AD67D32054E2D700ED3C08 /* SPIRV-Cross_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SPIRV-Cross_repo_revision"; sourceTree = "<group>"; };
-		A9AD67E92055D8A600ED3C08 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		A9D3560A20BB3A2900BE295C /* glslang_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = glslang_repo_revision; sourceTree = "<group>"; };
-		A9D3560B20BB3A5600BE295C /* Vulkan-Headers_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Vulkan-Headers_repo_revision"; sourceTree = "<group>"; };
-		A9D3560C20BB3A7200BE295C /* Vulkan-Tools_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Vulkan-Tools_repo_revision"; sourceTree = "<group>"; };
 		A9DA8340218A198C002AA662 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		A9DA8341218A198C002AA662 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
-		A9EE46412065766C00193200 /* cereal_repo_revision */ = {isa = PBXFileReference; lastKnownFileType = text; path = cereal_repo_revision; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -200,7 +192,6 @@
 			children = (
 				A92DB3EE1CE0F72500FBC835 /* MoltenVK.xcodeproj */,
 				A92DB40E1CE0F89600FBC835 /* MoltenVKShaderConverter.xcodeproj */,
-				A939A6FB1F5479D0006ACA0C /* External */,
 				A975D55B213F25AD00D4834F /* Scripts */,
 				A92DB3E11CE0F34500FBC835 /* Docs */,
 				A9DA833F218A193F002AA662 /* Git */,
@@ -225,22 +216,6 @@
 				A92DB3F71CE0F72500FBC835 /* libMoltenVK.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		A939A6FB1F5479D0006ACA0C /* External */ = {
-			isa = PBXGroup;
-			children = (
-				A9AD67E92055D8A600ED3C08 /* README.md */,
-				A943100220546CDD00F5CF87 /* fetchDependencies */,
-				A9EE46412065766C00193200 /* cereal_repo_revision */,
-				A9D3560A20BB3A2900BE295C /* glslang_repo_revision */,
-				A9AD67D32054E2D700ED3C08 /* SPIRV-Cross_repo_revision */,
-				A9D3560B20BB3A5600BE295C /* Vulkan-Headers_repo_revision */,
-				A9D3560C20BB3A7200BE295C /* Vulkan-Tools_repo_revision */,
-				A9AD67D12054E2D700ED3C08 /* VulkanSamples_repo_revision */,
-			);
-			name = External;
-			path = ExternalRevisions;
 			sourceTree = "<group>";
 		};
 		A975D55B213F25AD00D4834F /* Scripts */ = {

--- a/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
@@ -20,9 +20,9 @@
 #include "MVKCommonEnvironment.h"
 #include "SPIRVToMSLConverter.h"
 #include "MVKStrings.h"
-#include "GlslangToSpv.h"
+#include "../glslang/SPIRV/GlslangToSpv.h"
 #include "../glslang/SPIRV/disassemble.h"
-#include "doc.h"
+#include "../glslang/SPIRV/doc.h"
 #include <sstream>
 
 using namespace std;

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h
@@ -19,7 +19,7 @@
 #ifndef __SPIRVToMSLConverter_h_
 #define __SPIRVToMSLConverter_h_ 1
 
-#include "spirv.hpp"
+#include "../SPIRV-Cross/spirv.hpp"
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/spirv.hpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/spirv.hpp
@@ -1,1 +1,0 @@
-../../External/SPIRV-Cross/spirv.hpp

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -25,809 +25,21 @@
 		A928C91A1D0488DC00071B88 /* SPIRVConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A928C9171D0488DC00071B88 /* SPIRVConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A928C91B1D0488DC00071B88 /* SPIRVConversion.mm in Sources */ = {isa = PBXBuildFile; fileRef = A928C9181D0488DC00071B88 /* SPIRVConversion.mm */; };
 		A928C91C1D0488DC00071B88 /* SPIRVConversion.mm in Sources */ = {isa = PBXBuildFile; fileRef = A928C9181D0488DC00071B88 /* SPIRVConversion.mm */; };
-		A93E826E211F76F6001FEBD4 /* SPVRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8203211F76F5001FEBD4 /* SPVRemapper.h */; };
-		A93E826F211F76F6001FEBD4 /* SPVRemapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8203211F76F5001FEBD4 /* SPVRemapper.h */; };
-		A93E8270211F76F6001FEBD4 /* SpvBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8204211F76F5001FEBD4 /* SpvBuilder.h */; };
-		A93E8271211F76F6001FEBD4 /* SpvBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8204211F76F5001FEBD4 /* SpvBuilder.h */; };
-		A93E8272211F76F6001FEBD4 /* SpvPostProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8206211F76F5001FEBD4 /* SpvPostProcess.cpp */; };
-		A93E8273211F76F6001FEBD4 /* SpvPostProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8206211F76F5001FEBD4 /* SpvPostProcess.cpp */; };
-		A93E8274211F76F6001FEBD4 /* InReadableOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8207211F76F5001FEBD4 /* InReadableOrder.cpp */; };
-		A93E8275211F76F6001FEBD4 /* InReadableOrder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8207211F76F5001FEBD4 /* InReadableOrder.cpp */; };
-		A93E8276211F76F6001FEBD4 /* GLSL.ext.AMD.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8208211F76F5001FEBD4 /* GLSL.ext.AMD.h */; };
-		A93E8277211F76F6001FEBD4 /* GLSL.ext.AMD.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8208211F76F5001FEBD4 /* GLSL.ext.AMD.h */; };
-		A93E8278211F76F6001FEBD4 /* doc.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8209211F76F5001FEBD4 /* doc.h */; };
-		A93E8279211F76F6001FEBD4 /* doc.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8209211F76F5001FEBD4 /* doc.h */; };
-		A93E827A211F76F6001FEBD4 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A93E820A211F76F5001FEBD4 /* spirv.hpp */; };
-		A93E827B211F76F6001FEBD4 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A93E820A211F76F5001FEBD4 /* spirv.hpp */; };
-		A93E827C211F76F6001FEBD4 /* SpvBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E820B211F76F5001FEBD4 /* SpvBuilder.cpp */; };
-		A93E827D211F76F6001FEBD4 /* SpvBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E820B211F76F5001FEBD4 /* SpvBuilder.cpp */; };
-		A93E827E211F76F6001FEBD4 /* GLSL.ext.EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820C211F76F6001FEBD4 /* GLSL.ext.EXT.h */; };
-		A93E827F211F76F6001FEBD4 /* GLSL.ext.EXT.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820C211F76F6001FEBD4 /* GLSL.ext.EXT.h */; };
-		A93E8280211F76F6001FEBD4 /* GLSL.ext.KHR.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820D211F76F6001FEBD4 /* GLSL.ext.KHR.h */; };
-		A93E8281211F76F6001FEBD4 /* GLSL.ext.KHR.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820D211F76F6001FEBD4 /* GLSL.ext.KHR.h */; };
-		A93E8282211F76F6001FEBD4 /* GLSL.ext.NV.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820E211F76F6001FEBD4 /* GLSL.ext.NV.h */; };
-		A93E8283211F76F6001FEBD4 /* GLSL.ext.NV.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E820E211F76F6001FEBD4 /* GLSL.ext.NV.h */; };
-		A93E8284211F76F6001FEBD4 /* GlslangToSpv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E820F211F76F6001FEBD4 /* GlslangToSpv.cpp */; };
-		A93E8285211F76F6001FEBD4 /* GlslangToSpv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E820F211F76F6001FEBD4 /* GlslangToSpv.cpp */; };
-		A93E8286211F76F6001FEBD4 /* spvIR.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8210211F76F6001FEBD4 /* spvIR.h */; };
-		A93E8287211F76F6001FEBD4 /* spvIR.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8210211F76F6001FEBD4 /* spvIR.h */; };
-		A93E8288211F76F6001FEBD4 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8211211F76F6001FEBD4 /* bitutils.h */; };
-		A93E8289211F76F6001FEBD4 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8211211F76F6001FEBD4 /* bitutils.h */; };
-		A93E828A211F76F6001FEBD4 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8212211F76F6001FEBD4 /* disassemble.h */; };
-		A93E828B211F76F6001FEBD4 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8212211F76F6001FEBD4 /* disassemble.h */; };
-		A93E828C211F76F6001FEBD4 /* GlslangToSpv.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8213211F76F6001FEBD4 /* GlslangToSpv.h */; };
-		A93E828D211F76F6001FEBD4 /* GlslangToSpv.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8213211F76F6001FEBD4 /* GlslangToSpv.h */; };
-		A93E828E211F76F6001FEBD4 /* GLSL.std.450.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8214211F76F6001FEBD4 /* GLSL.std.450.h */; };
-		A93E828F211F76F6001FEBD4 /* GLSL.std.450.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8214211F76F6001FEBD4 /* GLSL.std.450.h */; };
-		A93E8290211F76F6001FEBD4 /* SPVRemapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8215211F76F6001FEBD4 /* SPVRemapper.cpp */; };
-		A93E8291211F76F6001FEBD4 /* SPVRemapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8215211F76F6001FEBD4 /* SPVRemapper.cpp */; };
-		A93E8292211F76F6001FEBD4 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8216211F76F6001FEBD4 /* Logger.cpp */; };
-		A93E8293211F76F6001FEBD4 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8216211F76F6001FEBD4 /* Logger.cpp */; };
-		A93E8294211F76F6001FEBD4 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8217211F76F6001FEBD4 /* hex_float.h */; };
-		A93E8295211F76F6001FEBD4 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8217211F76F6001FEBD4 /* hex_float.h */; };
-		A93E8296211F76F6001FEBD4 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8218211F76F6001FEBD4 /* Logger.h */; };
-		A93E8297211F76F6001FEBD4 /* Logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8218211F76F6001FEBD4 /* Logger.h */; };
-		A93E8298211F76F6001FEBD4 /* doc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8219211F76F6001FEBD4 /* doc.cpp */; };
-		A93E8299211F76F6001FEBD4 /* doc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8219211F76F6001FEBD4 /* doc.cpp */; };
-		A93E829A211F76F6001FEBD4 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E821A211F76F6001FEBD4 /* disassemble.cpp */; };
-		A93E829B211F76F6001FEBD4 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E821A211F76F6001FEBD4 /* disassemble.cpp */; };
-		A93E829C211F76F6001FEBD4 /* ossource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E821F211F76F6001FEBD4 /* ossource.cpp */; };
-		A93E829D211F76F6001FEBD4 /* ossource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E821F211F76F6001FEBD4 /* ossource.cpp */; };
-		A93E829E211F76F6001FEBD4 /* osinclude.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8221211F76F6001FEBD4 /* osinclude.h */; };
-		A93E829F211F76F6001FEBD4 /* osinclude.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8221211F76F6001FEBD4 /* osinclude.h */; };
-		A93E82A4211F76F6001FEBD4 /* ResourceLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8227211F76F6001FEBD4 /* ResourceLimits.h */; };
-		A93E82A5211F76F6001FEBD4 /* ResourceLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8227211F76F6001FEBD4 /* ResourceLimits.h */; };
-		A93E82A6211F76F6001FEBD4 /* Types.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8228211F76F6001FEBD4 /* Types.h */; };
-		A93E82A7211F76F6001FEBD4 /* Types.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8228211F76F6001FEBD4 /* Types.h */; };
-		A93E82A8211F76F6001FEBD4 /* intermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8229211F76F6001FEBD4 /* intermediate.h */; };
-		A93E82A9211F76F6001FEBD4 /* intermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8229211F76F6001FEBD4 /* intermediate.h */; };
-		A93E82AA211F76F6001FEBD4 /* BaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822A211F76F6001FEBD4 /* BaseTypes.h */; };
-		A93E82AB211F76F6001FEBD4 /* BaseTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822A211F76F6001FEBD4 /* BaseTypes.h */; };
-		A93E82AC211F76F6001FEBD4 /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822B211F76F6001FEBD4 /* revision.h */; };
-		A93E82AD211F76F6001FEBD4 /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822B211F76F6001FEBD4 /* revision.h */; };
-		A93E82AE211F76F6001FEBD4 /* InitializeGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822C211F76F6001FEBD4 /* InitializeGlobals.h */; };
-		A93E82AF211F76F6001FEBD4 /* InitializeGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822C211F76F6001FEBD4 /* InitializeGlobals.h */; };
-		A93E82B0211F76F6001FEBD4 /* ShHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822D211F76F6001FEBD4 /* ShHandle.h */; };
-		A93E82B1211F76F6001FEBD4 /* ShHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822D211F76F6001FEBD4 /* ShHandle.h */; };
-		A93E82B2211F76F6001FEBD4 /* arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822E211F76F6001FEBD4 /* arrays.h */; };
-		A93E82B3211F76F6001FEBD4 /* arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822E211F76F6001FEBD4 /* arrays.h */; };
-		A93E82B4211F76F6001FEBD4 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822F211F76F6001FEBD4 /* Common.h */; };
-		A93E82B5211F76F6001FEBD4 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E822F211F76F6001FEBD4 /* Common.h */; };
-		A93E82B6211F76F6001FEBD4 /* ConstantUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8231211F76F6001FEBD4 /* ConstantUnion.h */; };
-		A93E82B7211F76F6001FEBD4 /* ConstantUnion.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8231211F76F6001FEBD4 /* ConstantUnion.h */; };
-		A93E82B8211F76F6001FEBD4 /* InfoSink.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8232211F76F6001FEBD4 /* InfoSink.h */; };
-		A93E82B9211F76F6001FEBD4 /* InfoSink.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8232211F76F6001FEBD4 /* InfoSink.h */; };
-		A93E82BA211F76F6001FEBD4 /* PoolAlloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8233211F76F6001FEBD4 /* PoolAlloc.h */; };
-		A93E82BB211F76F6001FEBD4 /* PoolAlloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8233211F76F6001FEBD4 /* PoolAlloc.h */; };
-		A93E82BC211F76F6001FEBD4 /* ParseHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8236211F76F6001FEBD4 /* ParseHelper.cpp */; };
-		A93E82BD211F76F6001FEBD4 /* ParseHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8236211F76F6001FEBD4 /* ParseHelper.cpp */; };
-		A93E82BE211F76F6001FEBD4 /* parseVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8237211F76F6001FEBD4 /* parseVersions.h */; };
-		A93E82BF211F76F6001FEBD4 /* parseVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8237211F76F6001FEBD4 /* parseVersions.h */; };
-		A93E82C0211F76F6001FEBD4 /* gl_types.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8238211F76F6001FEBD4 /* gl_types.h */; };
-		A93E82C1211F76F6001FEBD4 /* gl_types.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8238211F76F6001FEBD4 /* gl_types.h */; };
-		A93E82C2211F76F6001FEBD4 /* propagateNoContraction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8239211F76F6001FEBD4 /* propagateNoContraction.cpp */; };
-		A93E82C3211F76F6001FEBD4 /* propagateNoContraction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8239211F76F6001FEBD4 /* propagateNoContraction.cpp */; };
-		A93E82C4211F76F6001FEBD4 /* ScanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823A211F76F6001FEBD4 /* ScanContext.h */; };
-		A93E82C5211F76F6001FEBD4 /* ScanContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823A211F76F6001FEBD4 /* ScanContext.h */; };
-		A93E82C6211F76F6001FEBD4 /* iomapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823B211F76F6001FEBD4 /* iomapper.h */; };
-		A93E82C7211F76F6001FEBD4 /* iomapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823B211F76F6001FEBD4 /* iomapper.h */; };
-		A93E82C8211F76F6001FEBD4 /* localintermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823C211F76F6001FEBD4 /* localintermediate.h */; };
-		A93E82C9211F76F6001FEBD4 /* localintermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823C211F76F6001FEBD4 /* localintermediate.h */; };
-		A93E82CA211F76F6001FEBD4 /* Scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E823D211F76F6001FEBD4 /* Scan.cpp */; };
-		A93E82CB211F76F6001FEBD4 /* Scan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E823D211F76F6001FEBD4 /* Scan.cpp */; };
-		A93E82CE211F76F6001FEBD4 /* RemoveTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823F211F76F6001FEBD4 /* RemoveTree.h */; };
-		A93E82CF211F76F6001FEBD4 /* RemoveTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E823F211F76F6001FEBD4 /* RemoveTree.h */; };
-		A93E82D0211F76F6001FEBD4 /* Initialize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8240211F76F6001FEBD4 /* Initialize.cpp */; };
-		A93E82D1211F76F6001FEBD4 /* Initialize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8240211F76F6001FEBD4 /* Initialize.cpp */; };
-		A93E82D2211F76F6001FEBD4 /* glslang_tab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8241211F76F6001FEBD4 /* glslang_tab.cpp */; };
-		A93E82D3211F76F6001FEBD4 /* glslang_tab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8241211F76F6001FEBD4 /* glslang_tab.cpp */; };
-		A93E82D4211F76F6001FEBD4 /* limits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8242211F76F6001FEBD4 /* limits.cpp */; };
-		A93E82D5211F76F6001FEBD4 /* limits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8242211F76F6001FEBD4 /* limits.cpp */; };
-		A93E82D6211F76F6001FEBD4 /* parseConst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8243211F76F6001FEBD4 /* parseConst.cpp */; };
-		A93E82D7211F76F6001FEBD4 /* parseConst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8243211F76F6001FEBD4 /* parseConst.cpp */; };
-		A93E82D8211F76F6001FEBD4 /* propagateNoContraction.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8244211F76F6001FEBD4 /* propagateNoContraction.h */; };
-		A93E82D9211F76F6001FEBD4 /* propagateNoContraction.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8244211F76F6001FEBD4 /* propagateNoContraction.h */; };
-		A93E82DA211F76F6001FEBD4 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8245211F76F6001FEBD4 /* Versions.h */; };
-		A93E82DB211F76F6001FEBD4 /* Versions.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8245211F76F6001FEBD4 /* Versions.h */; };
-		A93E82DC211F76F6001FEBD4 /* IntermTraverse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8246211F76F6001FEBD4 /* IntermTraverse.cpp */; };
-		A93E82DD211F76F6001FEBD4 /* IntermTraverse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8246211F76F6001FEBD4 /* IntermTraverse.cpp */; };
-		A93E82DE211F76F6001FEBD4 /* intermOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8247211F76F6001FEBD4 /* intermOut.cpp */; };
-		A93E82DF211F76F6001FEBD4 /* intermOut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8247211F76F6001FEBD4 /* intermOut.cpp */; };
-		A93E82E0211F76F6001FEBD4 /* iomapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8248211F76F6001FEBD4 /* iomapper.cpp */; };
-		A93E82E1211F76F6001FEBD4 /* iomapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8248211F76F6001FEBD4 /* iomapper.cpp */; };
-		A93E82E2211F76F6001FEBD4 /* PoolAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8249211F76F6001FEBD4 /* PoolAlloc.cpp */; };
-		A93E82E3211F76F6001FEBD4 /* PoolAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8249211F76F6001FEBD4 /* PoolAlloc.cpp */; };
-		A93E82E4211F76F6001FEBD4 /* ShaderLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824A211F76F6001FEBD4 /* ShaderLang.cpp */; };
-		A93E82E5211F76F6001FEBD4 /* ShaderLang.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824A211F76F6001FEBD4 /* ShaderLang.cpp */; };
-		A93E82E6211F76F6001FEBD4 /* SymbolTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E824B211F76F6001FEBD4 /* SymbolTable.h */; };
-		A93E82E7211F76F6001FEBD4 /* SymbolTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E824B211F76F6001FEBD4 /* SymbolTable.h */; };
-		A93E82E8211F76F6001FEBD4 /* InfoSink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824C211F76F6001FEBD4 /* InfoSink.cpp */; };
-		A93E82E9211F76F6001FEBD4 /* InfoSink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824C211F76F6001FEBD4 /* InfoSink.cpp */; };
-		A93E82EA211F76F6001FEBD4 /* Intermediate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824D211F76F6001FEBD4 /* Intermediate.cpp */; };
-		A93E82EB211F76F6001FEBD4 /* Intermediate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824D211F76F6001FEBD4 /* Intermediate.cpp */; };
-		A93E82EC211F76F6001FEBD4 /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824E211F76F6001FEBD4 /* SymbolTable.cpp */; };
-		A93E82ED211F76F6001FEBD4 /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E824E211F76F6001FEBD4 /* SymbolTable.cpp */; };
-		A93E82EE211F76F6001FEBD4 /* glslang_tab.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E824F211F76F6001FEBD4 /* glslang_tab.cpp.h */; };
-		A93E82EF211F76F6001FEBD4 /* glslang_tab.cpp.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E824F211F76F6001FEBD4 /* glslang_tab.cpp.h */; };
-		A93E82F0211F76F6001FEBD4 /* LiveTraverser.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8250211F76F6001FEBD4 /* LiveTraverser.h */; };
-		A93E82F1211F76F6001FEBD4 /* LiveTraverser.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8250211F76F6001FEBD4 /* LiveTraverser.h */; };
-		A93E82F2211F76F6001FEBD4 /* Initialize.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8251211F76F6001FEBD4 /* Initialize.h */; };
-		A93E82F3211F76F6001FEBD4 /* Initialize.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8251211F76F6001FEBD4 /* Initialize.h */; };
-		A93E82F4211F76F6001FEBD4 /* attribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8252211F76F6001FEBD4 /* attribute.cpp */; };
-		A93E82F5211F76F6001FEBD4 /* attribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8252211F76F6001FEBD4 /* attribute.cpp */; };
-		A93E82F6211F76F6001FEBD4 /* reflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8253211F76F6001FEBD4 /* reflection.cpp */; };
-		A93E82F7211F76F6001FEBD4 /* reflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8253211F76F6001FEBD4 /* reflection.cpp */; };
-		A93E82F8211F76F6001FEBD4 /* RemoveTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8254211F76F6001FEBD4 /* RemoveTree.cpp */; };
-		A93E82F9211F76F6001FEBD4 /* RemoveTree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8254211F76F6001FEBD4 /* RemoveTree.cpp */; };
-		A93E82FA211F76F6001FEBD4 /* attribute.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8255211F76F6001FEBD4 /* attribute.h */; };
-		A93E82FB211F76F6001FEBD4 /* attribute.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8255211F76F6001FEBD4 /* attribute.h */; };
-		A93E82FC211F76F6001FEBD4 /* Versions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8256211F76F6001FEBD4 /* Versions.cpp */; };
-		A93E82FD211F76F6001FEBD4 /* Versions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8256211F76F6001FEBD4 /* Versions.cpp */; };
-		A93E82FE211F76F6001FEBD4 /* Constant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8257211F76F6001FEBD4 /* Constant.cpp */; };
-		A93E82FF211F76F6001FEBD4 /* Constant.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8257211F76F6001FEBD4 /* Constant.cpp */; };
-		A93E8300211F76F6001FEBD4 /* linkValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8258211F76F6001FEBD4 /* linkValidate.cpp */; };
-		A93E8301211F76F6001FEBD4 /* linkValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8258211F76F6001FEBD4 /* linkValidate.cpp */; };
-		A93E8302211F76F6001FEBD4 /* ParseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8259211F76F6001FEBD4 /* ParseHelper.h */; };
-		A93E8303211F76F6001FEBD4 /* ParseHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8259211F76F6001FEBD4 /* ParseHelper.h */; };
-		A93E8304211F76F6001FEBD4 /* PpAtom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825B211F76F6001FEBD4 /* PpAtom.cpp */; };
-		A93E8305211F76F6001FEBD4 /* PpAtom.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825B211F76F6001FEBD4 /* PpAtom.cpp */; };
-		A93E8306211F76F6001FEBD4 /* PpTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E825C211F76F6001FEBD4 /* PpTokens.h */; };
-		A93E8307211F76F6001FEBD4 /* PpTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E825C211F76F6001FEBD4 /* PpTokens.h */; };
-		A93E8308211F76F6001FEBD4 /* Pp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825D211F76F6001FEBD4 /* Pp.cpp */; };
-		A93E8309211F76F6001FEBD4 /* Pp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825D211F76F6001FEBD4 /* Pp.cpp */; };
-		A93E830A211F76F6001FEBD4 /* PpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E825E211F76F6001FEBD4 /* PpContext.h */; };
-		A93E830B211F76F6001FEBD4 /* PpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E825E211F76F6001FEBD4 /* PpContext.h */; };
-		A93E830C211F76F6001FEBD4 /* PpTokens.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825F211F76F6001FEBD4 /* PpTokens.cpp */; };
-		A93E830D211F76F6001FEBD4 /* PpTokens.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E825F211F76F6001FEBD4 /* PpTokens.cpp */; };
-		A93E830E211F76F6001FEBD4 /* PpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8260211F76F6001FEBD4 /* PpContext.cpp */; };
-		A93E830F211F76F6001FEBD4 /* PpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8260211F76F6001FEBD4 /* PpContext.cpp */; };
-		A93E8310211F76F6001FEBD4 /* PpScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8261211F76F6001FEBD4 /* PpScanner.cpp */; };
-		A93E8311211F76F6001FEBD4 /* PpScanner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8261211F76F6001FEBD4 /* PpScanner.cpp */; };
-		A93E8312211F76F6001FEBD4 /* ParseContextBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8262211F76F6001FEBD4 /* ParseContextBase.cpp */; };
-		A93E8313211F76F6001FEBD4 /* ParseContextBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8262211F76F6001FEBD4 /* ParseContextBase.cpp */; };
-		A93E8314211F76F6001FEBD4 /* reflection.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8263211F76F6001FEBD4 /* reflection.h */; };
-		A93E8315211F76F6001FEBD4 /* reflection.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8263211F76F6001FEBD4 /* reflection.h */; };
-		A93E8316211F76F6001FEBD4 /* Scan.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8264211F76F6001FEBD4 /* Scan.h */; };
-		A93E8317211F76F6001FEBD4 /* Scan.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8264211F76F6001FEBD4 /* Scan.h */; };
-		A93E8318211F76F6001FEBD4 /* ShaderLang.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8266211F76F6001FEBD4 /* ShaderLang.h */; };
-		A93E8319211F76F6001FEBD4 /* ShaderLang.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E8266211F76F6001FEBD4 /* ShaderLang.h */; };
-		A93E831A211F76F6001FEBD4 /* CodeGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8268211F76F6001FEBD4 /* CodeGen.cpp */; };
-		A93E831B211F76F6001FEBD4 /* CodeGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8268211F76F6001FEBD4 /* CodeGen.cpp */; };
-		A93E831C211F76F6001FEBD4 /* Link.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8269211F76F6001FEBD4 /* Link.cpp */; };
-		A93E831D211F76F6001FEBD4 /* Link.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E8269211F76F6001FEBD4 /* Link.cpp */; };
-		A93E831E211F76F6001FEBD4 /* InitializeDll.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E826C211F76F6001FEBD4 /* InitializeDll.h */; };
-		A93E831F211F76F6001FEBD4 /* InitializeDll.h in Headers */ = {isa = PBXBuildFile; fileRef = A93E826C211F76F6001FEBD4 /* InitializeDll.h */; };
-		A93E8320211F76F6001FEBD4 /* InitializeDll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E826D211F76F6001FEBD4 /* InitializeDll.cpp */; };
-		A93E8321211F76F6001FEBD4 /* InitializeDll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A93E826D211F76F6001FEBD4 /* InitializeDll.cpp */; };
-		A94E30CF219209C700394673 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94E30CD219209C700394673 /* spirv_parser.cpp */; };
-		A94E30D0219209C700394673 /* spirv_parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94E30CD219209C700394673 /* spirv_parser.cpp */; };
-		A94E30D1219209C700394673 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A94E30CE219209C700394673 /* spirv_parser.hpp */; };
-		A94E30D2219209C700394673 /* spirv_parser.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A94E30CE219209C700394673 /* spirv_parser.hpp */; };
-		A94E30D521920A8C00394673 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A94E30D321920A8C00394673 /* spirv_cross_parsed_ir.hpp */; };
-		A94E30D621920A8C00394673 /* spirv_cross_parsed_ir.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A94E30D321920A8C00394673 /* spirv_cross_parsed_ir.hpp */; };
-		A94E30D721920A8C00394673 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94E30D421920A8C00394673 /* spirv_cross_parsed_ir.cpp */; };
-		A94E30D821920A8C00394673 /* spirv_cross_parsed_ir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A94E30D421920A8C00394673 /* spirv_cross_parsed_ir.cpp */; };
 		A95096BB2003D00300F10950 /* FileSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = A925B70A1C7754B2006E7ECD /* FileSupport.mm */; };
 		A95096BC2003D00300F10950 /* FileSupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = A925B70A1C7754B2006E7ECD /* FileSupport.mm */; };
 		A95096BF2003D32400F10950 /* DirectorySupport.mm in Sources */ = {isa = PBXBuildFile; fileRef = A95096BD2003D32400F10950 /* DirectorySupport.mm */; };
-		A95C5F3F1DEA9070000D17B6 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A95C5F3D1DEA9070000D17B6 /* spirv_cfg.cpp */; };
-		A95C5F401DEA9070000D17B6 /* spirv_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A95C5F3D1DEA9070000D17B6 /* spirv_cfg.cpp */; };
-		A95C5F411DEA9070000D17B6 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A95C5F3E1DEA9070000D17B6 /* spirv_cfg.hpp */; };
-		A95C5F421DEA9070000D17B6 /* spirv_cfg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A95C5F3E1DEA9070000D17B6 /* spirv_cfg.hpp */; };
-		A96FE6D6215473A00060D1A3 /* spirv_target_env.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A02154739F0060D1A3 /* spirv_target_env.cpp */; };
-		A96FE6D7215473A00060D1A3 /* spirv_target_env.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A02154739F0060D1A3 /* spirv_target_env.cpp */; };
-		A96FE6D8215473A00060D1A3 /* assembly_grammar.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A22154739F0060D1A3 /* assembly_grammar.h */; };
-		A96FE6D9215473A00060D1A3 /* assembly_grammar.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A22154739F0060D1A3 /* assembly_grammar.h */; };
-		A96FE6DA215473A00060D1A3 /* enum_set.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A32154739F0060D1A3 /* enum_set.h */; };
-		A96FE6DB215473A00060D1A3 /* enum_set.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A32154739F0060D1A3 /* enum_set.h */; };
-		A96FE6DC215473A00060D1A3 /* text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A62154739F0060D1A3 /* text.cpp */; };
-		A96FE6DD215473A00060D1A3 /* text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A62154739F0060D1A3 /* text.cpp */; };
-		A96FE6DE215473A00060D1A3 /* assembly_grammar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A72154739F0060D1A3 /* assembly_grammar.cpp */; };
-		A96FE6DF215473A00060D1A3 /* assembly_grammar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A72154739F0060D1A3 /* assembly_grammar.cpp */; };
-		A96FE6E0215473A00060D1A3 /* text.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A82154739F0060D1A3 /* text.h */; };
-		A96FE6E1215473A00060D1A3 /* text.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5A82154739F0060D1A3 /* text.h */; };
-		A96FE6E2215473A00060D1A3 /* extensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A92154739F0060D1A3 /* extensions.cpp */; };
-		A96FE6E3215473A00060D1A3 /* extensions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5A92154739F0060D1A3 /* extensions.cpp */; };
-		A96FE6E4215473A00060D1A3 /* parse_number.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AB2154739F0060D1A3 /* parse_number.h */; };
-		A96FE6E5215473A00060D1A3 /* parse_number.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AB2154739F0060D1A3 /* parse_number.h */; };
-		A96FE6E6215473A00060D1A3 /* ilist_node.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AC2154739F0060D1A3 /* ilist_node.h */; };
-		A96FE6E7215473A00060D1A3 /* ilist_node.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AC2154739F0060D1A3 /* ilist_node.h */; };
-		A96FE6E8215473A00060D1A3 /* make_unique.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AD2154739F0060D1A3 /* make_unique.h */; };
-		A96FE6E9215473A00060D1A3 /* make_unique.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AD2154739F0060D1A3 /* make_unique.h */; };
-		A96FE6EA215473A00060D1A3 /* string_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AE2154739F0060D1A3 /* string_utils.h */; };
-		A96FE6EB215473A00060D1A3 /* string_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AE2154739F0060D1A3 /* string_utils.h */; };
-		A96FE6EC215473A00060D1A3 /* small_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AF2154739F0060D1A3 /* small_vector.h */; };
-		A96FE6ED215473A00060D1A3 /* small_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5AF2154739F0060D1A3 /* small_vector.h */; };
-		A96FE6EE215473A00060D1A3 /* timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B02154739F0060D1A3 /* timer.cpp */; };
-		A96FE6EF215473A00060D1A3 /* timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B02154739F0060D1A3 /* timer.cpp */; };
-		A96FE6F0215473A00060D1A3 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B12154739F0060D1A3 /* timer.h */; };
-		A96FE6F1215473A00060D1A3 /* timer.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B12154739F0060D1A3 /* timer.h */; };
-		A96FE6F2215473A00060D1A3 /* string_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B22154739F0060D1A3 /* string_utils.cpp */; };
-		A96FE6F3215473A00060D1A3 /* string_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B22154739F0060D1A3 /* string_utils.cpp */; };
-		A96FE6F4215473A00060D1A3 /* bit_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B32154739F0060D1A3 /* bit_vector.h */; };
-		A96FE6F5215473A00060D1A3 /* bit_vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B32154739F0060D1A3 /* bit_vector.h */; };
-		A96FE6F6215473A00060D1A3 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B42154739F0060D1A3 /* bitutils.h */; };
-		A96FE6F7215473A00060D1A3 /* bitutils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B42154739F0060D1A3 /* bitutils.h */; };
-		A96FE6F8215473A00060D1A3 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B52154739F0060D1A3 /* hex_float.h */; };
-		A96FE6F9215473A00060D1A3 /* hex_float.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B52154739F0060D1A3 /* hex_float.h */; };
-		A96FE6FA215473A00060D1A3 /* parse_number.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B62154739F0060D1A3 /* parse_number.cpp */; };
-		A96FE6FB215473A00060D1A3 /* parse_number.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B62154739F0060D1A3 /* parse_number.cpp */; };
-		A96FE6FC215473A00060D1A3 /* bit_vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B72154739F0060D1A3 /* bit_vector.cpp */; };
-		A96FE6FD215473A00060D1A3 /* bit_vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5B72154739F0060D1A3 /* bit_vector.cpp */; };
-		A96FE6FE215473A00060D1A3 /* ilist.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B82154739F0060D1A3 /* ilist.h */; };
-		A96FE6FF215473A00060D1A3 /* ilist.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B82154739F0060D1A3 /* ilist.h */; };
-		A96FE700215473A00060D1A3 /* spirv_target_env.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B92154739F0060D1A3 /* spirv_target_env.h */; };
-		A96FE701215473A00060D1A3 /* spirv_target_env.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5B92154739F0060D1A3 /* spirv_target_env.h */; };
-		A96FE702215473A00060D1A3 /* table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BA2154739F0060D1A3 /* table.cpp */; };
-		A96FE703215473A00060D1A3 /* table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BA2154739F0060D1A3 /* table.cpp */; };
-		A96FE704215473A00060D1A3 /* id_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BB2154739F0060D1A3 /* id_descriptor.cpp */; };
-		A96FE705215473A00060D1A3 /* id_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BB2154739F0060D1A3 /* id_descriptor.cpp */; };
-		A96FE706215473A00060D1A3 /* latest_version_opencl_std_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BC2154739F0060D1A3 /* latest_version_opencl_std_header.h */; };
-		A96FE707215473A00060D1A3 /* latest_version_opencl_std_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BC2154739F0060D1A3 /* latest_version_opencl_std_header.h */; };
-		A96FE708215473A00060D1A3 /* spirv_optimizer_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BD2154739F0060D1A3 /* spirv_optimizer_options.cpp */; };
-		A96FE709215473A00060D1A3 /* spirv_optimizer_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5BD2154739F0060D1A3 /* spirv_optimizer_options.cpp */; };
-		A96FE70A215473A00060D1A3 /* cfa.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BE2154739F0060D1A3 /* cfa.h */; };
-		A96FE70B215473A00060D1A3 /* cfa.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BE2154739F0060D1A3 /* cfa.h */; };
-		A96FE70C215473A00060D1A3 /* enum_string_mapping.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BF2154739F0060D1A3 /* enum_string_mapping.h */; };
-		A96FE70D215473A00060D1A3 /* enum_string_mapping.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5BF2154739F0060D1A3 /* enum_string_mapping.h */; };
-		A96FE70E215473A00060D1A3 /* spirv_validator_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C02154739F0060D1A3 /* spirv_validator_options.cpp */; };
-		A96FE70F215473A00060D1A3 /* spirv_validator_options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C02154739F0060D1A3 /* spirv_validator_options.cpp */; };
-		A96FE710215473A00060D1A3 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C22154739F0060D1A3 /* print.cpp */; };
-		A96FE711215473A00060D1A3 /* print.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C22154739F0060D1A3 /* print.cpp */; };
-		A96FE712215473A00060D1A3 /* spirv_definition.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C32154739F0060D1A3 /* spirv_definition.h */; };
-		A96FE713215473A00060D1A3 /* spirv_definition.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C32154739F0060D1A3 /* spirv_definition.h */; };
-		A96FE714215473A00060D1A3 /* operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C42154739F0060D1A3 /* operand.h */; };
-		A96FE715215473A00060D1A3 /* operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C42154739F0060D1A3 /* operand.h */; };
-		A96FE716215473A00060D1A3 /* spirv_endian.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C52154739F0060D1A3 /* spirv_endian.cpp */; };
-		A96FE717215473A00060D1A3 /* spirv_endian.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C52154739F0060D1A3 /* spirv_endian.cpp */; };
-		A96FE718215473A00060D1A3 /* macro.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C62154739F0060D1A3 /* macro.h */; };
-		A96FE719215473A00060D1A3 /* macro.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C62154739F0060D1A3 /* macro.h */; };
-		A96FE71A215473A00060D1A3 /* spirv_constant.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C72154739F0060D1A3 /* spirv_constant.h */; };
-		A96FE71B215473A00060D1A3 /* spirv_constant.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5C72154739F0060D1A3 /* spirv_constant.h */; };
-		A96FE71C215473A00060D1A3 /* binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C92154739F0060D1A3 /* binary.cpp */; };
-		A96FE71D215473A00060D1A3 /* binary.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5C92154739F0060D1A3 /* binary.cpp */; };
-		A96FE71E215473A00060D1A3 /* spirv_validator_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5CA2154739F0060D1A3 /* spirv_validator_options.h */; };
-		A96FE71F215473A00060D1A3 /* spirv_validator_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5CA2154739F0060D1A3 /* spirv_validator_options.h */; };
-		A96FE720215473A00060D1A3 /* markv_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5CC2154739F0060D1A3 /* markv_codec.cpp */; };
-		A96FE721215473A00060D1A3 /* markv_codec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5CC2154739F0060D1A3 /* markv_codec.cpp */; };
-		A96FE722215473A00060D1A3 /* markv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5CD2154739F0060D1A3 /* markv.cpp */; };
-		A96FE723215473A00060D1A3 /* markv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5CD2154739F0060D1A3 /* markv.cpp */; };
-		A96FE724215473A00060D1A3 /* huffman_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5CE2154739F0060D1A3 /* huffman_codec.h */; };
-		A96FE725215473A00060D1A3 /* huffman_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5CE2154739F0060D1A3 /* huffman_codec.h */; };
-		A96FE726215473A00060D1A3 /* bit_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D02154739F0060D1A3 /* bit_stream.h */; };
-		A96FE727215473A00060D1A3 /* bit_stream.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D02154739F0060D1A3 /* bit_stream.h */; };
-		A96FE728215473A00060D1A3 /* move_to_front.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5D12154739F0060D1A3 /* move_to_front.cpp */; };
-		A96FE729215473A00060D1A3 /* move_to_front.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5D12154739F0060D1A3 /* move_to_front.cpp */; };
-		A96FE72A215473A00060D1A3 /* markv_encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D22154739F0060D1A3 /* markv_encoder.h */; };
-		A96FE72B215473A00060D1A3 /* markv_encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D22154739F0060D1A3 /* markv_encoder.h */; };
-		A96FE72C215473A00060D1A3 /* markv_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D32154739F0060D1A3 /* markv_decoder.h */; };
-		A96FE72D215473A00060D1A3 /* markv_decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D32154739F0060D1A3 /* markv_decoder.h */; };
-		A96FE72E215473A00060D1A3 /* markv.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D42154739F0060D1A3 /* markv.h */; };
-		A96FE72F215473A00060D1A3 /* markv.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D42154739F0060D1A3 /* markv.h */; };
-		A96FE730215473A00060D1A3 /* markv_model.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D52154739F0060D1A3 /* markv_model.h */; };
-		A96FE731215473A00060D1A3 /* markv_model.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D52154739F0060D1A3 /* markv_model.h */; };
-		A96FE732215473A00060D1A3 /* markv_decoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5D62154739F0060D1A3 /* markv_decoder.cpp */; };
-		A96FE733215473A00060D1A3 /* markv_decoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5D62154739F0060D1A3 /* markv_decoder.cpp */; };
-		A96FE734215473A00060D1A3 /* move_to_front.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D72154739F0060D1A3 /* move_to_front.h */; };
-		A96FE735215473A00060D1A3 /* move_to_front.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D72154739F0060D1A3 /* move_to_front.h */; };
-		A96FE736215473A00060D1A3 /* markv_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D82154739F0060D1A3 /* markv_codec.h */; };
-		A96FE737215473A00060D1A3 /* markv_codec.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D82154739F0060D1A3 /* markv_codec.h */; };
-		A96FE738215473A00060D1A3 /* markv_logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D92154739F0060D1A3 /* markv_logger.h */; };
-		A96FE739215473A00060D1A3 /* markv_logger.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5D92154739F0060D1A3 /* markv_logger.h */; };
-		A96FE73A215473A00060D1A3 /* bit_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DA2154739F0060D1A3 /* bit_stream.cpp */; };
-		A96FE73B215473A00060D1A3 /* bit_stream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DA2154739F0060D1A3 /* bit_stream.cpp */; };
-		A96FE73C215473A00060D1A3 /* markv_encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DB2154739F0060D1A3 /* markv_encoder.cpp */; };
-		A96FE73D215473A00060D1A3 /* markv_encoder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DB2154739F0060D1A3 /* markv_encoder.cpp */; };
-		A96FE73E215473A00060D1A3 /* enum_string_mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DC2154739F0060D1A3 /* enum_string_mapping.cpp */; };
-		A96FE73F215473A00060D1A3 /* enum_string_mapping.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5DC2154739F0060D1A3 /* enum_string_mapping.cpp */; };
-		A96FE740215473A00060D1A3 /* text_handler.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DD2154739F0060D1A3 /* text_handler.h */; };
-		A96FE741215473A00060D1A3 /* text_handler.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DD2154739F0060D1A3 /* text_handler.h */; };
-		A96FE742215473A00060D1A3 /* parsed_operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DE2154739F0060D1A3 /* parsed_operand.h */; };
-		A96FE743215473A00060D1A3 /* parsed_operand.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DE2154739F0060D1A3 /* parsed_operand.h */; };
-		A96FE744215473A00060D1A3 /* name_mapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DF2154739F0060D1A3 /* name_mapper.h */; };
-		A96FE745215473A00060D1A3 /* name_mapper.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5DF2154739F0060D1A3 /* name_mapper.h */; };
-		A96FE746215473A00060D1A3 /* parsed_operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E02154739F0060D1A3 /* parsed_operand.cpp */; };
-		A96FE747215473A00060D1A3 /* parsed_operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E02154739F0060D1A3 /* parsed_operand.cpp */; };
-		A96FE748215473A00060D1A3 /* diagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5E12154739F0060D1A3 /* diagnostic.h */; };
-		A96FE749215473A00060D1A3 /* diagnostic.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5E12154739F0060D1A3 /* diagnostic.h */; };
-		A96FE74A215473A00060D1A3 /* spirv_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5E22154739F0060D1A3 /* spirv_endian.h */; };
-		A96FE74B215473A00060D1A3 /* spirv_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5E22154739F0060D1A3 /* spirv_endian.h */; };
-		A96FE74C215473A00060D1A3 /* name_mapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E32154739F0060D1A3 /* name_mapper.cpp */; };
-		A96FE74D215473A00060D1A3 /* name_mapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E32154739F0060D1A3 /* name_mapper.cpp */; };
-		A96FE74E215473A00060D1A3 /* linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E72154739F0060D1A3 /* linker.cpp */; };
-		A96FE74F215473A00060D1A3 /* linker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E72154739F0060D1A3 /* linker.cpp */; };
-		A96FE750215473A00060D1A3 /* software_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E82154739F0060D1A3 /* software_version.cpp */; };
-		A96FE751215473A00060D1A3 /* software_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E82154739F0060D1A3 /* software_version.cpp */; };
-		A96FE752215473A00060D1A3 /* opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E92154739F0060D1A3 /* opcode.cpp */; };
-		A96FE753215473A00060D1A3 /* opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5E92154739F0060D1A3 /* opcode.cpp */; };
-		A96FE754215473A00060D1A3 /* print.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EA2154739F0060D1A3 /* print.h */; };
-		A96FE755215473A00060D1A3 /* print.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EA2154739F0060D1A3 /* print.h */; };
-		A96FE756215473A00060D1A3 /* ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5EB2154739F0060D1A3 /* ext_inst.cpp */; };
-		A96FE757215473A00060D1A3 /* ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5EB2154739F0060D1A3 /* ext_inst.cpp */; };
-		A96FE758215473A00060D1A3 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EC2154739F0060D1A3 /* disassemble.h */; };
-		A96FE759215473A00060D1A3 /* disassemble.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EC2154739F0060D1A3 /* disassemble.h */; };
-		A96FE75A215473A00060D1A3 /* optimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5EE2154739F0060D1A3 /* optimizer.cpp */; };
-		A96FE75B215473A00060D1A3 /* optimizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5EE2154739F0060D1A3 /* optimizer.cpp */; };
-		A96FE75C215473A00060D1A3 /* if_conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EF2154739F0060D1A3 /* if_conversion.h */; };
-		A96FE75D215473A00060D1A3 /* if_conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5EF2154739F0060D1A3 /* if_conversion.h */; };
-		A96FE75E215473A00060D1A3 /* register_pressure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F02154739F0060D1A3 /* register_pressure.cpp */; };
-		A96FE75F215473A00060D1A3 /* register_pressure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F02154739F0060D1A3 /* register_pressure.cpp */; };
-		A96FE760215473A00060D1A3 /* loop_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F12154739F0060D1A3 /* loop_utils.cpp */; };
-		A96FE761215473A00060D1A3 /* loop_utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F12154739F0060D1A3 /* loop_utils.cpp */; };
-		A96FE762215473A00060D1A3 /* merge_return_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F22154739F0060D1A3 /* merge_return_pass.h */; };
-		A96FE763215473A00060D1A3 /* merge_return_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F22154739F0060D1A3 /* merge_return_pass.h */; };
-		A96FE764215473A00060D1A3 /* inline_opaque_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F32154739F0060D1A3 /* inline_opaque_pass.h */; };
-		A96FE765215473A00060D1A3 /* inline_opaque_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F32154739F0060D1A3 /* inline_opaque_pass.h */; };
-		A96FE766215473A00060D1A3 /* loop_fusion.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F42154739F0060D1A3 /* loop_fusion.h */; };
-		A96FE767215473A00060D1A3 /* loop_fusion.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F42154739F0060D1A3 /* loop_fusion.h */; };
-		A96FE768215473A00060D1A3 /* combine_access_chains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F52154739F0060D1A3 /* combine_access_chains.cpp */; };
-		A96FE769215473A00060D1A3 /* combine_access_chains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F52154739F0060D1A3 /* combine_access_chains.cpp */; };
-		A96FE76A215473A00060D1A3 /* build_module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F62154739F0060D1A3 /* build_module.cpp */; };
-		A96FE76B215473A00060D1A3 /* build_module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5F62154739F0060D1A3 /* build_module.cpp */; };
-		A96FE76C215473A00060D1A3 /* composite.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F72154739F0060D1A3 /* composite.h */; };
-		A96FE76D215473A00060D1A3 /* composite.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F72154739F0060D1A3 /* composite.h */; };
-		A96FE76E215473A00060D1A3 /* compact_ids_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F82154739F0060D1A3 /* compact_ids_pass.h */; };
-		A96FE76F215473A00060D1A3 /* compact_ids_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F82154739F0060D1A3 /* compact_ids_pass.h */; };
-		A96FE770215473A00060D1A3 /* register_pressure.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F92154739F0060D1A3 /* register_pressure.h */; };
-		A96FE771215473A00060D1A3 /* register_pressure.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5F92154739F0060D1A3 /* register_pressure.h */; };
-		A96FE772215473A00060D1A3 /* tree_iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FA2154739F0060D1A3 /* tree_iterator.h */; };
-		A96FE773215473A00060D1A3 /* tree_iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FA2154739F0060D1A3 /* tree_iterator.h */; };
-		A96FE774215473A00060D1A3 /* local_single_store_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FB2154739F0060D1A3 /* local_single_store_elim_pass.h */; };
-		A96FE775215473A00060D1A3 /* local_single_store_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FB2154739F0060D1A3 /* local_single_store_elim_pass.h */; };
-		A96FE776215473A00060D1A3 /* reduce_load_size.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FC2154739F0060D1A3 /* reduce_load_size.h */; };
-		A96FE777215473A00060D1A3 /* reduce_load_size.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FC2154739F0060D1A3 /* reduce_load_size.h */; };
-		A96FE778215473A00060D1A3 /* types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5FD2154739F0060D1A3 /* types.cpp */; };
-		A96FE779215473A00060D1A3 /* types.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE5FD2154739F0060D1A3 /* types.cpp */; };
-		A96FE77A215473A00060D1A3 /* scalar_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FE2154739F0060D1A3 /* scalar_analysis.h */; };
-		A96FE77B215473A00060D1A3 /* scalar_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FE2154739F0060D1A3 /* scalar_analysis.h */; };
-		A96FE77C215473A00060D1A3 /* strip_debug_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FF2154739F0060D1A3 /* strip_debug_info_pass.h */; };
-		A96FE77D215473A00060D1A3 /* strip_debug_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE5FF2154739F0060D1A3 /* strip_debug_info_pass.h */; };
-		A96FE77E215473A00060D1A3 /* cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6002154739F0060D1A3 /* cfg.cpp */; };
-		A96FE77F215473A00060D1A3 /* cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6002154739F0060D1A3 /* cfg.cpp */; };
-		A96FE780215473A00060D1A3 /* decoration_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6012154739F0060D1A3 /* decoration_manager.cpp */; };
-		A96FE781215473A00060D1A3 /* decoration_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6012154739F0060D1A3 /* decoration_manager.cpp */; };
-		A96FE782215473A00060D1A3 /* local_single_block_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6022154739F0060D1A3 /* local_single_block_elim_pass.cpp */; };
-		A96FE783215473A00060D1A3 /* local_single_block_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6022154739F0060D1A3 /* local_single_block_elim_pass.cpp */; };
-		A96FE784215473A00060D1A3 /* freeze_spec_constant_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6032154739F0060D1A3 /* freeze_spec_constant_value_pass.cpp */; };
-		A96FE785215473A00060D1A3 /* freeze_spec_constant_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6032154739F0060D1A3 /* freeze_spec_constant_value_pass.cpp */; };
-		A96FE786215473A00060D1A3 /* replace_invalid_opc.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6042154739F0060D1A3 /* replace_invalid_opc.h */; };
-		A96FE787215473A00060D1A3 /* replace_invalid_opc.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6042154739F0060D1A3 /* replace_invalid_opc.h */; };
-		A96FE788215473A00060D1A3 /* local_access_chain_convert_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6052154739F0060D1A3 /* local_access_chain_convert_pass.h */; };
-		A96FE789215473A00060D1A3 /* local_access_chain_convert_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6052154739F0060D1A3 /* local_access_chain_convert_pass.h */; };
-		A96FE78A215473A00060D1A3 /* local_redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6062154739F0060D1A3 /* local_redundancy_elimination.cpp */; };
-		A96FE78B215473A00060D1A3 /* local_redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6062154739F0060D1A3 /* local_redundancy_elimination.cpp */; };
-		A96FE78C215473A00060D1A3 /* propagator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6082154739F0060D1A3 /* propagator.h */; };
-		A96FE78D215473A00060D1A3 /* propagator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6082154739F0060D1A3 /* propagator.h */; };
-		A96FE78E215473A00060D1A3 /* instruction_list.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6092154739F0060D1A3 /* instruction_list.h */; };
-		A96FE78F215473A00060D1A3 /* instruction_list.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6092154739F0060D1A3 /* instruction_list.h */; };
-		A96FE790215473A00060D1A3 /* feature_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60A2154739F0060D1A3 /* feature_manager.cpp */; };
-		A96FE791215473A00060D1A3 /* feature_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60A2154739F0060D1A3 /* feature_manager.cpp */; };
-		A96FE792215473A00060D1A3 /* pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60B2154739F0060D1A3 /* pass.cpp */; };
-		A96FE793215473A00060D1A3 /* pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60B2154739F0060D1A3 /* pass.cpp */; };
-		A96FE794215473A00060D1A3 /* loop_fission.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60C2154739F0060D1A3 /* loop_fission.cpp */; };
-		A96FE795215473A00060D1A3 /* loop_fission.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60C2154739F0060D1A3 /* loop_fission.cpp */; };
-		A96FE796215473A00060D1A3 /* dominator_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60D2154739F0060D1A3 /* dominator_tree.cpp */; };
-		A96FE797215473A00060D1A3 /* dominator_tree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60D2154739F0060D1A3 /* dominator_tree.cpp */; };
-		A96FE798215473A00060D1A3 /* merge_return_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60E2154739F0060D1A3 /* merge_return_pass.cpp */; };
-		A96FE799215473A00060D1A3 /* merge_return_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE60E2154739F0060D1A3 /* merge_return_pass.cpp */; };
-		A96FE79A215473A00060D1A3 /* ir_context.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE60F2154739F0060D1A3 /* ir_context.h */; };
-		A96FE79B215473A00060D1A3 /* ir_context.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE60F2154739F0060D1A3 /* ir_context.h */; };
-		A96FE79C215473A00060D1A3 /* eliminate_dead_constant_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6102154739F0060D1A3 /* eliminate_dead_constant_pass.cpp */; };
-		A96FE79D215473A00060D1A3 /* eliminate_dead_constant_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6102154739F0060D1A3 /* eliminate_dead_constant_pass.cpp */; };
-		A96FE79E215473A00060D1A3 /* cfg_cleanup_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6112154739F0060D1A3 /* cfg_cleanup_pass.cpp */; };
-		A96FE79F215473A00060D1A3 /* cfg_cleanup_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6112154739F0060D1A3 /* cfg_cleanup_pass.cpp */; };
-		A96FE7A0215473A00060D1A3 /* const_folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6122154739F0060D1A3 /* const_folding_rules.cpp */; };
-		A96FE7A1215473A00060D1A3 /* const_folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6122154739F0060D1A3 /* const_folding_rules.cpp */; };
-		A96FE7A2215473A00060D1A3 /* loop_unroller.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6132154739F0060D1A3 /* loop_unroller.h */; };
-		A96FE7A3215473A00060D1A3 /* loop_unroller.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6132154739F0060D1A3 /* loop_unroller.h */; };
-		A96FE7A4215473A00060D1A3 /* strip_debug_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6142154739F0060D1A3 /* strip_debug_info_pass.cpp */; };
-		A96FE7A5215473A00060D1A3 /* strip_debug_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6142154739F0060D1A3 /* strip_debug_info_pass.cpp */; };
-		A96FE7A6215473A00060D1A3 /* ssa_rewrite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6152154739F0060D1A3 /* ssa_rewrite_pass.cpp */; };
-		A96FE7A7215473A00060D1A3 /* ssa_rewrite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6152154739F0060D1A3 /* ssa_rewrite_pass.cpp */; };
-		A96FE7A8215473A00060D1A3 /* loop_dependence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6162154739F0060D1A3 /* loop_dependence.cpp */; };
-		A96FE7A9215473A00060D1A3 /* loop_dependence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6162154739F0060D1A3 /* loop_dependence.cpp */; };
-		A96FE7AA215473A00060D1A3 /* unify_const_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6172154739F0060D1A3 /* unify_const_pass.h */; };
-		A96FE7AB215473A00060D1A3 /* unify_const_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6172154739F0060D1A3 /* unify_const_pass.h */; };
-		A96FE7AC215473A00060D1A3 /* ir_loader.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6182154739F0060D1A3 /* ir_loader.h */; };
-		A96FE7AD215473A00060D1A3 /* ir_loader.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6182154739F0060D1A3 /* ir_loader.h */; };
-		A96FE7AE215473A00060D1A3 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6192154739F0060D1A3 /* types.h */; };
-		A96FE7AF215473A00060D1A3 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6192154739F0060D1A3 /* types.h */; };
-		A96FE7B0215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61A2154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.h */; };
-		A96FE7B1215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61A2154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.h */; };
-		A96FE7B2215473A00060D1A3 /* mem_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61B2154739F0060D1A3 /* mem_pass.cpp */; };
-		A96FE7B3215473A00060D1A3 /* mem_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61B2154739F0060D1A3 /* mem_pass.cpp */; };
-		A96FE7B4215473A00060D1A3 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61C2154739F0060D1A3 /* basic_block.h */; };
-		A96FE7B5215473A00060D1A3 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61C2154739F0060D1A3 /* basic_block.h */; };
-		A96FE7B6215473A00060D1A3 /* remove_duplicates_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61D2154739F0060D1A3 /* remove_duplicates_pass.cpp */; };
-		A96FE7B7215473A00060D1A3 /* remove_duplicates_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61D2154739F0060D1A3 /* remove_duplicates_pass.cpp */; };
-		A96FE7B8215473A00060D1A3 /* dead_variable_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61E2154739F0060D1A3 /* dead_variable_elimination.cpp */; };
-		A96FE7B9215473A00060D1A3 /* dead_variable_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE61E2154739F0060D1A3 /* dead_variable_elimination.cpp */; };
-		A96FE7BA215473A00060D1A3 /* block_merge_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61F2154739F0060D1A3 /* block_merge_pass.h */; };
-		A96FE7BB215473A00060D1A3 /* block_merge_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE61F2154739F0060D1A3 /* block_merge_pass.h */; };
-		A96FE7BC215473A00060D1A3 /* module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6202154739F0060D1A3 /* module.cpp */; };
-		A96FE7BD215473A00060D1A3 /* module.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6202154739F0060D1A3 /* module.cpp */; };
-		A96FE7BE215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6212154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp */; };
-		A96FE7BF215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6212154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp */; };
-		A96FE7C0215473A00060D1A3 /* loop_unswitch_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6222154739F0060D1A3 /* loop_unswitch_pass.cpp */; };
-		A96FE7C1215473A00060D1A3 /* loop_unswitch_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6222154739F0060D1A3 /* loop_unswitch_pass.cpp */; };
-		A96FE7C2215473A00060D1A3 /* unify_const_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6232154739F0060D1A3 /* unify_const_pass.cpp */; };
-		A96FE7C3215473A00060D1A3 /* unify_const_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6232154739F0060D1A3 /* unify_const_pass.cpp */; };
-		A96FE7C4215473A00060D1A3 /* type_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6242154739F0060D1A3 /* type_manager.cpp */; };
-		A96FE7C5215473A00060D1A3 /* type_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6242154739F0060D1A3 /* type_manager.cpp */; };
-		A96FE7C6215473A00060D1A3 /* private_to_local_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6252154739F0060D1A3 /* private_to_local_pass.h */; };
-		A96FE7C7215473A00060D1A3 /* private_to_local_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6252154739F0060D1A3 /* private_to_local_pass.h */; };
-		A96FE7C8215473A00060D1A3 /* inline_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6262154739F0060D1A3 /* inline_pass.cpp */; };
-		A96FE7C9215473A00060D1A3 /* inline_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6262154739F0060D1A3 /* inline_pass.cpp */; };
-		A96FE7CA215473A00060D1A3 /* def_use_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6272154739F0060D1A3 /* def_use_manager.h */; };
-		A96FE7CB215473A00060D1A3 /* def_use_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6272154739F0060D1A3 /* def_use_manager.h */; };
-		A96FE7CC215473A00060D1A3 /* ir_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6282154739F0060D1A3 /* ir_loader.cpp */; };
-		A96FE7CD215473A00060D1A3 /* ir_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6282154739F0060D1A3 /* ir_loader.cpp */; };
-		A96FE7CE215473A00060D1A3 /* cfg_cleanup_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6292154739F0060D1A3 /* cfg_cleanup_pass.h */; };
-		A96FE7CF215473A00060D1A3 /* cfg_cleanup_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6292154739F0060D1A3 /* cfg_cleanup_pass.h */; };
-		A96FE7D0215473A00060D1A3 /* licm_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62A2154739F0060D1A3 /* licm_pass.cpp */; };
-		A96FE7D1215473A00060D1A3 /* licm_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62A2154739F0060D1A3 /* licm_pass.cpp */; };
-		A96FE7D2215473A00060D1A3 /* eliminate_dead_functions_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62B2154739F0060D1A3 /* eliminate_dead_functions_pass.cpp */; };
-		A96FE7D3215473A00060D1A3 /* eliminate_dead_functions_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62B2154739F0060D1A3 /* eliminate_dead_functions_pass.cpp */; };
-		A96FE7D4215473A00060D1A3 /* local_redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE62C2154739F0060D1A3 /* local_redundancy_elimination.h */; };
-		A96FE7D5215473A00060D1A3 /* local_redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE62C2154739F0060D1A3 /* local_redundancy_elimination.h */; };
-		A96FE7D6215473A00060D1A3 /* loop_peeling.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE62D2154739F0060D1A3 /* loop_peeling.h */; };
-		A96FE7D7215473A00060D1A3 /* loop_peeling.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE62D2154739F0060D1A3 /* loop_peeling.h */; };
-		A96FE7D8215473A00060D1A3 /* vector_dce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62E2154739F0060D1A3 /* vector_dce.cpp */; };
-		A96FE7D9215473A00060D1A3 /* vector_dce.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62E2154739F0060D1A3 /* vector_dce.cpp */; };
-		A96FE7DA215473A00060D1A3 /* loop_unroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62F2154739F0060D1A3 /* loop_unroller.cpp */; };
-		A96FE7DB215473A00060D1A3 /* loop_unroller.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE62F2154739F0060D1A3 /* loop_unroller.cpp */; };
-		A96FE7DC215473A00060D1A3 /* constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6302154739F0060D1A3 /* constants.cpp */; };
-		A96FE7DD215473A00060D1A3 /* constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6302154739F0060D1A3 /* constants.cpp */; };
-		A96FE7DE215473A00060D1A3 /* loop_fusion_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6312154739F0060D1A3 /* loop_fusion_pass.h */; };
-		A96FE7DF215473A00060D1A3 /* loop_fusion_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6312154739F0060D1A3 /* loop_fusion_pass.h */; };
-		A96FE7E0215473A00060D1A3 /* struct_cfg_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6322154739F0060D1A3 /* struct_cfg_analysis.h */; };
-		A96FE7E1215473A00060D1A3 /* struct_cfg_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6322154739F0060D1A3 /* struct_cfg_analysis.h */; };
-		A96FE7E2215473A00060D1A3 /* common_uniform_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6332154739F0060D1A3 /* common_uniform_elim_pass.cpp */; };
-		A96FE7E3215473A00060D1A3 /* common_uniform_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6332154739F0060D1A3 /* common_uniform_elim_pass.cpp */; };
-		A96FE7E4215473A00060D1A3 /* def_use_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6342154739F0060D1A3 /* def_use_manager.cpp */; };
-		A96FE7E5215473A00060D1A3 /* def_use_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6342154739F0060D1A3 /* def_use_manager.cpp */; };
-		A96FE7E6215473A00060D1A3 /* strip_reflect_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6352154739F0060D1A3 /* strip_reflect_info_pass.cpp */; };
-		A96FE7E7215473A00060D1A3 /* strip_reflect_info_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6352154739F0060D1A3 /* strip_reflect_info_pass.cpp */; };
-		A96FE7E8215473A00060D1A3 /* decoration_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6362154739F0060D1A3 /* decoration_manager.h */; };
-		A96FE7E9215473A00060D1A3 /* decoration_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6362154739F0060D1A3 /* decoration_manager.h */; };
-		A96FE7EA215473A00060D1A3 /* ccp_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6372154739F0060D1A3 /* ccp_pass.cpp */; };
-		A96FE7EB215473A00060D1A3 /* ccp_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6372154739F0060D1A3 /* ccp_pass.cpp */; };
-		A96FE7EC215473A00060D1A3 /* local_single_block_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6382154739F0060D1A3 /* local_single_block_elim_pass.h */; };
-		A96FE7ED215473A00060D1A3 /* local_single_block_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6382154739F0060D1A3 /* local_single_block_elim_pass.h */; };
-		A96FE7EE215473A00060D1A3 /* strength_reduction_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6392154739F0060D1A3 /* strength_reduction_pass.h */; };
-		A96FE7EF215473A00060D1A3 /* strength_reduction_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6392154739F0060D1A3 /* strength_reduction_pass.h */; };
-		A96FE7F0215473A00060D1A3 /* aggressive_dead_code_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63A2154739F0060D1A3 /* aggressive_dead_code_elim_pass.cpp */; };
-		A96FE7F1215473A00060D1A3 /* aggressive_dead_code_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63A2154739F0060D1A3 /* aggressive_dead_code_elim_pass.cpp */; };
-		A96FE7F2215473A00060D1A3 /* simplification_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63B2154739F0060D1A3 /* simplification_pass.cpp */; };
-		A96FE7F3215473A00060D1A3 /* simplification_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63B2154739F0060D1A3 /* simplification_pass.cpp */; };
-		A96FE7F4215473A00060D1A3 /* dead_branch_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63C2154739F0060D1A3 /* dead_branch_elim_pass.cpp */; };
-		A96FE7F5215473A00060D1A3 /* dead_branch_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63C2154739F0060D1A3 /* dead_branch_elim_pass.cpp */; };
-		A96FE7F6215473A00060D1A3 /* flatten_decoration_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63D2154739F0060D1A3 /* flatten_decoration_pass.cpp */; };
-		A96FE7F7215473A00060D1A3 /* flatten_decoration_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63D2154739F0060D1A3 /* flatten_decoration_pass.cpp */; };
-		A96FE7F8215473A00060D1A3 /* dead_insert_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE63E2154739F0060D1A3 /* dead_insert_elim_pass.h */; };
-		A96FE7F9215473A00060D1A3 /* dead_insert_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE63E2154739F0060D1A3 /* dead_insert_elim_pass.h */; };
-		A96FE7FA215473A00060D1A3 /* folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63F2154739F0060D1A3 /* folding_rules.cpp */; };
-		A96FE7FB215473A00060D1A3 /* folding_rules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE63F2154739F0060D1A3 /* folding_rules.cpp */; };
-		A96FE7FC215473A00060D1A3 /* freeze_spec_constant_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6402154739F0060D1A3 /* freeze_spec_constant_value_pass.h */; };
-		A96FE7FD215473A00060D1A3 /* freeze_spec_constant_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6402154739F0060D1A3 /* freeze_spec_constant_value_pass.h */; };
-		A96FE7FE215473A00060D1A3 /* ir_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6412154739F0060D1A3 /* ir_context.cpp */; };
-		A96FE7FF215473A00060D1A3 /* ir_context.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6412154739F0060D1A3 /* ir_context.cpp */; };
-		A96FE800215473A00060D1A3 /* mem_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6422154739F0060D1A3 /* mem_pass.h */; };
-		A96FE801215473A00060D1A3 /* mem_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6422154739F0060D1A3 /* mem_pass.h */; };
-		A96FE802215473A00060D1A3 /* loop_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6432154739F0060D1A3 /* loop_descriptor.cpp */; };
-		A96FE803215473A00060D1A3 /* loop_descriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6432154739F0060D1A3 /* loop_descriptor.cpp */; };
-		A96FE804215473A00060D1A3 /* local_ssa_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6442154739F0060D1A3 /* local_ssa_elim_pass.cpp */; };
-		A96FE805215473A00060D1A3 /* local_ssa_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6442154739F0060D1A3 /* local_ssa_elim_pass.cpp */; };
-		A96FE806215473A00060D1A3 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6452154739F0060D1A3 /* function.cpp */; };
-		A96FE807215473A00060D1A3 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6452154739F0060D1A3 /* function.cpp */; };
-		A96FE808215473A00060D1A3 /* instruction_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6462154739F0060D1A3 /* instruction_list.cpp */; };
-		A96FE809215473A00060D1A3 /* instruction_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6462154739F0060D1A3 /* instruction_list.cpp */; };
-		A96FE80A215473A00060D1A3 /* composite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6472154739F0060D1A3 /* composite.cpp */; };
-		A96FE80B215473A00060D1A3 /* composite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6472154739F0060D1A3 /* composite.cpp */; };
-		A96FE80C215473A00060D1A3 /* inline_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6482154739F0060D1A3 /* inline_pass.h */; };
-		A96FE80D215473A00060D1A3 /* inline_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6482154739F0060D1A3 /* inline_pass.h */; };
-		A96FE80E215473A00060D1A3 /* loop_dependence.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6492154739F0060D1A3 /* loop_dependence.h */; };
-		A96FE80F215473A00060D1A3 /* loop_dependence.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6492154739F0060D1A3 /* loop_dependence.h */; };
-		A96FE810215473A00060D1A3 /* value_number_table.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64A2154739F0060D1A3 /* value_number_table.h */; };
-		A96FE811215473A00060D1A3 /* value_number_table.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64A2154739F0060D1A3 /* value_number_table.h */; };
-		A96FE812215473A00060D1A3 /* flatten_decoration_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64B2154739F0060D1A3 /* flatten_decoration_pass.h */; };
-		A96FE813215473A00060D1A3 /* flatten_decoration_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64B2154739F0060D1A3 /* flatten_decoration_pass.h */; };
-		A96FE814215473A00060D1A3 /* if_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE64C2154739F0060D1A3 /* if_conversion.cpp */; };
-		A96FE815215473A00060D1A3 /* if_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE64C2154739F0060D1A3 /* if_conversion.cpp */; };
-		A96FE816215473A00060D1A3 /* inline_exhaustive_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64D2154739F0060D1A3 /* inline_exhaustive_pass.h */; };
-		A96FE817215473A00060D1A3 /* inline_exhaustive_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64D2154739F0060D1A3 /* inline_exhaustive_pass.h */; };
-		A96FE818215473A00060D1A3 /* constants.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64E2154739F0060D1A3 /* constants.h */; };
-		A96FE819215473A00060D1A3 /* constants.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE64E2154739F0060D1A3 /* constants.h */; };
-		A96FE81A215473A00060D1A3 /* strength_reduction_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE64F2154739F0060D1A3 /* strength_reduction_pass.cpp */; };
-		A96FE81B215473A00060D1A3 /* strength_reduction_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE64F2154739F0060D1A3 /* strength_reduction_pass.cpp */; };
-		A96FE81C215473A00060D1A3 /* copy_prop_arrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6502154739F0060D1A3 /* copy_prop_arrays.cpp */; };
-		A96FE81D215473A00060D1A3 /* copy_prop_arrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6502154739F0060D1A3 /* copy_prop_arrays.cpp */; };
-		A96FE81E215473A00060D1A3 /* pass_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6512154739F0060D1A3 /* pass_manager.cpp */; };
-		A96FE81F215473A00060D1A3 /* pass_manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6512154739F0060D1A3 /* pass_manager.cpp */; };
-		A96FE820215473A00060D1A3 /* inline_exhaustive_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6522154739F0060D1A3 /* inline_exhaustive_pass.cpp */; };
-		A96FE821215473A00060D1A3 /* inline_exhaustive_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6522154739F0060D1A3 /* inline_exhaustive_pass.cpp */; };
-		A96FE822215473A00060D1A3 /* loop_fission.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6532154739F0060D1A3 /* loop_fission.h */; };
-		A96FE823215473A00060D1A3 /* loop_fission.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6532154739F0060D1A3 /* loop_fission.h */; };
-		A96FE824215473A00060D1A3 /* workaround1209.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6542154739F0060D1A3 /* workaround1209.h */; };
-		A96FE825215473A00060D1A3 /* workaround1209.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6542154739F0060D1A3 /* workaround1209.h */; };
-		A96FE826215473A00060D1A3 /* loop_fusion_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6552154739F0060D1A3 /* loop_fusion_pass.cpp */; };
-		A96FE827215473A00060D1A3 /* loop_fusion_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6552154739F0060D1A3 /* loop_fusion_pass.cpp */; };
-		A96FE828215473A00060D1A3 /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6562154739F0060D1A3 /* log.h */; };
-		A96FE829215473A00060D1A3 /* log.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6562154739F0060D1A3 /* log.h */; };
-		A96FE82A215473A00060D1A3 /* copy_prop_arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6572154739F0060D1A3 /* copy_prop_arrays.h */; };
-		A96FE82B215473A00060D1A3 /* copy_prop_arrays.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6572154739F0060D1A3 /* copy_prop_arrays.h */; };
-		A96FE82C215473A00060D1A3 /* eliminate_dead_constant_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE658215473A00060D1A3 /* eliminate_dead_constant_pass.h */; };
-		A96FE82D215473A00060D1A3 /* eliminate_dead_constant_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE658215473A00060D1A3 /* eliminate_dead_constant_pass.h */; };
-		A96FE82E215473A00060D1A3 /* dead_insert_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE659215473A00060D1A3 /* dead_insert_elim_pass.cpp */; };
-		A96FE82F215473A00060D1A3 /* dead_insert_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE659215473A00060D1A3 /* dead_insert_elim_pass.cpp */; };
-		A96FE830215473A00060D1A3 /* ssa_rewrite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65A215473A00060D1A3 /* ssa_rewrite_pass.h */; };
-		A96FE831215473A00060D1A3 /* ssa_rewrite_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65A215473A00060D1A3 /* ssa_rewrite_pass.h */; };
-		A96FE832215473A00060D1A3 /* scalar_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE65B215473A00060D1A3 /* scalar_analysis.cpp */; };
-		A96FE833215473A00060D1A3 /* scalar_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE65B215473A00060D1A3 /* scalar_analysis.cpp */; };
-		A96FE834215473A00060D1A3 /* dead_variable_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65C215473A00060D1A3 /* dead_variable_elimination.h */; };
-		A96FE835215473A00060D1A3 /* dead_variable_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65C215473A00060D1A3 /* dead_variable_elimination.h */; };
-		A96FE836215473A00060D1A3 /* block_merge_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE65D215473A00060D1A3 /* block_merge_pass.cpp */; };
-		A96FE837215473A00060D1A3 /* block_merge_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE65D215473A00060D1A3 /* block_merge_pass.cpp */; };
-		A96FE838215473A00060D1A3 /* dominator_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65E215473A00060D1A3 /* dominator_analysis.h */; };
-		A96FE839215473A00060D1A3 /* dominator_analysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65E215473A00060D1A3 /* dominator_analysis.h */; };
-		A96FE83A215473A00060D1A3 /* pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65F215473A00060D1A3 /* pass.h */; };
-		A96FE83B215473A00060D1A3 /* pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE65F215473A00060D1A3 /* pass.h */; };
-		A96FE83C215473A00060D1A3 /* folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE660215473A00060D1A3 /* folding_rules.h */; };
-		A96FE83D215473A00060D1A3 /* folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE660215473A00060D1A3 /* folding_rules.h */; };
-		A96FE83E215473A00060D1A3 /* eliminate_dead_functions_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE661215473A00060D1A3 /* eliminate_dead_functions_pass.h */; };
-		A96FE83F215473A00060D1A3 /* eliminate_dead_functions_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE661215473A00060D1A3 /* eliminate_dead_functions_pass.h */; };
-		A96FE840215473A00060D1A3 /* common_uniform_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE662215473A00060D1A3 /* common_uniform_elim_pass.h */; };
-		A96FE841215473A00060D1A3 /* common_uniform_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE662215473A00060D1A3 /* common_uniform_elim_pass.h */; };
-		A96FE842215473A00060D1A3 /* fold.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE663215473A00060D1A3 /* fold.h */; };
-		A96FE843215473A00060D1A3 /* fold.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE663215473A00060D1A3 /* fold.h */; };
-		A96FE844215473A00060D1A3 /* local_single_store_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE664215473A00060D1A3 /* local_single_store_elim_pass.cpp */; };
-		A96FE845215473A00060D1A3 /* local_single_store_elim_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE664215473A00060D1A3 /* local_single_store_elim_pass.cpp */; };
-		A96FE846215473A00060D1A3 /* dead_branch_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE665215473A00060D1A3 /* dead_branch_elim_pass.h */; };
-		A96FE847215473A00060D1A3 /* dead_branch_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE665215473A00060D1A3 /* dead_branch_elim_pass.h */; };
-		A96FE848215473A00060D1A3 /* private_to_local_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE666215473A00060D1A3 /* private_to_local_pass.cpp */; };
-		A96FE849215473A00060D1A3 /* private_to_local_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE666215473A00060D1A3 /* private_to_local_pass.cpp */; };
-		A96FE84A215473A00060D1A3 /* scalar_analysis_nodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE667215473A00060D1A3 /* scalar_analysis_nodes.h */; };
-		A96FE84B215473A00060D1A3 /* scalar_analysis_nodes.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE667215473A00060D1A3 /* scalar_analysis_nodes.h */; };
-		A96FE84C215473A00060D1A3 /* propagator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE668215473A00060D1A3 /* propagator.cpp */; };
-		A96FE84D215473A00060D1A3 /* propagator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE668215473A00060D1A3 /* propagator.cpp */; };
-		A96FE84E215473A00060D1A3 /* loop_dependence_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE669215473A00060D1A3 /* loop_dependence_helpers.cpp */; };
-		A96FE84F215473A00060D1A3 /* loop_dependence_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE669215473A00060D1A3 /* loop_dependence_helpers.cpp */; };
-		A96FE850215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66A215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp */; };
-		A96FE851215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66A215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp */; };
-		A96FE852215473A00060D1A3 /* passes.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66B215473A00060D1A3 /* passes.h */; };
-		A96FE853215473A00060D1A3 /* passes.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66B215473A00060D1A3 /* passes.h */; };
-		A96FE854215473A00060D1A3 /* fold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66C215473A00060D1A3 /* fold.cpp */; };
-		A96FE855215473A00060D1A3 /* fold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66C215473A00060D1A3 /* fold.cpp */; };
-		A96FE856215473A00060D1A3 /* strip_reflect_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66D215473A00060D1A3 /* strip_reflect_info_pass.h */; };
-		A96FE857215473A00060D1A3 /* strip_reflect_info_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66D215473A00060D1A3 /* strip_reflect_info_pass.h */; };
-		A96FE858215473A00060D1A3 /* scalar_replacement_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66E215473A00060D1A3 /* scalar_replacement_pass.cpp */; };
-		A96FE859215473A00060D1A3 /* scalar_replacement_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE66E215473A00060D1A3 /* scalar_replacement_pass.cpp */; };
-		A96FE85A215473A00060D1A3 /* simplification_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66F215473A00060D1A3 /* simplification_pass.h */; };
-		A96FE85B215473A00060D1A3 /* simplification_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE66F215473A00060D1A3 /* simplification_pass.h */; };
-		A96FE85C215473A00060D1A3 /* remove_duplicates_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE670215473A00060D1A3 /* remove_duplicates_pass.h */; };
-		A96FE85D215473A00060D1A3 /* remove_duplicates_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE670215473A00060D1A3 /* remove_duplicates_pass.h */; };
-		A96FE85E215473A00060D1A3 /* redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE671215473A00060D1A3 /* redundancy_elimination.cpp */; };
-		A96FE85F215473A00060D1A3 /* redundancy_elimination.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE671215473A00060D1A3 /* redundancy_elimination.cpp */; };
-		A96FE860215473A00060D1A3 /* reflect.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE672215473A00060D1A3 /* reflect.h */; };
-		A96FE861215473A00060D1A3 /* reflect.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE672215473A00060D1A3 /* reflect.h */; };
-		A96FE862215473A00060D1A3 /* workaround1209.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE673215473A00060D1A3 /* workaround1209.cpp */; };
-		A96FE863215473A00060D1A3 /* workaround1209.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE673215473A00060D1A3 /* workaround1209.cpp */; };
-		A96FE864215473A00060D1A3 /* null_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE674215473A00060D1A3 /* null_pass.h */; };
-		A96FE865215473A00060D1A3 /* null_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE674215473A00060D1A3 /* null_pass.h */; };
-		A96FE866215473A00060D1A3 /* const_folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE675215473A00060D1A3 /* const_folding_rules.h */; };
-		A96FE867215473A00060D1A3 /* const_folding_rules.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE675215473A00060D1A3 /* const_folding_rules.h */; };
-		A96FE868215473A00060D1A3 /* scalar_replacement_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE676215473A00060D1A3 /* scalar_replacement_pass.h */; };
-		A96FE869215473A00060D1A3 /* scalar_replacement_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE676215473A00060D1A3 /* scalar_replacement_pass.h */; };
-		A96FE86A215473A00060D1A3 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE677215473A00060D1A3 /* instruction.cpp */; };
-		A96FE86B215473A00060D1A3 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE677215473A00060D1A3 /* instruction.cpp */; };
-		A96FE86C215473A00060D1A3 /* reduce_load_size.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE678215473A00060D1A3 /* reduce_load_size.cpp */; };
-		A96FE86D215473A00060D1A3 /* reduce_load_size.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE678215473A00060D1A3 /* reduce_load_size.cpp */; };
-		A96FE86E215473A00060D1A3 /* redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE679215473A00060D1A3 /* redundancy_elimination.h */; };
-		A96FE86F215473A00060D1A3 /* redundancy_elimination.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE679215473A00060D1A3 /* redundancy_elimination.h */; };
-		A96FE870215473A00060D1A3 /* value_number_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67A215473A00060D1A3 /* value_number_table.cpp */; };
-		A96FE871215473A00060D1A3 /* value_number_table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67A215473A00060D1A3 /* value_number_table.cpp */; };
-		A96FE872215473A00060D1A3 /* local_ssa_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67B215473A00060D1A3 /* local_ssa_elim_pass.h */; };
-		A96FE873215473A00060D1A3 /* local_ssa_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67B215473A00060D1A3 /* local_ssa_elim_pass.h */; };
-		A96FE874215473A00060D1A3 /* inline_opaque_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67C215473A00060D1A3 /* inline_opaque_pass.cpp */; };
-		A96FE875215473A00060D1A3 /* inline_opaque_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67C215473A00060D1A3 /* inline_opaque_pass.cpp */; };
-		A96FE876215473A00060D1A3 /* replace_invalid_opc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67D215473A00060D1A3 /* replace_invalid_opc.cpp */; };
-		A96FE877215473A00060D1A3 /* replace_invalid_opc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE67D215473A00060D1A3 /* replace_invalid_opc.cpp */; };
-		A96FE878215473A00060D1A3 /* loop_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67E215473A00060D1A3 /* loop_utils.h */; };
-		A96FE879215473A00060D1A3 /* loop_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67E215473A00060D1A3 /* loop_utils.h */; };
-		A96FE87A215473A00060D1A3 /* module.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67F215473A00060D1A3 /* module.h */; };
-		A96FE87B215473A00060D1A3 /* module.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE67F215473A00060D1A3 /* module.h */; };
-		A96FE87C215473A00060D1A3 /* dominator_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE680215473A00060D1A3 /* dominator_analysis.cpp */; };
-		A96FE87D215473A00060D1A3 /* dominator_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE680215473A00060D1A3 /* dominator_analysis.cpp */; };
-		A96FE87E215473A00060D1A3 /* ir_builder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE681215473A00060D1A3 /* ir_builder.h */; };
-		A96FE87F215473A00060D1A3 /* ir_builder.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE681215473A00060D1A3 /* ir_builder.h */; };
-		A96FE880215473A00060D1A3 /* loop_unswitch_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE682215473A00060D1A3 /* loop_unswitch_pass.h */; };
-		A96FE881215473A00060D1A3 /* loop_unswitch_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE682215473A00060D1A3 /* loop_unswitch_pass.h */; };
-		A96FE882215473A00060D1A3 /* cfg.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE683215473A00060D1A3 /* cfg.h */; };
-		A96FE883215473A00060D1A3 /* cfg.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE683215473A00060D1A3 /* cfg.h */; };
-		A96FE884215473A00060D1A3 /* loop_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE684215473A00060D1A3 /* loop_descriptor.h */; };
-		A96FE885215473A00060D1A3 /* loop_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE684215473A00060D1A3 /* loop_descriptor.h */; };
-		A96FE886215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE685215473A00060D1A3 /* instruction.h */; };
-		A96FE887215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE685215473A00060D1A3 /* instruction.h */; };
-		A96FE888215473A00060D1A3 /* aggressive_dead_code_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE686215473A00060D1A3 /* aggressive_dead_code_elim_pass.h */; };
-		A96FE889215473A00060D1A3 /* aggressive_dead_code_elim_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE686215473A00060D1A3 /* aggressive_dead_code_elim_pass.h */; };
-		A96FE88A215473A00060D1A3 /* struct_cfg_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE687215473A00060D1A3 /* struct_cfg_analysis.cpp */; };
-		A96FE88B215473A00060D1A3 /* struct_cfg_analysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE687215473A00060D1A3 /* struct_cfg_analysis.cpp */; };
-		A96FE88C215473A00060D1A3 /* vector_dce.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE688215473A00060D1A3 /* vector_dce.h */; };
-		A96FE88D215473A00060D1A3 /* vector_dce.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE688215473A00060D1A3 /* vector_dce.h */; };
-		A96FE88E215473A00060D1A3 /* combine_access_chains.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE689215473A00060D1A3 /* combine_access_chains.h */; };
-		A96FE88F215473A00060D1A3 /* combine_access_chains.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE689215473A00060D1A3 /* combine_access_chains.h */; };
-		A96FE890215473A00060D1A3 /* pass_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68A215473A00060D1A3 /* pass_manager.h */; };
-		A96FE891215473A00060D1A3 /* pass_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68A215473A00060D1A3 /* pass_manager.h */; };
-		A96FE892215473A00060D1A3 /* local_access_chain_convert_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE68B215473A00060D1A3 /* local_access_chain_convert_pass.cpp */; };
-		A96FE893215473A00060D1A3 /* local_access_chain_convert_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE68B215473A00060D1A3 /* local_access_chain_convert_pass.cpp */; };
-		A96FE894215473A00060D1A3 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE68C215473A00060D1A3 /* basic_block.cpp */; };
-		A96FE895215473A00060D1A3 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE68C215473A00060D1A3 /* basic_block.cpp */; };
-		A96FE896215473A00060D1A3 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68D215473A00060D1A3 /* iterator.h */; };
-		A96FE897215473A00060D1A3 /* iterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68D215473A00060D1A3 /* iterator.h */; };
-		A96FE898215473A00060D1A3 /* licm_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68E215473A00060D1A3 /* licm_pass.h */; };
-		A96FE899215473A00060D1A3 /* licm_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68E215473A00060D1A3 /* licm_pass.h */; };
-		A96FE89A215473A00060D1A3 /* build_module.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68F215473A00060D1A3 /* build_module.h */; };
-		A96FE89B215473A00060D1A3 /* build_module.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE68F215473A00060D1A3 /* build_module.h */; };
-		A96FE89C215473A00060D1A3 /* ccp_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE690215473A00060D1A3 /* ccp_pass.h */; };
-		A96FE89D215473A00060D1A3 /* ccp_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE690215473A00060D1A3 /* ccp_pass.h */; };
-		A96FE89E215473A00060D1A3 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE691215473A00060D1A3 /* function.h */; };
-		A96FE89F215473A00060D1A3 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE691215473A00060D1A3 /* function.h */; };
-		A96FE8A0215473A00060D1A3 /* loop_fusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE692215473A00060D1A3 /* loop_fusion.cpp */; };
-		A96FE8A1215473A00060D1A3 /* loop_fusion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE692215473A00060D1A3 /* loop_fusion.cpp */; };
-		A96FE8A2215473A00060D1A3 /* feature_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE693215473A00060D1A3 /* feature_manager.h */; };
-		A96FE8A3215473A00060D1A3 /* feature_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE693215473A00060D1A3 /* feature_manager.h */; };
-		A96FE8A4215473A00060D1A3 /* scalar_analysis_simplification.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE694215473A00060D1A3 /* scalar_analysis_simplification.cpp */; };
-		A96FE8A5215473A00060D1A3 /* scalar_analysis_simplification.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE694215473A00060D1A3 /* scalar_analysis_simplification.cpp */; };
-		A96FE8A6215473A00060D1A3 /* set_spec_constant_default_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE695215473A00060D1A3 /* set_spec_constant_default_value_pass.h */; };
-		A96FE8A7215473A00060D1A3 /* set_spec_constant_default_value_pass.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE695215473A00060D1A3 /* set_spec_constant_default_value_pass.h */; };
-		A96FE8A8215473A00060D1A3 /* dominator_tree.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE696215473A00060D1A3 /* dominator_tree.h */; };
-		A96FE8A9215473A00060D1A3 /* dominator_tree.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE696215473A00060D1A3 /* dominator_tree.h */; };
-		A96FE8AA215473A00060D1A3 /* type_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE697215473A00060D1A3 /* type_manager.h */; };
-		A96FE8AB215473A00060D1A3 /* type_manager.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE697215473A00060D1A3 /* type_manager.h */; };
-		A96FE8AC215473A00060D1A3 /* compact_ids_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE698215473A00060D1A3 /* compact_ids_pass.cpp */; };
-		A96FE8AD215473A00060D1A3 /* compact_ids_pass.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE698215473A00060D1A3 /* compact_ids_pass.cpp */; };
-		A96FE8AE215473A00060D1A3 /* loop_peeling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE699215473A00060D1A3 /* loop_peeling.cpp */; };
-		A96FE8AF215473A00060D1A3 /* loop_peeling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE699215473A00060D1A3 /* loop_peeling.cpp */; };
-		A96FE8B0215473A00060D1A3 /* table.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69A215473A00060D1A3 /* table.h */; };
-		A96FE8B1215473A00060D1A3 /* table.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69A215473A00060D1A3 /* table.h */; };
-		A96FE8B2215473A00060D1A3 /* ext_inst.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69B215473A00060D1A3 /* ext_inst.h */; };
-		A96FE8B3215473A00060D1A3 /* ext_inst.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69B215473A00060D1A3 /* ext_inst.h */; };
-		A96FE8B4215473A00060D1A3 /* diagnostic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE69C215473A00060D1A3 /* diagnostic.cpp */; };
-		A96FE8B5215473A00060D1A3 /* diagnostic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE69C215473A00060D1A3 /* diagnostic.cpp */; };
-		A96FE8B6215473A00060D1A3 /* latest_version_spirv_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69D215473A00060D1A3 /* latest_version_spirv_header.h */; };
-		A96FE8B7215473A00060D1A3 /* latest_version_spirv_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69D215473A00060D1A3 /* latest_version_spirv_header.h */; };
-		A96FE8B8215473A00060D1A3 /* libspirv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE69E215473A00060D1A3 /* libspirv.cpp */; };
-		A96FE8B9215473A00060D1A3 /* libspirv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE69E215473A00060D1A3 /* libspirv.cpp */; };
-		A96FE8BA215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69F215473A00060D1A3 /* instruction.h */; };
-		A96FE8BB215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE69F215473A00060D1A3 /* instruction.h */; };
-		A96FE8BC215473A00060D1A3 /* id_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A0215473A00060D1A3 /* id_descriptor.h */; };
-		A96FE8BD215473A00060D1A3 /* id_descriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A0215473A00060D1A3 /* id_descriptor.h */; };
-		A96FE8BE215473A00060D1A3 /* spirv_optimizer_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A1215473A00060D1A3 /* spirv_optimizer_options.h */; };
-		A96FE8BF215473A00060D1A3 /* spirv_optimizer_options.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A1215473A00060D1A3 /* spirv_optimizer_options.h */; };
-		A96FE8C0215473A00060D1A3 /* opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A2215473A00060D1A3 /* opcode.h */; };
-		A96FE8C1215473A00060D1A3 /* opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A2215473A00060D1A3 /* opcode.h */; };
-		A96FE8C2215473A00060D1A3 /* operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A3215473A00060D1A3 /* operand.cpp */; };
-		A96FE8C3215473A00060D1A3 /* operand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A3215473A00060D1A3 /* operand.cpp */; };
-		A96FE8C4215473A00060D1A3 /* latest_version_glsl_std_450_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A4215473A00060D1A3 /* latest_version_glsl_std_450_header.h */; };
-		A96FE8C5215473A00060D1A3 /* latest_version_glsl_std_450_header.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A4215473A00060D1A3 /* latest_version_glsl_std_450_header.h */; };
-		A96FE8C6215473A00060D1A3 /* extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A5215473A00060D1A3 /* extensions.h */; };
-		A96FE8C7215473A00060D1A3 /* extensions.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A5215473A00060D1A3 /* extensions.h */; };
-		A96FE8C8215473A00060D1A3 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A6215473A00060D1A3 /* disassemble.cpp */; };
-		A96FE8C9215473A00060D1A3 /* disassemble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A6215473A00060D1A3 /* disassemble.cpp */; };
-		A96FE8CA215473A00060D1A3 /* binary.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A7215473A00060D1A3 /* binary.h */; };
-		A96FE8CB215473A00060D1A3 /* binary.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6A7215473A00060D1A3 /* binary.h */; };
-		A96FE8CC215473A00060D1A3 /* text_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A8215473A00060D1A3 /* text_handler.cpp */; };
-		A96FE8CD215473A00060D1A3 /* text_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6A8215473A00060D1A3 /* text_handler.cpp */; };
-		A96FE8CE215473A00060D1A3 /* validate_annotation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AA215473A00060D1A3 /* validate_annotation.cpp */; };
-		A96FE8CF215473A00060D1A3 /* validate_annotation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AA215473A00060D1A3 /* validate_annotation.cpp */; };
-		A96FE8D0215473A00060D1A3 /* validate_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AB215473A00060D1A3 /* validate_cfg.cpp */; };
-		A96FE8D1215473A00060D1A3 /* validate_cfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AB215473A00060D1A3 /* validate_cfg.cpp */; };
-		A96FE8D2215473A00060D1A3 /* validate_capability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AC215473A00060D1A3 /* validate_capability.cpp */; };
-		A96FE8D3215473A00060D1A3 /* validate_capability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AC215473A00060D1A3 /* validate_capability.cpp */; };
-		A96FE8D4215473A00060D1A3 /* construct.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6AD215473A00060D1A3 /* construct.h */; };
-		A96FE8D5215473A00060D1A3 /* construct.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6AD215473A00060D1A3 /* construct.h */; };
-		A96FE8D6215473A00060D1A3 /* validate_barriers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AE215473A00060D1A3 /* validate_barriers.cpp */; };
-		A96FE8D7215473A00060D1A3 /* validate_barriers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AE215473A00060D1A3 /* validate_barriers.cpp */; };
-		A96FE8D8215473A00060D1A3 /* validate_non_uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AF215473A00060D1A3 /* validate_non_uniform.cpp */; };
-		A96FE8D9215473A00060D1A3 /* validate_non_uniform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6AF215473A00060D1A3 /* validate_non_uniform.cpp */; };
-		A96FE8DA215473A00060D1A3 /* validate_atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B0215473A00060D1A3 /* validate_atomics.cpp */; };
-		A96FE8DB215473A00060D1A3 /* validate_atomics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B0215473A00060D1A3 /* validate_atomics.cpp */; };
-		A96FE8DC215473A00060D1A3 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6B1215473A00060D1A3 /* basic_block.h */; };
-		A96FE8DD215473A00060D1A3 /* basic_block.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6B1215473A00060D1A3 /* basic_block.h */; };
-		A96FE8DE215473A00060D1A3 /* validate_instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B2215473A00060D1A3 /* validate_instruction.cpp */; };
-		A96FE8DF215473A00060D1A3 /* validate_instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B2215473A00060D1A3 /* validate_instruction.cpp */; };
-		A96FE8E0215473A00060D1A3 /* validate_decorations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B3215473A00060D1A3 /* validate_decorations.cpp */; };
-		A96FE8E1215473A00060D1A3 /* validate_decorations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B3215473A00060D1A3 /* validate_decorations.cpp */; };
-		A96FE8E2215473A00060D1A3 /* validate_debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B4215473A00060D1A3 /* validate_debug.cpp */; };
-		A96FE8E3215473A00060D1A3 /* validate_debug.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B4215473A00060D1A3 /* validate_debug.cpp */; };
-		A96FE8E4215473A00060D1A3 /* validate_builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B5215473A00060D1A3 /* validate_builtins.cpp */; };
-		A96FE8E5215473A00060D1A3 /* validate_builtins.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B5215473A00060D1A3 /* validate_builtins.cpp */; };
-		A96FE8E6215473A00060D1A3 /* validate_interfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B6215473A00060D1A3 /* validate_interfaces.cpp */; };
-		A96FE8E7215473A00060D1A3 /* validate_interfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B6215473A00060D1A3 /* validate_interfaces.cpp */; };
-		A96FE8E8215473A00060D1A3 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B7215473A00060D1A3 /* validate.cpp */; };
-		A96FE8E9215473A00060D1A3 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B7215473A00060D1A3 /* validate.cpp */; };
-		A96FE8EA215473A00060D1A3 /* validation_state.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6B8215473A00060D1A3 /* validation_state.h */; };
-		A96FE8EB215473A00060D1A3 /* validation_state.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6B8215473A00060D1A3 /* validation_state.h */; };
-		A96FE8EC215473A00060D1A3 /* validate_constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B9215473A00060D1A3 /* validate_constants.cpp */; };
-		A96FE8ED215473A00060D1A3 /* validate_constants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6B9215473A00060D1A3 /* validate_constants.cpp */; };
-		A96FE8EE215473A00060D1A3 /* validate_bitwise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BA215473A00060D1A3 /* validate_bitwise.cpp */; };
-		A96FE8EF215473A00060D1A3 /* validate_bitwise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BA215473A00060D1A3 /* validate_bitwise.cpp */; };
-		A96FE8F0215473A00060D1A3 /* construct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BB215473A00060D1A3 /* construct.cpp */; };
-		A96FE8F1215473A00060D1A3 /* construct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BB215473A00060D1A3 /* construct.cpp */; };
-		A96FE8F2215473A00060D1A3 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BC215473A00060D1A3 /* function.cpp */; };
-		A96FE8F3215473A00060D1A3 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BC215473A00060D1A3 /* function.cpp */; };
-		A96FE8F4215473A00060D1A3 /* validate.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6BD215473A00060D1A3 /* validate.h */; };
-		A96FE8F5215473A00060D1A3 /* validate.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6BD215473A00060D1A3 /* validate.h */; };
-		A96FE8F6215473A00060D1A3 /* validate_adjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BE215473A00060D1A3 /* validate_adjacency.cpp */; };
-		A96FE8F7215473A00060D1A3 /* validate_adjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BE215473A00060D1A3 /* validate_adjacency.cpp */; };
-		A96FE8F8215473A00060D1A3 /* validate_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BF215473A00060D1A3 /* validate_conversion.cpp */; };
-		A96FE8F9215473A00060D1A3 /* validate_conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6BF215473A00060D1A3 /* validate_conversion.cpp */; };
-		A96FE8FA215473A00060D1A3 /* validate_datarules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C0215473A00060D1A3 /* validate_datarules.cpp */; };
-		A96FE8FB215473A00060D1A3 /* validate_datarules.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C0215473A00060D1A3 /* validate_datarules.cpp */; };
-		A96FE8FC215473A00060D1A3 /* validate_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C1215473A00060D1A3 /* validate_id.cpp */; };
-		A96FE8FD215473A00060D1A3 /* validate_id.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C1215473A00060D1A3 /* validate_id.cpp */; };
-		A96FE8FE215473A00060D1A3 /* validate_arithmetics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C2215473A00060D1A3 /* validate_arithmetics.cpp */; };
-		A96FE8FF215473A00060D1A3 /* validate_arithmetics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C2215473A00060D1A3 /* validate_arithmetics.cpp */; };
-		A96FE900215473A00060D1A3 /* validate_mode_setting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C3215473A00060D1A3 /* validate_mode_setting.cpp */; };
-		A96FE901215473A00060D1A3 /* validate_mode_setting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C3215473A00060D1A3 /* validate_mode_setting.cpp */; };
-		A96FE902215473A00060D1A3 /* validate_logicals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C4215473A00060D1A3 /* validate_logicals.cpp */; };
-		A96FE903215473A00060D1A3 /* validate_logicals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C4215473A00060D1A3 /* validate_logicals.cpp */; };
-		A96FE904215473A00060D1A3 /* validate_derivatives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C5215473A00060D1A3 /* validate_derivatives.cpp */; };
-		A96FE905215473A00060D1A3 /* validate_derivatives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C5215473A00060D1A3 /* validate_derivatives.cpp */; };
-		A96FE906215473A00060D1A3 /* validate_memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C6215473A00060D1A3 /* validate_memory.cpp */; };
-		A96FE907215473A00060D1A3 /* validate_memory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C6215473A00060D1A3 /* validate_memory.cpp */; };
-		A96FE908215473A00060D1A3 /* validate_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C7215473A00060D1A3 /* validate_image.cpp */; };
-		A96FE909215473A00060D1A3 /* validate_image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C7215473A00060D1A3 /* validate_image.cpp */; };
-		A96FE90A215473A00060D1A3 /* validate_literals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C8215473A00060D1A3 /* validate_literals.cpp */; };
-		A96FE90B215473A00060D1A3 /* validate_literals.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C8215473A00060D1A3 /* validate_literals.cpp */; };
-		A96FE90C215473A00060D1A3 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C9215473A00060D1A3 /* instruction.cpp */; };
-		A96FE90D215473A00060D1A3 /* instruction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6C9215473A00060D1A3 /* instruction.cpp */; };
-		A96FE90E215473A00060D1A3 /* validate_type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CA215473A00060D1A3 /* validate_type.cpp */; };
-		A96FE90F215473A00060D1A3 /* validate_type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CA215473A00060D1A3 /* validate_type.cpp */; };
-		A96FE910215473A00060D1A3 /* validate_ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CB215473A00060D1A3 /* validate_ext_inst.cpp */; };
-		A96FE911215473A00060D1A3 /* validate_ext_inst.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CB215473A00060D1A3 /* validate_ext_inst.cpp */; };
-		A96FE912215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6CC215473A00060D1A3 /* instruction.h */; };
-		A96FE913215473A00060D1A3 /* instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6CC215473A00060D1A3 /* instruction.h */; };
-		A96FE914215473A00060D1A3 /* validate_execution_limitations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CD215473A00060D1A3 /* validate_execution_limitations.cpp */; };
-		A96FE915215473A00060D1A3 /* validate_execution_limitations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CD215473A00060D1A3 /* validate_execution_limitations.cpp */; };
-		A96FE916215473A00060D1A3 /* validate_layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CE215473A00060D1A3 /* validate_layout.cpp */; };
-		A96FE917215473A00060D1A3 /* validate_layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CE215473A00060D1A3 /* validate_layout.cpp */; };
-		A96FE918215473A00060D1A3 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CF215473A00060D1A3 /* basic_block.cpp */; };
-		A96FE919215473A00060D1A3 /* basic_block.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6CF215473A00060D1A3 /* basic_block.cpp */; };
-		A96FE91A215473A00060D1A3 /* validate_function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D0215473A00060D1A3 /* validate_function.cpp */; };
-		A96FE91B215473A00060D1A3 /* validate_function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D0215473A00060D1A3 /* validate_function.cpp */; };
-		A96FE91C215473A00060D1A3 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6D1215473A00060D1A3 /* function.h */; };
-		A96FE91D215473A00060D1A3 /* function.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6D1215473A00060D1A3 /* function.h */; };
-		A96FE91E215473A00060D1A3 /* validate_composites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D2215473A00060D1A3 /* validate_composites.cpp */; };
-		A96FE91F215473A00060D1A3 /* validate_composites.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D2215473A00060D1A3 /* validate_composites.cpp */; };
-		A96FE920215473A00060D1A3 /* validation_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D3215473A00060D1A3 /* validation_state.cpp */; };
-		A96FE921215473A00060D1A3 /* validation_state.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D3215473A00060D1A3 /* validation_state.cpp */; };
-		A96FE922215473A00060D1A3 /* validate_primitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D4215473A00060D1A3 /* validate_primitives.cpp */; };
-		A96FE923215473A00060D1A3 /* validate_primitives.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A96FE6D4215473A00060D1A3 /* validate_primitives.cpp */; };
-		A96FE924215473A00060D1A3 /* decoration.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6D5215473A00060D1A3 /* decoration.h */; };
-		A96FE925215473A00060D1A3 /* decoration.h in Headers */ = {isa = PBXBuildFile; fileRef = A96FE6D5215473A00060D1A3 /* decoration.h */; };
+		A972AD2B21CEE6A90013AB25 /* libglslang.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD2A21CEE6A90013AB25 /* libglslang.a */; };
+		A972AD3121CEE7040013AB25 /* libSPIRVCross.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */; };
+		A972AD3221CEE7040013AB25 /* libSPIRVTools.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD3021CEE7040013AB25 /* libSPIRVTools.a */; };
+		A972AD3621CEE7330013AB25 /* libSPIRVTools.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD3421CEE7330013AB25 /* libSPIRVTools.a */; };
+		A972AD3721CEE7330013AB25 /* libSPIRVCross.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD3521CEE7330013AB25 /* libSPIRVCross.a */; };
+		A972AD3921CEE7480013AB25 /* libglslang.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A972AD3821CEE7480013AB25 /* libglslang.a */; };
 		A97CC7401C7527F3004A5C7E /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A97CC73D1C7527F3004A5C7E /* main.cpp */; };
 		A97CC7411C7527F3004A5C7E /* MoltenVKShaderConverterTool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A97CC73E1C7527F3004A5C7E /* MoltenVKShaderConverterTool.cpp */; };
 		A98149661FB6A98A005F00B4 /* MVKStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = A98149651FB6A98A005F00B4 /* MVKStrings.h */; };
 		A98149671FB6A98A005F00B4 /* MVKStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = A98149651FB6A98A005F00B4 /* MVKStrings.h */; };
 		A98149681FB6A98A005F00B4 /* MVKStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = A98149651FB6A98A005F00B4 /* MVKStrings.h */; };
 		A98149691FB6A98A005F00B4 /* MVKStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = A98149651FB6A98A005F00B4 /* MVKStrings.h */; };
-		A9AB19971CB5B5A80001E7F9 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19901CB5B5A80001E7F9 /* spirv_common.hpp */; };
-		A9AB19981CB5B5A80001E7F9 /* spirv_common.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19901CB5B5A80001E7F9 /* spirv_common.hpp */; };
-		A9AB19991CB5B5A80001E7F9 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19911CB5B5A80001E7F9 /* spirv_cross.cpp */; };
-		A9AB199A1CB5B5A80001E7F9 /* spirv_cross.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19911CB5B5A80001E7F9 /* spirv_cross.cpp */; };
-		A9AB199B1CB5B5A80001E7F9 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19921CB5B5A80001E7F9 /* spirv_cross.hpp */; };
-		A9AB199C1CB5B5A80001E7F9 /* spirv_cross.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19921CB5B5A80001E7F9 /* spirv_cross.hpp */; };
-		A9AB199D1CB5B5A80001E7F9 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19931CB5B5A80001E7F9 /* spirv_glsl.cpp */; };
-		A9AB199E1CB5B5A80001E7F9 /* spirv_glsl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19931CB5B5A80001E7F9 /* spirv_glsl.cpp */; };
-		A9AB199F1CB5B5A80001E7F9 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19941CB5B5A80001E7F9 /* spirv_glsl.hpp */; };
-		A9AB19A01CB5B5A80001E7F9 /* spirv_glsl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19941CB5B5A80001E7F9 /* spirv_glsl.hpp */; };
-		A9AB19A11CB5B5A80001E7F9 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19951CB5B5A80001E7F9 /* spirv_msl.cpp */; };
-		A9AB19A21CB5B5A80001E7F9 /* spirv_msl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9AB19951CB5B5A80001E7F9 /* spirv_msl.cpp */; };
-		A9AB19A31CB5B5A80001E7F9 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19961CB5B5A80001E7F9 /* spirv_msl.hpp */; };
-		A9AB19A41CB5B5A80001E7F9 /* spirv_msl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9AB19961CB5B5A80001E7F9 /* spirv_msl.hpp */; };
-		A9BB09761CEF89B100CCAB22 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9BB09751CEF89B100CCAB22 /* spirv.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9BB09771CEF89B100CCAB22 /* spirv.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9BB09751CEF89B100CCAB22 /* spirv.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9F042B01FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F042AA1FB4D060009FCCB8 /* MVKCommonEnvironment.h */; };
 		A9F042B11FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F042AA1FB4D060009FCCB8 /* MVKCommonEnvironment.h */; };
 		A9F042B21FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F042AA1FB4D060009FCCB8 /* MVKCommonEnvironment.h */; };
@@ -868,427 +80,21 @@
 		A928C9181D0488DC00071B88 /* SPIRVConversion.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SPIRVConversion.mm; sourceTree = "<group>"; };
 		A93903BF1C57E9D700FE90DC /* MoltenVKSPIRVToMSLConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKSPIRVToMSLConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A93903C71C57E9ED00FE90DC /* MoltenVKSPIRVToMSLConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKSPIRVToMSLConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A93E8203211F76F5001FEBD4 /* SPVRemapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPVRemapper.h; sourceTree = "<group>"; };
-		A93E8204211F76F5001FEBD4 /* SpvBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpvBuilder.h; sourceTree = "<group>"; };
-		A93E8205211F76F5001FEBD4 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A93E8206211F76F5001FEBD4 /* SpvPostProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpvPostProcess.cpp; sourceTree = "<group>"; };
-		A93E8207211F76F5001FEBD4 /* InReadableOrder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InReadableOrder.cpp; sourceTree = "<group>"; };
-		A93E8208211F76F5001FEBD4 /* GLSL.ext.AMD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.AMD.h; sourceTree = "<group>"; };
-		A93E8209211F76F5001FEBD4 /* doc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = doc.h; sourceTree = "<group>"; };
-		A93E820A211F76F5001FEBD4 /* spirv.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv.hpp; sourceTree = "<group>"; };
-		A93E820B211F76F5001FEBD4 /* SpvBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpvBuilder.cpp; sourceTree = "<group>"; };
-		A93E820C211F76F6001FEBD4 /* GLSL.ext.EXT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.EXT.h; sourceTree = "<group>"; };
-		A93E820D211F76F6001FEBD4 /* GLSL.ext.KHR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.KHR.h; sourceTree = "<group>"; };
-		A93E820E211F76F6001FEBD4 /* GLSL.ext.NV.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.ext.NV.h; sourceTree = "<group>"; };
-		A93E820F211F76F6001FEBD4 /* GlslangToSpv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlslangToSpv.cpp; sourceTree = "<group>"; };
-		A93E8210211F76F6001FEBD4 /* spvIR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spvIR.h; sourceTree = "<group>"; };
-		A93E8211211F76F6001FEBD4 /* bitutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitutils.h; sourceTree = "<group>"; };
-		A93E8212211F76F6001FEBD4 /* disassemble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disassemble.h; sourceTree = "<group>"; };
-		A93E8213211F76F6001FEBD4 /* GlslangToSpv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlslangToSpv.h; sourceTree = "<group>"; };
-		A93E8214211F76F6001FEBD4 /* GLSL.std.450.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GLSL.std.450.h; sourceTree = "<group>"; };
-		A93E8215211F76F6001FEBD4 /* SPVRemapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SPVRemapper.cpp; sourceTree = "<group>"; };
-		A93E8216211F76F6001FEBD4 /* Logger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Logger.cpp; sourceTree = "<group>"; };
-		A93E8217211F76F6001FEBD4 /* hex_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hex_float.h; sourceTree = "<group>"; };
-		A93E8218211F76F6001FEBD4 /* Logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logger.h; sourceTree = "<group>"; };
-		A93E8219211F76F6001FEBD4 /* doc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = doc.cpp; sourceTree = "<group>"; };
-		A93E821A211F76F6001FEBD4 /* disassemble.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = disassemble.cpp; sourceTree = "<group>"; };
-		A93E821C211F76F6001FEBD4 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A93E821F211F76F6001FEBD4 /* ossource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ossource.cpp; sourceTree = "<group>"; };
-		A93E8220211F76F6001FEBD4 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A93E8221211F76F6001FEBD4 /* osinclude.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = osinclude.h; sourceTree = "<group>"; };
-		A93E8227211F76F6001FEBD4 /* ResourceLimits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLimits.h; sourceTree = "<group>"; };
-		A93E8228211F76F6001FEBD4 /* Types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Types.h; sourceTree = "<group>"; };
-		A93E8229211F76F6001FEBD4 /* intermediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = intermediate.h; sourceTree = "<group>"; };
-		A93E822A211F76F6001FEBD4 /* BaseTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseTypes.h; sourceTree = "<group>"; };
-		A93E822B211F76F6001FEBD4 /* revision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = revision.h; sourceTree = "<group>"; };
-		A93E822C211F76F6001FEBD4 /* InitializeGlobals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitializeGlobals.h; sourceTree = "<group>"; };
-		A93E822D211F76F6001FEBD4 /* ShHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShHandle.h; sourceTree = "<group>"; };
-		A93E822E211F76F6001FEBD4 /* arrays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = arrays.h; sourceTree = "<group>"; };
-		A93E822F211F76F6001FEBD4 /* Common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
-		A93E8230211F76F6001FEBD4 /* revision.template */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = revision.template; sourceTree = "<group>"; };
-		A93E8231211F76F6001FEBD4 /* ConstantUnion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantUnion.h; sourceTree = "<group>"; };
-		A93E8232211F76F6001FEBD4 /* InfoSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoSink.h; sourceTree = "<group>"; };
-		A93E8233211F76F6001FEBD4 /* PoolAlloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PoolAlloc.h; sourceTree = "<group>"; };
-		A93E8234211F76F6001FEBD4 /* updateGrammar */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = updateGrammar; sourceTree = "<group>"; };
-		A93E8236211F76F6001FEBD4 /* ParseHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParseHelper.cpp; sourceTree = "<group>"; };
-		A93E8237211F76F6001FEBD4 /* parseVersions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parseVersions.h; sourceTree = "<group>"; };
-		A93E8238211F76F6001FEBD4 /* gl_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gl_types.h; sourceTree = "<group>"; };
-		A93E8239211F76F6001FEBD4 /* propagateNoContraction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = propagateNoContraction.cpp; sourceTree = "<group>"; };
-		A93E823A211F76F6001FEBD4 /* ScanContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScanContext.h; sourceTree = "<group>"; };
-		A93E823B211F76F6001FEBD4 /* iomapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iomapper.h; sourceTree = "<group>"; };
-		A93E823C211F76F6001FEBD4 /* localintermediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = localintermediate.h; sourceTree = "<group>"; };
-		A93E823D211F76F6001FEBD4 /* Scan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Scan.cpp; sourceTree = "<group>"; };
-		A93E823F211F76F6001FEBD4 /* RemoveTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveTree.h; sourceTree = "<group>"; };
-		A93E8240211F76F6001FEBD4 /* Initialize.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Initialize.cpp; sourceTree = "<group>"; };
-		A93E8241211F76F6001FEBD4 /* glslang_tab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = glslang_tab.cpp; sourceTree = "<group>"; };
-		A93E8242211F76F6001FEBD4 /* limits.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = limits.cpp; sourceTree = "<group>"; };
-		A93E8243211F76F6001FEBD4 /* parseConst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parseConst.cpp; sourceTree = "<group>"; };
-		A93E8244211F76F6001FEBD4 /* propagateNoContraction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagateNoContraction.h; sourceTree = "<group>"; };
-		A93E8245211F76F6001FEBD4 /* Versions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Versions.h; sourceTree = "<group>"; };
-		A93E8246211F76F6001FEBD4 /* IntermTraverse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntermTraverse.cpp; sourceTree = "<group>"; };
-		A93E8247211F76F6001FEBD4 /* intermOut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = intermOut.cpp; sourceTree = "<group>"; };
-		A93E8248211F76F6001FEBD4 /* iomapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = iomapper.cpp; sourceTree = "<group>"; };
-		A93E8249211F76F6001FEBD4 /* PoolAlloc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PoolAlloc.cpp; sourceTree = "<group>"; };
-		A93E824A211F76F6001FEBD4 /* ShaderLang.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShaderLang.cpp; sourceTree = "<group>"; };
-		A93E824B211F76F6001FEBD4 /* SymbolTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolTable.h; sourceTree = "<group>"; };
-		A93E824C211F76F6001FEBD4 /* InfoSink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InfoSink.cpp; sourceTree = "<group>"; };
-		A93E824D211F76F6001FEBD4 /* Intermediate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Intermediate.cpp; sourceTree = "<group>"; };
-		A93E824E211F76F6001FEBD4 /* SymbolTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolTable.cpp; sourceTree = "<group>"; };
-		A93E824F211F76F6001FEBD4 /* glslang_tab.cpp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = glslang_tab.cpp.h; sourceTree = "<group>"; };
-		A93E8250211F76F6001FEBD4 /* LiveTraverser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LiveTraverser.h; sourceTree = "<group>"; };
-		A93E8251211F76F6001FEBD4 /* Initialize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Initialize.h; sourceTree = "<group>"; };
-		A93E8252211F76F6001FEBD4 /* attribute.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = attribute.cpp; sourceTree = "<group>"; };
-		A93E8253211F76F6001FEBD4 /* reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reflection.cpp; sourceTree = "<group>"; };
-		A93E8254211F76F6001FEBD4 /* RemoveTree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveTree.cpp; sourceTree = "<group>"; };
-		A93E8255211F76F6001FEBD4 /* attribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attribute.h; sourceTree = "<group>"; };
-		A93E8256211F76F6001FEBD4 /* Versions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Versions.cpp; sourceTree = "<group>"; };
-		A93E8257211F76F6001FEBD4 /* Constant.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constant.cpp; sourceTree = "<group>"; };
-		A93E8258211F76F6001FEBD4 /* linkValidate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = linkValidate.cpp; sourceTree = "<group>"; };
-		A93E8259211F76F6001FEBD4 /* ParseHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseHelper.h; sourceTree = "<group>"; };
-		A93E825B211F76F6001FEBD4 /* PpAtom.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpAtom.cpp; sourceTree = "<group>"; };
-		A93E825C211F76F6001FEBD4 /* PpTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PpTokens.h; sourceTree = "<group>"; };
-		A93E825D211F76F6001FEBD4 /* Pp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pp.cpp; sourceTree = "<group>"; };
-		A93E825E211F76F6001FEBD4 /* PpContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PpContext.h; sourceTree = "<group>"; };
-		A93E825F211F76F6001FEBD4 /* PpTokens.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpTokens.cpp; sourceTree = "<group>"; };
-		A93E8260211F76F6001FEBD4 /* PpContext.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpContext.cpp; sourceTree = "<group>"; };
-		A93E8261211F76F6001FEBD4 /* PpScanner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PpScanner.cpp; sourceTree = "<group>"; };
-		A93E8262211F76F6001FEBD4 /* ParseContextBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParseContextBase.cpp; sourceTree = "<group>"; };
-		A93E8263211F76F6001FEBD4 /* reflection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reflection.h; sourceTree = "<group>"; };
-		A93E8264211F76F6001FEBD4 /* Scan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scan.h; sourceTree = "<group>"; };
-		A93E8266211F76F6001FEBD4 /* ShaderLang.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShaderLang.h; sourceTree = "<group>"; };
-		A93E8268211F76F6001FEBD4 /* CodeGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CodeGen.cpp; sourceTree = "<group>"; };
-		A93E8269211F76F6001FEBD4 /* Link.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Link.cpp; sourceTree = "<group>"; };
-		A93E826B211F76F6001FEBD4 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A93E826C211F76F6001FEBD4 /* InitializeDll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitializeDll.h; sourceTree = "<group>"; };
-		A93E826D211F76F6001FEBD4 /* InitializeDll.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = InitializeDll.cpp; sourceTree = "<group>"; };
-		A94E30CD219209C700394673 /* spirv_parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_parser.cpp; sourceTree = "<group>"; };
-		A94E30CE219209C700394673 /* spirv_parser.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_parser.hpp; sourceTree = "<group>"; };
-		A94E30D321920A8C00394673 /* spirv_cross_parsed_ir.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cross_parsed_ir.hpp; sourceTree = "<group>"; };
-		A94E30D421920A8C00394673 /* spirv_cross_parsed_ir.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cross_parsed_ir.cpp; sourceTree = "<group>"; };
 		A95096BD2003D32400F10950 /* DirectorySupport.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DirectorySupport.mm; sourceTree = "<group>"; };
 		A95096BE2003D32400F10950 /* DirectorySupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectorySupport.h; sourceTree = "<group>"; };
-		A95C5F3D1DEA9070000D17B6 /* spirv_cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cfg.cpp; sourceTree = "<group>"; };
-		A95C5F3E1DEA9070000D17B6 /* spirv_cfg.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cfg.hpp; sourceTree = "<group>"; };
 		A964BD5F1C57EFBD00D930D8 /* MoltenVKShaderConverter */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MoltenVKShaderConverter; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD601C57EFBD00D930D8 /* MoltenVKGLSLToSPIRVConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKGLSLToSPIRVConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD611C57EFBD00D930D8 /* MoltenVKGLSLToSPIRVConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKGLSLToSPIRVConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A96FE5A02154739F0060D1A3 /* spirv_target_env.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_target_env.cpp; sourceTree = "<group>"; };
-		A96FE5A12154739F0060D1A3 /* extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json"; sourceTree = "<group>"; };
-		A96FE5A22154739F0060D1A3 /* assembly_grammar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assembly_grammar.h; sourceTree = "<group>"; };
-		A96FE5A32154739F0060D1A3 /* enum_set.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_set.h; sourceTree = "<group>"; };
-		A96FE5A42154739F0060D1A3 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A96FE5A52154739F0060D1A3 /* extinst.spv-amd-shader-ballot.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-ballot.grammar.json"; sourceTree = "<group>"; };
-		A96FE5A62154739F0060D1A3 /* text.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = text.cpp; sourceTree = "<group>"; };
-		A96FE5A72154739F0060D1A3 /* assembly_grammar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = assembly_grammar.cpp; sourceTree = "<group>"; };
-		A96FE5A82154739F0060D1A3 /* text.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = text.h; sourceTree = "<group>"; };
-		A96FE5A92154739F0060D1A3 /* extensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = extensions.cpp; sourceTree = "<group>"; };
-		A96FE5AB2154739F0060D1A3 /* parse_number.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parse_number.h; sourceTree = "<group>"; };
-		A96FE5AC2154739F0060D1A3 /* ilist_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ilist_node.h; sourceTree = "<group>"; };
-		A96FE5AD2154739F0060D1A3 /* make_unique.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = make_unique.h; sourceTree = "<group>"; };
-		A96FE5AE2154739F0060D1A3 /* string_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = string_utils.h; sourceTree = "<group>"; };
-		A96FE5AF2154739F0060D1A3 /* small_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = small_vector.h; sourceTree = "<group>"; };
-		A96FE5B02154739F0060D1A3 /* timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = timer.cpp; sourceTree = "<group>"; };
-		A96FE5B12154739F0060D1A3 /* timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = timer.h; sourceTree = "<group>"; };
-		A96FE5B22154739F0060D1A3 /* string_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_utils.cpp; sourceTree = "<group>"; };
-		A96FE5B32154739F0060D1A3 /* bit_vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_vector.h; sourceTree = "<group>"; };
-		A96FE5B42154739F0060D1A3 /* bitutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bitutils.h; sourceTree = "<group>"; };
-		A96FE5B52154739F0060D1A3 /* hex_float.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hex_float.h; sourceTree = "<group>"; };
-		A96FE5B62154739F0060D1A3 /* parse_number.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parse_number.cpp; sourceTree = "<group>"; };
-		A96FE5B72154739F0060D1A3 /* bit_vector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bit_vector.cpp; sourceTree = "<group>"; };
-		A96FE5B82154739F0060D1A3 /* ilist.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ilist.h; sourceTree = "<group>"; };
-		A96FE5B92154739F0060D1A3 /* spirv_target_env.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_target_env.h; sourceTree = "<group>"; };
-		A96FE5BA2154739F0060D1A3 /* table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = table.cpp; sourceTree = "<group>"; };
-		A96FE5BB2154739F0060D1A3 /* id_descriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = id_descriptor.cpp; sourceTree = "<group>"; };
-		A96FE5BC2154739F0060D1A3 /* latest_version_opencl_std_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_opencl_std_header.h; sourceTree = "<group>"; };
-		A96FE5BD2154739F0060D1A3 /* spirv_optimizer_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_optimizer_options.cpp; sourceTree = "<group>"; };
-		A96FE5BE2154739F0060D1A3 /* cfa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfa.h; sourceTree = "<group>"; };
-		A96FE5BF2154739F0060D1A3 /* enum_string_mapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enum_string_mapping.h; sourceTree = "<group>"; };
-		A96FE5C02154739F0060D1A3 /* spirv_validator_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_validator_options.cpp; sourceTree = "<group>"; };
-		A96FE5C12154739F0060D1A3 /* extinst.spv-amd-shader-trinary-minmax.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-shader-trinary-minmax.grammar.json"; sourceTree = "<group>"; };
-		A96FE5C22154739F0060D1A3 /* print.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = print.cpp; sourceTree = "<group>"; };
-		A96FE5C32154739F0060D1A3 /* spirv_definition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_definition.h; sourceTree = "<group>"; };
-		A96FE5C42154739F0060D1A3 /* operand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = operand.h; sourceTree = "<group>"; };
-		A96FE5C52154739F0060D1A3 /* spirv_endian.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_endian.cpp; sourceTree = "<group>"; };
-		A96FE5C62154739F0060D1A3 /* macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = macro.h; sourceTree = "<group>"; };
-		A96FE5C72154739F0060D1A3 /* spirv_constant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_constant.h; sourceTree = "<group>"; };
-		A96FE5C82154739F0060D1A3 /* extinst.spv-amd-gcn-shader.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "extinst.spv-amd-gcn-shader.grammar.json"; sourceTree = "<group>"; };
-		A96FE5C92154739F0060D1A3 /* binary.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = binary.cpp; sourceTree = "<group>"; };
-		A96FE5CA2154739F0060D1A3 /* spirv_validator_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_validator_options.h; sourceTree = "<group>"; };
-		A96FE5CC2154739F0060D1A3 /* markv_codec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_codec.cpp; sourceTree = "<group>"; };
-		A96FE5CD2154739F0060D1A3 /* markv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv.cpp; sourceTree = "<group>"; };
-		A96FE5CE2154739F0060D1A3 /* huffman_codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman_codec.h; sourceTree = "<group>"; };
-		A96FE5CF2154739F0060D1A3 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A96FE5D02154739F0060D1A3 /* bit_stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_stream.h; sourceTree = "<group>"; };
-		A96FE5D12154739F0060D1A3 /* move_to_front.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = move_to_front.cpp; sourceTree = "<group>"; };
-		A96FE5D22154739F0060D1A3 /* markv_encoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_encoder.h; sourceTree = "<group>"; };
-		A96FE5D32154739F0060D1A3 /* markv_decoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_decoder.h; sourceTree = "<group>"; };
-		A96FE5D42154739F0060D1A3 /* markv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv.h; sourceTree = "<group>"; };
-		A96FE5D52154739F0060D1A3 /* markv_model.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_model.h; sourceTree = "<group>"; };
-		A96FE5D62154739F0060D1A3 /* markv_decoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_decoder.cpp; sourceTree = "<group>"; };
-		A96FE5D72154739F0060D1A3 /* move_to_front.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = move_to_front.h; sourceTree = "<group>"; };
-		A96FE5D82154739F0060D1A3 /* markv_codec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_codec.h; sourceTree = "<group>"; };
-		A96FE5D92154739F0060D1A3 /* markv_logger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = markv_logger.h; sourceTree = "<group>"; };
-		A96FE5DA2154739F0060D1A3 /* bit_stream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = bit_stream.cpp; sourceTree = "<group>"; };
-		A96FE5DB2154739F0060D1A3 /* markv_encoder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = markv_encoder.cpp; sourceTree = "<group>"; };
-		A96FE5DC2154739F0060D1A3 /* enum_string_mapping.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = enum_string_mapping.cpp; sourceTree = "<group>"; };
-		A96FE5DD2154739F0060D1A3 /* text_handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = text_handler.h; sourceTree = "<group>"; };
-		A96FE5DE2154739F0060D1A3 /* parsed_operand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = parsed_operand.h; sourceTree = "<group>"; };
-		A96FE5DF2154739F0060D1A3 /* name_mapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = name_mapper.h; sourceTree = "<group>"; };
-		A96FE5E02154739F0060D1A3 /* parsed_operand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = parsed_operand.cpp; sourceTree = "<group>"; };
-		A96FE5E12154739F0060D1A3 /* diagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = diagnostic.h; sourceTree = "<group>"; };
-		A96FE5E22154739F0060D1A3 /* spirv_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_endian.h; sourceTree = "<group>"; };
-		A96FE5E32154739F0060D1A3 /* name_mapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = name_mapper.cpp; sourceTree = "<group>"; };
-		A96FE5E42154739F0060D1A3 /* extinst.debuginfo.grammar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = extinst.debuginfo.grammar.json; sourceTree = "<group>"; };
-		A96FE5E62154739F0060D1A3 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A96FE5E72154739F0060D1A3 /* linker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = linker.cpp; sourceTree = "<group>"; };
-		A96FE5E82154739F0060D1A3 /* software_version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = software_version.cpp; sourceTree = "<group>"; };
-		A96FE5E92154739F0060D1A3 /* opcode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = opcode.cpp; sourceTree = "<group>"; };
-		A96FE5EA2154739F0060D1A3 /* print.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = print.h; sourceTree = "<group>"; };
-		A96FE5EB2154739F0060D1A3 /* ext_inst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ext_inst.cpp; sourceTree = "<group>"; };
-		A96FE5EC2154739F0060D1A3 /* disassemble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = disassemble.h; sourceTree = "<group>"; };
-		A96FE5EE2154739F0060D1A3 /* optimizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = optimizer.cpp; sourceTree = "<group>"; };
-		A96FE5EF2154739F0060D1A3 /* if_conversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = if_conversion.h; sourceTree = "<group>"; };
-		A96FE5F02154739F0060D1A3 /* register_pressure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = register_pressure.cpp; sourceTree = "<group>"; };
-		A96FE5F12154739F0060D1A3 /* loop_utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_utils.cpp; sourceTree = "<group>"; };
-		A96FE5F22154739F0060D1A3 /* merge_return_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = merge_return_pass.h; sourceTree = "<group>"; };
-		A96FE5F32154739F0060D1A3 /* inline_opaque_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_opaque_pass.h; sourceTree = "<group>"; };
-		A96FE5F42154739F0060D1A3 /* loop_fusion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fusion.h; sourceTree = "<group>"; };
-		A96FE5F52154739F0060D1A3 /* combine_access_chains.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = combine_access_chains.cpp; sourceTree = "<group>"; };
-		A96FE5F62154739F0060D1A3 /* build_module.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = build_module.cpp; sourceTree = "<group>"; };
-		A96FE5F72154739F0060D1A3 /* composite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = composite.h; sourceTree = "<group>"; };
-		A96FE5F82154739F0060D1A3 /* compact_ids_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = compact_ids_pass.h; sourceTree = "<group>"; };
-		A96FE5F92154739F0060D1A3 /* register_pressure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = register_pressure.h; sourceTree = "<group>"; };
-		A96FE5FA2154739F0060D1A3 /* tree_iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tree_iterator.h; sourceTree = "<group>"; };
-		A96FE5FB2154739F0060D1A3 /* local_single_store_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_single_store_elim_pass.h; sourceTree = "<group>"; };
-		A96FE5FC2154739F0060D1A3 /* reduce_load_size.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reduce_load_size.h; sourceTree = "<group>"; };
-		A96FE5FD2154739F0060D1A3 /* types.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = types.cpp; sourceTree = "<group>"; };
-		A96FE5FE2154739F0060D1A3 /* scalar_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_analysis.h; sourceTree = "<group>"; };
-		A96FE5FF2154739F0060D1A3 /* strip_debug_info_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strip_debug_info_pass.h; sourceTree = "<group>"; };
-		A96FE6002154739F0060D1A3 /* cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cfg.cpp; sourceTree = "<group>"; };
-		A96FE6012154739F0060D1A3 /* decoration_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = decoration_manager.cpp; sourceTree = "<group>"; };
-		A96FE6022154739F0060D1A3 /* local_single_block_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_single_block_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE6032154739F0060D1A3 /* freeze_spec_constant_value_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = freeze_spec_constant_value_pass.cpp; sourceTree = "<group>"; };
-		A96FE6042154739F0060D1A3 /* replace_invalid_opc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = replace_invalid_opc.h; sourceTree = "<group>"; };
-		A96FE6052154739F0060D1A3 /* local_access_chain_convert_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_access_chain_convert_pass.h; sourceTree = "<group>"; };
-		A96FE6062154739F0060D1A3 /* local_redundancy_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_redundancy_elimination.cpp; sourceTree = "<group>"; };
-		A96FE6072154739F0060D1A3 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
-		A96FE6082154739F0060D1A3 /* propagator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = propagator.h; sourceTree = "<group>"; };
-		A96FE6092154739F0060D1A3 /* instruction_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction_list.h; sourceTree = "<group>"; };
-		A96FE60A2154739F0060D1A3 /* feature_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = feature_manager.cpp; sourceTree = "<group>"; };
-		A96FE60B2154739F0060D1A3 /* pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass.cpp; sourceTree = "<group>"; };
-		A96FE60C2154739F0060D1A3 /* loop_fission.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fission.cpp; sourceTree = "<group>"; };
-		A96FE60D2154739F0060D1A3 /* dominator_tree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dominator_tree.cpp; sourceTree = "<group>"; };
-		A96FE60E2154739F0060D1A3 /* merge_return_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = merge_return_pass.cpp; sourceTree = "<group>"; };
-		A96FE60F2154739F0060D1A3 /* ir_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_context.h; sourceTree = "<group>"; };
-		A96FE6102154739F0060D1A3 /* eliminate_dead_constant_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = eliminate_dead_constant_pass.cpp; sourceTree = "<group>"; };
-		A96FE6112154739F0060D1A3 /* cfg_cleanup_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cfg_cleanup_pass.cpp; sourceTree = "<group>"; };
-		A96FE6122154739F0060D1A3 /* const_folding_rules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = const_folding_rules.cpp; sourceTree = "<group>"; };
-		A96FE6132154739F0060D1A3 /* loop_unroller.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_unroller.h; sourceTree = "<group>"; };
-		A96FE6142154739F0060D1A3 /* strip_debug_info_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strip_debug_info_pass.cpp; sourceTree = "<group>"; };
-		A96FE6152154739F0060D1A3 /* ssa_rewrite_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ssa_rewrite_pass.cpp; sourceTree = "<group>"; };
-		A96FE6162154739F0060D1A3 /* loop_dependence.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_dependence.cpp; sourceTree = "<group>"; };
-		A96FE6172154739F0060D1A3 /* unify_const_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unify_const_pass.h; sourceTree = "<group>"; };
-		A96FE6182154739F0060D1A3 /* ir_loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_loader.h; sourceTree = "<group>"; };
-		A96FE6192154739F0060D1A3 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
-		A96FE61A2154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold_spec_constant_op_and_composite_pass.h; sourceTree = "<group>"; };
-		A96FE61B2154739F0060D1A3 /* mem_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mem_pass.cpp; sourceTree = "<group>"; };
-		A96FE61C2154739F0060D1A3 /* basic_block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_block.h; sourceTree = "<group>"; };
-		A96FE61D2154739F0060D1A3 /* remove_duplicates_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = remove_duplicates_pass.cpp; sourceTree = "<group>"; };
-		A96FE61E2154739F0060D1A3 /* dead_variable_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_variable_elimination.cpp; sourceTree = "<group>"; };
-		A96FE61F2154739F0060D1A3 /* block_merge_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = block_merge_pass.h; sourceTree = "<group>"; };
-		A96FE6202154739F0060D1A3 /* module.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = module.cpp; sourceTree = "<group>"; };
-		A96FE6212154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fold_spec_constant_op_and_composite_pass.cpp; sourceTree = "<group>"; };
-		A96FE6222154739F0060D1A3 /* loop_unswitch_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_unswitch_pass.cpp; sourceTree = "<group>"; };
-		A96FE6232154739F0060D1A3 /* unify_const_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unify_const_pass.cpp; sourceTree = "<group>"; };
-		A96FE6242154739F0060D1A3 /* type_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = type_manager.cpp; sourceTree = "<group>"; };
-		A96FE6252154739F0060D1A3 /* private_to_local_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = private_to_local_pass.h; sourceTree = "<group>"; };
-		A96FE6262154739F0060D1A3 /* inline_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_pass.cpp; sourceTree = "<group>"; };
-		A96FE6272154739F0060D1A3 /* def_use_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = def_use_manager.h; sourceTree = "<group>"; };
-		A96FE6282154739F0060D1A3 /* ir_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ir_loader.cpp; sourceTree = "<group>"; };
-		A96FE6292154739F0060D1A3 /* cfg_cleanup_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfg_cleanup_pass.h; sourceTree = "<group>"; };
-		A96FE62A2154739F0060D1A3 /* licm_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = licm_pass.cpp; sourceTree = "<group>"; };
-		A96FE62B2154739F0060D1A3 /* eliminate_dead_functions_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = eliminate_dead_functions_pass.cpp; sourceTree = "<group>"; };
-		A96FE62C2154739F0060D1A3 /* local_redundancy_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_redundancy_elimination.h; sourceTree = "<group>"; };
-		A96FE62D2154739F0060D1A3 /* loop_peeling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_peeling.h; sourceTree = "<group>"; };
-		A96FE62E2154739F0060D1A3 /* vector_dce.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vector_dce.cpp; sourceTree = "<group>"; };
-		A96FE62F2154739F0060D1A3 /* loop_unroller.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_unroller.cpp; sourceTree = "<group>"; };
-		A96FE6302154739F0060D1A3 /* constants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = constants.cpp; sourceTree = "<group>"; };
-		A96FE6312154739F0060D1A3 /* loop_fusion_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fusion_pass.h; sourceTree = "<group>"; };
-		A96FE6322154739F0060D1A3 /* struct_cfg_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = struct_cfg_analysis.h; sourceTree = "<group>"; };
-		A96FE6332154739F0060D1A3 /* common_uniform_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common_uniform_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE6342154739F0060D1A3 /* def_use_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = def_use_manager.cpp; sourceTree = "<group>"; };
-		A96FE6352154739F0060D1A3 /* strip_reflect_info_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strip_reflect_info_pass.cpp; sourceTree = "<group>"; };
-		A96FE6362154739F0060D1A3 /* decoration_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoration_manager.h; sourceTree = "<group>"; };
-		A96FE6372154739F0060D1A3 /* ccp_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ccp_pass.cpp; sourceTree = "<group>"; };
-		A96FE6382154739F0060D1A3 /* local_single_block_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_single_block_elim_pass.h; sourceTree = "<group>"; };
-		A96FE6392154739F0060D1A3 /* strength_reduction_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strength_reduction_pass.h; sourceTree = "<group>"; };
-		A96FE63A2154739F0060D1A3 /* aggressive_dead_code_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = aggressive_dead_code_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE63B2154739F0060D1A3 /* simplification_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simplification_pass.cpp; sourceTree = "<group>"; };
-		A96FE63C2154739F0060D1A3 /* dead_branch_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_branch_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE63D2154739F0060D1A3 /* flatten_decoration_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flatten_decoration_pass.cpp; sourceTree = "<group>"; };
-		A96FE63E2154739F0060D1A3 /* dead_insert_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_insert_elim_pass.h; sourceTree = "<group>"; };
-		A96FE63F2154739F0060D1A3 /* folding_rules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = folding_rules.cpp; sourceTree = "<group>"; };
-		A96FE6402154739F0060D1A3 /* freeze_spec_constant_value_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = freeze_spec_constant_value_pass.h; sourceTree = "<group>"; };
-		A96FE6412154739F0060D1A3 /* ir_context.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ir_context.cpp; sourceTree = "<group>"; };
-		A96FE6422154739F0060D1A3 /* mem_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem_pass.h; sourceTree = "<group>"; };
-		A96FE6432154739F0060D1A3 /* loop_descriptor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_descriptor.cpp; sourceTree = "<group>"; };
-		A96FE6442154739F0060D1A3 /* local_ssa_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_ssa_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE6452154739F0060D1A3 /* function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = function.cpp; sourceTree = "<group>"; };
-		A96FE6462154739F0060D1A3 /* instruction_list.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction_list.cpp; sourceTree = "<group>"; };
-		A96FE6472154739F0060D1A3 /* composite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = composite.cpp; sourceTree = "<group>"; };
-		A96FE6482154739F0060D1A3 /* inline_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_pass.h; sourceTree = "<group>"; };
-		A96FE6492154739F0060D1A3 /* loop_dependence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_dependence.h; sourceTree = "<group>"; };
-		A96FE64A2154739F0060D1A3 /* value_number_table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = value_number_table.h; sourceTree = "<group>"; };
-		A96FE64B2154739F0060D1A3 /* flatten_decoration_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flatten_decoration_pass.h; sourceTree = "<group>"; };
-		A96FE64C2154739F0060D1A3 /* if_conversion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = if_conversion.cpp; sourceTree = "<group>"; };
-		A96FE64D2154739F0060D1A3 /* inline_exhaustive_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inline_exhaustive_pass.h; sourceTree = "<group>"; };
-		A96FE64E2154739F0060D1A3 /* constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = constants.h; sourceTree = "<group>"; };
-		A96FE64F2154739F0060D1A3 /* strength_reduction_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = strength_reduction_pass.cpp; sourceTree = "<group>"; };
-		A96FE6502154739F0060D1A3 /* copy_prop_arrays.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = copy_prop_arrays.cpp; sourceTree = "<group>"; };
-		A96FE6512154739F0060D1A3 /* pass_manager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = pass_manager.cpp; sourceTree = "<group>"; };
-		A96FE6522154739F0060D1A3 /* inline_exhaustive_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_exhaustive_pass.cpp; sourceTree = "<group>"; };
-		A96FE6532154739F0060D1A3 /* loop_fission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_fission.h; sourceTree = "<group>"; };
-		A96FE6542154739F0060D1A3 /* workaround1209.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = workaround1209.h; sourceTree = "<group>"; };
-		A96FE6552154739F0060D1A3 /* loop_fusion_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fusion_pass.cpp; sourceTree = "<group>"; };
-		A96FE6562154739F0060D1A3 /* log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log.h; sourceTree = "<group>"; };
-		A96FE6572154739F0060D1A3 /* copy_prop_arrays.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copy_prop_arrays.h; sourceTree = "<group>"; };
-		A96FE658215473A00060D1A3 /* eliminate_dead_constant_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eliminate_dead_constant_pass.h; sourceTree = "<group>"; };
-		A96FE659215473A00060D1A3 /* dead_insert_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dead_insert_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE65A215473A00060D1A3 /* ssa_rewrite_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ssa_rewrite_pass.h; sourceTree = "<group>"; };
-		A96FE65B215473A00060D1A3 /* scalar_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_analysis.cpp; sourceTree = "<group>"; };
-		A96FE65C215473A00060D1A3 /* dead_variable_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_variable_elimination.h; sourceTree = "<group>"; };
-		A96FE65D215473A00060D1A3 /* block_merge_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = block_merge_pass.cpp; sourceTree = "<group>"; };
-		A96FE65E215473A00060D1A3 /* dominator_analysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dominator_analysis.h; sourceTree = "<group>"; };
-		A96FE65F215473A00060D1A3 /* pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pass.h; sourceTree = "<group>"; };
-		A96FE660215473A00060D1A3 /* folding_rules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = folding_rules.h; sourceTree = "<group>"; };
-		A96FE661215473A00060D1A3 /* eliminate_dead_functions_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eliminate_dead_functions_pass.h; sourceTree = "<group>"; };
-		A96FE662215473A00060D1A3 /* common_uniform_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_uniform_elim_pass.h; sourceTree = "<group>"; };
-		A96FE663215473A00060D1A3 /* fold.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fold.h; sourceTree = "<group>"; };
-		A96FE664215473A00060D1A3 /* local_single_store_elim_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_single_store_elim_pass.cpp; sourceTree = "<group>"; };
-		A96FE665215473A00060D1A3 /* dead_branch_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dead_branch_elim_pass.h; sourceTree = "<group>"; };
-		A96FE666215473A00060D1A3 /* private_to_local_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = private_to_local_pass.cpp; sourceTree = "<group>"; };
-		A96FE667215473A00060D1A3 /* scalar_analysis_nodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_analysis_nodes.h; sourceTree = "<group>"; };
-		A96FE668215473A00060D1A3 /* propagator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = propagator.cpp; sourceTree = "<group>"; };
-		A96FE669215473A00060D1A3 /* loop_dependence_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_dependence_helpers.cpp; sourceTree = "<group>"; };
-		A96FE66A215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = set_spec_constant_default_value_pass.cpp; sourceTree = "<group>"; };
-		A96FE66B215473A00060D1A3 /* passes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passes.h; sourceTree = "<group>"; };
-		A96FE66C215473A00060D1A3 /* fold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fold.cpp; sourceTree = "<group>"; };
-		A96FE66D215473A00060D1A3 /* strip_reflect_info_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strip_reflect_info_pass.h; sourceTree = "<group>"; };
-		A96FE66E215473A00060D1A3 /* scalar_replacement_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_replacement_pass.cpp; sourceTree = "<group>"; };
-		A96FE66F215473A00060D1A3 /* simplification_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = simplification_pass.h; sourceTree = "<group>"; };
-		A96FE670215473A00060D1A3 /* remove_duplicates_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remove_duplicates_pass.h; sourceTree = "<group>"; };
-		A96FE671215473A00060D1A3 /* redundancy_elimination.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = redundancy_elimination.cpp; sourceTree = "<group>"; };
-		A96FE672215473A00060D1A3 /* reflect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = reflect.h; sourceTree = "<group>"; };
-		A96FE673215473A00060D1A3 /* workaround1209.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = workaround1209.cpp; sourceTree = "<group>"; };
-		A96FE674215473A00060D1A3 /* null_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = null_pass.h; sourceTree = "<group>"; };
-		A96FE675215473A00060D1A3 /* const_folding_rules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = const_folding_rules.h; sourceTree = "<group>"; };
-		A96FE676215473A00060D1A3 /* scalar_replacement_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scalar_replacement_pass.h; sourceTree = "<group>"; };
-		A96FE677215473A00060D1A3 /* instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction.cpp; sourceTree = "<group>"; };
-		A96FE678215473A00060D1A3 /* reduce_load_size.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reduce_load_size.cpp; sourceTree = "<group>"; };
-		A96FE679215473A00060D1A3 /* redundancy_elimination.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = redundancy_elimination.h; sourceTree = "<group>"; };
-		A96FE67A215473A00060D1A3 /* value_number_table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = value_number_table.cpp; sourceTree = "<group>"; };
-		A96FE67B215473A00060D1A3 /* local_ssa_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = local_ssa_elim_pass.h; sourceTree = "<group>"; };
-		A96FE67C215473A00060D1A3 /* inline_opaque_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inline_opaque_pass.cpp; sourceTree = "<group>"; };
-		A96FE67D215473A00060D1A3 /* replace_invalid_opc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = replace_invalid_opc.cpp; sourceTree = "<group>"; };
-		A96FE67E215473A00060D1A3 /* loop_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_utils.h; sourceTree = "<group>"; };
-		A96FE67F215473A00060D1A3 /* module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = module.h; sourceTree = "<group>"; };
-		A96FE680215473A00060D1A3 /* dominator_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dominator_analysis.cpp; sourceTree = "<group>"; };
-		A96FE681215473A00060D1A3 /* ir_builder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ir_builder.h; sourceTree = "<group>"; };
-		A96FE682215473A00060D1A3 /* loop_unswitch_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_unswitch_pass.h; sourceTree = "<group>"; };
-		A96FE683215473A00060D1A3 /* cfg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cfg.h; sourceTree = "<group>"; };
-		A96FE684215473A00060D1A3 /* loop_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loop_descriptor.h; sourceTree = "<group>"; };
-		A96FE685215473A00060D1A3 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
-		A96FE686215473A00060D1A3 /* aggressive_dead_code_elim_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aggressive_dead_code_elim_pass.h; sourceTree = "<group>"; };
-		A96FE687215473A00060D1A3 /* struct_cfg_analysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = struct_cfg_analysis.cpp; sourceTree = "<group>"; };
-		A96FE688215473A00060D1A3 /* vector_dce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vector_dce.h; sourceTree = "<group>"; };
-		A96FE689215473A00060D1A3 /* combine_access_chains.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = combine_access_chains.h; sourceTree = "<group>"; };
-		A96FE68A215473A00060D1A3 /* pass_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pass_manager.h; sourceTree = "<group>"; };
-		A96FE68B215473A00060D1A3 /* local_access_chain_convert_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = local_access_chain_convert_pass.cpp; sourceTree = "<group>"; };
-		A96FE68C215473A00060D1A3 /* basic_block.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = basic_block.cpp; sourceTree = "<group>"; };
-		A96FE68D215473A00060D1A3 /* iterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iterator.h; sourceTree = "<group>"; };
-		A96FE68E215473A00060D1A3 /* licm_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = licm_pass.h; sourceTree = "<group>"; };
-		A96FE68F215473A00060D1A3 /* build_module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = build_module.h; sourceTree = "<group>"; };
-		A96FE690215473A00060D1A3 /* ccp_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ccp_pass.h; sourceTree = "<group>"; };
-		A96FE691215473A00060D1A3 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
-		A96FE692215473A00060D1A3 /* loop_fusion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_fusion.cpp; sourceTree = "<group>"; };
-		A96FE693215473A00060D1A3 /* feature_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = feature_manager.h; sourceTree = "<group>"; };
-		A96FE694215473A00060D1A3 /* scalar_analysis_simplification.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scalar_analysis_simplification.cpp; sourceTree = "<group>"; };
-		A96FE695215473A00060D1A3 /* set_spec_constant_default_value_pass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = set_spec_constant_default_value_pass.h; sourceTree = "<group>"; };
-		A96FE696215473A00060D1A3 /* dominator_tree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dominator_tree.h; sourceTree = "<group>"; };
-		A96FE697215473A00060D1A3 /* type_manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = type_manager.h; sourceTree = "<group>"; };
-		A96FE698215473A00060D1A3 /* compact_ids_pass.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = compact_ids_pass.cpp; sourceTree = "<group>"; };
-		A96FE699215473A00060D1A3 /* loop_peeling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loop_peeling.cpp; sourceTree = "<group>"; };
-		A96FE69A215473A00060D1A3 /* table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = table.h; sourceTree = "<group>"; };
-		A96FE69B215473A00060D1A3 /* ext_inst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ext_inst.h; sourceTree = "<group>"; };
-		A96FE69C215473A00060D1A3 /* diagnostic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = diagnostic.cpp; sourceTree = "<group>"; };
-		A96FE69D215473A00060D1A3 /* latest_version_spirv_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_spirv_header.h; sourceTree = "<group>"; };
-		A96FE69E215473A00060D1A3 /* libspirv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = libspirv.cpp; sourceTree = "<group>"; };
-		A96FE69F215473A00060D1A3 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
-		A96FE6A0215473A00060D1A3 /* id_descriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = id_descriptor.h; sourceTree = "<group>"; };
-		A96FE6A1215473A00060D1A3 /* spirv_optimizer_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spirv_optimizer_options.h; sourceTree = "<group>"; };
-		A96FE6A2215473A00060D1A3 /* opcode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = opcode.h; sourceTree = "<group>"; };
-		A96FE6A3215473A00060D1A3 /* operand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = operand.cpp; sourceTree = "<group>"; };
-		A96FE6A4215473A00060D1A3 /* latest_version_glsl_std_450_header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latest_version_glsl_std_450_header.h; sourceTree = "<group>"; };
-		A96FE6A5215473A00060D1A3 /* extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = extensions.h; sourceTree = "<group>"; };
-		A96FE6A6215473A00060D1A3 /* disassemble.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = disassemble.cpp; sourceTree = "<group>"; };
-		A96FE6A7215473A00060D1A3 /* binary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = binary.h; sourceTree = "<group>"; };
-		A96FE6A8215473A00060D1A3 /* text_handler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = text_handler.cpp; sourceTree = "<group>"; };
-		A96FE6AA215473A00060D1A3 /* validate_annotation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_annotation.cpp; sourceTree = "<group>"; };
-		A96FE6AB215473A00060D1A3 /* validate_cfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_cfg.cpp; sourceTree = "<group>"; };
-		A96FE6AC215473A00060D1A3 /* validate_capability.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_capability.cpp; sourceTree = "<group>"; };
-		A96FE6AD215473A00060D1A3 /* construct.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = construct.h; sourceTree = "<group>"; };
-		A96FE6AE215473A00060D1A3 /* validate_barriers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_barriers.cpp; sourceTree = "<group>"; };
-		A96FE6AF215473A00060D1A3 /* validate_non_uniform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_non_uniform.cpp; sourceTree = "<group>"; };
-		A96FE6B0215473A00060D1A3 /* validate_atomics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_atomics.cpp; sourceTree = "<group>"; };
-		A96FE6B1215473A00060D1A3 /* basic_block.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = basic_block.h; sourceTree = "<group>"; };
-		A96FE6B2215473A00060D1A3 /* validate_instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_instruction.cpp; sourceTree = "<group>"; };
-		A96FE6B3215473A00060D1A3 /* validate_decorations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_decorations.cpp; sourceTree = "<group>"; };
-		A96FE6B4215473A00060D1A3 /* validate_debug.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_debug.cpp; sourceTree = "<group>"; };
-		A96FE6B5215473A00060D1A3 /* validate_builtins.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_builtins.cpp; sourceTree = "<group>"; };
-		A96FE6B6215473A00060D1A3 /* validate_interfaces.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_interfaces.cpp; sourceTree = "<group>"; };
-		A96FE6B7215473A00060D1A3 /* validate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate.cpp; sourceTree = "<group>"; };
-		A96FE6B8215473A00060D1A3 /* validation_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = validation_state.h; sourceTree = "<group>"; };
-		A96FE6B9215473A00060D1A3 /* validate_constants.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_constants.cpp; sourceTree = "<group>"; };
-		A96FE6BA215473A00060D1A3 /* validate_bitwise.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_bitwise.cpp; sourceTree = "<group>"; };
-		A96FE6BB215473A00060D1A3 /* construct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = construct.cpp; sourceTree = "<group>"; };
-		A96FE6BC215473A00060D1A3 /* function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = function.cpp; sourceTree = "<group>"; };
-		A96FE6BD215473A00060D1A3 /* validate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = validate.h; sourceTree = "<group>"; };
-		A96FE6BE215473A00060D1A3 /* validate_adjacency.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_adjacency.cpp; sourceTree = "<group>"; };
-		A96FE6BF215473A00060D1A3 /* validate_conversion.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_conversion.cpp; sourceTree = "<group>"; };
-		A96FE6C0215473A00060D1A3 /* validate_datarules.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_datarules.cpp; sourceTree = "<group>"; };
-		A96FE6C1215473A00060D1A3 /* validate_id.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_id.cpp; sourceTree = "<group>"; };
-		A96FE6C2215473A00060D1A3 /* validate_arithmetics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_arithmetics.cpp; sourceTree = "<group>"; };
-		A96FE6C3215473A00060D1A3 /* validate_mode_setting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_mode_setting.cpp; sourceTree = "<group>"; };
-		A96FE6C4215473A00060D1A3 /* validate_logicals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_logicals.cpp; sourceTree = "<group>"; };
-		A96FE6C5215473A00060D1A3 /* validate_derivatives.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_derivatives.cpp; sourceTree = "<group>"; };
-		A96FE6C6215473A00060D1A3 /* validate_memory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_memory.cpp; sourceTree = "<group>"; };
-		A96FE6C7215473A00060D1A3 /* validate_image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_image.cpp; sourceTree = "<group>"; };
-		A96FE6C8215473A00060D1A3 /* validate_literals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_literals.cpp; sourceTree = "<group>"; };
-		A96FE6C9215473A00060D1A3 /* instruction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = instruction.cpp; sourceTree = "<group>"; };
-		A96FE6CA215473A00060D1A3 /* validate_type.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_type.cpp; sourceTree = "<group>"; };
-		A96FE6CB215473A00060D1A3 /* validate_ext_inst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_ext_inst.cpp; sourceTree = "<group>"; };
-		A96FE6CC215473A00060D1A3 /* instruction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = instruction.h; sourceTree = "<group>"; };
-		A96FE6CD215473A00060D1A3 /* validate_execution_limitations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_execution_limitations.cpp; sourceTree = "<group>"; };
-		A96FE6CE215473A00060D1A3 /* validate_layout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_layout.cpp; sourceTree = "<group>"; };
-		A96FE6CF215473A00060D1A3 /* basic_block.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = basic_block.cpp; sourceTree = "<group>"; };
-		A96FE6D0215473A00060D1A3 /* validate_function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_function.cpp; sourceTree = "<group>"; };
-		A96FE6D1215473A00060D1A3 /* function.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = function.h; sourceTree = "<group>"; };
-		A96FE6D2215473A00060D1A3 /* validate_composites.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_composites.cpp; sourceTree = "<group>"; };
-		A96FE6D3215473A00060D1A3 /* validation_state.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validation_state.cpp; sourceTree = "<group>"; };
-		A96FE6D4215473A00060D1A3 /* validate_primitives.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = validate_primitives.cpp; sourceTree = "<group>"; };
-		A96FE6D5215473A00060D1A3 /* decoration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decoration.h; sourceTree = "<group>"; };
+		A972AD2A21CEE6A90013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = "../External/build/Build/Products/Release-iphoneos/libglslang.a"; sourceTree = "<group>"; };
+		A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = "../External/build/Build/Products/Release-iphoneos/libSPIRVCross.a"; sourceTree = "<group>"; };
+		A972AD3021CEE7040013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = "../External/build/Build/Products/Release-iphoneos/libSPIRVTools.a"; sourceTree = "<group>"; };
+		A972AD3421CEE7330013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = ../External/build/Build/Products/Release/libSPIRVTools.a; sourceTree = "<group>"; };
+		A972AD3521CEE7330013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = ../External/build/Build/Products/Release/libSPIRVCross.a; sourceTree = "<group>"; };
+		A972AD3821CEE7480013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = ../External/build/Build/Products/Release/libglslang.a; sourceTree = "<group>"; };
 		A97CC73D1C7527F3004A5C7E /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		A97CC73E1C7527F3004A5C7E /* MoltenVKShaderConverterTool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MoltenVKShaderConverterTool.cpp; sourceTree = "<group>"; };
 		A97CC73F1C7527F3004A5C7E /* MoltenVKShaderConverterTool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoltenVKShaderConverterTool.h; sourceTree = "<group>"; };
 		A98149651FB6A98A005F00B4 /* MVKStrings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKStrings.h; sourceTree = "<group>"; };
-		A9AB19901CB5B5A80001E7F9 /* spirv_common.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_common.hpp; sourceTree = "<group>"; };
-		A9AB19911CB5B5A80001E7F9 /* spirv_cross.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_cross.cpp; sourceTree = "<group>"; };
-		A9AB19921CB5B5A80001E7F9 /* spirv_cross.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_cross.hpp; sourceTree = "<group>"; };
-		A9AB19931CB5B5A80001E7F9 /* spirv_glsl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_glsl.cpp; sourceTree = "<group>"; };
-		A9AB19941CB5B5A80001E7F9 /* spirv_glsl.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_glsl.hpp; sourceTree = "<group>"; };
-		A9AB19951CB5B5A80001E7F9 /* spirv_msl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spirv_msl.cpp; sourceTree = "<group>"; };
-		A9AB19961CB5B5A80001E7F9 /* spirv_msl.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv_msl.hpp; sourceTree = "<group>"; };
-		A9BB09751CEF89B100CCAB22 /* spirv.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = spirv.hpp; sourceTree = "<group>"; };
 		A9F042AA1FB4D060009FCCB8 /* MVKCommonEnvironment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKCommonEnvironment.h; sourceTree = "<group>"; };
 		A9F042AB1FB4D060009FCCB8 /* MVKLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKLogging.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1303,21 +109,52 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A972AD2821CEE6310013AB25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AD2B21CEE6A90013AB25 /* libglslang.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972AD2C21CEE6C30013AB25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AD3921CEE7480013AB25 /* libglslang.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972AD2E21CEE6F50013AB25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AD3121CEE7040013AB25 /* libSPIRVCross.a in Frameworks */,
+				A972AD3221CEE7040013AB25 /* libSPIRVTools.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A972AD3321CEE7230013AB25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A972AD3621CEE7330013AB25 /* libSPIRVTools.a in Frameworks */,
+				A972AD3721CEE7330013AB25 /* libSPIRVCross.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		A9093C561C58013D0094110D /* MoltenVKSPIRVToMSLConverter */ = {
 			isa = PBXGroup;
 			children = (
-				A9FE521B1D440E17001DD573 /* SPIRV-Tools */,
-				A9381E5C1CB55F4600287A79 /* SPIRV-Cross */,
 				A925B70B1C7754B2006E7ECD /* FileSupport.h */,
 				A925B70A1C7754B2006E7ECD /* FileSupport.mm */,
 				A928C9171D0488DC00071B88 /* SPIRVConversion.h */,
 				A928C9181D0488DC00071B88 /* SPIRVConversion.mm */,
 				A9093F5A1C58013E0094110D /* SPIRVToMSLConverter.cpp */,
 				A9093F5B1C58013E0094110D /* SPIRVToMSLConverter.h */,
-				A9BB09751CEF89B100CCAB22 /* spirv.hpp */,
 			);
 			path = MoltenVKSPIRVToMSLConverter;
 			sourceTree = "<group>";
@@ -1325,204 +162,12 @@
 		A90940A11C5808BB0094110D /* MoltenVKGLSLToSPIRVConverter */ = {
 			isa = PBXGroup;
 			children = (
-				A97B21311C80B38D003F0FB4 /* glslang */,
 				A90940A31C5808BB0094110D /* GLSLToSPIRVConverter.cpp */,
 				A90940A41C5808BB0094110D /* GLSLToSPIRVConverter.h */,
 				A90941A11C581F840094110D /* GLSLConversion.mm */,
 				A90941A21C581F840094110D /* GLSLConversion.h */,
 			);
 			path = MoltenVKGLSLToSPIRVConverter;
-			sourceTree = "<group>";
-		};
-		A9381E5C1CB55F4600287A79 /* SPIRV-Cross */ = {
-			isa = PBXGroup;
-			children = (
-				A95C5F3D1DEA9070000D17B6 /* spirv_cfg.cpp */,
-				A95C5F3E1DEA9070000D17B6 /* spirv_cfg.hpp */,
-				A9AB19901CB5B5A80001E7F9 /* spirv_common.hpp */,
-				A94E30D421920A8C00394673 /* spirv_cross_parsed_ir.cpp */,
-				A94E30D321920A8C00394673 /* spirv_cross_parsed_ir.hpp */,
-				A9AB19911CB5B5A80001E7F9 /* spirv_cross.cpp */,
-				A9AB19921CB5B5A80001E7F9 /* spirv_cross.hpp */,
-				A9AB19931CB5B5A80001E7F9 /* spirv_glsl.cpp */,
-				A9AB19941CB5B5A80001E7F9 /* spirv_glsl.hpp */,
-				A9AB19951CB5B5A80001E7F9 /* spirv_msl.cpp */,
-				A9AB19961CB5B5A80001E7F9 /* spirv_msl.hpp */,
-				A94E30CD219209C700394673 /* spirv_parser.cpp */,
-				A94E30CE219209C700394673 /* spirv_parser.hpp */,
-			);
-			name = "SPIRV-Cross";
-			path = "../SPIRV-Cross";
-			sourceTree = "<group>";
-		};
-		A93E8202211F76F5001FEBD4 /* SPIRV */ = {
-			isa = PBXGroup;
-			children = (
-				A93E8203211F76F5001FEBD4 /* SPVRemapper.h */,
-				A93E8204211F76F5001FEBD4 /* SpvBuilder.h */,
-				A93E8205211F76F5001FEBD4 /* CMakeLists.txt */,
-				A93E8206211F76F5001FEBD4 /* SpvPostProcess.cpp */,
-				A93E8207211F76F5001FEBD4 /* InReadableOrder.cpp */,
-				A93E8208211F76F5001FEBD4 /* GLSL.ext.AMD.h */,
-				A93E8209211F76F5001FEBD4 /* doc.h */,
-				A93E820A211F76F5001FEBD4 /* spirv.hpp */,
-				A93E820B211F76F5001FEBD4 /* SpvBuilder.cpp */,
-				A93E820C211F76F6001FEBD4 /* GLSL.ext.EXT.h */,
-				A93E820D211F76F6001FEBD4 /* GLSL.ext.KHR.h */,
-				A93E820E211F76F6001FEBD4 /* GLSL.ext.NV.h */,
-				A93E820F211F76F6001FEBD4 /* GlslangToSpv.cpp */,
-				A93E8210211F76F6001FEBD4 /* spvIR.h */,
-				A93E8211211F76F6001FEBD4 /* bitutils.h */,
-				A93E8212211F76F6001FEBD4 /* disassemble.h */,
-				A93E8213211F76F6001FEBD4 /* GlslangToSpv.h */,
-				A93E8214211F76F6001FEBD4 /* GLSL.std.450.h */,
-				A93E8215211F76F6001FEBD4 /* SPVRemapper.cpp */,
-				A93E8216211F76F6001FEBD4 /* Logger.cpp */,
-				A93E8217211F76F6001FEBD4 /* hex_float.h */,
-				A93E8218211F76F6001FEBD4 /* Logger.h */,
-				A93E8219211F76F6001FEBD4 /* doc.cpp */,
-				A93E821A211F76F6001FEBD4 /* disassemble.cpp */,
-			);
-			path = SPIRV;
-			sourceTree = "<group>";
-		};
-		A93E821B211F76F6001FEBD4 /* glslang */ = {
-			isa = PBXGroup;
-			children = (
-				A93E821C211F76F6001FEBD4 /* CMakeLists.txt */,
-				A93E821D211F76F6001FEBD4 /* OSDependent */,
-				A93E8226211F76F6001FEBD4 /* Include */,
-				A93E8234211F76F6001FEBD4 /* updateGrammar */,
-				A93E8235211F76F6001FEBD4 /* MachineIndependent */,
-				A93E8265211F76F6001FEBD4 /* Public */,
-				A93E8267211F76F6001FEBD4 /* GenericCodeGen */,
-			);
-			path = glslang;
-			sourceTree = "<group>";
-		};
-		A93E821D211F76F6001FEBD4 /* OSDependent */ = {
-			isa = PBXGroup;
-			children = (
-				A93E821E211F76F6001FEBD4 /* Unix */,
-				A93E8221211F76F6001FEBD4 /* osinclude.h */,
-			);
-			path = OSDependent;
-			sourceTree = "<group>";
-		};
-		A93E821E211F76F6001FEBD4 /* Unix */ = {
-			isa = PBXGroup;
-			children = (
-				A93E821F211F76F6001FEBD4 /* ossource.cpp */,
-				A93E8220211F76F6001FEBD4 /* CMakeLists.txt */,
-			);
-			path = Unix;
-			sourceTree = "<group>";
-		};
-		A93E8226211F76F6001FEBD4 /* Include */ = {
-			isa = PBXGroup;
-			children = (
-				A93E8227211F76F6001FEBD4 /* ResourceLimits.h */,
-				A93E8228211F76F6001FEBD4 /* Types.h */,
-				A93E8229211F76F6001FEBD4 /* intermediate.h */,
-				A93E822A211F76F6001FEBD4 /* BaseTypes.h */,
-				A93E822B211F76F6001FEBD4 /* revision.h */,
-				A93E822C211F76F6001FEBD4 /* InitializeGlobals.h */,
-				A93E822D211F76F6001FEBD4 /* ShHandle.h */,
-				A93E822E211F76F6001FEBD4 /* arrays.h */,
-				A93E822F211F76F6001FEBD4 /* Common.h */,
-				A93E8230211F76F6001FEBD4 /* revision.template */,
-				A93E8231211F76F6001FEBD4 /* ConstantUnion.h */,
-				A93E8232211F76F6001FEBD4 /* InfoSink.h */,
-				A93E8233211F76F6001FEBD4 /* PoolAlloc.h */,
-			);
-			path = Include;
-			sourceTree = "<group>";
-		};
-		A93E8235211F76F6001FEBD4 /* MachineIndependent */ = {
-			isa = PBXGroup;
-			children = (
-				A93E8236211F76F6001FEBD4 /* ParseHelper.cpp */,
-				A93E8237211F76F6001FEBD4 /* parseVersions.h */,
-				A93E8238211F76F6001FEBD4 /* gl_types.h */,
-				A93E8239211F76F6001FEBD4 /* propagateNoContraction.cpp */,
-				A93E823A211F76F6001FEBD4 /* ScanContext.h */,
-				A93E823B211F76F6001FEBD4 /* iomapper.h */,
-				A93E823C211F76F6001FEBD4 /* localintermediate.h */,
-				A93E823D211F76F6001FEBD4 /* Scan.cpp */,
-				A93E823F211F76F6001FEBD4 /* RemoveTree.h */,
-				A93E8240211F76F6001FEBD4 /* Initialize.cpp */,
-				A93E8241211F76F6001FEBD4 /* glslang_tab.cpp */,
-				A93E8242211F76F6001FEBD4 /* limits.cpp */,
-				A93E8243211F76F6001FEBD4 /* parseConst.cpp */,
-				A93E8244211F76F6001FEBD4 /* propagateNoContraction.h */,
-				A93E8245211F76F6001FEBD4 /* Versions.h */,
-				A93E8246211F76F6001FEBD4 /* IntermTraverse.cpp */,
-				A93E8247211F76F6001FEBD4 /* intermOut.cpp */,
-				A93E8248211F76F6001FEBD4 /* iomapper.cpp */,
-				A93E8249211F76F6001FEBD4 /* PoolAlloc.cpp */,
-				A93E824A211F76F6001FEBD4 /* ShaderLang.cpp */,
-				A93E824B211F76F6001FEBD4 /* SymbolTable.h */,
-				A93E824C211F76F6001FEBD4 /* InfoSink.cpp */,
-				A93E824D211F76F6001FEBD4 /* Intermediate.cpp */,
-				A93E824E211F76F6001FEBD4 /* SymbolTable.cpp */,
-				A93E824F211F76F6001FEBD4 /* glslang_tab.cpp.h */,
-				A93E8250211F76F6001FEBD4 /* LiveTraverser.h */,
-				A93E8251211F76F6001FEBD4 /* Initialize.h */,
-				A93E8252211F76F6001FEBD4 /* attribute.cpp */,
-				A93E8253211F76F6001FEBD4 /* reflection.cpp */,
-				A93E8254211F76F6001FEBD4 /* RemoveTree.cpp */,
-				A93E8255211F76F6001FEBD4 /* attribute.h */,
-				A93E8256211F76F6001FEBD4 /* Versions.cpp */,
-				A93E8257211F76F6001FEBD4 /* Constant.cpp */,
-				A93E8258211F76F6001FEBD4 /* linkValidate.cpp */,
-				A93E8259211F76F6001FEBD4 /* ParseHelper.h */,
-				A93E825A211F76F6001FEBD4 /* preprocessor */,
-				A93E8262211F76F6001FEBD4 /* ParseContextBase.cpp */,
-				A93E8263211F76F6001FEBD4 /* reflection.h */,
-				A93E8264211F76F6001FEBD4 /* Scan.h */,
-			);
-			path = MachineIndependent;
-			sourceTree = "<group>";
-		};
-		A93E825A211F76F6001FEBD4 /* preprocessor */ = {
-			isa = PBXGroup;
-			children = (
-				A93E825B211F76F6001FEBD4 /* PpAtom.cpp */,
-				A93E825C211F76F6001FEBD4 /* PpTokens.h */,
-				A93E825D211F76F6001FEBD4 /* Pp.cpp */,
-				A93E825E211F76F6001FEBD4 /* PpContext.h */,
-				A93E825F211F76F6001FEBD4 /* PpTokens.cpp */,
-				A93E8260211F76F6001FEBD4 /* PpContext.cpp */,
-				A93E8261211F76F6001FEBD4 /* PpScanner.cpp */,
-			);
-			path = preprocessor;
-			sourceTree = "<group>";
-		};
-		A93E8265211F76F6001FEBD4 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				A93E8266211F76F6001FEBD4 /* ShaderLang.h */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		A93E8267211F76F6001FEBD4 /* GenericCodeGen */ = {
-			isa = PBXGroup;
-			children = (
-				A93E8268211F76F6001FEBD4 /* CodeGen.cpp */,
-				A93E8269211F76F6001FEBD4 /* Link.cpp */,
-			);
-			path = GenericCodeGen;
-			sourceTree = "<group>";
-		};
-		A93E826A211F76F6001FEBD4 /* OGLCompilersDLL */ = {
-			isa = PBXGroup;
-			children = (
-				A93E826B211F76F6001FEBD4 /* CMakeLists.txt */,
-				A93E826C211F76F6001FEBD4 /* InitializeDll.h */,
-				A93E826D211F76F6001FEBD4 /* InitializeDll.cpp */,
-			);
-			path = OGLCompilersDLL;
 			sourceTree = "<group>";
 		};
 		A964B28D1C57EBC400D930D8 /* Products */ = {
@@ -1537,368 +182,17 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		A96FE59F2154739F0060D1A3 /* source */ = {
+		A972AD2921CEE6A80013AB25 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A96FE5A02154739F0060D1A3 /* spirv_target_env.cpp */,
-				A96FE5A12154739F0060D1A3 /* extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json */,
-				A96FE5A22154739F0060D1A3 /* assembly_grammar.h */,
-				A96FE5A32154739F0060D1A3 /* enum_set.h */,
-				A96FE5A42154739F0060D1A3 /* CMakeLists.txt */,
-				A96FE5A52154739F0060D1A3 /* extinst.spv-amd-shader-ballot.grammar.json */,
-				A96FE5A62154739F0060D1A3 /* text.cpp */,
-				A96FE5A72154739F0060D1A3 /* assembly_grammar.cpp */,
-				A96FE5A82154739F0060D1A3 /* text.h */,
-				A96FE5A92154739F0060D1A3 /* extensions.cpp */,
-				A96FE5AA2154739F0060D1A3 /* util */,
-				A96FE5B92154739F0060D1A3 /* spirv_target_env.h */,
-				A96FE5BA2154739F0060D1A3 /* table.cpp */,
-				A96FE5BB2154739F0060D1A3 /* id_descriptor.cpp */,
-				A96FE5BC2154739F0060D1A3 /* latest_version_opencl_std_header.h */,
-				A96FE5BD2154739F0060D1A3 /* spirv_optimizer_options.cpp */,
-				A96FE5BE2154739F0060D1A3 /* cfa.h */,
-				A96FE5BF2154739F0060D1A3 /* enum_string_mapping.h */,
-				A96FE5C02154739F0060D1A3 /* spirv_validator_options.cpp */,
-				A96FE5C12154739F0060D1A3 /* extinst.spv-amd-shader-trinary-minmax.grammar.json */,
-				A96FE5C22154739F0060D1A3 /* print.cpp */,
-				A96FE5C32154739F0060D1A3 /* spirv_definition.h */,
-				A96FE5C42154739F0060D1A3 /* operand.h */,
-				A96FE5C52154739F0060D1A3 /* spirv_endian.cpp */,
-				A96FE5C62154739F0060D1A3 /* macro.h */,
-				A96FE5C72154739F0060D1A3 /* spirv_constant.h */,
-				A96FE5C82154739F0060D1A3 /* extinst.spv-amd-gcn-shader.grammar.json */,
-				A96FE5C92154739F0060D1A3 /* binary.cpp */,
-				A96FE5CA2154739F0060D1A3 /* spirv_validator_options.h */,
-				A96FE5CB2154739F0060D1A3 /* comp */,
-				A96FE5DC2154739F0060D1A3 /* enum_string_mapping.cpp */,
-				A96FE5DD2154739F0060D1A3 /* text_handler.h */,
-				A96FE5DE2154739F0060D1A3 /* parsed_operand.h */,
-				A96FE5DF2154739F0060D1A3 /* name_mapper.h */,
-				A96FE5E02154739F0060D1A3 /* parsed_operand.cpp */,
-				A96FE5E12154739F0060D1A3 /* diagnostic.h */,
-				A96FE5E22154739F0060D1A3 /* spirv_endian.h */,
-				A96FE5E32154739F0060D1A3 /* name_mapper.cpp */,
-				A96FE5E42154739F0060D1A3 /* extinst.debuginfo.grammar.json */,
-				A96FE5E52154739F0060D1A3 /* link */,
-				A96FE5E82154739F0060D1A3 /* software_version.cpp */,
-				A96FE5E92154739F0060D1A3 /* opcode.cpp */,
-				A96FE5EA2154739F0060D1A3 /* print.h */,
-				A96FE5EB2154739F0060D1A3 /* ext_inst.cpp */,
-				A96FE5EC2154739F0060D1A3 /* disassemble.h */,
-				A96FE5ED2154739F0060D1A3 /* opt */,
-				A96FE69A215473A00060D1A3 /* table.h */,
-				A96FE69B215473A00060D1A3 /* ext_inst.h */,
-				A96FE69C215473A00060D1A3 /* diagnostic.cpp */,
-				A96FE69D215473A00060D1A3 /* latest_version_spirv_header.h */,
-				A96FE69E215473A00060D1A3 /* libspirv.cpp */,
-				A96FE69F215473A00060D1A3 /* instruction.h */,
-				A96FE6A0215473A00060D1A3 /* id_descriptor.h */,
-				A96FE6A1215473A00060D1A3 /* spirv_optimizer_options.h */,
-				A96FE6A2215473A00060D1A3 /* opcode.h */,
-				A96FE6A3215473A00060D1A3 /* operand.cpp */,
-				A96FE6A4215473A00060D1A3 /* latest_version_glsl_std_450_header.h */,
-				A96FE6A5215473A00060D1A3 /* extensions.h */,
-				A96FE6A6215473A00060D1A3 /* disassemble.cpp */,
-				A96FE6A7215473A00060D1A3 /* binary.h */,
-				A96FE6A8215473A00060D1A3 /* text_handler.cpp */,
-				A96FE6A9215473A00060D1A3 /* val */,
+				A972AD3821CEE7480013AB25 /* libglslang.a */,
+				A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */,
+				A972AD3521CEE7330013AB25 /* libSPIRVCross.a */,
+				A972AD3021CEE7040013AB25 /* libSPIRVTools.a */,
+				A972AD3421CEE7330013AB25 /* libSPIRVTools.a */,
+				A972AD2A21CEE6A90013AB25 /* libglslang.a */,
 			);
-			name = source;
-			path = "../../../../External/glslang/External/spirv-tools/source";
-			sourceTree = "<group>";
-		};
-		A96FE5AA2154739F0060D1A3 /* util */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE5AB2154739F0060D1A3 /* parse_number.h */,
-				A96FE5AC2154739F0060D1A3 /* ilist_node.h */,
-				A96FE5AD2154739F0060D1A3 /* make_unique.h */,
-				A96FE5AE2154739F0060D1A3 /* string_utils.h */,
-				A96FE5AF2154739F0060D1A3 /* small_vector.h */,
-				A96FE5B02154739F0060D1A3 /* timer.cpp */,
-				A96FE5B12154739F0060D1A3 /* timer.h */,
-				A96FE5B22154739F0060D1A3 /* string_utils.cpp */,
-				A96FE5B32154739F0060D1A3 /* bit_vector.h */,
-				A96FE5B42154739F0060D1A3 /* bitutils.h */,
-				A96FE5B52154739F0060D1A3 /* hex_float.h */,
-				A96FE5B62154739F0060D1A3 /* parse_number.cpp */,
-				A96FE5B72154739F0060D1A3 /* bit_vector.cpp */,
-				A96FE5B82154739F0060D1A3 /* ilist.h */,
-			);
-			path = util;
-			sourceTree = "<group>";
-		};
-		A96FE5CB2154739F0060D1A3 /* comp */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE5CC2154739F0060D1A3 /* markv_codec.cpp */,
-				A96FE5CD2154739F0060D1A3 /* markv.cpp */,
-				A96FE5CE2154739F0060D1A3 /* huffman_codec.h */,
-				A96FE5CF2154739F0060D1A3 /* CMakeLists.txt */,
-				A96FE5D02154739F0060D1A3 /* bit_stream.h */,
-				A96FE5D12154739F0060D1A3 /* move_to_front.cpp */,
-				A96FE5D22154739F0060D1A3 /* markv_encoder.h */,
-				A96FE5D32154739F0060D1A3 /* markv_decoder.h */,
-				A96FE5D42154739F0060D1A3 /* markv.h */,
-				A96FE5D52154739F0060D1A3 /* markv_model.h */,
-				A96FE5D62154739F0060D1A3 /* markv_decoder.cpp */,
-				A96FE5D72154739F0060D1A3 /* move_to_front.h */,
-				A96FE5D82154739F0060D1A3 /* markv_codec.h */,
-				A96FE5D92154739F0060D1A3 /* markv_logger.h */,
-				A96FE5DA2154739F0060D1A3 /* bit_stream.cpp */,
-				A96FE5DB2154739F0060D1A3 /* markv_encoder.cpp */,
-			);
-			path = comp;
-			sourceTree = "<group>";
-		};
-		A96FE5E52154739F0060D1A3 /* link */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE5E62154739F0060D1A3 /* CMakeLists.txt */,
-				A96FE5E72154739F0060D1A3 /* linker.cpp */,
-			);
-			path = link;
-			sourceTree = "<group>";
-		};
-		A96FE5ED2154739F0060D1A3 /* opt */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE5EE2154739F0060D1A3 /* optimizer.cpp */,
-				A96FE5EF2154739F0060D1A3 /* if_conversion.h */,
-				A96FE5F02154739F0060D1A3 /* register_pressure.cpp */,
-				A96FE5F12154739F0060D1A3 /* loop_utils.cpp */,
-				A96FE5F22154739F0060D1A3 /* merge_return_pass.h */,
-				A96FE5F32154739F0060D1A3 /* inline_opaque_pass.h */,
-				A96FE5F42154739F0060D1A3 /* loop_fusion.h */,
-				A96FE5F52154739F0060D1A3 /* combine_access_chains.cpp */,
-				A96FE5F62154739F0060D1A3 /* build_module.cpp */,
-				A96FE5F72154739F0060D1A3 /* composite.h */,
-				A96FE5F82154739F0060D1A3 /* compact_ids_pass.h */,
-				A96FE5F92154739F0060D1A3 /* register_pressure.h */,
-				A96FE5FA2154739F0060D1A3 /* tree_iterator.h */,
-				A96FE5FB2154739F0060D1A3 /* local_single_store_elim_pass.h */,
-				A96FE5FC2154739F0060D1A3 /* reduce_load_size.h */,
-				A96FE5FD2154739F0060D1A3 /* types.cpp */,
-				A96FE5FE2154739F0060D1A3 /* scalar_analysis.h */,
-				A96FE5FF2154739F0060D1A3 /* strip_debug_info_pass.h */,
-				A96FE6002154739F0060D1A3 /* cfg.cpp */,
-				A96FE6012154739F0060D1A3 /* decoration_manager.cpp */,
-				A96FE6022154739F0060D1A3 /* local_single_block_elim_pass.cpp */,
-				A96FE6032154739F0060D1A3 /* freeze_spec_constant_value_pass.cpp */,
-				A96FE6042154739F0060D1A3 /* replace_invalid_opc.h */,
-				A96FE6052154739F0060D1A3 /* local_access_chain_convert_pass.h */,
-				A96FE6062154739F0060D1A3 /* local_redundancy_elimination.cpp */,
-				A96FE6072154739F0060D1A3 /* CMakeLists.txt */,
-				A96FE6082154739F0060D1A3 /* propagator.h */,
-				A96FE6092154739F0060D1A3 /* instruction_list.h */,
-				A96FE60A2154739F0060D1A3 /* feature_manager.cpp */,
-				A96FE60B2154739F0060D1A3 /* pass.cpp */,
-				A96FE60C2154739F0060D1A3 /* loop_fission.cpp */,
-				A96FE60D2154739F0060D1A3 /* dominator_tree.cpp */,
-				A96FE60E2154739F0060D1A3 /* merge_return_pass.cpp */,
-				A96FE60F2154739F0060D1A3 /* ir_context.h */,
-				A96FE6102154739F0060D1A3 /* eliminate_dead_constant_pass.cpp */,
-				A96FE6112154739F0060D1A3 /* cfg_cleanup_pass.cpp */,
-				A96FE6122154739F0060D1A3 /* const_folding_rules.cpp */,
-				A96FE6132154739F0060D1A3 /* loop_unroller.h */,
-				A96FE6142154739F0060D1A3 /* strip_debug_info_pass.cpp */,
-				A96FE6152154739F0060D1A3 /* ssa_rewrite_pass.cpp */,
-				A96FE6162154739F0060D1A3 /* loop_dependence.cpp */,
-				A96FE6172154739F0060D1A3 /* unify_const_pass.h */,
-				A96FE6182154739F0060D1A3 /* ir_loader.h */,
-				A96FE6192154739F0060D1A3 /* types.h */,
-				A96FE61A2154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.h */,
-				A96FE61B2154739F0060D1A3 /* mem_pass.cpp */,
-				A96FE61C2154739F0060D1A3 /* basic_block.h */,
-				A96FE61D2154739F0060D1A3 /* remove_duplicates_pass.cpp */,
-				A96FE61E2154739F0060D1A3 /* dead_variable_elimination.cpp */,
-				A96FE61F2154739F0060D1A3 /* block_merge_pass.h */,
-				A96FE6202154739F0060D1A3 /* module.cpp */,
-				A96FE6212154739F0060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp */,
-				A96FE6222154739F0060D1A3 /* loop_unswitch_pass.cpp */,
-				A96FE6232154739F0060D1A3 /* unify_const_pass.cpp */,
-				A96FE6242154739F0060D1A3 /* type_manager.cpp */,
-				A96FE6252154739F0060D1A3 /* private_to_local_pass.h */,
-				A96FE6262154739F0060D1A3 /* inline_pass.cpp */,
-				A96FE6272154739F0060D1A3 /* def_use_manager.h */,
-				A96FE6282154739F0060D1A3 /* ir_loader.cpp */,
-				A96FE6292154739F0060D1A3 /* cfg_cleanup_pass.h */,
-				A96FE62A2154739F0060D1A3 /* licm_pass.cpp */,
-				A96FE62B2154739F0060D1A3 /* eliminate_dead_functions_pass.cpp */,
-				A96FE62C2154739F0060D1A3 /* local_redundancy_elimination.h */,
-				A96FE62D2154739F0060D1A3 /* loop_peeling.h */,
-				A96FE62E2154739F0060D1A3 /* vector_dce.cpp */,
-				A96FE62F2154739F0060D1A3 /* loop_unroller.cpp */,
-				A96FE6302154739F0060D1A3 /* constants.cpp */,
-				A96FE6312154739F0060D1A3 /* loop_fusion_pass.h */,
-				A96FE6322154739F0060D1A3 /* struct_cfg_analysis.h */,
-				A96FE6332154739F0060D1A3 /* common_uniform_elim_pass.cpp */,
-				A96FE6342154739F0060D1A3 /* def_use_manager.cpp */,
-				A96FE6352154739F0060D1A3 /* strip_reflect_info_pass.cpp */,
-				A96FE6362154739F0060D1A3 /* decoration_manager.h */,
-				A96FE6372154739F0060D1A3 /* ccp_pass.cpp */,
-				A96FE6382154739F0060D1A3 /* local_single_block_elim_pass.h */,
-				A96FE6392154739F0060D1A3 /* strength_reduction_pass.h */,
-				A96FE63A2154739F0060D1A3 /* aggressive_dead_code_elim_pass.cpp */,
-				A96FE63B2154739F0060D1A3 /* simplification_pass.cpp */,
-				A96FE63C2154739F0060D1A3 /* dead_branch_elim_pass.cpp */,
-				A96FE63D2154739F0060D1A3 /* flatten_decoration_pass.cpp */,
-				A96FE63E2154739F0060D1A3 /* dead_insert_elim_pass.h */,
-				A96FE63F2154739F0060D1A3 /* folding_rules.cpp */,
-				A96FE6402154739F0060D1A3 /* freeze_spec_constant_value_pass.h */,
-				A96FE6412154739F0060D1A3 /* ir_context.cpp */,
-				A96FE6422154739F0060D1A3 /* mem_pass.h */,
-				A96FE6432154739F0060D1A3 /* loop_descriptor.cpp */,
-				A96FE6442154739F0060D1A3 /* local_ssa_elim_pass.cpp */,
-				A96FE6452154739F0060D1A3 /* function.cpp */,
-				A96FE6462154739F0060D1A3 /* instruction_list.cpp */,
-				A96FE6472154739F0060D1A3 /* composite.cpp */,
-				A96FE6482154739F0060D1A3 /* inline_pass.h */,
-				A96FE6492154739F0060D1A3 /* loop_dependence.h */,
-				A96FE64A2154739F0060D1A3 /* value_number_table.h */,
-				A96FE64B2154739F0060D1A3 /* flatten_decoration_pass.h */,
-				A96FE64C2154739F0060D1A3 /* if_conversion.cpp */,
-				A96FE64D2154739F0060D1A3 /* inline_exhaustive_pass.h */,
-				A96FE64E2154739F0060D1A3 /* constants.h */,
-				A96FE64F2154739F0060D1A3 /* strength_reduction_pass.cpp */,
-				A96FE6502154739F0060D1A3 /* copy_prop_arrays.cpp */,
-				A96FE6512154739F0060D1A3 /* pass_manager.cpp */,
-				A96FE6522154739F0060D1A3 /* inline_exhaustive_pass.cpp */,
-				A96FE6532154739F0060D1A3 /* loop_fission.h */,
-				A96FE6542154739F0060D1A3 /* workaround1209.h */,
-				A96FE6552154739F0060D1A3 /* loop_fusion_pass.cpp */,
-				A96FE6562154739F0060D1A3 /* log.h */,
-				A96FE6572154739F0060D1A3 /* copy_prop_arrays.h */,
-				A96FE658215473A00060D1A3 /* eliminate_dead_constant_pass.h */,
-				A96FE659215473A00060D1A3 /* dead_insert_elim_pass.cpp */,
-				A96FE65A215473A00060D1A3 /* ssa_rewrite_pass.h */,
-				A96FE65B215473A00060D1A3 /* scalar_analysis.cpp */,
-				A96FE65C215473A00060D1A3 /* dead_variable_elimination.h */,
-				A96FE65D215473A00060D1A3 /* block_merge_pass.cpp */,
-				A96FE65E215473A00060D1A3 /* dominator_analysis.h */,
-				A96FE65F215473A00060D1A3 /* pass.h */,
-				A96FE660215473A00060D1A3 /* folding_rules.h */,
-				A96FE661215473A00060D1A3 /* eliminate_dead_functions_pass.h */,
-				A96FE662215473A00060D1A3 /* common_uniform_elim_pass.h */,
-				A96FE663215473A00060D1A3 /* fold.h */,
-				A96FE664215473A00060D1A3 /* local_single_store_elim_pass.cpp */,
-				A96FE665215473A00060D1A3 /* dead_branch_elim_pass.h */,
-				A96FE666215473A00060D1A3 /* private_to_local_pass.cpp */,
-				A96FE667215473A00060D1A3 /* scalar_analysis_nodes.h */,
-				A96FE668215473A00060D1A3 /* propagator.cpp */,
-				A96FE669215473A00060D1A3 /* loop_dependence_helpers.cpp */,
-				A96FE66A215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp */,
-				A96FE66B215473A00060D1A3 /* passes.h */,
-				A96FE66C215473A00060D1A3 /* fold.cpp */,
-				A96FE66D215473A00060D1A3 /* strip_reflect_info_pass.h */,
-				A96FE66E215473A00060D1A3 /* scalar_replacement_pass.cpp */,
-				A96FE66F215473A00060D1A3 /* simplification_pass.h */,
-				A96FE670215473A00060D1A3 /* remove_duplicates_pass.h */,
-				A96FE671215473A00060D1A3 /* redundancy_elimination.cpp */,
-				A96FE672215473A00060D1A3 /* reflect.h */,
-				A96FE673215473A00060D1A3 /* workaround1209.cpp */,
-				A96FE674215473A00060D1A3 /* null_pass.h */,
-				A96FE675215473A00060D1A3 /* const_folding_rules.h */,
-				A96FE676215473A00060D1A3 /* scalar_replacement_pass.h */,
-				A96FE677215473A00060D1A3 /* instruction.cpp */,
-				A96FE678215473A00060D1A3 /* reduce_load_size.cpp */,
-				A96FE679215473A00060D1A3 /* redundancy_elimination.h */,
-				A96FE67A215473A00060D1A3 /* value_number_table.cpp */,
-				A96FE67B215473A00060D1A3 /* local_ssa_elim_pass.h */,
-				A96FE67C215473A00060D1A3 /* inline_opaque_pass.cpp */,
-				A96FE67D215473A00060D1A3 /* replace_invalid_opc.cpp */,
-				A96FE67E215473A00060D1A3 /* loop_utils.h */,
-				A96FE67F215473A00060D1A3 /* module.h */,
-				A96FE680215473A00060D1A3 /* dominator_analysis.cpp */,
-				A96FE681215473A00060D1A3 /* ir_builder.h */,
-				A96FE682215473A00060D1A3 /* loop_unswitch_pass.h */,
-				A96FE683215473A00060D1A3 /* cfg.h */,
-				A96FE684215473A00060D1A3 /* loop_descriptor.h */,
-				A96FE685215473A00060D1A3 /* instruction.h */,
-				A96FE686215473A00060D1A3 /* aggressive_dead_code_elim_pass.h */,
-				A96FE687215473A00060D1A3 /* struct_cfg_analysis.cpp */,
-				A96FE688215473A00060D1A3 /* vector_dce.h */,
-				A96FE689215473A00060D1A3 /* combine_access_chains.h */,
-				A96FE68A215473A00060D1A3 /* pass_manager.h */,
-				A96FE68B215473A00060D1A3 /* local_access_chain_convert_pass.cpp */,
-				A96FE68C215473A00060D1A3 /* basic_block.cpp */,
-				A96FE68D215473A00060D1A3 /* iterator.h */,
-				A96FE68E215473A00060D1A3 /* licm_pass.h */,
-				A96FE68F215473A00060D1A3 /* build_module.h */,
-				A96FE690215473A00060D1A3 /* ccp_pass.h */,
-				A96FE691215473A00060D1A3 /* function.h */,
-				A96FE692215473A00060D1A3 /* loop_fusion.cpp */,
-				A96FE693215473A00060D1A3 /* feature_manager.h */,
-				A96FE694215473A00060D1A3 /* scalar_analysis_simplification.cpp */,
-				A96FE695215473A00060D1A3 /* set_spec_constant_default_value_pass.h */,
-				A96FE696215473A00060D1A3 /* dominator_tree.h */,
-				A96FE697215473A00060D1A3 /* type_manager.h */,
-				A96FE698215473A00060D1A3 /* compact_ids_pass.cpp */,
-				A96FE699215473A00060D1A3 /* loop_peeling.cpp */,
-			);
-			path = opt;
-			sourceTree = "<group>";
-		};
-		A96FE6A9215473A00060D1A3 /* val */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE6AA215473A00060D1A3 /* validate_annotation.cpp */,
-				A96FE6AB215473A00060D1A3 /* validate_cfg.cpp */,
-				A96FE6AC215473A00060D1A3 /* validate_capability.cpp */,
-				A96FE6AD215473A00060D1A3 /* construct.h */,
-				A96FE6AE215473A00060D1A3 /* validate_barriers.cpp */,
-				A96FE6AF215473A00060D1A3 /* validate_non_uniform.cpp */,
-				A96FE6B0215473A00060D1A3 /* validate_atomics.cpp */,
-				A96FE6B1215473A00060D1A3 /* basic_block.h */,
-				A96FE6B2215473A00060D1A3 /* validate_instruction.cpp */,
-				A96FE6B3215473A00060D1A3 /* validate_decorations.cpp */,
-				A96FE6B4215473A00060D1A3 /* validate_debug.cpp */,
-				A96FE6B5215473A00060D1A3 /* validate_builtins.cpp */,
-				A96FE6B6215473A00060D1A3 /* validate_interfaces.cpp */,
-				A96FE6B7215473A00060D1A3 /* validate.cpp */,
-				A96FE6B8215473A00060D1A3 /* validation_state.h */,
-				A96FE6B9215473A00060D1A3 /* validate_constants.cpp */,
-				A96FE6BA215473A00060D1A3 /* validate_bitwise.cpp */,
-				A96FE6BB215473A00060D1A3 /* construct.cpp */,
-				A96FE6BC215473A00060D1A3 /* function.cpp */,
-				A96FE6BD215473A00060D1A3 /* validate.h */,
-				A96FE6BE215473A00060D1A3 /* validate_adjacency.cpp */,
-				A96FE6BF215473A00060D1A3 /* validate_conversion.cpp */,
-				A96FE6C0215473A00060D1A3 /* validate_datarules.cpp */,
-				A96FE6C1215473A00060D1A3 /* validate_id.cpp */,
-				A96FE6C2215473A00060D1A3 /* validate_arithmetics.cpp */,
-				A96FE6C3215473A00060D1A3 /* validate_mode_setting.cpp */,
-				A96FE6C4215473A00060D1A3 /* validate_logicals.cpp */,
-				A96FE6C5215473A00060D1A3 /* validate_derivatives.cpp */,
-				A96FE6C6215473A00060D1A3 /* validate_memory.cpp */,
-				A96FE6C7215473A00060D1A3 /* validate_image.cpp */,
-				A96FE6C8215473A00060D1A3 /* validate_literals.cpp */,
-				A96FE6C9215473A00060D1A3 /* instruction.cpp */,
-				A96FE6CA215473A00060D1A3 /* validate_type.cpp */,
-				A96FE6CB215473A00060D1A3 /* validate_ext_inst.cpp */,
-				A96FE6CC215473A00060D1A3 /* instruction.h */,
-				A96FE6CD215473A00060D1A3 /* validate_execution_limitations.cpp */,
-				A96FE6CE215473A00060D1A3 /* validate_layout.cpp */,
-				A96FE6CF215473A00060D1A3 /* basic_block.cpp */,
-				A96FE6D0215473A00060D1A3 /* validate_function.cpp */,
-				A96FE6D1215473A00060D1A3 /* function.h */,
-				A96FE6D2215473A00060D1A3 /* validate_composites.cpp */,
-				A96FE6D3215473A00060D1A3 /* validation_state.cpp */,
-				A96FE6D4215473A00060D1A3 /* validate_primitives.cpp */,
-				A96FE6D5215473A00060D1A3 /* decoration.h */,
-			);
-			path = val;
-			sourceTree = "<group>";
-		};
-		A97B21311C80B38D003F0FB4 /* glslang */ = {
-			isa = PBXGroup;
-			children = (
-				A93E821B211F76F6001FEBD4 /* glslang */,
-				A93E826A211F76F6001FEBD4 /* OGLCompilersDLL */,
-				A93E8202211F76F5001FEBD4 /* SPIRV */,
-			);
-			name = glslang;
-			path = ../glslang;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		A97CC73C1C7527F3004A5C7E /* MoltenVKShaderConverterTool */ = {
@@ -1932,16 +226,8 @@
 				A97CC73C1C7527F3004A5C7E /* MoltenVKShaderConverterTool */,
 				A9F042A81FB4D060009FCCB8 /* Common */,
 				A964B28D1C57EBC400D930D8 /* Products */,
+				A972AD2921CEE6A80013AB25 /* Frameworks */,
 			);
-			sourceTree = "<group>";
-		};
-		A9FE521B1D440E17001DD573 /* SPIRV-Tools */ = {
-			isa = PBXGroup;
-			children = (
-				A96FE59F2154739F0060D1A3 /* source */,
-			);
-			name = "SPIRV-Tools";
-			path = "../glslang/External/spirv-tools";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1952,58 +238,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A90941A51C581F840094110D /* GLSLConversion.h in Headers */,
-				A93E82C4211F76F6001FEBD4 /* ScanContext.h in Headers */,
-				A93E82D8211F76F6001FEBD4 /* propagateNoContraction.h in Headers */,
-				A93E831E211F76F6001FEBD4 /* InitializeDll.h in Headers */,
-				A93E82F0211F76F6001FEBD4 /* LiveTraverser.h in Headers */,
-				A93E8306211F76F6001FEBD4 /* PpTokens.h in Headers */,
-				A93E82B8211F76F6001FEBD4 /* InfoSink.h in Headers */,
-				A93E82FA211F76F6001FEBD4 /* attribute.h in Headers */,
-				A93E827A211F76F6001FEBD4 /* spirv.hpp in Headers */,
 				A9F042B41FB4D060009FCCB8 /* MVKLogging.h in Headers */,
 				A90940A91C5808BB0094110D /* GLSLToSPIRVConverter.h in Headers */,
-				A93E82A4211F76F6001FEBD4 /* ResourceLimits.h in Headers */,
-				A93E82C6211F76F6001FEBD4 /* iomapper.h in Headers */,
-				A93E829E211F76F6001FEBD4 /* osinclude.h in Headers */,
-				A93E8302211F76F6001FEBD4 /* ParseHelper.h in Headers */,
-				A93E82CE211F76F6001FEBD4 /* RemoveTree.h in Headers */,
-				A93E82C8211F76F6001FEBD4 /* localintermediate.h in Headers */,
-				A93E830A211F76F6001FEBD4 /* PpContext.h in Headers */,
-				A93E82A6211F76F6001FEBD4 /* Types.h in Headers */,
-				A93E8316211F76F6001FEBD4 /* Scan.h in Headers */,
-				A93E8278211F76F6001FEBD4 /* doc.h in Headers */,
-				A93E82BA211F76F6001FEBD4 /* PoolAlloc.h in Headers */,
-				A93E82AE211F76F6001FEBD4 /* InitializeGlobals.h in Headers */,
-				A93E82BE211F76F6001FEBD4 /* parseVersions.h in Headers */,
 				A9F042B01FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */,
-				A93E8314211F76F6001FEBD4 /* reflection.h in Headers */,
-				A93E82DA211F76F6001FEBD4 /* Versions.h in Headers */,
-				A93E82C0211F76F6001FEBD4 /* gl_types.h in Headers */,
-				A93E82EE211F76F6001FEBD4 /* glslang_tab.cpp.h in Headers */,
-				A93E82AC211F76F6001FEBD4 /* revision.h in Headers */,
-				A93E82B0211F76F6001FEBD4 /* ShHandle.h in Headers */,
-				A93E828E211F76F6001FEBD4 /* GLSL.std.450.h in Headers */,
-				A93E82AA211F76F6001FEBD4 /* BaseTypes.h in Headers */,
-				A93E82B6211F76F6001FEBD4 /* ConstantUnion.h in Headers */,
-				A93E8294211F76F6001FEBD4 /* hex_float.h in Headers */,
-				A93E8282211F76F6001FEBD4 /* GLSL.ext.NV.h in Headers */,
-				A93E8318211F76F6001FEBD4 /* ShaderLang.h in Headers */,
-				A93E826E211F76F6001FEBD4 /* SPVRemapper.h in Headers */,
-				A93E82B4211F76F6001FEBD4 /* Common.h in Headers */,
-				A93E82F2211F76F6001FEBD4 /* Initialize.h in Headers */,
-				A93E827E211F76F6001FEBD4 /* GLSL.ext.EXT.h in Headers */,
-				A93E8280211F76F6001FEBD4 /* GLSL.ext.KHR.h in Headers */,
-				A93E82A8211F76F6001FEBD4 /* intermediate.h in Headers */,
-				A93E8276211F76F6001FEBD4 /* GLSL.ext.AMD.h in Headers */,
-				A93E82E6211F76F6001FEBD4 /* SymbolTable.h in Headers */,
-				A93E828C211F76F6001FEBD4 /* GlslangToSpv.h in Headers */,
-				A93E82B2211F76F6001FEBD4 /* arrays.h in Headers */,
-				A93E8296211F76F6001FEBD4 /* Logger.h in Headers */,
-				A93E8270211F76F6001FEBD4 /* SpvBuilder.h in Headers */,
-				A93E8288211F76F6001FEBD4 /* bitutils.h in Headers */,
 				A98149661FB6A98A005F00B4 /* MVKStrings.h in Headers */,
-				A93E8286211F76F6001FEBD4 /* spvIR.h in Headers */,
-				A93E828A211F76F6001FEBD4 /* disassemble.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2012,58 +250,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A90941A61C581F840094110D /* GLSLConversion.h in Headers */,
-				A93E82C5211F76F6001FEBD4 /* ScanContext.h in Headers */,
-				A93E82D9211F76F6001FEBD4 /* propagateNoContraction.h in Headers */,
-				A93E831F211F76F6001FEBD4 /* InitializeDll.h in Headers */,
-				A93E82F1211F76F6001FEBD4 /* LiveTraverser.h in Headers */,
-				A93E8307211F76F6001FEBD4 /* PpTokens.h in Headers */,
-				A93E82B9211F76F6001FEBD4 /* InfoSink.h in Headers */,
-				A93E82FB211F76F6001FEBD4 /* attribute.h in Headers */,
-				A93E827B211F76F6001FEBD4 /* spirv.hpp in Headers */,
 				A9F042B51FB4D060009FCCB8 /* MVKLogging.h in Headers */,
 				A90940AA1C5808BB0094110D /* GLSLToSPIRVConverter.h in Headers */,
-				A93E82A5211F76F6001FEBD4 /* ResourceLimits.h in Headers */,
-				A93E82C7211F76F6001FEBD4 /* iomapper.h in Headers */,
-				A93E829F211F76F6001FEBD4 /* osinclude.h in Headers */,
-				A93E8303211F76F6001FEBD4 /* ParseHelper.h in Headers */,
-				A93E82CF211F76F6001FEBD4 /* RemoveTree.h in Headers */,
-				A93E82C9211F76F6001FEBD4 /* localintermediate.h in Headers */,
-				A93E830B211F76F6001FEBD4 /* PpContext.h in Headers */,
-				A93E82A7211F76F6001FEBD4 /* Types.h in Headers */,
-				A93E8317211F76F6001FEBD4 /* Scan.h in Headers */,
-				A93E8279211F76F6001FEBD4 /* doc.h in Headers */,
-				A93E82BB211F76F6001FEBD4 /* PoolAlloc.h in Headers */,
-				A93E82AF211F76F6001FEBD4 /* InitializeGlobals.h in Headers */,
-				A93E82BF211F76F6001FEBD4 /* parseVersions.h in Headers */,
 				A9F042B11FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */,
-				A93E8315211F76F6001FEBD4 /* reflection.h in Headers */,
-				A93E82DB211F76F6001FEBD4 /* Versions.h in Headers */,
-				A93E82C1211F76F6001FEBD4 /* gl_types.h in Headers */,
-				A93E82EF211F76F6001FEBD4 /* glslang_tab.cpp.h in Headers */,
-				A93E82AD211F76F6001FEBD4 /* revision.h in Headers */,
-				A93E82B1211F76F6001FEBD4 /* ShHandle.h in Headers */,
-				A93E828F211F76F6001FEBD4 /* GLSL.std.450.h in Headers */,
-				A93E82AB211F76F6001FEBD4 /* BaseTypes.h in Headers */,
-				A93E82B7211F76F6001FEBD4 /* ConstantUnion.h in Headers */,
-				A93E8295211F76F6001FEBD4 /* hex_float.h in Headers */,
-				A93E8283211F76F6001FEBD4 /* GLSL.ext.NV.h in Headers */,
-				A93E8319211F76F6001FEBD4 /* ShaderLang.h in Headers */,
-				A93E826F211F76F6001FEBD4 /* SPVRemapper.h in Headers */,
-				A93E82B5211F76F6001FEBD4 /* Common.h in Headers */,
-				A93E82F3211F76F6001FEBD4 /* Initialize.h in Headers */,
-				A93E827F211F76F6001FEBD4 /* GLSL.ext.EXT.h in Headers */,
-				A93E8281211F76F6001FEBD4 /* GLSL.ext.KHR.h in Headers */,
-				A93E82A9211F76F6001FEBD4 /* intermediate.h in Headers */,
-				A93E8277211F76F6001FEBD4 /* GLSL.ext.AMD.h in Headers */,
-				A93E82E7211F76F6001FEBD4 /* SymbolTable.h in Headers */,
-				A93E828D211F76F6001FEBD4 /* GlslangToSpv.h in Headers */,
-				A93E82B3211F76F6001FEBD4 /* arrays.h in Headers */,
-				A93E8297211F76F6001FEBD4 /* Logger.h in Headers */,
-				A93E8271211F76F6001FEBD4 /* SpvBuilder.h in Headers */,
-				A93E8289211F76F6001FEBD4 /* bitutils.h in Headers */,
 				A98149671FB6A98A005F00B4 /* MVKStrings.h in Headers */,
-				A93E8287211F76F6001FEBD4 /* spvIR.h in Headers */,
-				A93E828B211F76F6001FEBD4 /* disassemble.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2071,162 +261,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A96FE8BE215473A00060D1A3 /* spirv_optimizer_options.h in Headers */,
-				A96FE76E215473A00060D1A3 /* compact_ids_pass.h in Headers */,
-				A96FE712215473A00060D1A3 /* spirv_definition.h in Headers */,
-				A94E30D1219209C700394673 /* spirv_parser.hpp in Headers */,
-				A96FE8A8215473A00060D1A3 /* dominator_tree.h in Headers */,
-				A96FE7E0215473A00060D1A3 /* struct_cfg_analysis.h in Headers */,
-				A96FE766215473A00060D1A3 /* loop_fusion.h in Headers */,
-				A96FE824215473A00060D1A3 /* workaround1209.h in Headers */,
 				A98149681FB6A98A005F00B4 /* MVKStrings.h in Headers */,
-				A96FE846215473A00060D1A3 /* dead_branch_elim_pass.h in Headers */,
-				A96FE8B2215473A00060D1A3 /* ext_inst.h in Headers */,
-				A96FE816215473A00060D1A3 /* inline_exhaustive_pass.h in Headers */,
-				A96FE800215473A00060D1A3 /* mem_pass.h in Headers */,
-				A96FE812215473A00060D1A3 /* flatten_decoration_pass.h in Headers */,
-				A96FE864215473A00060D1A3 /* null_pass.h in Headers */,
-				A96FE83E215473A00060D1A3 /* eliminate_dead_functions_pass.h in Headers */,
-				A96FE8C4215473A00060D1A3 /* latest_version_glsl_std_450_header.h in Headers */,
-				A96FE718215473A00060D1A3 /* macro.h in Headers */,
-				A96FE71A215473A00060D1A3 /* spirv_constant.h in Headers */,
-				A96FE8BC215473A00060D1A3 /* id_descriptor.h in Headers */,
-				A96FE822215473A00060D1A3 /* loop_fission.h in Headers */,
-				A96FE758215473A00060D1A3 /* disassemble.h in Headers */,
-				A96FE83A215473A00060D1A3 /* pass.h in Headers */,
-				A96FE896215473A00060D1A3 /* iterator.h in Headers */,
-				A96FE78E215473A00060D1A3 /* instruction_list.h in Headers */,
-				A96FE838215473A00060D1A3 /* dominator_analysis.h in Headers */,
-				A96FE6E0215473A00060D1A3 /* text.h in Headers */,
-				A96FE706215473A00060D1A3 /* latest_version_opencl_std_header.h in Headers */,
-				A96FE890215473A00060D1A3 /* pass_manager.h in Headers */,
-				A96FE91C215473A00060D1A3 /* function.h in Headers */,
-				A96FE84A215473A00060D1A3 /* scalar_analysis_nodes.h in Headers */,
-				A96FE83C215473A00060D1A3 /* folding_rules.h in Headers */,
-				A96FE85A215473A00060D1A3 /* simplification_pass.h in Headers */,
-				A96FE89A215473A00060D1A3 /* build_module.h in Headers */,
-				A96FE714215473A00060D1A3 /* operand.h in Headers */,
-				A96FE762215473A00060D1A3 /* merge_return_pass.h in Headers */,
-				A96FE884215473A00060D1A3 /* loop_descriptor.h in Headers */,
-				A96FE72C215473A00060D1A3 /* markv_decoder.h in Headers */,
-				A96FE7FC215473A00060D1A3 /* freeze_spec_constant_value_pass.h in Headers */,
-				A96FE912215473A00060D1A3 /* instruction.h in Headers */,
-				A96FE82A215473A00060D1A3 /* copy_prop_arrays.h in Headers */,
-				A96FE85C215473A00060D1A3 /* remove_duplicates_pass.h in Headers */,
-				A96FE878215473A00060D1A3 /* loop_utils.h in Headers */,
-				A96FE7D6215473A00060D1A3 /* loop_peeling.h in Headers */,
-				A96FE726215473A00060D1A3 /* bit_stream.h in Headers */,
-				A96FE74A215473A00060D1A3 /* spirv_endian.h in Headers */,
-				A96FE8B0215473A00060D1A3 /* table.h in Headers */,
-				A96FE7B4215473A00060D1A3 /* basic_block.h in Headers */,
-				A96FE818215473A00060D1A3 /* constants.h in Headers */,
-				A96FE86E215473A00060D1A3 /* redundancy_elimination.h in Headers */,
-				A96FE736215473A00060D1A3 /* markv_codec.h in Headers */,
-				A96FE6F0215473A00060D1A3 /* timer.h in Headers */,
-				A9BB09761CEF89B100CCAB22 /* spirv.hpp in Headers */,
-				A96FE810215473A00060D1A3 /* value_number_table.h in Headers */,
-				A96FE6EA215473A00060D1A3 /* string_utils.h in Headers */,
-				A96FE748215473A00060D1A3 /* diagnostic.h in Headers */,
-				A96FE7DE215473A00060D1A3 /* loop_fusion_pass.h in Headers */,
-				A96FE89C215473A00060D1A3 /* ccp_pass.h in Headers */,
-				A96FE742215473A00060D1A3 /* parsed_operand.h in Headers */,
-				A96FE924215473A00060D1A3 /* decoration.h in Headers */,
 				A928C9191D0488DC00071B88 /* SPIRVConversion.h in Headers */,
-				A96FE8C0215473A00060D1A3 /* opcode.h in Headers */,
-				A96FE7CA215473A00060D1A3 /* def_use_manager.h in Headers */,
-				A96FE6E8215473A00060D1A3 /* make_unique.h in Headers */,
-				A96FE734215473A00060D1A3 /* move_to_front.h in Headers */,
-				A96FE880215473A00060D1A3 /* loop_unswitch_pass.h in Headers */,
-				A96FE7E8215473A00060D1A3 /* decoration_manager.h in Headers */,
-				A9AB19971CB5B5A80001E7F9 /* spirv_common.hpp in Headers */,
-				A96FE6F6215473A00060D1A3 /* bitutils.h in Headers */,
 				A9F042B61FB4D060009FCCB8 /* MVKLogging.h in Headers */,
-				A96FE80C215473A00060D1A3 /* inline_pass.h in Headers */,
-				A96FE6DA215473A00060D1A3 /* enum_set.h in Headers */,
-				A96FE860215473A00060D1A3 /* reflect.h in Headers */,
-				A96FE70A215473A00060D1A3 /* cfa.h in Headers */,
-				A96FE77A215473A00060D1A3 /* scalar_analysis.h in Headers */,
-				A96FE776215473A00060D1A3 /* reduce_load_size.h in Headers */,
-				A96FE888215473A00060D1A3 /* aggressive_dead_code_elim_pass.h in Headers */,
-				A96FE8DC215473A00060D1A3 /* basic_block.h in Headers */,
-				A96FE834215473A00060D1A3 /* dead_variable_elimination.h in Headers */,
-				A96FE740215473A00060D1A3 /* text_handler.h in Headers */,
-				A94E30D521920A8C00394673 /* spirv_cross_parsed_ir.hpp in Headers */,
-				A9AB199B1CB5B5A80001E7F9 /* spirv_cross.hpp in Headers */,
-				A96FE7F8215473A00060D1A3 /* dead_insert_elim_pass.h in Headers */,
-				A96FE872215473A00060D1A3 /* local_ssa_elim_pass.h in Headers */,
-				A96FE72E215473A00060D1A3 /* markv.h in Headers */,
-				A96FE866215473A00060D1A3 /* const_folding_rules.h in Headers */,
-				A96FE7D4215473A00060D1A3 /* local_redundancy_elimination.h in Headers */,
-				A96FE898215473A00060D1A3 /* licm_pass.h in Headers */,
-				A96FE78C215473A00060D1A3 /* propagator.h in Headers */,
-				A96FE744215473A00060D1A3 /* name_mapper.h in Headers */,
-				A96FE774215473A00060D1A3 /* local_single_store_elim_pass.h in Headers */,
-				A96FE75C215473A00060D1A3 /* if_conversion.h in Headers */,
-				A96FE6D8215473A00060D1A3 /* assembly_grammar.h in Headers */,
-				A96FE856215473A00060D1A3 /* strip_reflect_info_pass.h in Headers */,
-				A96FE724215473A00060D1A3 /* huffman_codec.h in Headers */,
-				A96FE828215473A00060D1A3 /* log.h in Headers */,
-				A96FE786215473A00060D1A3 /* replace_invalid_opc.h in Headers */,
-				A96FE764215473A00060D1A3 /* inline_opaque_pass.h in Headers */,
-				A96FE72A215473A00060D1A3 /* markv_encoder.h in Headers */,
-				A96FE7EC215473A00060D1A3 /* local_single_block_elim_pass.h in Headers */,
-				A96FE87A215473A00060D1A3 /* module.h in Headers */,
-				A96FE76C215473A00060D1A3 /* composite.h in Headers */,
-				A96FE8EA215473A00060D1A3 /* validation_state.h in Headers */,
-				A96FE770215473A00060D1A3 /* register_pressure.h in Headers */,
-				A96FE842215473A00060D1A3 /* fold.h in Headers */,
-				A96FE852215473A00060D1A3 /* passes.h in Headers */,
-				A96FE7C6215473A00060D1A3 /* private_to_local_pass.h in Headers */,
-				A96FE77C215473A00060D1A3 /* strip_debug_info_pass.h in Headers */,
-				A96FE738215473A00060D1A3 /* markv_logger.h in Headers */,
-				A96FE7BA215473A00060D1A3 /* block_merge_pass.h in Headers */,
 				A909408C1C58013E0094110D /* SPIRVToMSLConverter.h in Headers */,
-				A96FE8C6215473A00060D1A3 /* extensions.h in Headers */,
-				A96FE8BA215473A00060D1A3 /* instruction.h in Headers */,
-				A9AB19A31CB5B5A80001E7F9 /* spirv_msl.hpp in Headers */,
 				A9F042B21FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */,
-				A96FE7B0215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.h in Headers */,
-				A96FE6E6215473A00060D1A3 /* ilist_node.h in Headers */,
-				A96FE8B6215473A00060D1A3 /* latest_version_spirv_header.h in Headers */,
-				A96FE8AA215473A00060D1A3 /* type_manager.h in Headers */,
-				A96FE6E4215473A00060D1A3 /* parse_number.h in Headers */,
-				A96FE7AC215473A00060D1A3 /* ir_loader.h in Headers */,
-				A96FE886215473A00060D1A3 /* instruction.h in Headers */,
-				A96FE8F4215473A00060D1A3 /* validate.h in Headers */,
-				A96FE830215473A00060D1A3 /* ssa_rewrite_pass.h in Headers */,
-				A96FE71E215473A00060D1A3 /* spirv_validator_options.h in Headers */,
-				A96FE6FE215473A00060D1A3 /* ilist.h in Headers */,
-				A96FE70C215473A00060D1A3 /* enum_string_mapping.h in Headers */,
-				A96FE79A215473A00060D1A3 /* ir_context.h in Headers */,
-				A96FE88C215473A00060D1A3 /* vector_dce.h in Headers */,
-				A9AB199F1CB5B5A80001E7F9 /* spirv_glsl.hpp in Headers */,
-				A96FE7AE215473A00060D1A3 /* types.h in Headers */,
-				A96FE6F8215473A00060D1A3 /* hex_float.h in Headers */,
-				A96FE7A2215473A00060D1A3 /* loop_unroller.h in Headers */,
-				A96FE8CA215473A00060D1A3 /* binary.h in Headers */,
-				A96FE754215473A00060D1A3 /* print.h in Headers */,
-				A96FE730215473A00060D1A3 /* markv_model.h in Headers */,
-				A96FE82C215473A00060D1A3 /* eliminate_dead_constant_pass.h in Headers */,
-				A96FE87E215473A00060D1A3 /* ir_builder.h in Headers */,
-				A96FE772215473A00060D1A3 /* tree_iterator.h in Headers */,
-				A96FE700215473A00060D1A3 /* spirv_target_env.h in Headers */,
-				A95C5F411DEA9070000D17B6 /* spirv_cfg.hpp in Headers */,
-				A96FE8A2215473A00060D1A3 /* feature_manager.h in Headers */,
-				A96FE6F4215473A00060D1A3 /* bit_vector.h in Headers */,
-				A96FE788215473A00060D1A3 /* local_access_chain_convert_pass.h in Headers */,
-				A96FE80E215473A00060D1A3 /* loop_dependence.h in Headers */,
-				A96FE882215473A00060D1A3 /* cfg.h in Headers */,
-				A96FE7CE215473A00060D1A3 /* cfg_cleanup_pass.h in Headers */,
-				A96FE89E215473A00060D1A3 /* function.h in Headers */,
-				A96FE840215473A00060D1A3 /* common_uniform_elim_pass.h in Headers */,
-				A96FE7EE215473A00060D1A3 /* strength_reduction_pass.h in Headers */,
-				A96FE8D4215473A00060D1A3 /* construct.h in Headers */,
-				A96FE8A6215473A00060D1A3 /* set_spec_constant_default_value_pass.h in Headers */,
-				A96FE6EC215473A00060D1A3 /* small_vector.h in Headers */,
-				A96FE868215473A00060D1A3 /* scalar_replacement_pass.h in Headers */,
-				A96FE88E215473A00060D1A3 /* combine_access_chains.h in Headers */,
-				A96FE7AA215473A00060D1A3 /* unify_const_pass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2234,162 +273,11 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A96FE8BF215473A00060D1A3 /* spirv_optimizer_options.h in Headers */,
-				A96FE76F215473A00060D1A3 /* compact_ids_pass.h in Headers */,
-				A96FE713215473A00060D1A3 /* spirv_definition.h in Headers */,
-				A94E30D2219209C700394673 /* spirv_parser.hpp in Headers */,
-				A96FE8A9215473A00060D1A3 /* dominator_tree.h in Headers */,
-				A96FE7E1215473A00060D1A3 /* struct_cfg_analysis.h in Headers */,
-				A96FE767215473A00060D1A3 /* loop_fusion.h in Headers */,
-				A96FE825215473A00060D1A3 /* workaround1209.h in Headers */,
 				A98149691FB6A98A005F00B4 /* MVKStrings.h in Headers */,
-				A96FE847215473A00060D1A3 /* dead_branch_elim_pass.h in Headers */,
-				A96FE8B3215473A00060D1A3 /* ext_inst.h in Headers */,
-				A96FE817215473A00060D1A3 /* inline_exhaustive_pass.h in Headers */,
-				A96FE801215473A00060D1A3 /* mem_pass.h in Headers */,
-				A96FE813215473A00060D1A3 /* flatten_decoration_pass.h in Headers */,
-				A96FE865215473A00060D1A3 /* null_pass.h in Headers */,
-				A96FE83F215473A00060D1A3 /* eliminate_dead_functions_pass.h in Headers */,
-				A96FE8C5215473A00060D1A3 /* latest_version_glsl_std_450_header.h in Headers */,
-				A96FE719215473A00060D1A3 /* macro.h in Headers */,
-				A96FE71B215473A00060D1A3 /* spirv_constant.h in Headers */,
-				A96FE8BD215473A00060D1A3 /* id_descriptor.h in Headers */,
-				A96FE823215473A00060D1A3 /* loop_fission.h in Headers */,
-				A96FE759215473A00060D1A3 /* disassemble.h in Headers */,
-				A96FE83B215473A00060D1A3 /* pass.h in Headers */,
-				A96FE897215473A00060D1A3 /* iterator.h in Headers */,
-				A96FE78F215473A00060D1A3 /* instruction_list.h in Headers */,
-				A96FE839215473A00060D1A3 /* dominator_analysis.h in Headers */,
-				A96FE6E1215473A00060D1A3 /* text.h in Headers */,
-				A96FE707215473A00060D1A3 /* latest_version_opencl_std_header.h in Headers */,
-				A96FE891215473A00060D1A3 /* pass_manager.h in Headers */,
-				A96FE91D215473A00060D1A3 /* function.h in Headers */,
-				A96FE84B215473A00060D1A3 /* scalar_analysis_nodes.h in Headers */,
-				A96FE83D215473A00060D1A3 /* folding_rules.h in Headers */,
-				A96FE85B215473A00060D1A3 /* simplification_pass.h in Headers */,
-				A96FE89B215473A00060D1A3 /* build_module.h in Headers */,
-				A96FE715215473A00060D1A3 /* operand.h in Headers */,
-				A96FE763215473A00060D1A3 /* merge_return_pass.h in Headers */,
-				A96FE885215473A00060D1A3 /* loop_descriptor.h in Headers */,
-				A96FE72D215473A00060D1A3 /* markv_decoder.h in Headers */,
-				A96FE7FD215473A00060D1A3 /* freeze_spec_constant_value_pass.h in Headers */,
-				A96FE913215473A00060D1A3 /* instruction.h in Headers */,
-				A96FE82B215473A00060D1A3 /* copy_prop_arrays.h in Headers */,
-				A96FE85D215473A00060D1A3 /* remove_duplicates_pass.h in Headers */,
-				A96FE879215473A00060D1A3 /* loop_utils.h in Headers */,
-				A96FE7D7215473A00060D1A3 /* loop_peeling.h in Headers */,
-				A96FE727215473A00060D1A3 /* bit_stream.h in Headers */,
-				A96FE74B215473A00060D1A3 /* spirv_endian.h in Headers */,
-				A96FE8B1215473A00060D1A3 /* table.h in Headers */,
-				A96FE7B5215473A00060D1A3 /* basic_block.h in Headers */,
-				A96FE819215473A00060D1A3 /* constants.h in Headers */,
-				A96FE86F215473A00060D1A3 /* redundancy_elimination.h in Headers */,
-				A96FE737215473A00060D1A3 /* markv_codec.h in Headers */,
-				A96FE6F1215473A00060D1A3 /* timer.h in Headers */,
-				A9BB09771CEF89B100CCAB22 /* spirv.hpp in Headers */,
-				A96FE811215473A00060D1A3 /* value_number_table.h in Headers */,
-				A96FE6EB215473A00060D1A3 /* string_utils.h in Headers */,
-				A96FE749215473A00060D1A3 /* diagnostic.h in Headers */,
-				A96FE7DF215473A00060D1A3 /* loop_fusion_pass.h in Headers */,
-				A96FE89D215473A00060D1A3 /* ccp_pass.h in Headers */,
-				A96FE743215473A00060D1A3 /* parsed_operand.h in Headers */,
-				A96FE925215473A00060D1A3 /* decoration.h in Headers */,
 				A928C91A1D0488DC00071B88 /* SPIRVConversion.h in Headers */,
-				A96FE8C1215473A00060D1A3 /* opcode.h in Headers */,
-				A96FE7CB215473A00060D1A3 /* def_use_manager.h in Headers */,
-				A96FE6E9215473A00060D1A3 /* make_unique.h in Headers */,
-				A96FE735215473A00060D1A3 /* move_to_front.h in Headers */,
-				A96FE881215473A00060D1A3 /* loop_unswitch_pass.h in Headers */,
-				A96FE7E9215473A00060D1A3 /* decoration_manager.h in Headers */,
-				A9AB19981CB5B5A80001E7F9 /* spirv_common.hpp in Headers */,
-				A96FE6F7215473A00060D1A3 /* bitutils.h in Headers */,
 				A9F042B71FB4D060009FCCB8 /* MVKLogging.h in Headers */,
-				A96FE80D215473A00060D1A3 /* inline_pass.h in Headers */,
-				A96FE6DB215473A00060D1A3 /* enum_set.h in Headers */,
-				A96FE861215473A00060D1A3 /* reflect.h in Headers */,
-				A96FE70B215473A00060D1A3 /* cfa.h in Headers */,
-				A96FE77B215473A00060D1A3 /* scalar_analysis.h in Headers */,
-				A96FE777215473A00060D1A3 /* reduce_load_size.h in Headers */,
-				A96FE889215473A00060D1A3 /* aggressive_dead_code_elim_pass.h in Headers */,
-				A96FE8DD215473A00060D1A3 /* basic_block.h in Headers */,
-				A96FE835215473A00060D1A3 /* dead_variable_elimination.h in Headers */,
-				A96FE741215473A00060D1A3 /* text_handler.h in Headers */,
-				A94E30D621920A8C00394673 /* spirv_cross_parsed_ir.hpp in Headers */,
-				A9AB199C1CB5B5A80001E7F9 /* spirv_cross.hpp in Headers */,
-				A96FE7F9215473A00060D1A3 /* dead_insert_elim_pass.h in Headers */,
-				A96FE873215473A00060D1A3 /* local_ssa_elim_pass.h in Headers */,
-				A96FE72F215473A00060D1A3 /* markv.h in Headers */,
-				A96FE867215473A00060D1A3 /* const_folding_rules.h in Headers */,
-				A96FE7D5215473A00060D1A3 /* local_redundancy_elimination.h in Headers */,
-				A96FE899215473A00060D1A3 /* licm_pass.h in Headers */,
-				A96FE78D215473A00060D1A3 /* propagator.h in Headers */,
-				A96FE745215473A00060D1A3 /* name_mapper.h in Headers */,
-				A96FE775215473A00060D1A3 /* local_single_store_elim_pass.h in Headers */,
-				A96FE75D215473A00060D1A3 /* if_conversion.h in Headers */,
-				A96FE6D9215473A00060D1A3 /* assembly_grammar.h in Headers */,
-				A96FE857215473A00060D1A3 /* strip_reflect_info_pass.h in Headers */,
-				A96FE725215473A00060D1A3 /* huffman_codec.h in Headers */,
-				A96FE829215473A00060D1A3 /* log.h in Headers */,
-				A96FE787215473A00060D1A3 /* replace_invalid_opc.h in Headers */,
-				A96FE765215473A00060D1A3 /* inline_opaque_pass.h in Headers */,
-				A96FE72B215473A00060D1A3 /* markv_encoder.h in Headers */,
-				A96FE7ED215473A00060D1A3 /* local_single_block_elim_pass.h in Headers */,
-				A96FE87B215473A00060D1A3 /* module.h in Headers */,
-				A96FE76D215473A00060D1A3 /* composite.h in Headers */,
-				A96FE8EB215473A00060D1A3 /* validation_state.h in Headers */,
-				A96FE771215473A00060D1A3 /* register_pressure.h in Headers */,
-				A96FE843215473A00060D1A3 /* fold.h in Headers */,
-				A96FE853215473A00060D1A3 /* passes.h in Headers */,
-				A96FE7C7215473A00060D1A3 /* private_to_local_pass.h in Headers */,
-				A96FE77D215473A00060D1A3 /* strip_debug_info_pass.h in Headers */,
-				A96FE739215473A00060D1A3 /* markv_logger.h in Headers */,
-				A96FE7BB215473A00060D1A3 /* block_merge_pass.h in Headers */,
 				A909408D1C58013E0094110D /* SPIRVToMSLConverter.h in Headers */,
-				A96FE8C7215473A00060D1A3 /* extensions.h in Headers */,
-				A96FE8BB215473A00060D1A3 /* instruction.h in Headers */,
-				A9AB19A41CB5B5A80001E7F9 /* spirv_msl.hpp in Headers */,
 				A9F042B31FB4D060009FCCB8 /* MVKCommonEnvironment.h in Headers */,
-				A96FE7B1215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.h in Headers */,
-				A96FE6E7215473A00060D1A3 /* ilist_node.h in Headers */,
-				A96FE8B7215473A00060D1A3 /* latest_version_spirv_header.h in Headers */,
-				A96FE8AB215473A00060D1A3 /* type_manager.h in Headers */,
-				A96FE6E5215473A00060D1A3 /* parse_number.h in Headers */,
-				A96FE7AD215473A00060D1A3 /* ir_loader.h in Headers */,
-				A96FE887215473A00060D1A3 /* instruction.h in Headers */,
-				A96FE8F5215473A00060D1A3 /* validate.h in Headers */,
-				A96FE831215473A00060D1A3 /* ssa_rewrite_pass.h in Headers */,
-				A96FE71F215473A00060D1A3 /* spirv_validator_options.h in Headers */,
-				A96FE6FF215473A00060D1A3 /* ilist.h in Headers */,
-				A96FE70D215473A00060D1A3 /* enum_string_mapping.h in Headers */,
-				A96FE79B215473A00060D1A3 /* ir_context.h in Headers */,
-				A96FE88D215473A00060D1A3 /* vector_dce.h in Headers */,
-				A9AB19A01CB5B5A80001E7F9 /* spirv_glsl.hpp in Headers */,
-				A96FE7AF215473A00060D1A3 /* types.h in Headers */,
-				A96FE6F9215473A00060D1A3 /* hex_float.h in Headers */,
-				A96FE7A3215473A00060D1A3 /* loop_unroller.h in Headers */,
-				A96FE8CB215473A00060D1A3 /* binary.h in Headers */,
-				A96FE755215473A00060D1A3 /* print.h in Headers */,
-				A96FE731215473A00060D1A3 /* markv_model.h in Headers */,
-				A96FE82D215473A00060D1A3 /* eliminate_dead_constant_pass.h in Headers */,
-				A96FE87F215473A00060D1A3 /* ir_builder.h in Headers */,
-				A96FE773215473A00060D1A3 /* tree_iterator.h in Headers */,
-				A96FE701215473A00060D1A3 /* spirv_target_env.h in Headers */,
-				A95C5F421DEA9070000D17B6 /* spirv_cfg.hpp in Headers */,
-				A96FE8A3215473A00060D1A3 /* feature_manager.h in Headers */,
-				A96FE6F5215473A00060D1A3 /* bit_vector.h in Headers */,
-				A96FE789215473A00060D1A3 /* local_access_chain_convert_pass.h in Headers */,
-				A96FE80F215473A00060D1A3 /* loop_dependence.h in Headers */,
-				A96FE883215473A00060D1A3 /* cfg.h in Headers */,
-				A96FE7CF215473A00060D1A3 /* cfg_cleanup_pass.h in Headers */,
-				A96FE89F215473A00060D1A3 /* function.h in Headers */,
-				A96FE841215473A00060D1A3 /* common_uniform_elim_pass.h in Headers */,
-				A96FE7EF215473A00060D1A3 /* strength_reduction_pass.h in Headers */,
-				A96FE8D5215473A00060D1A3 /* construct.h in Headers */,
-				A96FE8A7215473A00060D1A3 /* set_spec_constant_default_value_pass.h in Headers */,
-				A96FE6ED215473A00060D1A3 /* small_vector.h in Headers */,
-				A96FE869215473A00060D1A3 /* scalar_replacement_pass.h in Headers */,
-				A96FE88F215473A00060D1A3 /* combine_access_chains.h in Headers */,
-				A96FE7AB215473A00060D1A3 /* unify_const_pass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2420,6 +308,7 @@
 			buildPhases = (
 				A93747291A9A8B2900F29B34 /* Headers */,
 				A93747271A9A8B2900F29B34 /* Sources */,
+				A972AD2821CEE6310013AB25 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2436,6 +325,7 @@
 			buildPhases = (
 				A937476E1A9A98D000F29B34 /* Headers */,
 				A937476C1A9A98D000F29B34 /* Sources */,
+				A972AD2C21CEE6C30013AB25 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2452,6 +342,7 @@
 			buildPhases = (
 				A93903B91C57E9D700FE90DC /* Headers */,
 				A93903BA1C57E9D700FE90DC /* Sources */,
+				A972AD2E21CEE6F50013AB25 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2468,6 +359,7 @@
 			buildPhases = (
 				A93903C11C57E9ED00FE90DC /* Headers */,
 				A93903C21C57E9ED00FE90DC /* Sources */,
+				A972AD3321CEE7230013AB25 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2543,47 +435,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A93E8298211F76F6001FEBD4 /* doc.cpp in Sources */,
-				A93E831C211F76F6001FEBD4 /* Link.cpp in Sources */,
-				A93E8272211F76F6001FEBD4 /* SpvPostProcess.cpp in Sources */,
-				A93E82E4211F76F6001FEBD4 /* ShaderLang.cpp in Sources */,
-				A93E831A211F76F6001FEBD4 /* CodeGen.cpp in Sources */,
-				A93E830C211F76F6001FEBD4 /* PpTokens.cpp in Sources */,
-				A93E8290211F76F6001FEBD4 /* SPVRemapper.cpp in Sources */,
-				A93E82C2211F76F6001FEBD4 /* propagateNoContraction.cpp in Sources */,
-				A93E82FE211F76F6001FEBD4 /* Constant.cpp in Sources */,
 				A90941A31C581F840094110D /* GLSLConversion.mm in Sources */,
-				A93E82D4211F76F6001FEBD4 /* limits.cpp in Sources */,
-				A93E8300211F76F6001FEBD4 /* linkValidate.cpp in Sources */,
-				A93E8292211F76F6001FEBD4 /* Logger.cpp in Sources */,
-				A93E829C211F76F6001FEBD4 /* ossource.cpp in Sources */,
 				A90940A71C5808BB0094110D /* GLSLToSPIRVConverter.cpp in Sources */,
-				A93E82E0211F76F6001FEBD4 /* iomapper.cpp in Sources */,
-				A93E82DC211F76F6001FEBD4 /* IntermTraverse.cpp in Sources */,
-				A93E829A211F76F6001FEBD4 /* disassemble.cpp in Sources */,
-				A93E82E8211F76F6001FEBD4 /* InfoSink.cpp in Sources */,
-				A93E8312211F76F6001FEBD4 /* ParseContextBase.cpp in Sources */,
-				A93E8284211F76F6001FEBD4 /* GlslangToSpv.cpp in Sources */,
-				A93E82EC211F76F6001FEBD4 /* SymbolTable.cpp in Sources */,
-				A93E8304211F76F6001FEBD4 /* PpAtom.cpp in Sources */,
-				A93E8274211F76F6001FEBD4 /* InReadableOrder.cpp in Sources */,
-				A93E82D2211F76F6001FEBD4 /* glslang_tab.cpp in Sources */,
-				A93E8310211F76F6001FEBD4 /* PpScanner.cpp in Sources */,
-				A93E82E2211F76F6001FEBD4 /* PoolAlloc.cpp in Sources */,
-				A93E82F6211F76F6001FEBD4 /* reflection.cpp in Sources */,
-				A93E82EA211F76F6001FEBD4 /* Intermediate.cpp in Sources */,
-				A93E8308211F76F6001FEBD4 /* Pp.cpp in Sources */,
-				A93E82F4211F76F6001FEBD4 /* attribute.cpp in Sources */,
-				A93E82D6211F76F6001FEBD4 /* parseConst.cpp in Sources */,
-				A93E827C211F76F6001FEBD4 /* SpvBuilder.cpp in Sources */,
-				A93E82CA211F76F6001FEBD4 /* Scan.cpp in Sources */,
-				A93E82BC211F76F6001FEBD4 /* ParseHelper.cpp in Sources */,
-				A93E82F8211F76F6001FEBD4 /* RemoveTree.cpp in Sources */,
-				A93E82FC211F76F6001FEBD4 /* Versions.cpp in Sources */,
-				A93E8320211F76F6001FEBD4 /* InitializeDll.cpp in Sources */,
-				A93E82D0211F76F6001FEBD4 /* Initialize.cpp in Sources */,
-				A93E830E211F76F6001FEBD4 /* PpContext.cpp in Sources */,
-				A93E82DE211F76F6001FEBD4 /* intermOut.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2591,47 +444,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A93E8299211F76F6001FEBD4 /* doc.cpp in Sources */,
-				A93E831D211F76F6001FEBD4 /* Link.cpp in Sources */,
-				A93E8273211F76F6001FEBD4 /* SpvPostProcess.cpp in Sources */,
-				A93E82E5211F76F6001FEBD4 /* ShaderLang.cpp in Sources */,
-				A93E831B211F76F6001FEBD4 /* CodeGen.cpp in Sources */,
-				A93E830D211F76F6001FEBD4 /* PpTokens.cpp in Sources */,
-				A93E8291211F76F6001FEBD4 /* SPVRemapper.cpp in Sources */,
-				A93E82C3211F76F6001FEBD4 /* propagateNoContraction.cpp in Sources */,
-				A93E82FF211F76F6001FEBD4 /* Constant.cpp in Sources */,
 				A90941A41C581F840094110D /* GLSLConversion.mm in Sources */,
-				A93E82D5211F76F6001FEBD4 /* limits.cpp in Sources */,
-				A93E8301211F76F6001FEBD4 /* linkValidate.cpp in Sources */,
-				A93E8293211F76F6001FEBD4 /* Logger.cpp in Sources */,
-				A93E829D211F76F6001FEBD4 /* ossource.cpp in Sources */,
 				A90940A81C5808BB0094110D /* GLSLToSPIRVConverter.cpp in Sources */,
-				A93E82E1211F76F6001FEBD4 /* iomapper.cpp in Sources */,
-				A93E82DD211F76F6001FEBD4 /* IntermTraverse.cpp in Sources */,
-				A93E829B211F76F6001FEBD4 /* disassemble.cpp in Sources */,
-				A93E82E9211F76F6001FEBD4 /* InfoSink.cpp in Sources */,
-				A93E8313211F76F6001FEBD4 /* ParseContextBase.cpp in Sources */,
-				A93E8285211F76F6001FEBD4 /* GlslangToSpv.cpp in Sources */,
-				A93E82ED211F76F6001FEBD4 /* SymbolTable.cpp in Sources */,
-				A93E8305211F76F6001FEBD4 /* PpAtom.cpp in Sources */,
-				A93E8275211F76F6001FEBD4 /* InReadableOrder.cpp in Sources */,
-				A93E82D3211F76F6001FEBD4 /* glslang_tab.cpp in Sources */,
-				A93E8311211F76F6001FEBD4 /* PpScanner.cpp in Sources */,
-				A93E82E3211F76F6001FEBD4 /* PoolAlloc.cpp in Sources */,
-				A93E82F7211F76F6001FEBD4 /* reflection.cpp in Sources */,
-				A93E82EB211F76F6001FEBD4 /* Intermediate.cpp in Sources */,
-				A93E8309211F76F6001FEBD4 /* Pp.cpp in Sources */,
-				A93E82F5211F76F6001FEBD4 /* attribute.cpp in Sources */,
-				A93E82D7211F76F6001FEBD4 /* parseConst.cpp in Sources */,
-				A93E827D211F76F6001FEBD4 /* SpvBuilder.cpp in Sources */,
-				A93E82CB211F76F6001FEBD4 /* Scan.cpp in Sources */,
-				A93E82BD211F76F6001FEBD4 /* ParseHelper.cpp in Sources */,
-				A93E82F9211F76F6001FEBD4 /* RemoveTree.cpp in Sources */,
-				A93E82FD211F76F6001FEBD4 /* Versions.cpp in Sources */,
-				A93E8321211F76F6001FEBD4 /* InitializeDll.cpp in Sources */,
-				A93E82D1211F76F6001FEBD4 /* Initialize.cpp in Sources */,
-				A93E830F211F76F6001FEBD4 /* PpContext.cpp in Sources */,
-				A93E82DF211F76F6001FEBD4 /* intermOut.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2639,168 +453,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A96FE86A215473A00060D1A3 /* instruction.cpp in Sources */,
-				A96FE91E215473A00060D1A3 /* validate_composites.cpp in Sources */,
-				A96FE8C2215473A00060D1A3 /* operand.cpp in Sources */,
-				A96FE7A8215473A00060D1A3 /* loop_dependence.cpp in Sources */,
-				A96FE7C8215473A00060D1A3 /* inline_pass.cpp in Sources */,
-				A96FE8FC215473A00060D1A3 /* validate_id.cpp in Sources */,
-				A96FE7FE215473A00060D1A3 /* ir_context.cpp in Sources */,
-				A96FE7B8215473A00060D1A3 /* dead_variable_elimination.cpp in Sources */,
-				A96FE756215473A00060D1A3 /* ext_inst.cpp in Sources */,
-				A96FE8B4215473A00060D1A3 /* diagnostic.cpp in Sources */,
-				A96FE7CC215473A00060D1A3 /* ir_loader.cpp in Sources */,
-				A96FE74E215473A00060D1A3 /* linker.cpp in Sources */,
-				A96FE874215473A00060D1A3 /* inline_opaque_pass.cpp in Sources */,
-				A96FE746215473A00060D1A3 /* parsed_operand.cpp in Sources */,
-				A96FE85E215473A00060D1A3 /* redundancy_elimination.cpp in Sources */,
-				A96FE8EC215473A00060D1A3 /* validate_constants.cpp in Sources */,
-				A96FE7DA215473A00060D1A3 /* loop_unroller.cpp in Sources */,
-				A96FE8FA215473A00060D1A3 /* validate_datarules.cpp in Sources */,
-				A96FE7A0215473A00060D1A3 /* const_folding_rules.cpp in Sources */,
-				A96FE71C215473A00060D1A3 /* binary.cpp in Sources */,
-				A96FE8C8215473A00060D1A3 /* disassemble.cpp in Sources */,
-				A96FE80A215473A00060D1A3 /* composite.cpp in Sources */,
-				A96FE73E215473A00060D1A3 /* enum_string_mapping.cpp in Sources */,
-				A96FE900215473A00060D1A3 /* validate_mode_setting.cpp in Sources */,
-				A96FE910215473A00060D1A3 /* validate_ext_inst.cpp in Sources */,
-				A96FE780215473A00060D1A3 /* decoration_manager.cpp in Sources */,
-				A96FE8F0215473A00060D1A3 /* construct.cpp in Sources */,
-				A96FE892215473A00060D1A3 /* local_access_chain_convert_pass.cpp in Sources */,
-				A96FE720215473A00060D1A3 /* markv_codec.cpp in Sources */,
-				A96FE8CC215473A00060D1A3 /* text_handler.cpp in Sources */,
-				A96FE8AC215473A00060D1A3 /* compact_ids_pass.cpp in Sources */,
-				A96FE7D2215473A00060D1A3 /* eliminate_dead_functions_pass.cpp in Sources */,
-				A96FE7A4215473A00060D1A3 /* strip_debug_info_pass.cpp in Sources */,
-				A96FE7E6215473A00060D1A3 /* strip_reflect_info_pass.cpp in Sources */,
-				A96FE8FE215473A00060D1A3 /* validate_arithmetics.cpp in Sources */,
-				A96FE77E215473A00060D1A3 /* cfg.cpp in Sources */,
-				A96FE7F4215473A00060D1A3 /* dead_branch_elim_pass.cpp in Sources */,
-				A96FE7C2215473A00060D1A3 /* unify_const_pass.cpp in Sources */,
-				A96FE836215473A00060D1A3 /* block_merge_pass.cpp in Sources */,
-				A96FE820215473A00060D1A3 /* inline_exhaustive_pass.cpp in Sources */,
-				A96FE906215473A00060D1A3 /* validate_memory.cpp in Sources */,
-				A96FE8DE215473A00060D1A3 /* validate_instruction.cpp in Sources */,
-				A96FE8A0215473A00060D1A3 /* loop_fusion.cpp in Sources */,
-				A96FE81C215473A00060D1A3 /* copy_prop_arrays.cpp in Sources */,
-				A96FE808215473A00060D1A3 /* instruction_list.cpp in Sources */,
-				A96FE794215473A00060D1A3 /* loop_fission.cpp in Sources */,
-				A96FE902215473A00060D1A3 /* validate_logicals.cpp in Sources */,
-				A96FE8EE215473A00060D1A3 /* validate_bitwise.cpp in Sources */,
-				A96FE752215473A00060D1A3 /* opcode.cpp in Sources */,
-				A96FE73A215473A00060D1A3 /* bit_stream.cpp in Sources */,
-				A96FE798215473A00060D1A3 /* merge_return_pass.cpp in Sources */,
-				A96FE704215473A00060D1A3 /* id_descriptor.cpp in Sources */,
-				A96FE722215473A00060D1A3 /* markv.cpp in Sources */,
-				A96FE862215473A00060D1A3 /* workaround1209.cpp in Sources */,
-				A96FE7B6215473A00060D1A3 /* remove_duplicates_pass.cpp in Sources */,
-				A96FE6E2215473A00060D1A3 /* extensions.cpp in Sources */,
-				A96FE73C215473A00060D1A3 /* markv_encoder.cpp in Sources */,
-				A96FE90C215473A00060D1A3 /* instruction.cpp in Sources */,
-				A96FE81A215473A00060D1A3 /* strength_reduction_pass.cpp in Sources */,
-				A94E30D721920A8C00394673 /* spirv_cross_parsed_ir.cpp in Sources */,
-				A96FE78A215473A00060D1A3 /* local_redundancy_elimination.cpp in Sources */,
-				A96FE826215473A00060D1A3 /* loop_fusion_pass.cpp in Sources */,
-				A96FE782215473A00060D1A3 /* local_single_block_elim_pass.cpp in Sources */,
-				A96FE854215473A00060D1A3 /* fold.cpp in Sources */,
-				A96FE790215473A00060D1A3 /* feature_manager.cpp in Sources */,
-				A9AB19991CB5B5A80001E7F9 /* spirv_cross.cpp in Sources */,
-				A96FE8AE215473A00060D1A3 /* loop_peeling.cpp in Sources */,
-				A96FE876215473A00060D1A3 /* replace_invalid_opc.cpp in Sources */,
-				A96FE7BC215473A00060D1A3 /* module.cpp in Sources */,
-				A96FE84C215473A00060D1A3 /* propagator.cpp in Sources */,
-				A96FE914215473A00060D1A3 /* validate_execution_limitations.cpp in Sources */,
-				A96FE86C215473A00060D1A3 /* reduce_load_size.cpp in Sources */,
-				A96FE796215473A00060D1A3 /* dominator_tree.cpp in Sources */,
-				A96FE7EA215473A00060D1A3 /* ccp_pass.cpp in Sources */,
-				A96FE768215473A00060D1A3 /* combine_access_chains.cpp in Sources */,
-				A96FE760215473A00060D1A3 /* loop_utils.cpp in Sources */,
-				A96FE778215473A00060D1A3 /* types.cpp in Sources */,
-				A96FE702215473A00060D1A3 /* table.cpp in Sources */,
-				A96FE850215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp in Sources */,
-				A96FE8E4215473A00060D1A3 /* validate_builtins.cpp in Sources */,
-				A96FE8D6215473A00060D1A3 /* validate_barriers.cpp in Sources */,
-				A96FE8F2215473A00060D1A3 /* function.cpp in Sources */,
-				A96FE7E2215473A00060D1A3 /* common_uniform_elim_pass.cpp in Sources */,
-				A96FE908215473A00060D1A3 /* validate_image.cpp in Sources */,
-				A96FE7C4215473A00060D1A3 /* type_manager.cpp in Sources */,
-				A96FE6FA215473A00060D1A3 /* parse_number.cpp in Sources */,
-				A9AB19A11CB5B5A80001E7F9 /* spirv_msl.cpp in Sources */,
-				A96FE814215473A00060D1A3 /* if_conversion.cpp in Sources */,
-				A96FE79E215473A00060D1A3 /* cfg_cleanup_pass.cpp in Sources */,
-				A96FE90E215473A00060D1A3 /* validate_type.cpp in Sources */,
-				A96FE6DC215473A00060D1A3 /* text.cpp in Sources */,
-				A96FE904215473A00060D1A3 /* validate_derivatives.cpp in Sources */,
-				A96FE894215473A00060D1A3 /* basic_block.cpp in Sources */,
-				A96FE802215473A00060D1A3 /* loop_descriptor.cpp in Sources */,
-				A96FE70E215473A00060D1A3 /* spirv_validator_options.cpp in Sources */,
-				A96FE870215473A00060D1A3 /* value_number_table.cpp in Sources */,
-				A96FE7F2215473A00060D1A3 /* simplification_pass.cpp in Sources */,
 				A95096BB2003D00300F10950 /* FileSupport.mm in Sources */,
-				A96FE6F2215473A00060D1A3 /* string_utils.cpp in Sources */,
-				A94E30CF219209C700394673 /* spirv_parser.cpp in Sources */,
 				A909408A1C58013E0094110D /* SPIRVToMSLConverter.cpp in Sources */,
-				A96FE7C0215473A00060D1A3 /* loop_unswitch_pass.cpp in Sources */,
-				A96FE82E215473A00060D1A3 /* dead_insert_elim_pass.cpp in Sources */,
-				A96FE7BE215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */,
-				A96FE8E0215473A00060D1A3 /* validate_decorations.cpp in Sources */,
-				A96FE7A6215473A00060D1A3 /* ssa_rewrite_pass.cpp in Sources */,
-				A96FE75A215473A00060D1A3 /* optimizer.cpp in Sources */,
-				A96FE8E2215473A00060D1A3 /* validate_debug.cpp in Sources */,
 				A928C91B1D0488DC00071B88 /* SPIRVConversion.mm in Sources */,
-				A96FE7F6215473A00060D1A3 /* flatten_decoration_pass.cpp in Sources */,
-				A9AB199D1CB5B5A80001E7F9 /* spirv_glsl.cpp in Sources */,
-				A96FE792215473A00060D1A3 /* pass.cpp in Sources */,
-				A95C5F3F1DEA9070000D17B6 /* spirv_cfg.cpp in Sources */,
-				A96FE7B2215473A00060D1A3 /* mem_pass.cpp in Sources */,
-				A96FE7FA215473A00060D1A3 /* folding_rules.cpp in Sources */,
-				A96FE8D8215473A00060D1A3 /* validate_non_uniform.cpp in Sources */,
-				A96FE8E8215473A00060D1A3 /* validate.cpp in Sources */,
-				A96FE8D2215473A00060D1A3 /* validate_capability.cpp in Sources */,
-				A96FE7D8215473A00060D1A3 /* vector_dce.cpp in Sources */,
-				A96FE84E215473A00060D1A3 /* loop_dependence_helpers.cpp in Sources */,
-				A96FE8F8215473A00060D1A3 /* validate_conversion.cpp in Sources */,
-				A96FE750215473A00060D1A3 /* software_version.cpp in Sources */,
-				A96FE804215473A00060D1A3 /* local_ssa_elim_pass.cpp in Sources */,
-				A96FE916215473A00060D1A3 /* validate_layout.cpp in Sources */,
-				A96FE848215473A00060D1A3 /* private_to_local_pass.cpp in Sources */,
-				A96FE708215473A00060D1A3 /* spirv_optimizer_options.cpp in Sources */,
-				A96FE710215473A00060D1A3 /* print.cpp in Sources */,
-				A96FE76A215473A00060D1A3 /* build_module.cpp in Sources */,
-				A96FE7F0215473A00060D1A3 /* aggressive_dead_code_elim_pass.cpp in Sources */,
-				A96FE8A4215473A00060D1A3 /* scalar_analysis_simplification.cpp in Sources */,
-				A96FE8DA215473A00060D1A3 /* validate_atomics.cpp in Sources */,
-				A96FE90A215473A00060D1A3 /* validate_literals.cpp in Sources */,
-				A96FE81E215473A00060D1A3 /* pass_manager.cpp in Sources */,
-				A96FE7DC215473A00060D1A3 /* constants.cpp in Sources */,
-				A96FE6D6215473A00060D1A3 /* spirv_target_env.cpp in Sources */,
-				A96FE79C215473A00060D1A3 /* eliminate_dead_constant_pass.cpp in Sources */,
-				A96FE88A215473A00060D1A3 /* struct_cfg_analysis.cpp in Sources */,
-				A96FE920215473A00060D1A3 /* validation_state.cpp in Sources */,
-				A96FE806215473A00060D1A3 /* function.cpp in Sources */,
-				A96FE8B8215473A00060D1A3 /* libspirv.cpp in Sources */,
-				A96FE74C215473A00060D1A3 /* name_mapper.cpp in Sources */,
-				A96FE87C215473A00060D1A3 /* dominator_analysis.cpp in Sources */,
-				A96FE6FC215473A00060D1A3 /* bit_vector.cpp in Sources */,
-				A96FE6DE215473A00060D1A3 /* assembly_grammar.cpp in Sources */,
-				A96FE7D0215473A00060D1A3 /* licm_pass.cpp in Sources */,
-				A96FE8F6215473A00060D1A3 /* validate_adjacency.cpp in Sources */,
-				A96FE75E215473A00060D1A3 /* register_pressure.cpp in Sources */,
-				A96FE8D0215473A00060D1A3 /* validate_cfg.cpp in Sources */,
-				A96FE844215473A00060D1A3 /* local_single_store_elim_pass.cpp in Sources */,
-				A96FE728215473A00060D1A3 /* move_to_front.cpp in Sources */,
-				A96FE6EE215473A00060D1A3 /* timer.cpp in Sources */,
-				A96FE784215473A00060D1A3 /* freeze_spec_constant_value_pass.cpp in Sources */,
-				A96FE918215473A00060D1A3 /* basic_block.cpp in Sources */,
-				A96FE732215473A00060D1A3 /* markv_decoder.cpp in Sources */,
-				A96FE832215473A00060D1A3 /* scalar_analysis.cpp in Sources */,
-				A96FE8CE215473A00060D1A3 /* validate_annotation.cpp in Sources */,
-				A96FE91A215473A00060D1A3 /* validate_function.cpp in Sources */,
-				A96FE858215473A00060D1A3 /* scalar_replacement_pass.cpp in Sources */,
-				A96FE716215473A00060D1A3 /* spirv_endian.cpp in Sources */,
-				A96FE922215473A00060D1A3 /* validate_primitives.cpp in Sources */,
-				A96FE7E4215473A00060D1A3 /* def_use_manager.cpp in Sources */,
-				A96FE8E6215473A00060D1A3 /* validate_interfaces.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2808,168 +463,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A96FE86B215473A00060D1A3 /* instruction.cpp in Sources */,
-				A96FE91F215473A00060D1A3 /* validate_composites.cpp in Sources */,
-				A96FE8C3215473A00060D1A3 /* operand.cpp in Sources */,
-				A96FE7A9215473A00060D1A3 /* loop_dependence.cpp in Sources */,
-				A96FE7C9215473A00060D1A3 /* inline_pass.cpp in Sources */,
-				A96FE8FD215473A00060D1A3 /* validate_id.cpp in Sources */,
-				A96FE7FF215473A00060D1A3 /* ir_context.cpp in Sources */,
-				A96FE7B9215473A00060D1A3 /* dead_variable_elimination.cpp in Sources */,
-				A96FE757215473A00060D1A3 /* ext_inst.cpp in Sources */,
-				A96FE8B5215473A00060D1A3 /* diagnostic.cpp in Sources */,
-				A96FE7CD215473A00060D1A3 /* ir_loader.cpp in Sources */,
-				A96FE74F215473A00060D1A3 /* linker.cpp in Sources */,
-				A96FE875215473A00060D1A3 /* inline_opaque_pass.cpp in Sources */,
-				A96FE747215473A00060D1A3 /* parsed_operand.cpp in Sources */,
-				A96FE85F215473A00060D1A3 /* redundancy_elimination.cpp in Sources */,
-				A96FE8ED215473A00060D1A3 /* validate_constants.cpp in Sources */,
-				A96FE7DB215473A00060D1A3 /* loop_unroller.cpp in Sources */,
-				A96FE8FB215473A00060D1A3 /* validate_datarules.cpp in Sources */,
-				A96FE7A1215473A00060D1A3 /* const_folding_rules.cpp in Sources */,
-				A96FE71D215473A00060D1A3 /* binary.cpp in Sources */,
-				A96FE8C9215473A00060D1A3 /* disassemble.cpp in Sources */,
-				A96FE80B215473A00060D1A3 /* composite.cpp in Sources */,
-				A96FE73F215473A00060D1A3 /* enum_string_mapping.cpp in Sources */,
-				A96FE901215473A00060D1A3 /* validate_mode_setting.cpp in Sources */,
-				A96FE911215473A00060D1A3 /* validate_ext_inst.cpp in Sources */,
-				A96FE781215473A00060D1A3 /* decoration_manager.cpp in Sources */,
-				A96FE8F1215473A00060D1A3 /* construct.cpp in Sources */,
-				A96FE893215473A00060D1A3 /* local_access_chain_convert_pass.cpp in Sources */,
-				A96FE721215473A00060D1A3 /* markv_codec.cpp in Sources */,
-				A96FE8CD215473A00060D1A3 /* text_handler.cpp in Sources */,
-				A96FE8AD215473A00060D1A3 /* compact_ids_pass.cpp in Sources */,
-				A96FE7D3215473A00060D1A3 /* eliminate_dead_functions_pass.cpp in Sources */,
-				A96FE7A5215473A00060D1A3 /* strip_debug_info_pass.cpp in Sources */,
-				A96FE7E7215473A00060D1A3 /* strip_reflect_info_pass.cpp in Sources */,
-				A96FE8FF215473A00060D1A3 /* validate_arithmetics.cpp in Sources */,
-				A96FE77F215473A00060D1A3 /* cfg.cpp in Sources */,
-				A96FE7F5215473A00060D1A3 /* dead_branch_elim_pass.cpp in Sources */,
-				A96FE7C3215473A00060D1A3 /* unify_const_pass.cpp in Sources */,
-				A96FE837215473A00060D1A3 /* block_merge_pass.cpp in Sources */,
-				A96FE821215473A00060D1A3 /* inline_exhaustive_pass.cpp in Sources */,
-				A96FE907215473A00060D1A3 /* validate_memory.cpp in Sources */,
-				A96FE8DF215473A00060D1A3 /* validate_instruction.cpp in Sources */,
-				A96FE8A1215473A00060D1A3 /* loop_fusion.cpp in Sources */,
-				A96FE81D215473A00060D1A3 /* copy_prop_arrays.cpp in Sources */,
-				A96FE809215473A00060D1A3 /* instruction_list.cpp in Sources */,
-				A96FE795215473A00060D1A3 /* loop_fission.cpp in Sources */,
-				A96FE903215473A00060D1A3 /* validate_logicals.cpp in Sources */,
-				A96FE8EF215473A00060D1A3 /* validate_bitwise.cpp in Sources */,
-				A96FE753215473A00060D1A3 /* opcode.cpp in Sources */,
-				A96FE73B215473A00060D1A3 /* bit_stream.cpp in Sources */,
-				A96FE799215473A00060D1A3 /* merge_return_pass.cpp in Sources */,
-				A96FE705215473A00060D1A3 /* id_descriptor.cpp in Sources */,
-				A96FE723215473A00060D1A3 /* markv.cpp in Sources */,
-				A96FE863215473A00060D1A3 /* workaround1209.cpp in Sources */,
-				A96FE7B7215473A00060D1A3 /* remove_duplicates_pass.cpp in Sources */,
-				A96FE6E3215473A00060D1A3 /* extensions.cpp in Sources */,
-				A96FE73D215473A00060D1A3 /* markv_encoder.cpp in Sources */,
-				A96FE90D215473A00060D1A3 /* instruction.cpp in Sources */,
-				A96FE81B215473A00060D1A3 /* strength_reduction_pass.cpp in Sources */,
-				A94E30D821920A8C00394673 /* spirv_cross_parsed_ir.cpp in Sources */,
-				A96FE78B215473A00060D1A3 /* local_redundancy_elimination.cpp in Sources */,
-				A96FE827215473A00060D1A3 /* loop_fusion_pass.cpp in Sources */,
-				A96FE783215473A00060D1A3 /* local_single_block_elim_pass.cpp in Sources */,
-				A96FE855215473A00060D1A3 /* fold.cpp in Sources */,
-				A96FE791215473A00060D1A3 /* feature_manager.cpp in Sources */,
-				A9AB199A1CB5B5A80001E7F9 /* spirv_cross.cpp in Sources */,
-				A96FE8AF215473A00060D1A3 /* loop_peeling.cpp in Sources */,
-				A96FE877215473A00060D1A3 /* replace_invalid_opc.cpp in Sources */,
-				A96FE7BD215473A00060D1A3 /* module.cpp in Sources */,
-				A96FE84D215473A00060D1A3 /* propagator.cpp in Sources */,
-				A96FE915215473A00060D1A3 /* validate_execution_limitations.cpp in Sources */,
-				A96FE86D215473A00060D1A3 /* reduce_load_size.cpp in Sources */,
-				A96FE797215473A00060D1A3 /* dominator_tree.cpp in Sources */,
-				A96FE7EB215473A00060D1A3 /* ccp_pass.cpp in Sources */,
-				A96FE769215473A00060D1A3 /* combine_access_chains.cpp in Sources */,
-				A96FE761215473A00060D1A3 /* loop_utils.cpp in Sources */,
-				A96FE779215473A00060D1A3 /* types.cpp in Sources */,
-				A96FE703215473A00060D1A3 /* table.cpp in Sources */,
-				A96FE851215473A00060D1A3 /* set_spec_constant_default_value_pass.cpp in Sources */,
-				A96FE8E5215473A00060D1A3 /* validate_builtins.cpp in Sources */,
-				A96FE8D7215473A00060D1A3 /* validate_barriers.cpp in Sources */,
-				A96FE8F3215473A00060D1A3 /* function.cpp in Sources */,
-				A96FE7E3215473A00060D1A3 /* common_uniform_elim_pass.cpp in Sources */,
-				A96FE909215473A00060D1A3 /* validate_image.cpp in Sources */,
-				A96FE7C5215473A00060D1A3 /* type_manager.cpp in Sources */,
-				A96FE6FB215473A00060D1A3 /* parse_number.cpp in Sources */,
-				A9AB19A21CB5B5A80001E7F9 /* spirv_msl.cpp in Sources */,
-				A96FE815215473A00060D1A3 /* if_conversion.cpp in Sources */,
-				A96FE79F215473A00060D1A3 /* cfg_cleanup_pass.cpp in Sources */,
-				A96FE90F215473A00060D1A3 /* validate_type.cpp in Sources */,
-				A96FE6DD215473A00060D1A3 /* text.cpp in Sources */,
-				A96FE905215473A00060D1A3 /* validate_derivatives.cpp in Sources */,
-				A96FE895215473A00060D1A3 /* basic_block.cpp in Sources */,
-				A96FE803215473A00060D1A3 /* loop_descriptor.cpp in Sources */,
-				A96FE70F215473A00060D1A3 /* spirv_validator_options.cpp in Sources */,
-				A96FE871215473A00060D1A3 /* value_number_table.cpp in Sources */,
-				A96FE7F3215473A00060D1A3 /* simplification_pass.cpp in Sources */,
 				A95096BC2003D00300F10950 /* FileSupport.mm in Sources */,
-				A96FE6F3215473A00060D1A3 /* string_utils.cpp in Sources */,
-				A94E30D0219209C700394673 /* spirv_parser.cpp in Sources */,
 				A909408B1C58013E0094110D /* SPIRVToMSLConverter.cpp in Sources */,
-				A96FE7C1215473A00060D1A3 /* loop_unswitch_pass.cpp in Sources */,
-				A96FE82F215473A00060D1A3 /* dead_insert_elim_pass.cpp in Sources */,
-				A96FE7BF215473A00060D1A3 /* fold_spec_constant_op_and_composite_pass.cpp in Sources */,
-				A96FE8E1215473A00060D1A3 /* validate_decorations.cpp in Sources */,
-				A96FE7A7215473A00060D1A3 /* ssa_rewrite_pass.cpp in Sources */,
-				A96FE75B215473A00060D1A3 /* optimizer.cpp in Sources */,
-				A96FE8E3215473A00060D1A3 /* validate_debug.cpp in Sources */,
 				A928C91C1D0488DC00071B88 /* SPIRVConversion.mm in Sources */,
-				A96FE7F7215473A00060D1A3 /* flatten_decoration_pass.cpp in Sources */,
-				A9AB199E1CB5B5A80001E7F9 /* spirv_glsl.cpp in Sources */,
-				A96FE793215473A00060D1A3 /* pass.cpp in Sources */,
-				A95C5F401DEA9070000D17B6 /* spirv_cfg.cpp in Sources */,
-				A96FE7B3215473A00060D1A3 /* mem_pass.cpp in Sources */,
-				A96FE7FB215473A00060D1A3 /* folding_rules.cpp in Sources */,
-				A96FE8D9215473A00060D1A3 /* validate_non_uniform.cpp in Sources */,
-				A96FE8E9215473A00060D1A3 /* validate.cpp in Sources */,
-				A96FE8D3215473A00060D1A3 /* validate_capability.cpp in Sources */,
-				A96FE7D9215473A00060D1A3 /* vector_dce.cpp in Sources */,
-				A96FE84F215473A00060D1A3 /* loop_dependence_helpers.cpp in Sources */,
-				A96FE8F9215473A00060D1A3 /* validate_conversion.cpp in Sources */,
-				A96FE751215473A00060D1A3 /* software_version.cpp in Sources */,
-				A96FE805215473A00060D1A3 /* local_ssa_elim_pass.cpp in Sources */,
-				A96FE917215473A00060D1A3 /* validate_layout.cpp in Sources */,
-				A96FE849215473A00060D1A3 /* private_to_local_pass.cpp in Sources */,
-				A96FE709215473A00060D1A3 /* spirv_optimizer_options.cpp in Sources */,
-				A96FE711215473A00060D1A3 /* print.cpp in Sources */,
-				A96FE76B215473A00060D1A3 /* build_module.cpp in Sources */,
-				A96FE7F1215473A00060D1A3 /* aggressive_dead_code_elim_pass.cpp in Sources */,
-				A96FE8A5215473A00060D1A3 /* scalar_analysis_simplification.cpp in Sources */,
-				A96FE8DB215473A00060D1A3 /* validate_atomics.cpp in Sources */,
-				A96FE90B215473A00060D1A3 /* validate_literals.cpp in Sources */,
-				A96FE81F215473A00060D1A3 /* pass_manager.cpp in Sources */,
-				A96FE7DD215473A00060D1A3 /* constants.cpp in Sources */,
-				A96FE6D7215473A00060D1A3 /* spirv_target_env.cpp in Sources */,
-				A96FE79D215473A00060D1A3 /* eliminate_dead_constant_pass.cpp in Sources */,
-				A96FE88B215473A00060D1A3 /* struct_cfg_analysis.cpp in Sources */,
-				A96FE921215473A00060D1A3 /* validation_state.cpp in Sources */,
-				A96FE807215473A00060D1A3 /* function.cpp in Sources */,
-				A96FE8B9215473A00060D1A3 /* libspirv.cpp in Sources */,
-				A96FE74D215473A00060D1A3 /* name_mapper.cpp in Sources */,
-				A96FE87D215473A00060D1A3 /* dominator_analysis.cpp in Sources */,
-				A96FE6FD215473A00060D1A3 /* bit_vector.cpp in Sources */,
-				A96FE6DF215473A00060D1A3 /* assembly_grammar.cpp in Sources */,
-				A96FE7D1215473A00060D1A3 /* licm_pass.cpp in Sources */,
-				A96FE8F7215473A00060D1A3 /* validate_adjacency.cpp in Sources */,
-				A96FE75F215473A00060D1A3 /* register_pressure.cpp in Sources */,
-				A96FE8D1215473A00060D1A3 /* validate_cfg.cpp in Sources */,
-				A96FE845215473A00060D1A3 /* local_single_store_elim_pass.cpp in Sources */,
-				A96FE729215473A00060D1A3 /* move_to_front.cpp in Sources */,
-				A96FE6EF215473A00060D1A3 /* timer.cpp in Sources */,
-				A96FE785215473A00060D1A3 /* freeze_spec_constant_value_pass.cpp in Sources */,
-				A96FE919215473A00060D1A3 /* basic_block.cpp in Sources */,
-				A96FE733215473A00060D1A3 /* markv_decoder.cpp in Sources */,
-				A96FE833215473A00060D1A3 /* scalar_analysis.cpp in Sources */,
-				A96FE8CF215473A00060D1A3 /* validate_annotation.cpp in Sources */,
-				A96FE91B215473A00060D1A3 /* validate_function.cpp in Sources */,
-				A96FE859215473A00060D1A3 /* scalar_replacement_pass.cpp in Sources */,
-				A96FE717215473A00060D1A3 /* spirv_endian.cpp in Sources */,
-				A96FE923215473A00060D1A3 /* validate_primitives.cpp in Sources */,
-				A96FE7E5215473A00060D1A3 /* def_use_manager.cpp in Sources */,
-				A96FE8E7215473A00060D1A3 /* validate_interfaces.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3020,7 +516,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = iphoneos;
@@ -3040,7 +536,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = iphoneos;
@@ -3058,6 +554,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -3073,6 +570,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -3088,12 +586,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -3111,12 +610,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -3132,11 +632,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;
@@ -3150,11 +652,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;
@@ -3203,7 +707,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				ONLY_ACTIVE_ARCH = YES;
 				SKIP_INSTALL = YES;
 			};
@@ -3248,7 +753,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_PARAMETER = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				SKIP_INSTALL = YES;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -85,12 +85,12 @@
 		A964BD5F1C57EFBD00D930D8 /* MoltenVKShaderConverter */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MoltenVKShaderConverter; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD601C57EFBD00D930D8 /* MoltenVKGLSLToSPIRVConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKGLSLToSPIRVConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD611C57EFBD00D930D8 /* MoltenVKGLSLToSPIRVConverter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MoltenVKGLSLToSPIRVConverter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A972AD2A21CEE6A90013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = "../External/build/Build/Products/Release-iphoneos/libglslang.a"; sourceTree = "<group>"; };
-		A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = "../External/build/Build/Products/Release-iphoneos/libSPIRVCross.a"; sourceTree = "<group>"; };
-		A972AD3021CEE7040013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = "../External/build/Build/Products/Release-iphoneos/libSPIRVTools.a"; sourceTree = "<group>"; };
-		A972AD3421CEE7330013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = ../External/build/Build/Products/Release/libSPIRVTools.a; sourceTree = "<group>"; };
-		A972AD3521CEE7330013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = ../External/build/Build/Products/Release/libSPIRVCross.a; sourceTree = "<group>"; };
-		A972AD3821CEE7480013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = ../External/build/Build/Products/Release/libglslang.a; sourceTree = "<group>"; };
+		A972AD2A21CEE6A90013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = "../External/build/iOS/libglslang.a"; sourceTree = "<group>"; };
+		A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = "../External/build/iOS/libSPIRVCross.a"; sourceTree = "<group>"; };
+		A972AD3021CEE7040013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = "../External/build/iOS/libSPIRVTools.a"; sourceTree = "<group>"; };
+		A972AD3421CEE7330013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = ../External/build/macOS/libSPIRVTools.a; sourceTree = "<group>"; };
+		A972AD3521CEE7330013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = ../External/build/macOS/libSPIRVCross.a; sourceTree = "<group>"; };
+		A972AD3821CEE7480013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = ../External/build/macOS/libglslang.a; sourceTree = "<group>"; };
 		A97CC73D1C7527F3004A5C7E /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		A97CC73E1C7527F3004A5C7E /* MoltenVKShaderConverterTool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MoltenVKShaderConverterTool.cpp; sourceTree = "<group>"; };
 		A97CC73F1C7527F3004A5C7E /* MoltenVKShaderConverterTool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoltenVKShaderConverterTool.h; sourceTree = "<group>"; };
@@ -516,7 +516,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/iOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = iphoneos;
@@ -536,7 +536,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/iOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = iphoneos;
@@ -554,7 +554,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/macOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -570,7 +570,7 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/macOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -592,7 +592,7 @@
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/iOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -616,7 +616,7 @@
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release-iphoneos\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/iOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -638,7 +638,7 @@
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/macOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;
@@ -658,7 +658,7 @@
 					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
 				);
-				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Build/Products/Release\"";
+				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/macOS\"";
 				MACH_O_TYPE = staticlib;
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;

--- a/Scripts/package_ext_libs.sh
+++ b/Scripts/package_ext_libs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+export MVK_EXT_LIB_DST_DIR="External"
+export MVK_EXT_LIB_DST_OS_PATH="${PROJECT_DIR}/${MVK_EXT_LIB_DST_DIR}/build/${MVK_OS}"
+
+rm -rf "${MVK_EXT_LIB_DST_OS_PATH}"
+mkdir -p "${MVK_EXT_LIB_DST_OS_PATH}"
+
+cp -a "${MVK_BUILT_PROD_PATH}/"*.a "${MVK_EXT_LIB_DST_OS_PATH}"

--- a/Scripts/package_ext_libs_ios.sh
+++ b/Scripts/package_ext_libs_ios.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export MVK_OS="iOS"
+export MVK_BUILT_PROD_PATH="${BUILT_PRODUCTS_DIR}-iphoneos"
+
+"${SRCROOT}/Scripts/package_ext_libs.sh"
+

--- a/Scripts/package_ext_libs_macos.sh
+++ b/Scripts/package_ext_libs_macos.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export MVK_OS="macOS"
+export MVK_BUILT_PROD_PATH="${BUILT_PRODUCTS_DIR}"
+
+"${SRCROOT}/Scripts/package_ext_libs.sh"
+

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -22,17 +22,23 @@
 #              build directory must be in the specified directory.
 #              It should be built the same way this script builds it.
 #
+#      -v      verbose output
 #
 
 
 # ----------------- Functions -------------------
 
+XC_BUILD_VERBOSITY="-quiet"
 V_HEADERS_ROOT=""
 SPIRV_CROSS_ROOT=""
 GLSLANG_ROOT=""
 
 while (( "$#" )); do
   case "$1" in
+       -v)
+         XC_BUILD_VERBOSITY=""
+         shift 1
+         ;;
        --v-headers-root)
          V_HEADERS_ROOT=$2
          shift 2
@@ -235,7 +241,7 @@ xcodebuild 									\
 	-project "${EXT_DEPS}.xcodeproj"		\
 	-scheme "${EXT_DEPS}"					\
 	-derivedDataPath "${EXT_DIR}/build"		\
-	-quiet									\
+	${XC_BUILD_VERBOSITY}					\
 	build
 
 echo ========== Done! ==========

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -89,8 +89,6 @@ build_repo() {
 		make -j
 	fi
 
-	make install
-
 	cd -
 }
 
@@ -98,7 +96,7 @@ build_repo() {
 # ----------------- Main -------------------
 
 EXT_DIR=External
-EXT_REV_DIR=ExternalRevisions
+EXT_REV_DIR=../ExternalRevisions
 
 echo
 echo ========== Retrieving MoltenVK dependencies into ${EXT_DIR} ==========
@@ -115,7 +113,7 @@ echo
 
 REPO_NAME=cereal
 REPO_URL="https://github.com/USCiLab/${REPO_NAME}.git"
-REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
 update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
@@ -135,7 +133,7 @@ if [ ! "$V_HEADERS_ROOT" = "" ]; then
 else
        REPO_NAME=Vulkan-Headers
        REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"
-       REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+       REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
        update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 fi
@@ -156,7 +154,7 @@ if [ ! "$SPIRV_CROSS_ROOT" = "" ]; then
 else
        REPO_NAME=SPIRV-Cross
        REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"
-       REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+       REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
        update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 fi
@@ -177,7 +175,7 @@ if [ ! "$GLSLANG_ROOT" = "" ]; then
 else
        REPO_NAME=glslang
        REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"
-       REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+       REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
        update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
@@ -185,7 +183,7 @@ else
        ./update_glslang_sources.py
        cd -
 
-       build_repo ${REPO_NAME}
+       build_repo "${REPO_NAME}/External/spirv-tools"
 fi
 
 
@@ -197,7 +195,7 @@ echo
 
 REPO_NAME=Vulkan-Tools
 REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"
-REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
 update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
@@ -210,7 +208,7 @@ echo
 
 REPO_NAME=VulkanSamples
 REPO_URL="https://github.com/LunarG/${REPO_NAME}.git"
-REPO_REV=$(cat "../${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
+REPO_REV=$(cat "${EXT_REV_DIR}/${REPO_NAME}_repo_revision")
 
 update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 
@@ -224,4 +222,21 @@ cd -
 # ----------------- Cleanup -------------------
 
 cd ..
+
+
+# -------------- Build MoltenVK dependencies -----------------
+echo
+echo ========== Building dependencies quietly. Please be patient on first build. ==========
+echo
+
+EXT_DEPS=ExternalDependencies
+
+xcodebuild 									\
+	-project "${EXT_DEPS}.xcodeproj"		\
+	-scheme "${EXT_DEPS}"					\
+	-derivedDataPath "${EXT_DIR}/build"		\
+	-quiet									\
+	build
+
+echo ========== Done! ==========
 

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -232,7 +232,7 @@ cd ..
 
 # -------------- Build MoltenVK dependencies -----------------
 echo
-echo ========== Building dependencies quietly. Please be patient on first build. ==========
+echo ========== Building dependency libraries quietly. Please be patient on first build. ==========
 echo
 
 EXT_DEPS=ExternalDependencies


### PR DESCRIPTION
This is a build optimization for developers that work on MoltenVK development.

In the past, the MoltenVK project directly included significant code from the _SPIRV-Cross_, _glslang_ and _SPRIV-Tools_ external libraries...which would need to be recompiled each time MoltenVK was compiled (especially from clean). The presence of this fixed library code added significantly to the build time of MoltenVK (_SPIRV-Tools_ was particularly hefty).

These three external libraries are now managed by the `ExternalDependencies.xcodeproj` _Xcode_ project...and are built separately...automatically...and only once...when they are fetched from their respective repositories...as part of the `fetchDependencies` script.

The `fetchDependencies` script places build artifacts...and the finished set of static libraries for these dependencies in the new `External/build` directory...which is not affected by cleaning out the standard _Xcode_ build locations in `~/Library/.../DerivedData`.

@cdavis5e This change means that after making modifications to _SPIRV-Cross_ code...we need to first run the **_ExternalDependencies_** *Xcode* scheme (or at least the SPIRV-Cross schemes) in the `ExternalDependencies.xcodeproj` *Xcode* project...before rebuilding MoltenVK. I have not included target dependencies between targets in the `MoltenVKShaderConverter.xcodeproj` and `ExternalDependencies.xcodeproj` *Xcode* projects...but we could look to do this if this extra manual step becomes an irritation...or a point of failure. The main reason for not including those target dependencies was to allow the dependency libraries to be built in `External/build`.