### PR TITLE
Turn on shaderInt8.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -86,7 +86,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR: {
                 auto* f16Features = (VkPhysicalDeviceFloat16Int8FeaturesKHR*)next;
                 f16Features->shaderFloat16 = true;
-                f16Features->shaderInt8 = false;  // FIXME Needs SPIRV-Cross update
+                f16Features->shaderInt8 = true;
                 next = (MVKVkAPIStructHeader*)f16Features->pNext;
                 break;
             }


### PR DESCRIPTION
Now that SPIRV-Cross is updated to support it, we can safely advertise
this.

Fixes #372.