### PR TITLE
Stop on the first error in fetch dependencies script

### DIFF
--- a/fetchDependencies
+++ b/fetchDependencies
@@ -25,6 +25,7 @@
 #      -v      verbose output
 #
 
+set -o errexit
 
 # ----------------- Functions -------------------
 


### PR DESCRIPTION
For example, if CMake executable was not found, error message is hidden very well in quite long outputs of Git commands.