### PR TITLE
Fix crash with multisample layered rendering on older macOS devices.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,16 +23,18 @@ Released TBD
 - Change log indication of error in logs from `[***MoltenVK ERROR***]` to 
   `[mvk-error]`, for consistency with other log level indications. 
 - Tessellation fixes:
-	- Don't use setVertexBytes() for passing tessellation vertex counts.
+	- Don't use `setVertexBytes()` for passing tessellation vertex counts.
 	- Fix intermediate Metal renderpasses load and store actions maintaining 
 	  attachments appropriately.
 	- Use empty depth state for tessellation vertex pre-pass.
 	- Fix tessellated indirect draws using wrong kernels to map parameters.
 	- Work around potential Metal bug with stage-in indirect buffers.
-- Fix zero local threadgroup size in indirect tessellated rendering.
+	- Fix zero local threadgroup size in indirect tessellated rendering.
+- Fix crash with multisample layered rendering on older macOS devices.
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
-- Allow building external dependency libraries in Debug mode.
-- Enable AMD and NV GLSL extensions when building glslang for MoltenVKGLSLToSPIRVConverter.
+- Allow building external dependency libraries in `Debug` mode.
+- Enable AMD and NV GLSL extensions when building `glslang` for `MoltenVKGLSLToSPIRVConverter`.
+- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to 20.
 - Update to latest SPIRV-Cross version:
 	- MSL: Only use constant address space for tessellation control shader.
 	- MSL: Support native texture_buffer type, throw error on atomics.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -526,6 +526,7 @@ typedef struct {
 	VkBool32 depthSampleCompare;				/**< If true, depth texture samplers support the comparison of the pixel value against a reference value. */
 	VkBool32 events;							/**< If true, Metal synchronization events are supported. */
 	VkBool32 memoryBarriers;					/**< If true, full memory barriers within Metal render passes are supported. */
+	VkBool32 multisampleLayeredRendering;       /**< If true, layered rendering to multiple multi-sampled cube or texture array layers is supported. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /**

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -181,7 +181,7 @@ id<MTLFunction> MVKCommandResourceFactory::getBlitFragFunction(MVKRPSKeyBlitImg&
 
 id<MTLFunction> MVKCommandResourceFactory::getClearVertFunction(MVKRPSKeyClearAtt& attKey) {
 	id<MTLFunction> mtlFunc = nil;
-	bool allowLayers = _device->_pMetalFeatures->layeredRendering && (attKey.mtlSampleCount == 1 || _device->_pMetalFeatures->multisampleArrayTextures);
+	bool allowLayers = _device->_pMetalFeatures->layeredRendering && (attKey.mtlSampleCount == 1 || _device->_pMetalFeatures->multisampleLayeredRendering);
 	@autoreleasepool {
 		NSMutableString* msl = [NSMutableString stringWithCapacity: (2 * KIBI) ];
 		[msl appendLineMVK: @"#include <metal_stdlib>"];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -797,6 +797,10 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.memoryBarriers = true;
     }
 
+	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily2_v1] ) {
+		_metalFeatures.multisampleLayeredRendering = _metalFeatures.layeredRendering;
+	}
+
 #endif
 
     if ( [_mtlDevice respondsToSelector: @selector(maxBufferLength)] ) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
@@ -28,7 +28,7 @@ MVKFramebuffer::MVKFramebuffer(MVKDevice* device,
     _extent = { .width = pCreateInfo->width, .height = pCreateInfo->height };
 	_layerCount = pCreateInfo->layers;
 
-	// Add clear values
+	// Add attachments
 	_attachments.reserve(pCreateInfo->attachmentCount);
 	for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
 		_attachments.push_back((MVKImageView*)pCreateInfo->pAttachments[i]);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -213,6 +213,9 @@ protected:
 	using MVKResource::needsHostReadSync;
 
 	MVKImageSubresource* getSubresource(uint32_t mipLevel, uint32_t arrayLayer);
+	void validateConfig(const VkImageCreateInfo* pCreateInfo);
+	VkSampleCountFlagBits validateSamples(const VkImageCreateInfo* pCreateInfo);
+	uint32_t validateMipLevels(const VkImageCreateInfo* pCreateInfo);
 	bool validateLinear(const VkImageCreateInfo* pCreateInfo);
 	bool validateUseTexelBuffer();
 	void initSubresources(const VkImageCreateInfo* pCreateInfo);

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -798,7 +798,7 @@ MVK_PUBLIC_SYMBOL MTLTextureType mvkMTLTextureTypeFromVkImageType(VkImageType vk
 		case VK_IMAGE_TYPE_3D: return MTLTextureType3D;
 		case VK_IMAGE_TYPE_2D:
 		default: {
-#if !MVK_IOS  // This is marked unavailable on iOS :/
+#if MVK_MACOS
 			if (arraySize > 1 && isMultisample) { return MTLTextureType2DMultisampleArray; }
 #endif
 			if (arraySize > 1) { return MTLTextureType2DArray; }


### PR DESCRIPTION
- Add MVKPhysicalDeviceMetalFeatures::multisampleLayeredRendering feature.
- MVKCmdClearAttachments shader don't include [[render_target_array_index]] if multisample
and multisampleLayeredRendering is false.
- Refactor validation of VkImageCreateInfo when creating an MVKImage.
- Validate MVKImage multisample layered array attachments require multisampleLayeredRendering.

Fixes issue #594.