### PR TITLE
CTS fixes. MVKPushConstantsCommandEncoderState compute / tessellation conflict.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -202,6 +202,7 @@ public:
 protected:
     void encodeImpl(uint32_t stage) override;
     void resetImpl() override;
+	bool isTessellating();
 
     MVKVectorInline<char, 128> _pushConstants;
     VkShaderStageFlagBits _shaderStage;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -147,10 +147,9 @@ void MVKPushConstantsCommandEncoderState::setMTLBufferIndex(uint32_t mtlBufferIn
 void MVKPushConstantsCommandEncoderState::encodeImpl(uint32_t stage) {
     if (_pushConstants.empty() ) { return; }
 
-    bool forTessellation = ((MVKGraphicsPipeline*)_cmdEncoder->_graphicsPipelineState.getPipeline())->isTessellationPipeline();
     switch (_shaderStage) {
         case VK_SHADER_STAGE_VERTEX_BIT:
-            if (stage == (forTessellation ? kMVKGraphicsStageVertex : kMVKGraphicsStageRasterization)) {
+            if (stage == (isTessellating() ? kMVKGraphicsStageVertex : kMVKGraphicsStageRasterization)) {
                 _cmdEncoder->setVertexBytes(_cmdEncoder->_mtlRenderEncoder,
                                             _pushConstants.data(),
                                             _pushConstants.size(),
@@ -166,7 +165,7 @@ void MVKPushConstantsCommandEncoderState::encodeImpl(uint32_t stage) {
             }
             break;
         case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-            if (forTessellation && stage == kMVKGraphicsStageRasterization) {
+            if (isTessellating() && stage == kMVKGraphicsStageRasterization) {
                 _cmdEncoder->setVertexBytes(_cmdEncoder->_mtlRenderEncoder,
                                             _pushConstants.data(),
                                             _pushConstants.size(),
@@ -191,6 +190,11 @@ void MVKPushConstantsCommandEncoderState::encodeImpl(uint32_t stage) {
             MVKAssert(false, "Unsupported shader stage: %d", _shaderStage);
             break;
     }
+}
+
+bool MVKPushConstantsCommandEncoderState::isTessellating() {
+	MVKGraphicsPipeline* gp = (MVKGraphicsPipeline*)_cmdEncoder->_graphicsPipelineState.getPipeline();
+	return gp ? gp->isTessellationPipeline() : false;
 }
 
 void MVKPushConstantsCommandEncoderState::resetImpl() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -22,6 +22,7 @@
 #include "MVKBaseObject.h"
 #include "MVKLayers.h"
 #include "MVKObjectPool.h"
+#include "mvk_datatypes.h"
 #include "vk_mvk_moltenvk.h"
 #include <vector>
 #include <string>
@@ -659,7 +660,10 @@ protected:
 #pragma mark -
 #pragma mark MVKBaseDeviceObject
 
-/** Represents an object that is spawned from a Vulkan device, and tracks that device. */
+/**
+ * Represents an object that is spawned from a Vulkan device, and tracks that device.
+ * Implementation supports an instance where the device is null.
+ */
 class MVKBaseDeviceObject : public MVKConfigurableObject {
 
 public:
@@ -668,7 +672,7 @@ public:
 	inline MVKDevice* getDevice() { return _device; }
 
 	/** Returns the underlying Metal device. */
-	inline id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
+	inline id<MTLDevice> getMTLDevice() { return _device ? _device->getMTLDevice() : nil; }
 
 	/**
 	 * Returns the Metal MTLPixelFormat corresponding to the specified Vulkan VkFormat,
@@ -679,7 +683,7 @@ public:
 	 * are managed for each platform device.
 	 */
     inline MTLPixelFormat getMTLPixelFormatFromVkFormat(VkFormat vkFormat) {
-        return _device->getMTLPixelFormatFromVkFormat(vkFormat);
+		return _device ? _device->getMTLPixelFormatFromVkFormat(vkFormat) : mvkMTLPixelFormatFromVkFormat(vkFormat);
     }
 
 	/** Constructs an instance for the specified device. */
@@ -693,7 +697,10 @@ protected:
 #pragma mark -
 #pragma mark MVKDispatchableDeviceObject
 
-/** Represents a dispatchable object that is spawned from a Vulkan device, and tracks that device. */
+/**
+ * Represents a dispatchable object that is spawned from a Vulkan device, and tracks that device.
+ * Implementation supports an instance where the device is null.
+ */
 class MVKDispatchableDeviceObject : public MVKDispatchableObject {
 
 public:
@@ -702,7 +709,7 @@ public:
     inline MVKDevice* getDevice() { return _device; }
 
     /** Returns the underlying Metal device. */
-    inline id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
+	inline id<MTLDevice> getMTLDevice() { return _device ? _device->getMTLDevice() : nil; }
 
     /** Constructs an instance for the specified device. */
     MVKDispatchableDeviceObject(MVKDevice* device) : _device(device) {}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -34,7 +34,6 @@
 #include "MVKEnvironment.h"
 #include "MVKOSExtensions.h"
 #include <MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h>
-#include "mvk_datatypes.h"
 #include "vk_mvk_moltenvk.h"
 
 #import "CAMetalLayer+MoltenVK.h"


### PR DESCRIPTION
Fixed crash within MVKPushConstantsCommandEncoderState when accessing absent graphics pipeline during a compute stage.
MVKPushConstantsCommandEncoderState test for tessellation only during graphics stages.
Guard against possible missing graphics pipeline even during graphics stages.

Support null device in MVKBaseDeviceObject and MVKDispatchableDeviceObject instances.