### PR TITLE
Set options properly on a buffer view's MTLTextureDescriptor.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -56,6 +56,9 @@ public:
                                   MVKCommandEncoder* cmdEncoder,
                                   MVKCommandUse cmdUse);
 
+    /** Returns the intended usage of this buffer. */
+    VkBufferUsageFlags getUsage() const { return _usage; }
+
 
 #pragma mark Metal
 
@@ -78,6 +81,8 @@ protected:
 	bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
 						   VkPipelineStageFlags dstStageMask,
 						   VkBufferMemoryBarrier* pBufferMemoryBarrier);
+
+	VkBufferUsageFlags _usage;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -116,7 +116,7 @@ bool MVKBuffer::needsHostReadSync(VkPipelineStageFlags srcStageMask,
 
 #pragma mark Construction
 
-MVKBuffer::MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo) : MVKResource(device) {
+MVKBuffer::MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo) : MVKResource(device), _usage(pCreateInfo->usage) {
     _byteAlignment = _device->_pMetalFeatures->mtlBufferAlignment;
     _byteCount = pCreateInfo->size;
 }
@@ -142,6 +142,12 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
                                                                                               width: _textureSize.width
                                                                                              height: _textureSize.height
                                                                                           mipmapped: NO];
+        mtlTexDesc.storageMode = _buffer->getMTLBuffer().storageMode;
+        mtlTexDesc.cpuCacheMode = _buffer->getMTLBuffer().cpuCacheMode;
+        mtlTexDesc.usage = MTLTextureUsageShaderRead;
+        if ( mvkIsAnyFlagEnabled(_buffer->getUsage(), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) ) {
+            mtlTexDesc.usage |= MTLTextureUsageShaderWrite;
+        }
 		_mtlTexture = [_buffer->getMTLBuffer() newTextureWithDescriptor: mtlTexDesc
 																 offset: _mtlBufferOffset
 															bytesPerRow: _mtlBytesPerRow];


### PR DESCRIPTION
The resource options must match between an `MTLBuffer` and any linear
texture created from it. Further, to be writable, the
`MTLTextureDescriptor` should have the `MTLTextureUsageShaderWrite` bit
set.

Fixes #542.