### PR TITLE
Fixes for issues #459, #301, #446.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -48,12 +48,12 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   31
+#define MVK_VERSION_PATCH   32
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            16
+#define VK_MVK_MOLTENVK_SPEC_VERSION            17
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /**
@@ -133,7 +133,7 @@ typedef struct {
 	 * will be dispatched to a GCD dispatch_queue whose priority is determined by
 	 * VkDeviceQueueCreateInfo::pQueuePriorities during vkCreateDevice().
 	 *
-	 * The value of this parameter may be changed before creating a VkDevice,
+	 * The value of this parameter must be changed before creating a VkDevice,
 	 * for the change to take effect.
 	 *
 	 * The initial value or this parameter is set by the
@@ -193,7 +193,7 @@ typedef struct {
 	 * is required per command buffer queue submission, which may be significantly less than the
 	 * number of Vulkan command buffers.
 	 *
-	 * The value of this parameter may be changed before creating a VkDevice,
+	 * The value of this parameter must be changed before creating a VkDevice,
 	 * for the change to take effect.
 	 *
 	 * The initial value or this parameter is set by the
@@ -331,7 +331,7 @@ typedef struct {
 	 * as having specialized graphics OR compute OR transfer functionality, to make it easier for some
 	 * apps to select a queue family with the appropriate requirements.
 	 *
-	 * The value of this parameter may be changed before creating a VkDevice, and before
+	 * The value of this parameter must be changed before creating a VkDevice, and before
 	 * querying a VkPhysicalDevice for queue family properties, for the change to take effect.
 	 *
 	 * The initial value or this parameter is set by the
@@ -364,7 +364,7 @@ typedef struct {
 	 * system window compositor to determine how best to blend content with the windowing
 	 * system, and as a result, may want to disable this parameter.
 	 *
-	 * The value of this parameter may be changed before creating a VkDevice,
+	 * The value of this parameter must be changed before creating a VkDevice,
 	 * for the change to take effect.
 	 *
 	 * The initial value or this parameter is set by the
@@ -413,6 +413,35 @@ typedef struct {
 	 * If neither is set, the value of this parameter defaults to false.
 	 */
 	VkBool32 fullImageViewSwizzle;
+
+	/**
+	 * The index of the queue family whose presentation submissions will
+	 * be used as the default GPU Capture Scope during debugging in Xcode.
+	 *
+	 * The value of this parameter must be changed before creating a VkDevice,
+	 * for the change to take effect.
+	 *
+	 * The initial value or this parameter is set by the
+	 * MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX
+	 * runtime environment variable or MoltenVK compile-time build setting.
+	 * If neither is set, the value of this parameter defaults to zero (the first queue family).
+	 */
+	uint32_t defaultGPUCaptureScopeQueueFamilyIndex;
+
+	/**
+	 * The index of the queue, within the queue family identified by the
+	 * defaultGPUCaptureScopeQueueFamilyIndex parameter, whose presentation submissions
+	 * will be used as the default GPU Capture Scope during debugging in Xcode.
+	 *
+	 * The value of this parameter must be changed before creating a VkDevice,
+	 * for the change to take effect.
+	 *
+	 * The initial value or this parameter is set by the
+	 * MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX
+	 * runtime environment variable or MoltenVK compile-time build setting.
+	 * If neither is set, the value of this parameter defaults to zero (the first queue).
+	 */
+	uint32_t defaultGPUCaptureScopeQueueIndex;
 
 } MVKConfiguration;
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -483,6 +483,8 @@ typedef struct {
     VkSampleCountFlags supportedSampleCounts;   /**< A bitmask identifying the sample counts supported by the device. */
 	uint32_t minSwapchainImageCount;	 	  	/**< The minimum number of swapchain images that can be supported by a surface. */
 	uint32_t maxSwapchainImageCount;	 	  	/**< The maximum number of swapchain images that can be supported by a surface. */
+	VkBool32 arrayOfTextures;			 	  	/**< If true, arrays of textures is supported. */
+	VkBool32 arrayOfSamplers;			 	  	/**< If true, arrays of texture samplers is supported. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /**

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -73,7 +73,7 @@ typedef struct MVKShaderResourceBinding {
 #pragma mark MVKDescriptorSetLayoutBinding
 
 /** Represents a Vulkan descriptor set layout binding. */
-class MVKDescriptorSetLayoutBinding : public MVKConfigurableObject {
+class MVKDescriptorSetLayoutBinding : public MVKBaseDeviceObject {
 
 public:
 
@@ -100,7 +100,8 @@ public:
                                         uint32_t dslIndex);
 
 	/** Constructs an instance. */
-	MVKDescriptorSetLayoutBinding(MVKDescriptorSetLayout* layout,
+	MVKDescriptorSetLayoutBinding(MVKDevice* device,
+								  MVKDescriptorSetLayout* layout,
 								  const VkDescriptorSetLayoutBinding* pBinding);
 
 	MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding);
@@ -112,9 +113,9 @@ protected:
 	friend class MVKDescriptorBinding;
 	friend class MVKPipelineLayout;
 
-	VkResult initMetalResourceIndexOffsets(MVKShaderStageResourceBinding* pBindingIndexes,
-                                           MVKShaderStageResourceBinding* pDescSetCounts,
-                                           const VkDescriptorSetLayoutBinding* pBinding);
+	void initMetalResourceIndexOffsets(MVKShaderStageResourceBinding* pBindingIndexes,
+									   MVKShaderStageResourceBinding* pDescSetCounts,
+									   const VkDescriptorSetLayoutBinding* pBinding);
 
 	VkDescriptorSetLayoutBinding _info;
 	std::vector<MVKSampler*> _immutableSamplers;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -90,6 +90,9 @@ public:
 	/** Populates the specified structure with the properties of this device. */
 	void getProperties(VkPhysicalDeviceProperties2* properties);
 
+	/** Returns the name of this device. */
+	inline const char* getName() { return _properties.deviceName; }
+
 	/** Returns whether the specified format is supported on this device. */
 	bool getFormatIsSupported(VkFormat format);
 
@@ -314,6 +317,9 @@ public:
 
 	/** Returns the physical device underlying this logical device. */
 	inline MVKPhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
+
+	/** Returns the name of this device. */
+	inline const char* getName() { return _pProperties->deviceName; }
 
     /** Returns the common resource factory for creating command resources. */
     inline MVKCommandResourceFactory* getCommandResourceFactory() { return _commandResourceFactory; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1872,9 +1872,13 @@ void MVKDevice::initQueues(const VkDeviceCreateInfo* pCreateInfo) {
 		const VkDeviceQueueCreateInfo* pQFInfo = &pCreateInfo->pQueueCreateInfos[qrIdx];
 		uint32_t qfIdx = pQFInfo->queueFamilyIndex;
 		MVKQueueFamily* qFam = qFams[qfIdx];
+		VkQueueFamilyProperties qfProps;
+		qFam->getProperties(&qfProps);
+
 		_queuesByQueueFamilyIndex.resize(qfIdx + 1);	// Ensure an entry for this queue family exists
 		auto& queues = _queuesByQueueFamilyIndex[qfIdx];
-		for (uint32_t qIdx = 0; qIdx < pQFInfo->queueCount; qIdx++) {
+		uint32_t qCnt = min(pQFInfo->queueCount, qfProps.queueCount);
+		for (uint32_t qIdx = 0; qIdx < qCnt; qIdx++) {
 			queues.push_back(new MVKQueue(this, qFam, qIdx, pQFInfo->pQueuePriorities[qIdx]));
 		}
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -618,6 +618,14 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.mtlBufferAlignment = 16;     // Min float4 alignment for typical vertex buffers. MTLBuffer may go down to 4 bytes for other data.
 		_metalFeatures.maxTextureDimension = (16 * KIBI);
 	}
+
+	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily3_v2] ) {
+		_metalFeatures.arrayOfTextures = true;
+	}
+	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily3_v3] ) {
+		_metalFeatures.arrayOfSamplers = true;
+	}
+
 #endif
 
 #if MVK_MACOS
@@ -642,6 +650,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
         _metalFeatures.mslVersion = SPIRVToMSLConverterOptions::makeMSLVersion(2);
         _metalFeatures.texelBuffers = true;
+		_metalFeatures.arrayOfTextures = true;
+		_metalFeatures.arrayOfSamplers = true;
 		_metalFeatures.presentModeImmediate = true;
     }
 
@@ -683,6 +693,9 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderInt16 = true;
 	_features.multiDrawIndirect = true;
 
+	_features.shaderSampledImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
+	_features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
+
     if (_metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing) {
         _features.drawIndirectFirstInstance = true;
     }
@@ -696,10 +709,6 @@ void MVKPhysicalDevice::initFeatures() {
 
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily3_v1] ) {
         _features.occlusionQueryPrecise = true;
-    }
-    if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily3_v2] ) {
-        _features.shaderSampledImageArrayDynamicIndexing = true;
-        _features.shaderStorageImageArrayDynamicIndexing = true;
     }
 	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily2_v4] ) {
 		_features.depthClamp = true;
@@ -720,8 +729,6 @@ void MVKPhysicalDevice::initFeatures() {
 
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v3] ) {
         _features.multiViewport = true;
-        _features.shaderSampledImageArrayDynamicIndexing = true;
-        _features.shaderStorageImageArrayDynamicIndexing = true;
     }
 
 #endif

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -353,21 +353,23 @@ void MVKInstance::logVersions() {
 
 // Init config.
 void MVKInstance::initConfig() {
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.debugMode,                            MVK_DEBUG);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.shaderConversionFlipVertexY,          MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.synchronousQueueSubmits,              MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.prefillMetalCommandBuffers,           MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS);
-	MVK_SET_FROM_ENV_OR_BUILD_INT32(_mvkConfig.maxActiveMetalCommandBuffersPerQueue, MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.supportLargeQueryPools,               MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.presentWithCommandBuffer,             MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.swapchainMagFilterUseNearest,         MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST);
-	MVK_SET_FROM_ENV_OR_BUILD_INT64(_mvkConfig.metalCompileTimeout,                  MVK_CONFIG_METAL_COMPILE_TIMEOUT);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.performanceTracking,                  MVK_CONFIG_PERFORMANCE_TRACKING);
-	MVK_SET_FROM_ENV_OR_BUILD_INT32(_mvkConfig.performanceLoggingFrameCount,         MVK_CONFIG_PERFORMANCE_LOGGING_FRAME_COUNT);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.displayWatermark,                     MVK_CONFIG_DISPLAY_WATERMARK);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.specializedQueueFamilies,             MVK_CONFIG_SPECIALIZED_QUEUE_FAMILIES);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.switchSystemGPU,                      MVK_CONFIG_SWITCH_SYSTEM_GPU);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.fullImageViewSwizzle,                 MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.debugMode,                              MVK_DEBUG);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.shaderConversionFlipVertexY,            MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.synchronousQueueSubmits,                MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.prefillMetalCommandBuffers,             MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS);
+	MVK_SET_FROM_ENV_OR_BUILD_INT32(_mvkConfig.maxActiveMetalCommandBuffersPerQueue,   MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.supportLargeQueryPools,                 MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.presentWithCommandBuffer,               MVK_CONFIG_PRESENT_WITH_COMMAND_BUFFER);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.swapchainMagFilterUseNearest,           MVK_CONFIG_SWAPCHAIN_MAG_FILTER_USE_NEAREST);
+	MVK_SET_FROM_ENV_OR_BUILD_INT64(_mvkConfig.metalCompileTimeout,                    MVK_CONFIG_METAL_COMPILE_TIMEOUT);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.performanceTracking,                    MVK_CONFIG_PERFORMANCE_TRACKING);
+	MVK_SET_FROM_ENV_OR_BUILD_INT32(_mvkConfig.performanceLoggingFrameCount,           MVK_CONFIG_PERFORMANCE_LOGGING_FRAME_COUNT);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.displayWatermark,                       MVK_CONFIG_DISPLAY_WATERMARK);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.specializedQueueFamilies,               MVK_CONFIG_SPECIALIZED_QUEUE_FAMILIES);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.switchSystemGPU,                        MVK_CONFIG_SWITCH_SYSTEM_GPU);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.fullImageViewSwizzle,                   MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.defaultGPUCaptureScopeQueueFamilyIndex, MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.defaultGPUCaptureScopeQueueIndex,       MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX);
 }
 
 VkResult MVKInstance::verifyLayers(uint32_t count, const char* const* names) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -174,9 +174,15 @@ void MVKQueue::initMTLCommandQueue() {
 
 // Initializes Xcode GPU capture scopes
 void MVKQueue::initGPUCaptureScopes() {
+	const MVKConfiguration* pMVKConfig = _device->getInstance()->getMoltenVKConfiguration();
+
 	_submissionCaptureScope = new MVKGPUCaptureScope(this, "CommandBuffer-Submission");
+
 	_presentationCaptureScope = new MVKGPUCaptureScope(this, "Surface-Presentation");
-	_presentationCaptureScope->makeDefault();
+	if (_queueFamily->getIndex() == pMVKConfig->defaultGPUCaptureScopeQueueFamilyIndex &&
+		_index == pMVKConfig->defaultGPUCaptureScopeQueueIndex) {
+		_presentationCaptureScope->makeDefault();
+	}
 	_presentationCaptureScope->beginScope();	// Allow Xcode to capture the first frame if desired.
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -224,6 +224,7 @@ MVKMTLFunction MVKShaderModule::getMTLFunction(SPIRVToMSLConverterContext* pCont
 											   const VkSpecializationInfo* pSpecializationInfo,
 											   MVKPipelineCache* pipelineCache) {
 	lock_guard<mutex> lock(_accessLock);
+	
 	MVKShaderLibrary* mvkLib = _defaultLibrary;
 	if ( !mvkLib ) {
 		uint64_t startTime = _device->getPerformanceTimestamp();
@@ -233,7 +234,10 @@ MVKMTLFunction MVKShaderModule::getMTLFunction(SPIRVToMSLConverterContext* pCont
 			mvkLib = _shaderLibraryCache.getShaderLibrary(pContext, this);
 		}
 		_device->addActivityPerformance(_device->_performanceStatistics.shaderCompilation.shaderLibraryFromCache, startTime);
+	} else {
+		pContext->markAllAttributesAndResourcesUsed();
 	}
+
 	return mvkLib ? mvkLib->getMTLFunction(pSpecializationInfo) : MVKMTLFunctionNull;
 }
 

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -112,6 +112,23 @@
 #   define MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE    0
 #endif
 
+/**
+ * The index of the queue family whose presentation submissions will
+ * be used as the default GPU Capture Scope during debugging in Xcode.
+ */
+#ifndef MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX
+#   define MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX    0
+#endif
+
+/**
+ * The index of the queue, within the queue family identified by the
+ * MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX setting, whose presentation
+ * submissions will be used as the default GPU Capture Scope during debugging in Xcode.
+ */
+#ifndef MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX
+#   define MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX    0
+#endif
+
 
 /**
  * IOSurfaces are supported on macOS, and on iOS starting with iOS 11.

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
@@ -105,6 +105,15 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverterContext::isVertexBufferUsed(uint32_t m
     return false;
 }
 
+MVK_PUBLIC_SYMBOL void SPIRVToMSLConverterContext::markAllAttributesAndResourcesUsed() {
+
+	if (options.entryPointStage == spv::ExecutionModelVertex) {
+		for (auto& va : vertexAttributes) { va.isUsedByShader = true; }
+	}
+
+	for (auto& rb : resourceBindings) { rb.isUsedByShader = true; }
+}
+
 MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverterContext::matches(const SPIRVToMSLConverterContext& other) const {
 
     if ( !options.matches(other.options) ) { return false; }

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h
@@ -143,6 +143,9 @@ namespace mvk {
         /** Returns whether the vertex buffer at the specified Metal binding index is used by the shader. */
         bool isVertexBufferUsed(uint32_t mslBuffer) const;
 
+		/** Marks all vertex attributes and resources as being used by the shader. */
+		void markAllAttributesAndResourcesUsed();
+
         /**
          * Returns whether this context matches the other context. It does if the respective 
          * options match and any vertex attributes and resource bindings used by this context


### PR DESCRIPTION
Fixes for:

#459 Enable all vertex attributes and resources in shaders for pre-converted Metal code.
#301 Xcode GPU capture for multiple queues and queue families.
#446 Return error when array of textures or samplers are requested but is not supported by device.

Update MoltenVK to version 1.0.32.
Update `VK_MVK_MOLTENVK_SPEC_VERSION` to 17.