### PR TITLE
VkInstance: For idTech 6, always enable full image view swizzles.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released 2018/01/15
 
 - Support runtime config via runtime environment variables
 - Add full ImageView swizzling to config, and disable it by default.
+- For idTech 6, always enable full image view swizzling.
 - Add GPU switching to config, and enable it by default.
 - Add queue family specialization to config, and disable it by default.
 - Enable synchronous queue submits as config default.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -368,6 +368,10 @@ void MVKInstance::initConfig() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.specializedQueueFamilies,             MVK_CONFIG_SPECIALIZED_QUEUE_FAMILIES);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.switchSystemGPU,                      MVK_CONFIG_SWITCH_SYSTEM_GPU);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.fullImageViewSwizzle,                 MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE);
+
+	if (_appInfo.pEngineName && strcmp(_appInfo.pEngineName, "idTech") == 0) {
+		_mvkConfig.fullImageViewSwizzle = VK_TRUE;
+	}
 }
 
 VkResult MVKInstance::verifyLayers(uint32_t count, const char* const* names) {


### PR DESCRIPTION
id Software helped promulgate the original `GL_ARB_texture_swizzle`
extension in the first place. It's a safe bet anything they make is
going to need it.