### PR TITLE
MVKDevice: Don't unnecessarily iterate resources for global memory barriers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1930,6 +1930,8 @@ void MVKDevice::applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
 								   VkMemoryBarrier* pMemoryBarrier,
                                    MVKCommandEncoder* cmdEncoder,
                                    MVKCommandUse cmdUse) {
+	if (!mvkIsAnyFlagEnabled(dstStageMask, VK_PIPELINE_STAGE_HOST_BIT) ||
+		!mvkIsAnyFlagEnabled(pMemoryBarrier->dstAccessMask, VK_ACCESS_HOST_READ_BIT) ) { return; }
 	lock_guard<mutex> lock(_rezLock);
     for (auto& rez : _resources) {
 		rez->applyMemoryBarrier(srcStageMask, dstStageMask, pMemoryBarrier, cmdEncoder, cmdUse);


### PR DESCRIPTION
All of the resources' `applyMemoryBarrier()` methods check if the second
scope contains host operations. If they don't, they have no effect. If
there are a lot of resources, iterating them for a method that will
ultimately do nothing is wasteful. Bail out if we can see that they will
do nothing.