### PR TITLE
Only warn on non-default swizzles when fullImageViewSwizzle is off.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -466,6 +466,11 @@ void MVKGraphicsResourcesCommandEncoderState::markDirty() {
 
 void MVKGraphicsResourcesCommandEncoderState::encodeImpl() {
 
+    bool fullImageViewSwizzle = false;
+    MVKPipeline* pipeline = _cmdEncoder->_graphicsPipelineState.getPipeline();
+    if (pipeline)
+        fullImageViewSwizzle = pipeline->fullImageViewSwizzle();
+
     encodeBinding<MVKMTLBufferBinding>(_vertexBufferBindings, _areVertexBufferBindingsDirty,
                                        [](MVKCommandEncoder* cmdEncoder, MVKMTLBufferBinding& b)->void {
                                            [cmdEncoder->_mtlRenderEncoder setVertexBuffer: b.mtlBuffer
@@ -492,7 +497,7 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl() {
                                     _vertexAuxBufferBinding.index);
 
 	} else {
-		assertMissingSwizzles(_needsVertexSwizzle, "vertex", _vertexTextureBindings);
+		assertMissingSwizzles(_needsVertexSwizzle && !fullImageViewSwizzle, "vertex", _vertexTextureBindings);
 	}
 
     if (_fragmentAuxBufferBinding.isDirty) {
@@ -507,7 +512,7 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl() {
                                       _fragmentAuxBufferBinding.index);
 
 	} else {
-		assertMissingSwizzles(_needsFragmentSwizzle, "fragment", _fragmentTextureBindings);
+		assertMissingSwizzles(_needsFragmentSwizzle && !fullImageViewSwizzle, "fragment", _fragmentTextureBindings);
     }
 
     encodeBinding<MVKMTLTextureBinding>(_vertexTextureBindings, _areVertexTextureBindingsDirty,
@@ -590,6 +595,11 @@ void MVKComputeResourcesCommandEncoderState::markDirty() {
 
 void MVKComputeResourcesCommandEncoderState::encodeImpl() {
 
+    bool fullImageViewSwizzle = false;
+    MVKPipeline* pipeline = _cmdEncoder->_computePipelineState.getPipeline();
+    if (pipeline)
+        fullImageViewSwizzle = pipeline->fullImageViewSwizzle();
+
     encodeBinding<MVKMTLBufferBinding>(_bufferBindings, _areBufferBindingsDirty,
                                        [](MVKCommandEncoder* cmdEncoder, MVKMTLBufferBinding& b)->void {
                                            [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch) setBuffer: b.mtlBuffer
@@ -609,7 +619,7 @@ void MVKComputeResourcesCommandEncoderState::encodeImpl() {
                                      _auxBufferBinding.index);
 
 	} else {
-		assertMissingSwizzles(_needsSwizzle, "compute", _textureBindings);
+		assertMissingSwizzles(_needsSwizzle && !fullImageViewSwizzle, "compute", _textureBindings);
     }
 
     encodeBinding<MVKMTLTextureBinding>(_textureBindings, _areTextureBindingsDirty,

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -404,12 +404,14 @@ static void assertMissingSwizzles(bool needsSwizzle, const char* stageName, MVKV
 	if (needsSwizzle) {
 		for (MVKMTLTextureBinding& tb : texBindings) {
 			VkComponentMapping vkcm = mvkUnpackSwizzle(tb.swizzle);
-			MVKLogError("Pipeline does not support component swizzle (%s, %s, %s, %s) required by a VkImageView used in the %s shader."
-						" Full VkImageView component swizzling will be supported by a pipeline if the MVKConfiguration::fullImageViewSwizzle"
-						" config parameter or MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable was enabled when the pipeline is compiled.",
-						mvkVkComponentSwizzleName(vkcm.r), mvkVkComponentSwizzleName(vkcm.g),
-						mvkVkComponentSwizzleName(vkcm.b), mvkVkComponentSwizzleName(vkcm.a), stageName);
-			MVKAssert(false, "See previous logged error.");
+			if (!mvkVkComponentMappingsMatch(vkcm, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A})) {
+				MVKLogError("Pipeline does not support component swizzle (%s, %s, %s, %s) required by a VkImageView used in the %s shader."
+							" Full VkImageView component swizzling will be supported by a pipeline if the MVKConfiguration::fullImageViewSwizzle"
+							" config parameter or MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable was enabled when the pipeline is compiled.",
+							mvkVkComponentSwizzleName(vkcm.r), mvkVkComponentSwizzleName(vkcm.g),
+							mvkVkComponentSwizzleName(vkcm.b), mvkVkComponentSwizzleName(vkcm.a), stageName);
+				MVKAssert(false, "See previous logged error.");
+			}
 		}
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -99,13 +99,18 @@ public:
 	/** Returns the current auxiliary buffer bindings. */
 	const MVKShaderAuxBufferBinding& getAuxBufferIndex() { return _auxBufferIndex; }
 
+	/** Returns whether or not full image view swizzling is enabled for this pipeline. */
+	bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
+
 	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
 	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipeline* parent) : MVKBaseDeviceObject(device),
-																						   _pipelineCache(pipelineCache) {}
+																						   _pipelineCache(pipelineCache),
+	   																					   _fullImageViewSwizzle(device->_pMVKConfig->fullImageViewSwizzle)	{}
 
 protected:
 	MVKPipelineCache* _pipelineCache;
 	MVKShaderAuxBufferBinding _auxBufferIndex;
+	bool _fullImageViewSwizzle;
 
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -484,7 +484,7 @@ void MVKGraphicsPipeline::initMVKShaderConverterContext(SPIRVToMSLConverterConte
     shaderContext.options.isRenderingPoints = isRenderingPoints(pCreateInfo);
 	shaderContext.options.isRasterizationDisabled = (pCreateInfo->pRasterizationState && (pCreateInfo->pRasterizationState->rasterizerDiscardEnable));
     shaderContext.options.shouldFlipVertexY = _device->_pMVKConfig->shaderConversionFlipVertexY;
-	shaderContext.options.shouldSwizzleTextureSamples = _device->_pMVKConfig->fullImageViewSwizzle;
+	shaderContext.options.shouldSwizzleTextureSamples = _fullImageViewSwizzle;
 
     // Set the shader context vertex attribute information
     shaderContext.vertexAttributes.clear();
@@ -599,7 +599,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	shaderContext.options.entryPointName = pCreateInfo->stage.pName;
 	shaderContext.options.entryPointStage = spv::ExecutionModelGLCompute;
     shaderContext.options.mslVersion = _device->_pMetalFeatures->mslVersion;
-	shaderContext.options.shouldSwizzleTextureSamples = _device->_pMVKConfig->fullImageViewSwizzle;
+	shaderContext.options.shouldSwizzleTextureSamples = _fullImageViewSwizzle;
 
     MVKPipelineLayout* layout = (MVKPipelineLayout*)pCreateInfo->layout;
     layout->populateShaderConverterContext(shaderContext);


### PR DESCRIPTION
Otherwise, the log will be spammed with hundreds of useless messages
that the `IDENTITY` swizzle is not supported.