### PR TITLE
Fix wrong offset for vkCmdFillBuffer on VK_WHOLE_SIZE.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1092,8 +1092,10 @@ void MVKCmdFillBuffer::setContent(VkBuffer dstBuffer,
 void MVKCmdFillBuffer::encode(MVKCommandEncoder* cmdEncoder) {
     id<MTLBuffer> dstMTLBuff = _dstBuffer->getMTLBuffer();
     VkDeviceSize dstMTLBuffOffset = _dstBuffer->getMTLBufferOffset();
-    VkDeviceSize byteCnt = (_size == VK_WHOLE_SIZE) ? (_dstBuffer->getByteCount() - (dstMTLBuffOffset + _dstOffset)) : _size;
-	VkDeviceSize wordCnt = byteCnt >> 2;
+    VkDeviceSize byteCnt = (_size == VK_WHOLE_SIZE) ? (_dstBuffer->getByteCount() - _dstOffset) : _size;
+
+    // Round up in case of VK_WHOLE_SIZE on a buffer size which is not aligned to 4 bytes.
+    VkDeviceSize wordCnt = (byteCnt + 3) >> 2;
 
 	MVKAssert(mvkFits<uint32_t>(wordCnt),
 			  "Buffer fill size must fit into a 32-bit unsigned integer.");


### PR DESCRIPTION
A double offset would be applied by taking the user offset and global offset, causing the word count to wrap around and trigger an assertion and GPU lockup. This seems to be what caused a GPU hang in Granite for some time.

I also added a rounding bump for wordCount. I'm not sure if the internal buffer size is naturally rounded ahead of time, but the case for this rounding would be if a buffer was, say, 3 bytes, and the application calls for VK_WHOLE_SIZE.

This is related to:
https://github.com/KhronosGroup/MoltenVK/issues/544