### PR TITLE
Track enabled device features and clean up sparse binding errors.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Add correct function entry point handling.
 - Add support for `VK_KHR_get_surface_capabilities2` extension.
 - Implement newer `VK_KHR_swapchain` extension functions.
+- Add support for tracking device features enabled during `vkCreateDevice()`.
 - Allow zero offset and stride combo in `VkVertexInputBindingDescription`.
 - Fix conditions when multiple functions return VK_INCOMPLETE.
 - Fix potential memory leak on synchronous command buffer submission.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -148,7 +148,7 @@ void MVKCmdSetLineWidth::setContent(float lineWidth) {
 
     // Validate
     clearConfigurationResult();
-    if (_lineWidth != 1.0 || getDevice()->_pFeatures->wideLines) {
+    if (_lineWidth != 1.0 || getDevice()->_enabledFeatures.wideLines) {
         setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdSetLineWidth(): The current device does not support wide lines."));
     }
 }
@@ -207,7 +207,7 @@ void MVKCmdSetDepthBounds::setContent(float minDepthBounds, float maxDepthBounds
 
     // Validate
     clearConfigurationResult();
-    if (getDevice()->_pFeatures->depthBounds) {
+    if (getDevice()->_enabledFeatures.depthBounds) {
         setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdSetDepthBounds(): The current device does not support setting depth bounds."));
     }
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -532,7 +532,7 @@ MVKCommandEncoder::MVKCommandEncoder(MVKCommandBuffer* cmdBuffer) : MVKBaseDevic
         _computeResourcesState(this),
         _occlusionQueryState(this) {
 
-            _pDeviceFeatures = _device->_pFeatures;
+            _pDeviceFeatures = &_device->_enabledFeatures;
             _pDeviceMetalFeatures = _device->_pMetalFeatures;
             _pDeviceProperties = _device->_pProperties;
             _pDeviceMemoryProperties = _device->_pMemoryProperties;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -73,7 +73,7 @@ void MVKViewportCommandEncoderState::setViewports(const MVKVector<MTLViewport> &
 void MVKViewportCommandEncoderState::encodeImpl(uint32_t stage) {
     if (stage != kMVKGraphicsStageRasterization) { return; }
     MVKAssert(!_mtlViewports.empty(), "Must specify at least one viewport");
-    if (_cmdEncoder->getDevice()->_pFeatures->multiViewport) {
+    if (_cmdEncoder->_pDeviceFeatures->multiViewport) {
         [_cmdEncoder->_mtlRenderEncoder setViewports: &_mtlViewports[0] count: _mtlViewports.size()];
     } else {
         [_cmdEncoder->_mtlRenderEncoder setViewport: _mtlViewports[0]];
@@ -115,7 +115,7 @@ void MVKScissorCommandEncoderState::encodeImpl(uint32_t stage) {
 	std::for_each(clippedScissors.begin(), clippedScissors.end(), [this](MTLScissorRect& scissor) {
 		scissor = _cmdEncoder->clipToRenderArea(scissor);
 	});
-	if (_cmdEncoder->getDevice()->_pFeatures->multiViewport) {
+	if (_cmdEncoder->_pDeviceFeatures->multiViewport) {
 		[_cmdEncoder->_mtlRenderEncoder setScissorRects: &clippedScissors[0] count: clippedScissors.size()];
 	} else {
 		[_cmdEncoder->_mtlRenderEncoder setScissorRect: clippedScissors[0]];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -583,8 +583,18 @@ public:
 	/** Pointer to the MoltenVK configuration settings. */
 	const MVKConfiguration* _pMVKConfig;
 
-	/** Pointer to the feature set of the underlying physical device. */
-	const VkPhysicalDeviceFeatures* _pFeatures;
+	/** Device features available and enabled. */
+	const VkPhysicalDeviceFeatures _enabledFeatures;
+	const VkPhysicalDevice16BitStorageFeatures _enabledStorage16Features;
+	const VkPhysicalDevice8BitStorageFeaturesKHR _enabledStorage8Features;
+	const VkPhysicalDeviceFloat16Int8FeaturesKHR _enabledF16I8Features;
+	const VkPhysicalDeviceVariablePointerFeatures _enabledVarPtrFeatures;
+	const VkPhysicalDeviceHostQueryResetFeaturesEXT _enabledHostQryResetFeatures;
+	const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT _enabledVtxAttrDivFeatures;
+	const VkPhysicalDevicePortabilitySubsetFeaturesEXTX _enabledPortabilityFeatures;
+
+	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
+	const MVKExtensionList _enabledExtensions;
 
 	/** Pointer to the Metal-specific features of the underlying physical device. */
 	const MVKPhysicalDeviceMetalFeatures* _pMetalFeatures;
@@ -594,9 +604,6 @@ public:
 
 	/** Pointer to the memory properties of the underlying physical device. */
 	const VkPhysicalDeviceMemoryProperties* _pMemoryProperties;
-
-	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
-	const MVKExtensionList _enabledExtensions;
 
     /** Performance statistics. */
     MVKPerformanceStatistics _performanceStatistics;
@@ -629,6 +636,9 @@ protected:
     void initPerformanceTracking();
 	void initPhysicalDevice(MVKPhysicalDevice* physicalDevice);
 	void initQueues(const VkDeviceCreateInfo* pCreateInfo);
+	void enableFeatures(const VkDeviceCreateInfo* pCreateInfo);
+	void enableFeatures(const VkBool32* pEnable, const VkBool32* pRequested, const VkBool32* pAvailable, uint32_t count);
+	void enableExtensions(const VkDeviceCreateInfo* pCreateInfo);
     const char* getActivityPerformanceDescription(MVKPerformanceTracker& shaderCompilationEvent);
 	uint64_t getPerformanceTimestampImpl();
 	void addActivityPerformanceImpl(MVKPerformanceTracker& shaderCompilationEvent,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -226,7 +226,7 @@ void MVKGraphicsPipeline::encode(MVKCommandEncoder* cmdEncoder, uint32_t stage) 
             [mtlCmdEnc setFrontFacingWinding: _mtlFrontWinding];
             [mtlCmdEnc setTriangleFillMode: _mtlFillMode];
 
-            if (_device->_pFeatures->depthClamp) {
+            if (_device->_enabledFeatures.depthClamp) {
                 [mtlCmdEnc setDepthClipMode: _mtlDepthClipMode];
             }
 
@@ -323,7 +323,7 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 		_mtlFrontWinding = mvkMTLWindingFromVkFrontFace(_rasterInfo.frontFace);
 		_mtlFillMode = mvkMTLTriangleFillModeFromVkPolygonMode(_rasterInfo.polygonMode);
 		if (_rasterInfo.depthClampEnable) {
-			if (_device->_pFeatures->depthClamp) {
+			if (_device->_enabledFeatures.depthClamp) {
 				_mtlDepthClipMode = MTLDepthClipModeClamp;
 			} else {
 				setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "This device does not support depth clamping."));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -244,7 +244,7 @@ MVKOcclusionQueryPool::~MVKOcclusionQueryPool() {
 
 MVKPipelineStatisticsQueryPool::MVKPipelineStatisticsQueryPool(MVKDevice* device,
 															   const VkQueryPoolCreateInfo* pCreateInfo) : MVKQueryPool(device, pCreateInfo, 1) {
-	if ( !_device->_pFeatures->pipelineStatisticsQuery ) {
+	if ( !_device->_enabledFeatures.pipelineStatisticsQuery ) {
 		setConfigurationResult(mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateQueryPool: VK_QUERY_TYPE_PIPELINE_STATISTICS is not supported."));
 	}
 }

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -159,7 +159,7 @@ MVK_PUBLIC_SYMBOL VkResult vkCreateDevice(
 	MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
 	MVKDevice* mvkDev = new MVKDevice(mvkPD, pCreateInfo);
 	*pDevice = mvkDev->getVkDevice();
-	return VK_SUCCESS;
+	return mvkDev->getConfigurationResult();
 }
 
 MVK_PUBLIC_SYMBOL void vkDestroyDevice(
@@ -288,12 +288,14 @@ MVK_PUBLIC_SYMBOL VkResult vkFlushMappedMemoryRanges(
     uint32_t                                    memRangeCount,
     const VkMappedMemoryRange*                  pMemRanges) {
 
+	VkResult rslt = VK_SUCCESS;
 	for (uint32_t i = 0; i < memRangeCount; i++) {
 		const VkMappedMemoryRange* pMem = &pMemRanges[i];
 		MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
-		mvkMem->flushToDevice(pMem->offset, pMem->size);
+		VkResult r = mvkMem->flushToDevice(pMem->offset, pMem->size);
+		if (rslt == VK_SUCCESS) { rslt = r; }
 	}
-	return VK_SUCCESS;
+	return rslt;
 }
 
 MVK_PUBLIC_SYMBOL VkResult vkInvalidateMappedMemoryRanges(
@@ -301,12 +303,14 @@ MVK_PUBLIC_SYMBOL VkResult vkInvalidateMappedMemoryRanges(
     uint32_t                                    memRangeCount,
     const VkMappedMemoryRange*                  pMemRanges) {
 	
+	VkResult rslt = VK_SUCCESS;
 	for (uint32_t i = 0; i < memRangeCount; i++) {
 		const VkMappedMemoryRange* pMem = &pMemRanges[i];
 		MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
-		mvkMem->pullFromDevice(pMem->offset, pMem->size);
+		VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size);
+		if (rslt == VK_SUCCESS) { rslt = r; }
 	}
-	return VK_SUCCESS;
+	return rslt;
 }
 
 MVK_PUBLIC_SYMBOL void vkGetDeviceMemoryCommitment(

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -366,7 +366,10 @@ MVK_PUBLIC_SYMBOL void vkGetImageSparseMemoryRequirements(
     uint32_t*                                   pNumRequirements,
     VkSparseImageMemoryRequirements*            pSparseMemoryRequirements) {
 	
-	MVKLogUnimplemented("vkGetImageSparseMemoryRequirements");
+	// Metal does not support sparse images.
+	// Vulkan spec: "If the image was not created with VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT then
+	// pSparseMemoryRequirementCount will be set to zero and pSparseMemoryRequirements will not be written to.".
+
 	*pNumRequirements = 0;
 }
 
@@ -380,7 +383,10 @@ MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceSparseImageFormatProperties(
 	uint32_t*                                   pPropertyCount,
 	VkSparseImageFormatProperties*              pProperties) {
 
-	MVKLogUnimplemented("vkGetPhysicalDeviceSparseImageFormatProperties");
+	// Metal does not support sparse images.
+	// Vulkan spec: "If VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT is not supported for the given arguments,
+	// pPropertyCount will be set to zero upon return, and no data will be written to pProperties.".
+
 	*pPropertyCount = 0;
 }
 
@@ -390,7 +396,7 @@ MVK_PUBLIC_SYMBOL VkResult vkQueueBindSparse(
 	const VkBindSparseInfo*                     pBindInfo,
 	VkFence                                     fence) {
 
-	return MVKLogUnimplemented("vkQueueBindSparse");
+	return mvkNotifyErrorWithText(VK_ERROR_FEATURE_NOT_PRESENT, "vkQueueBindSparse(): Sparse binding is not supported.");
 }
 
 MVK_PUBLIC_SYMBOL VkResult vkCreateFence(
@@ -1569,7 +1575,10 @@ MVK_PUBLIC_SYMBOL void vkGetImageSparseMemoryRequirements2KHR(
     uint32_t*                                       pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2KHR*            pSparseMemoryRequirements) {
 
-    MVKLogUnimplemented("vkGetImageSparseMemoryRequirements2KHR");
+	// Metal does not support sparse images.
+	// Vulkan spec: "If the image was not created with VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT then
+	// pSparseMemoryRequirementCount will be set to zero and pSparseMemoryRequirements will not be written to.".
+
     *pSparseMemoryRequirementCount = 0;
 }
 
@@ -1634,7 +1643,10 @@ MVK_PUBLIC_SYMBOL void vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
     uint32_t*                                   pPropertyCount,
     VkSparseImageFormatProperties2KHR*          pProperties) {
 
-    MVKLogUnimplemented("vkGetPhysicalDeviceSparseImageFormatProperties");
+	// Metal does not support sparse images.
+	// Vulkan spec: "If VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT is not supported for the given arguments,
+	// pPropertyCount will be set to zero upon return, and no data will be written to pProperties.".
+
     *pPropertyCount = 0;
 }
 


### PR DESCRIPTION
- Enable device features based on content of pCreateDeviceInfo.
- Validate requested features are available and return  if not.
- Support returning error from vkCreateDevice(), vkFlushMappedMemoryRanges() and vkInvalidateMappedMemoryRanges().
- Remove "unimplemented" error reporting from sparse binding functions.
- As per Vulkan spec, sparse binding query functions simply return zero responses.
- vkQueueBindSparse() returns VK_ERROR_FEATURE_NOT_PRESENT error.
- Update What's New Document.
