### PR TITLE
Stop advertising atomic image support.

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -33,7 +33,6 @@ using namespace std;
 
 #define MVK_FMT_IMAGE_FEATS			(VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                    \
 									| VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT                   \
-									| VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT            \
                                     | VK_FORMAT_FEATURE_BLIT_SRC_BIT                        \
 									| VK_FORMAT_FEATURE_TRANSFER_SRC_BIT                    \
 									| VK_FORMAT_FEATURE_TRANSFER_DST_BIT)
@@ -79,8 +78,7 @@ using namespace std;
 #endif
 
 #define MVK_FMT_BUFFER_FEATS		(VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT             \
-									| VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT            \
-									| VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)
+									| VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)
 
 #define MVK_FMT_BUFFER_VTX_FEATS	(MVK_FMT_BUFFER_FEATS | VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)
 


### PR DESCRIPTION
We don't support this on any format--not even `VK_FORMAT_R32_UINT`,
which is the only format the spec requires support for. I'm still
waiting for Apple to add support for this to Metal. Until then, stop
telling applications they can use this.