### PR TITLE
Workaround GPU Hang on iPhone 6s (iOS 12.2) where setting the renderp…

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -250,8 +250,8 @@ void MVKCommandEncoder::beginMetalRenderPass() {
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues, _isRenderingEntireAttachment);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 	mtlRPDesc.renderTargetArrayLengthMVK = _framebuffer->getLayerCount();
-	mtlRPDesc.renderTargetWidthMVK = min(_framebuffer->getExtent2D().width, _renderArea.offset.x + _renderArea.extent.width);
-	mtlRPDesc.renderTargetHeightMVK = min(_framebuffer->getExtent2D().height, _renderArea.offset.y + _renderArea.extent.height);
+	mtlRPDesc.renderTargetWidthMVK = _framebuffer->getExtent2D().width;
+	mtlRPDesc.renderTargetHeightMVK = _framebuffer->getExtent2D().height;
 
     _mtlRenderEncoder = [_mtlCmdBuffer renderCommandEncoderWithDescriptor: mtlRPDesc];     // not retained
     _mtlRenderEncoder.label = getMTLRenderCommandEncoderName();


### PR DESCRIPTION
…ass descriptor to a size smaller than the rendertarget is causing a GPU hang.  We render with offset renderArea/scissor and for reasons unclear this is inducing a GPU hang with no validation errors.  On iPad Air (3rd Gen) it works fine.

@billhollings I'm not sure what to do with this one - I think it may have some performance implications for cases where the renderArea is smaller than the render target, although it seems necessary for us not to hang.  

