### PR TITLE
texture don't have coherent memory on mac os

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -195,7 +195,12 @@ public:
 	/** Returns the Metal CPU cache mode used by this image. */
 	inline MTLCPUCacheMode getMTLCPUCacheMode() { return _deviceMemory->getMTLCPUCacheMode(); }
 
-	
+	/** 
+	 * Returns whether the memory is automatically coherent between device and host. 
+	 * On macOS, this always returns false because textures cannot use Shared storage mode.
+	 */
+	bool isMemoryHostCoherent();
+
 #pragma mark Construction
 
 	MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -429,6 +429,8 @@ MTLTextureDescriptor* MVKImage::getMTLTextureDescriptor() {
 }
 
 MTLStorageMode MVKImage::getMTLStorageMode() {
+    if ( !_deviceMemory ) return MTLStorageModePrivate;
+
     // For macOS, textures cannot use Shared storage mode, so change to Managed storage mode.
     MTLStorageMode stgMode = _deviceMemory->getMTLStorageMode();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -440,6 +440,10 @@ MTLStorageMode MVKImage::getMTLStorageMode() {
     return stgMode;
 }
 
+bool MVKImage::isMemoryHostCoherent() {
+    return (getMTLStorageMode() == MTLStorageModeShared);
+}
+
 // Updates the contents of the underlying MTLTexture, corresponding to the
 // specified subresource definition, from the underlying memory buffer.
 void MVKImage::updateMTLTextureContent(MVKImageSubresource& subresource,


### PR DESCRIPTION
Since texture can't be coherent on macOS, they need to be synchronized for host read. This PR fixes this.