### PR TITLE
MVKDevice: Don't enable the shaderStorageImageArrayDynamicIndexing feature on iOS.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -817,7 +817,9 @@ void MVKPhysicalDevice::initFeatures() {
     _features.inheritedQueries = true;
 
 	_features.shaderSampledImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
+#if MVK_MACOS
 	_features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
+#endif
 
     if (_metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing) {
         _features.drawIndirectFirstInstance = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -817,9 +817,6 @@ void MVKPhysicalDevice::initFeatures() {
     _features.inheritedQueries = true;
 
 	_features.shaderSampledImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
-#if MVK_MACOS
-	_features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
-#endif
 
     if (_metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing) {
         _features.drawIndirectFirstInstance = true;
@@ -865,6 +862,8 @@ void MVKPhysicalDevice::initFeatures() {
     _features.depthClamp = true;
     _features.vertexPipelineStoresAndAtomics = true;
     _features.fragmentStoresAndAtomics = true;
+
+    _features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
 
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v2] ) {
         _features.tessellationShader = true;


### PR DESCRIPTION
iOS does not actually support arrays of writable textures. At all.