### PR TITLE
Allow mvkMTLRenderStagesFromVkPipelineStageFlags() to map to all Vulkan stages, by indicating whether the pipeline barrier should come before or after the stages.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -402,8 +402,11 @@ MTLWinding mvkMTLWindingFromSpvExecutionMode(uint32_t spvMode);
 /** Returns the Metal MTLTessellationPartitionMode corresponding to the specified SPIR-V spv::ExecutionMode. */
 MTLTessellationPartitionMode mvkMTLTessellationPartitionModeFromSpvExecutionMode(uint32_t spvMode);
 
-/** Returns the combination of Metal MTLRenderStage bits corresponding to the specified Vulkan VkPiplineStageFlags. */
-MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags vkStages);
+/**
+ * Returns the combination of Metal MTLRenderStage bits corresponding to the specified Vulkan VkPiplineStageFlags,
+ * taking into consideration whether the barrier is to be placed before or after the specified pipeline stages.
+ */
+MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags vkStages, bool placeBarrierBefore);
 
 /** Returns the combination of Metal MTLBarrierScope bits corresponding to the specified Vulkan VkAccessFlags. */
 MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags vkAccess);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -65,8 +65,9 @@ void MVKCmdPipelineBarrier::setContent(VkPipelineStageFlags srcStageMask,
 void MVKCmdPipelineBarrier::encode(MVKCommandEncoder* cmdEncoder) {
 
 #if MVK_MACOS
-    // Calls below invoke MTLBlitCommandEncoder so must apply this first
-	if ( getDevice()->_pMetalFeatures->memoryBarriers ) {
+    // Calls below invoke MTLBlitCommandEncoder so must apply this first.
+	// Check if pipeline barriers are available and we are in a renderpass.
+	if (getDevice()->_pMetalFeatures->memoryBarriers && cmdEncoder->_mtlRenderEncoder) {
 		MTLRenderStages srcStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_srcStageMask, false);
 		MTLRenderStages dstStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_dstStageMask, true);
 		for (auto& mb : _memoryBarriers) {

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -67,8 +67,8 @@ void MVKCmdPipelineBarrier::encode(MVKCommandEncoder* cmdEncoder) {
 #if MVK_MACOS
     // Calls below invoke MTLBlitCommandEncoder so must apply this first
 	if ( getDevice()->_pMetalFeatures->memoryBarriers ) {
-		MTLRenderStages srcStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_srcStageMask);
-		MTLRenderStages dstStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_dstStageMask);
+		MTLRenderStages srcStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_srcStageMask, false);
+		MTLRenderStages dstStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_dstStageMask, true);
 		for (auto& mb : _memoryBarriers) {
 			MTLBarrierScope scope = mvkMTLBarrierScopeFromVkAccessFlags(mb.dstAccessMask);
 			scope |= mvkMTLBarrierScopeFromVkAccessFlags(mb.srcAccessMask);

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -1320,33 +1320,26 @@ MTLTessellationPartitionMode mvkMTLTessellationPartitionModeFromSpvExecutionMode
 
 MVK_PUBLIC_SYMBOL MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags vkStages,
 																			 bool placeBarrierBefore) {
-	// First see if the Vulkan stages maps directly to a specific Metal render stage.
-	MTLRenderStages mtlStages = MTLRenderStages(0);
-	if ( mvkIsAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
-										VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
-										VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |
-										VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
-										VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
-										VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT)) ) {
-		mtlStages |= MTLRenderStageVertex;
-	}
-	if ( mvkIsAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
-										VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-										VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT |
-										VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
-										VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT)) ) {
-		mtlStages |= MTLRenderStageFragment;
-	}
-
 	// Although there are many combined render/compute/host stages in Vulkan, there are only two render
-	// stages in Metal. If the Vulkan stage did not map to a specific Metal render stage, then if the
+	// stages in Metal. If the Vulkan stage did not map ONLY to a specific Metal render stage, then if the
 	// barrier is to be placed before the render stages, it should come before the vertex stage, otherwise
 	// if the barrier is to be placed after the render stages, it should come after the fragment stage.
-	if ( !mtlStages ) {
-		mtlStages = placeBarrierBefore ? MTLRenderStageVertex : MTLRenderStageFragment;
+	if (placeBarrierBefore) {
+		bool placeBeforeFragment = mvkAreOnlyAnyFlagsEnabled(vkStages, (VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+																		VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
+																		VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT |
+																		VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+																		VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
+		return placeBeforeFragment ? MTLRenderStageFragment : MTLRenderStageVertex;
+	} else {
+		bool placeAfterVertex = mvkAreOnlyAnyFlagsEnabled(vkStages, (VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
+																	 VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
+																	 VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |
+																	 VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+																	 VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
+																	 VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT));
+		return placeAfterVertex ? MTLRenderStageVertex : MTLRenderStageFragment;
 	}
-
-	return mtlStages;
 }
 
 MVK_PUBLIC_SYMBOL MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags vkAccess) {


### PR DESCRIPTION
@cdavis5e 

`vkCmdPipelineBarrier()` can occur inside or outside a render pass I came across an app whose `vkCmdPipelineBarrier()` call included a source pipeline barrier for `VK_PIPELINE_STAGE_HOST_BIT`...and it caused `memoryBarrierWithScope:afterStages:beforeStages:` to barf.

It looks like the app might include any of the other non-renderpass pipeline stages as well (or even `VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT`). I've modified `mvkMTLRenderStagesFromVkPipelineStageFlags()` to handle these by taking into consideration whether the barrier should be placed before or after the two supported Metal render stages (note the change to using `mvkAreOnlyAnyFlagsEnabled()` instead of `mvkIsAnyFlagEnabled`).

Metal also doesn't allow for multiple stages to be specified (`MTLRenderStageVertex | MTLRenderStageFragment)`...so I've forced one or the other.

I've also included a test for the availability of `cmdEncoder->_mtlRenderEncoder`, to skip that processing outside a render pass (I think Objective-C's do nothing on a method call to a nil object behaviour was saving a crash on this code outside a renderpass).

Can you just have a quick look at my logic to make sure this makes sense, please? I'm not at all certain of it. Perhaps we need more robust logic about whether to call `memoryBarrierWithScope:afterStages:beforeStages:` at all.

BTW...we should probably also look at making use of `MTLComputeCommandEncoder memoryBarrierWithScope:` within `vkCmdPipelineBarrier()` if a `cmdEncoder->_computePipelineState` is available (and in all OS's)...but I've left that for now until we discuss it further.