### PR TITLE
MVKBuffer: Force managed storage for linear textures on shared buffers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -142,7 +142,16 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
                                                                                               width: _textureSize.width
                                                                                              height: _textureSize.height
                                                                                           mipmapped: NO];
+#if MVK_MACOS
+        // Textures on Mac cannot use shared storage, so force managed.
+        if (_buffer->getMTLBuffer().storageMode == MTLStorageModeShared) {
+            mtlTexDesc.storageMode = MTLStorageModeManaged;
+        } else {
+            mtlTexDesc.storageMode = _buffer->getMTLBuffer().storageMode;
+        }
+#else
         mtlTexDesc.storageMode = _buffer->getMTLBuffer().storageMode;
+#endif
         mtlTexDesc.cpuCacheMode = _buffer->getMTLBuffer().cpuCacheMode;
         mtlTexDesc.usage = MTLTextureUsageShaderRead;
         if ( mvkIsAnyFlagEnabled(_buffer->getUsage(), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) ) {


### PR DESCRIPTION
Shared storage on textures is disallowed on macOS.

Fixes #573.