### PR TITLE
Fixes to Metal renderpass layered rendering settings.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -31,6 +31,7 @@ Released TBD
 	- Work around potential Metal bug with stage-in indirect buffers.
 	- Fix zero local threadgroup size in indirect tessellated rendering.
 - Fix crash with multisample layered rendering on older macOS devices.
+- Fixes to Metal renderpass layered rendering settings.
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
 - Allow building external dependency libraries in `Debug` mode.
 - Enable AMD and NV GLSL extensions when building `glslang` for `MoltenVKGLSLToSPIRVConverter`.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -992,7 +992,6 @@ void MVKCmdClearImage::encode(MVKCommandEncoder* cmdEncoder) {
 	id<MTLTexture> imgMTLTex = _image->getMTLTexture();
     if ( !imgMTLTex ) { return; }
 
-	VkExtent3D imgBaseExtent = _image->getExtent3D();
 	NSString* mtlRendEncName = (_isDepthStencilClear
 								? mvkMTLRenderCommandEncoderLabel(kMVKCommandUseClearDepthStencilImage)
 								: mvkMTLRenderCommandEncoderLabel(kMVKCommandUseClearColorImage));
@@ -1053,8 +1052,6 @@ void MVKCmdClearImage::encode(MVKCommandEncoder* cmdEncoder) {
 			mtlRPCADesc.level = mipLvl;
 			mtlRPDADesc.level = mipLvl;
 			mtlRPSADesc.level = mipLvl;
-			uint32_t imgLayerCount = mvkMipmapLevelSizeFromBaseSize3D(imgBaseExtent, mipLvl).depth;
-			mtlRPDesc.renderTargetArrayLengthMVK = getDevice()->_pMetalFeatures->layeredRendering ? imgLayerCount : 0;
 
             for (uint32_t layer = layerStart; layer < layerEnd; layer++) {
                 mtlRPCADesc.slice = layer;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -292,7 +292,12 @@ void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride, bool storeOverri
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues, _isRenderingEntireAttachment, loadOverride, storeOverride);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 
-	if (_device->_pMetalFeatures->layeredRendering) {
+	// Only set the layered rendering properties if layered rendering is supported and the framebuffer really has multiple layers
+	if ((_framebuffer->getLayerCount() > 1) &&
+		_device->_pMetalFeatures->layeredRendering &&
+		(_device->_pMetalFeatures->multisampleLayeredRendering ||
+		 (getSubpass()->getSampleCount() == VK_SAMPLE_COUNT_1_BIT))) {
+
 		VkExtent2D fbExtent = _framebuffer->getExtent2D();
 		mtlRPDesc.renderTargetWidthMVK = min(_renderArea.offset.x + _renderArea.extent.width, fbExtent.width);
 		mtlRPDesc.renderTargetHeightMVK = min(_renderArea.offset.y + _renderArea.extent.height, fbExtent.height);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1371,7 +1371,7 @@ void MVKPhysicalDevice::initPipelineCacheUUID() {
 
 MTLFeatureSet MVKPhysicalDevice::getHighestMTLFeatureSet() {
 #if MVK_IOS
-	MTLFeatureSet maxFS = MTLFeatureSet_iOS_GPUFamily4_v2;
+	MTLFeatureSet maxFS = MTLFeatureSet_iOS_GPUFamily5_v1;
 	MTLFeatureSet minFS = MTLFeatureSet_iOS_GPUFamily1_v1;
 #endif
 


### PR DESCRIPTION
- Only set MTLRenderPassDescriptor layered rendering properties if layered rendering
is supported and the framebuffer really has multiple layers.
- MVKCmdClearImage don't set renderTargetArrayLength, since layers are cleared individually.
- Update highest available MTLFeatureSets for use in pipelineCacheUUID.

Fixes issue #579.
