### PR TITLE
fetchDependencies: Fix SPIRV-Tools including pre-built glslang

### DIFF
--- a/fetchDependencies
+++ b/fetchDependencies
@@ -178,6 +178,8 @@ if [ ! "$GLSLANG_ROOT" = "" ]; then
        REPO_NAME=glslang
        rm -rf ${REPO_NAME}
        ln -sfn ${GLSLANG_ROOT} ${REPO_NAME}
+
+       build_repo "${REPO_NAME}/External/spirv-tools"
 else
        REPO_NAME=glslang
        REPO_URL="https://github.com/KhronosGroup/${REPO_NAME}.git"


### PR DESCRIPTION
Glslang does not build SPIRV-Tools when including it.
The `fetchDependencies` script does this when cloning
the repo on its own, but neglects to do this when a path
to a pre-built glslang is provided.

This commit adds the SPIRV-Tools build step when given
a path to a pre-built glslang.