### PR TITLE
Handle surface loss.

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		45003E73214AD4E500E989CB /* MVKExtensions.def in Headers */ = {isa = PBXBuildFile; fileRef = 45003E6F214AD4C900E989CB /* MVKExtensions.def */; };
 		45003E74214AD4E600E989CB /* MVKExtensions.def in Headers */ = {isa = PBXBuildFile; fileRef = 45003E6F214AD4C900E989CB /* MVKExtensions.def */; };
+		4553AEFB2251617100E8EBCD /* MVKBlockObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 4553AEF62251617100E8EBCD /* MVKBlockObserver.m */; };
+		4553AEFC2251617100E8EBCD /* MVKBlockObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 4553AEF62251617100E8EBCD /* MVKBlockObserver.m */; };
+		4553AEFD2251617100E8EBCD /* MVKBlockObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4553AEFA2251617100E8EBCD /* MVKBlockObserver.h */; };
+		4553AEFE2251617100E8EBCD /* MVKBlockObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 4553AEFA2251617100E8EBCD /* MVKBlockObserver.h */; };
 		45557A5221C9EFF3008868BD /* MVKCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45557A4D21C9EFF3008868BD /* MVKCodec.cpp */; };
 		45557A5321C9EFF3008868BD /* MVKCodec.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45557A4D21C9EFF3008868BD /* MVKCodec.cpp */; };
 		45557A5421C9EFF3008868BD /* MVKCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 45557A5121C9EFF3008868BD /* MVKCodec.h */; };
@@ -271,6 +275,8 @@
 
 /* Begin PBXFileReference section */
 		45003E6F214AD4C900E989CB /* MVKExtensions.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = MVKExtensions.def; sourceTree = "<group>"; };
+		4553AEF62251617100E8EBCD /* MVKBlockObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MVKBlockObserver.m; sourceTree = "<group>"; };
+		4553AEFA2251617100E8EBCD /* MVKBlockObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKBlockObserver.h; sourceTree = "<group>"; };
 		45557A4D21C9EFF3008868BD /* MVKCodec.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MVKCodec.cpp; sourceTree = "<group>"; };
 		45557A5121C9EFF3008868BD /* MVKCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKCodec.h; sourceTree = "<group>"; };
 		45557A5721CD83C3008868BD /* MVKDXTnCodec.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = MVKDXTnCodec.def; sourceTree = "<group>"; };
@@ -508,6 +514,8 @@
 		A98149401FB6A3F7005F00B4 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				4553AEFA2251617100E8EBCD /* MVKBlockObserver.h */,
+				4553AEF62251617100E8EBCD /* MVKBlockObserver.m */,
 				45557A5721CD83C3008868BD /* MVKDXTnCodec.def */,
 				45557A4D21C9EFF3008868BD /* MVKCodec.cpp */,
 				45557A5121C9EFF3008868BD /* MVKCodec.h */,
@@ -654,6 +662,7 @@
 				A94FB7BC1C7DFB4800632CA3 /* MVKCmdPipeline.h in Headers */,
 				A94FB7F81C7DFB4800632CA3 /* MVKPipeline.h in Headers */,
 				A94FB7F01C7DFB4800632CA3 /* MVKImage.h in Headers */,
+				4553AEFD2251617100E8EBCD /* MVKBlockObserver.h in Headers */,
 				A94FB7B81C7DFB4800632CA3 /* MVKCmdTransfer.h in Headers */,
 				A94FB7C81C7DFB4800632CA3 /* MVKCmdDraw.h in Headers */,
 				A94FB7D01C7DFB4800632CA3 /* MVKCommandBuffer.h in Headers */,
@@ -718,6 +727,7 @@
 				A94FB7BD1C7DFB4800632CA3 /* MVKCmdPipeline.h in Headers */,
 				A94FB7F91C7DFB4800632CA3 /* MVKPipeline.h in Headers */,
 				A94FB7F11C7DFB4800632CA3 /* MVKImage.h in Headers */,
+				4553AEFE2251617100E8EBCD /* MVKBlockObserver.h in Headers */,
 				A94FB7B91C7DFB4800632CA3 /* MVKCmdTransfer.h in Headers */,
 				A94FB7C91C7DFB4800632CA3 /* MVKCmdDraw.h in Headers */,
 				A94FB7D11C7DFB4800632CA3 /* MVKCommandBuffer.h in Headers */,
@@ -929,6 +939,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4553AEFB2251617100E8EBCD /* MVKBlockObserver.m in Sources */,
 				A9E53DFF21064F84002781DD /* MTLRenderPipelineDescriptor+MoltenVK.m in Sources */,
 				A94FB80A1C7DFB4800632CA3 /* MVKResource.mm in Sources */,
 				A94FB7E21C7DFB4800632CA3 /* MVKDescriptorSet.mm in Sources */,
@@ -983,6 +994,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4553AEFC2251617100E8EBCD /* MVKBlockObserver.m in Sources */,
 				A9E53E0021064F84002781DD /* MTLRenderPipelineDescriptor+MoltenVK.m in Sources */,
 				A94FB80B1C7DFB4800632CA3 /* MVKResource.mm in Sources */,
 				A94FB7E31C7DFB4800632CA3 /* MVKDescriptorSet.mm in Sources */,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -390,7 +390,10 @@ MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKDevice* de
 	for (uint32_t i = 0; i < pPresentInfo->swapchainCount; i++) {
 		MVKSwapchain* mvkSC = (MVKSwapchain*)pPresentInfo->pSwapchains[i];
 		_surfaceImages.push_back(mvkSC->getImage(pPresentInfo->pImageIndices[i]));
-		if (mvkSC->getHasSurfaceSizeChanged()) {
+		// Surface loss takes precedence over out-of-date errors.
+		if (mvkSC->getIsSurfaceLost()) {
+			_submissionResult = VK_ERROR_SURFACE_LOST_KHR;
+		} else if (mvkSC->getHasSurfaceSizeChanged() && _submissionResult != VK_ERROR_SURFACE_LOST_KHR) {
 			_submissionResult = VK_ERROR_OUT_OF_DATE_KHR;
 		}
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -24,6 +24,8 @@
 class MVKSwapchainImage;
 class MVKWatermark;
 
+@class MVKBlockObserver;
+
 
 #pragma mark MVKSwapchain
 
@@ -62,6 +64,9 @@ public:
 
 	/** Returns whether the surface size has changed since the last time this function was called. */
 	bool getHasSurfaceSizeChanged();
+
+	/** Returns whether the parent surface is now lost and this swapchain must be recreated. */
+	bool getIsSurfaceLost() { return _surfaceLost; }
 
 	/** Returns the specified performance stats structure. */
 	const MVKSwapchainPerformance* getPerformanceStatistics() { return &_performanceStatistics; }
@@ -106,5 +111,7 @@ protected:
     uint64_t _lastFrameTime;
     double _averageFrameIntervalFilterAlpha;
     uint32_t _currentPerfLogFrameCount;
+    std::atomic<bool> _surfaceLost;
+    MVKBlockObserver* _layerObserver;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -222,8 +222,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 	//  - colorspace (macOS only) Vulkan only supports sRGB colorspace for now.
 	//  - wantsExtendedDynamicRangeContent (macOS only)
 
-#if MVK_MACOS
-	if ( [_mtlLayer.delegate isKindOfClass: [NSView class]] ) {
+	if ( [_mtlLayer.delegate isKindOfClass: [PLATFORM_VIEW_CLASS class]] ) {
 		// Sometimes, the owning view can replace its CAMetalLayer. In that case, the client
 		// needs to recreate the swapchain, or no content will be displayed.
 		_layerObserver = [MVKBlockObserver observerWithBlock: ^(NSString* path, id, NSDictionary*, void*) {
@@ -233,7 +232,6 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 			this->_layerObserver = nil;
 		} forObject: _mtlLayer.delegate atKeyPath: @"layer"];
 	}
-#endif
 }
 
 // Initializes the array of images used for the surface of this swapchain.

--- a/MoltenVK/MoltenVK/Utility/MVKBlockObserver.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBlockObserver.h
@@ -1,0 +1,47 @@
+/*
+ * MVKBlockObserver.h
+ *
+ * Copyright (c) 2019 Chip Davis for CodeWeavers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSKeyValueObserving.h>
+
+
+#pragma mark MVKBlockObserver
+
+typedef void (^MVKKeyValueObserverBlock)(NSString* keyPath, id object, NSDictionary* changeDict, void* context);
+
+/** Class that calls a block on any key-value observation callback. */
+@interface MVKBlockObserver : NSObject {
+	MVKKeyValueObserverBlock _block;
+	id _target;
+	NSString* _keyPath;
+}
+
+- (instancetype)initWithBlock:(MVKKeyValueObserverBlock) block;
+- (instancetype)initWithBlock:(MVKKeyValueObserverBlock) block forObject: object atKeyPath:(NSString*) keyPath;
+
++ (instancetype)observerWithBlock:(MVKKeyValueObserverBlock) block;
++ (instancetype)observerWithBlock:(MVKKeyValueObserverBlock) block forObject: object atKeyPath:(NSString*) keyPath;
+
+- (void)observeValueForKeyPath:(NSString*) path ofObject: object change:(NSDictionary*) changeDict context: (void*)context;
+
+- (void)startObservingObject: object atKeyPath:(NSString*) keyPath;
+- (void)stopObserving;
+
+@end
+

--- a/MoltenVK/MoltenVK/Utility/MVKBlockObserver.m
+++ b/MoltenVK/MoltenVK/Utility/MVKBlockObserver.m
@@ -1,0 +1,74 @@
+/*
+ * MVKBlockObserver.m
+ *
+ * Copyright (c) 2019 Chip Davis for CodeWeavers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#import "MVKBlockObserver.h"
+
+
+@implementation MVKBlockObserver
+
+- (instancetype)initWithBlock:(MVKKeyValueObserverBlock) block {
+	if ((self = [super init])) {
+		_block = [block copy];
+	}
+	return self;
+}
+
+- (instancetype)initWithBlock:(MVKKeyValueObserverBlock) block forObject: object atKeyPath:(NSString*) keyPath {
+	if ((self = [super init])) {
+		_block = [block copy];
+		[self startObservingObject: object atKeyPath: keyPath];
+	}
+	return self;
+}
+
++ (instancetype)observerWithBlock:(MVKKeyValueObserverBlock) block {
+	return [[self alloc] initWithBlock: block];
+}
+
++ (instancetype)observerWithBlock:(MVKKeyValueObserverBlock) block forObject: object atKeyPath:(NSString*) keyPath {
+	return [[self alloc] initWithBlock: block forObject: object atKeyPath: keyPath];
+}
+
+- (void)dealloc {
+	[self stopObserving];
+	[super dealloc];
+}
+
+- (void)observeValueForKeyPath:(NSString*) path ofObject: object change:(NSDictionary*) changeDict context:(void*) context {
+	_block(path, object, changeDict, context);
+}
+
+- (void)startObservingObject: object atKeyPath:(NSString*) path {
+	if ( !_target ) {
+		_target = [object retain];
+		_keyPath = [path copy];
+		[_target addObserver: self forKeyPath: _keyPath options: 0 context: NULL];
+	}
+}
+
+- (void)stopObserving {
+	[_target removeObserver: self forKeyPath: _keyPath context: NULL];
+	[_target release];
+	[_keyPath release];
+	_target = nil;
+	_keyPath = nil;
+}
+
+@end
+


### PR DESCRIPTION
Sometimes, the `CAMetalLayer` backing a view can be replaced--for
example, when the window is moved to another screen, or the style bits
on the window are changed. In that case, we must allow the client the
opportunity to recreate the surface and swapchain.

Layer-backed views always set themselves as the layer's delegate; we use
this fact to Key-Value Observe the view's `layer` property.

Other alternatives considered:

* Registering for `NSViewGlobalFrameDidChange` notifications. Aside from
  only working on macOS, this doesn't actually catch every case where we
  want to report a lost surface. I'm not even sure it works at all for
  Metal.
* Holding a reference to the view, and checking when its layer property
  has changed.
* Holding a weak reference to the layer; that way, the reference will
  become `nil` when the layer is replaced. But this requires ARC.