### PR TITLE
Advertise VkPhysicalDevicePortabilitySubsetFeaturesEXTX::standardImageViews

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -109,7 +109,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				portabilityFeatures->triangleFans = false;
 				portabilityFeatures->separateStencilMaskRef = true;
 				portabilityFeatures->events = false;
-				portabilityFeatures->standardImageViews = false;
+				portabilityFeatures->standardImageViews = _mvkInstance->getMoltenVKConfiguration()->fullImageViewSwizzle;
 				portabilityFeatures->samplerMipLodBias = false;
 				next = (MVKVkAPIStructHeader*)portabilityFeatures->pNext;
 				break;


### PR DESCRIPTION
Advertise VkPhysicalDevicePortabilitySubsetFeaturesEXTX::standardImageViews enabled if MVKConfiguration::fullImageViewSwizzle enabled.