### PR TITLE
vkCmdBlitImage: Remove check for invalid behavior.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -175,9 +175,6 @@ void MVKCmdBlitImage::setContent(VkImage srcImage,
     if (_blitKey.isDepthFormat() && renderRegionCount > 0) {
         setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdBlitImage(): Scaling of depth/stencil images is not supported."));
     }
-    if ((_srcImage->getMTLPixelFormat() != _mtlPixFmt) && mvkMTLPixelFormatIsStencilFormat(_mtlPixFmt)) {
-        setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdBlitImage(): The source and destination images must have the same format for depth/stencil images."));
-    }
     if ( !_mtlTexBlitRenders.empty() && mvkMTLPixelFormatIsStencilFormat(_mtlPixFmt)) {
         setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdBlitImage(): Stencil image formats cannot be scaled or inverted."));
     }


### PR DESCRIPTION
According to the Vulkan spec:

> * If either of `srcImage` or `dstImage` was created with a
>   depth/stencil format, the other **must** have exactly the same format

So this should not happen in well-behaved clients.

Is there a reason this check was added?