### PR TITLE
Set MTLRenderPassDescriptor renderTargetWidth & renderTargetHeight only when layered rendering supported, to avoid GPU crashes on older devices.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -39,7 +39,8 @@ Released TBD
 - Fix wrong offset for `vkCmdFillBuffer()` on `VK_WHOLE_SIZE`.
 - Fixed crash within `MVKPushConstantsCommandEncoderState` when accessing absent
   graphics pipeline during a compute stage.
-- Renderpass width/height clamped to the `renderArea` includes offset, not just the extent.
+- Renderpass width/height clamped to the `renderArea` includes `offset`, not just `extent`, 
+  and are set only when layered rendering is supported on device.
 - Set options properly on a buffer view's `MTLTextureDescriptor`.
 - Don't set `MTLSamplerDescriptor.compareFunction` on devices that don't support it.
 - Debug build mode includes `dSYM` file for each `dylib` file.


### PR DESCRIPTION
Replaces PR #555.