### PR TITLE
Set MSL version for shader compiling from Metal feature set.

### DIFF
--- a/Common/MVKLogging.h
+++ b/Common/MVKLogging.h
@@ -190,15 +190,18 @@ void MVKLogImpl(bool logToPrintf, bool logToASL, int aslLvl, const char* lvlStr,
 #define MVKLogDebugImpl(fmt, ...)	MVKLogImpl(true, !(MVK_DEBUG), ASL_LEVEL_DEBUG, "mvk-debug", fmt, ##__VA_ARGS__)
 
 // Assertions
-#if NS_BLOCK_ASSERTIONS
-#	define MVKAssert(test, fmt, ...)
+#ifdef NS_BLOCK_ASSERTIONS
+#	define MVK_BLOCK_ASSERTIONS		1
 #else
-#	define MVKAssert(test, fmt, ...)					\
-	if (!(test)) {										\
-		MVKLogError(fmt, ##__VA_ARGS__);				\
-		assert(false);									\
-	}
+#	define MVK_BLOCK_ASSERTIONS		0
 #endif
+
+#define MVKAssert(test, fmt, ...)				\
+do {											\
+	bool isErr = !(test);						\
+	MVKLogErrorIf(isErr, fmt, ##__VA_ARGS__);	\
+	assert(!isErr || MVK_BLOCK_ASSERTIONS);		\
+} while(0)
 
 #define MVKAssertUnimplemented(name) MVKAssert(false, "%s is not implemented!", name)
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -31,6 +31,8 @@ extern "C" {
 #ifdef __OBJC__
 #import <Metal/Metal.h>
 #import <IOSurface/IOSurfaceRef.h>
+#else
+typedef unsigned long MTLLanguageVersion;
 #endif
 
 
@@ -53,7 +55,7 @@ extern "C" {
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            17
+#define VK_MVK_MOLTENVK_SPEC_VERSION            18
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /**
@@ -512,6 +514,7 @@ typedef struct {
 	VkBool32 combinedStoreResolveAction;		/**< If true, the device supports VK_ATTACHMENT_STORE_OP_STORE with a simultaneous resolve attachment. */
 	VkBool32 arrayOfTextures;			 	  	/**< If true, arrays of textures is supported. */
 	VkBool32 arrayOfSamplers;			 	  	/**< If true, arrays of texture samplers is supported. */
+	MTLLanguageVersion mslVersionEnum;			/**< The version of the Metal Shading Language available on this device, as a Metal enumeration. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /**

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -443,7 +443,8 @@ void MVKCommandResourceFactory::initMTLLibrary() {
         _mtlLibrary = [getMTLDevice() newLibraryWithSource: _MVKStaticCmdShaderSource
                                                    options: getDevice()->getMTLCompileOptions()
                                                      error: &err];    // retained
-        MVKAssert( !err, "Could not compile command shaders %s (code %li) %s", err.localizedDescription.UTF8String, (long)err.code, err.localizedFailureReason.UTF8String);
+		MVKAssert( !err, "Could not compile command shaders (code %li):\n%s\n%s",
+				  (long)err.code, err.localizedDescription.UTF8String, err.localizedFailureReason.UTF8String);
     }
     _device->addActivityPerformance(_device->_performanceStatistics.shaderCompilation.mslCompile, startTime);
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -499,7 +499,7 @@ public:
 	inline id<MTLDevice> getMTLDevice() { return _physicalDevice->getMTLDevice(); }
 
 	/** Returns standard compilation options to be used when compiling MSL shaders. */
-	inline MTLCompileOptions* getMTLCompileOptions() { return [[MTLCompileOptions new] autorelease]; }
+	MTLCompileOptions* getMTLCompileOptions();
 
 	/** Returns the Metal vertex buffer index to use for the specified vertex attribute binding number.  */
 	uint32_t getMetalBufferIndexForVertexAttributeBinding(uint32_t binding);


### PR DESCRIPTION
Add MVKPhysicalDeviceMetalFeatures::mslVersionEnum and set from Metal feature sets.
Derive MVKPhysicalDeviceMetalFeatures:: mslVersion from mslVersionEnum.
MVKDevice::getMTLCompileOptions() sets MTLCompileOptions::languageVersion
from MVKPhysicalDeviceMetalFeatures::mslVersionEnum.
MVKAssert logs error even when assertions disabled.
Update VK_MVK_MOLTENVK_SPEC_VERSION to 18.