### PR TITLE
Building external dependency libraries cleans MoltenVK.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 XCODE_PROJ := MoltenVKPackaging.xcodeproj
+XCODE_SCHEME_BASE := MoltenVK Package
 
 .PHONY: all
 all:
-	xcodebuild -quiet -project $(XCODE_PROJ) -scheme "MoltenVK Package" build
+	xcodebuild -quiet -project "$(XCODE_PROJ)" -scheme "$(XCODE_SCHEME_BASE)" build
 
 .PHONY: macos
 macos:
-	xcodebuild -quiet -project $(XCODE_PROJ) -scheme "MoltenVK Package (macOS only)" build
+	xcodebuild -quiet -project "$(XCODE_PROJ)" -scheme "$(XCODE_SCHEME_BASE) (macOS only)" build
 
 .PHONY: ios
 ios:
-	xcodebuild -quiet -project $(XCODE_PROJ) -scheme "MoltenVK Package (iOS only)" build
+	xcodebuild -quiet -project "$(XCODE_PROJ)" -scheme "$(XCODE_SCHEME_BASE) (iOS only)" build
 
 .PHONY: clean
 clean:
-	xcodebuild -project $(XCODE_PROJ) -scheme "MoltenVK Package" clean
+	xcodebuild -quiet -project "$(XCODE_PROJ)" -scheme "$(XCODE_SCHEME_BASE)" clean
 	rm -rf Package
 

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -97,12 +97,12 @@
 		A964BD5F1C57EFBD00D930D8 /* MoltenVKShaderConverter */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MoltenVKShaderConverter; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD601C57EFBD00D930D8 /* libMoltenVKGLSLToSPIRVConverter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMoltenVKGLSLToSPIRVConverter.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A964BD611C57EFBD00D930D8 /* libMoltenVKGLSLToSPIRVConverter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMoltenVKGLSLToSPIRVConverter.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A972AD2A21CEE6A90013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = ../External/build/iOS/libglslang.a; sourceTree = "<group>"; };
-		A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = ../External/build/iOS/libSPIRVCross.a; sourceTree = "<group>"; };
-		A972AD3021CEE7040013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = ../External/build/iOS/libSPIRVTools.a; sourceTree = "<group>"; };
-		A972AD3421CEE7330013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = ../External/build/macOS/libSPIRVTools.a; sourceTree = "<group>"; };
-		A972AD3521CEE7330013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = ../External/build/macOS/libSPIRVCross.a; sourceTree = "<group>"; };
-		A972AD3821CEE7480013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = ../External/build/macOS/libglslang.a; sourceTree = "<group>"; };
+		A972AD2A21CEE6A90013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = iOS/libglslang.a; sourceTree = "<group>"; };
+		A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = iOS/libSPIRVCross.a; sourceTree = "<group>"; };
+		A972AD3021CEE7040013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = iOS/libSPIRVTools.a; sourceTree = "<group>"; };
+		A972AD3421CEE7330013AB25 /* libSPIRVTools.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVTools.a; path = macOS/libSPIRVTools.a; sourceTree = "<group>"; };
+		A972AD3521CEE7330013AB25 /* libSPIRVCross.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSPIRVCross.a; path = macOS/libSPIRVCross.a; sourceTree = "<group>"; };
+		A972AD3821CEE7480013AB25 /* libglslang.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libglslang.a; path = macOS/libglslang.a; sourceTree = "<group>"; };
 		A97CC73D1C7527F3004A5C7E /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		A97CC73E1C7527F3004A5C7E /* MoltenVKShaderConverterTool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MoltenVKShaderConverterTool.cpp; sourceTree = "<group>"; };
 		A97CC73F1C7527F3004A5C7E /* MoltenVKShaderConverterTool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MoltenVKShaderConverterTool.h; sourceTree = "<group>"; };
@@ -202,15 +202,16 @@
 		A972AD2921CEE6A80013AB25 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A972AD2A21CEE6A90013AB25 /* libglslang.a */,
 				A972AD3821CEE7480013AB25 /* libglslang.a */,
 				A972AD2F21CEE7040013AB25 /* libSPIRVCross.a */,
 				A972AD3521CEE7330013AB25 /* libSPIRVCross.a */,
 				A972AD3021CEE7040013AB25 /* libSPIRVTools.a */,
 				A972AD3421CEE7330013AB25 /* libSPIRVTools.a */,
-				A972AD2A21CEE6A90013AB25 /* libglslang.a */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
+			path = ../External/build;
+			sourceTree = SOURCE_ROOT;
 		};
 		A97CC73C1C7527F3004A5C7E /* MoltenVKShaderConverterTool */ = {
 			isa = PBXGroup;

--- a/Scripts/package_ext_libs.sh
+++ b/Scripts/package_ext_libs.sh
@@ -9,3 +9,7 @@ rm -rf "${MVK_EXT_LIB_DST_OS_PATH}"
 mkdir -p "${MVK_EXT_LIB_DST_OS_PATH}"
 
 cp -a "${MVK_BUILT_PROD_PATH}/"*.a "${MVK_EXT_LIB_DST_OS_PATH}"
+
+# Clean MoltenVK to ensure the next MoltenVK build will use the latest external library versions.
+make --quiet clean
+

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -260,5 +260,10 @@ xcodebuild 									\
 	${XC_BUILD_VERBOSITY}					\
 	build
 
+echo ========== Cleaning MoltenVK build. Be sure to build MoltenVK again. ==========
+
+make --quiet clean
+
+echo
 echo ========== Done! ==========
 

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -260,10 +260,5 @@ xcodebuild 									\
 	${XC_BUILD_VERBOSITY}					\
 	build
 
-echo ========== Cleaning MoltenVK build. Be sure to build MoltenVK again. ==========
-
-make --quiet clean
-
-echo
 echo ========== Done! ==========
 


### PR DESCRIPTION
Building external dependency libraries cleans MoltenVK to ensure subsequent MoltenVK builds will link to latest dependency library versions.

Fixes #507.