### PR TITLE
Clear attachments using layered rendering only if framebuffer is layered.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -30,7 +30,7 @@ Released TBD
 	- Fix tessellated indirect draws using wrong kernels to map parameters.
 	- Work around potential Metal bug with stage-in indirect buffers.
 	- Fix zero local threadgroup size in indirect tessellated rendering.
-- Fix crash with multisample layered rendering on older macOS devices.
+- Fix crash when clearing attachments using layered rendering on older macOS devices.
 - Fixes to Metal renderpass layered rendering settings.
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
 - Allow building external dependency libraries in `Debug` mode.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -115,7 +115,7 @@ public:
 
 private:
 	uint32_t _firstViewport;
-	MVKVectorInline<MTLViewport, kMVKCachedViewportCount> _mtlViewports;
+	MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports;
 };
 
 
@@ -134,7 +134,7 @@ public:
 
 private:
 	uint32_t _firstScissor;
-	MVKVectorInline<MTLScissorRect, kMVKCachedScissorCount> _mtlScissors;
+	MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -243,8 +243,8 @@ protected:
 
     std::vector<VkClearRect> _clearRects;
     std::vector<simd::float4> _vertices;
-    simd::float4 _clearColors[kMVKAttachmentFormatCount];
-    VkClearValue _vkClearValues[kMVKAttachmentFormatCount];
+    simd::float4 _clearColors[kMVKClearAttachmentCount];
+    VkClearValue _vkClearValues[kMVKClearAttachmentCount];
     MVKRPSKeyClearAtt _rpsKey;
     uint32_t _mtlStencilValue;
     bool _isClearingDepth;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -420,6 +420,9 @@ public:
     /** The size of the threadgroup for the compute shader. */
     MTLSize _mtlThreadgroupSize;
 
+	/** Indicates whether the current render subpass is rendering to an array (layered) framebuffer. */
+	bool _isUsingLayeredRendering;
+
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -151,7 +151,7 @@ protected:
     void encodeImpl(uint32_t stage) override;
     void resetImpl() override;
 
-    MVKVectorInline<MTLViewport, kMVKCachedViewportCount> _mtlViewports, _mtlDynamicViewports;
+    MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports, _mtlDynamicViewports;
 };
 
 
@@ -180,7 +180,7 @@ protected:
     void encodeImpl(uint32_t stage) override;
     void resetImpl() override;
 
-    MVKVectorInline<MTLScissorRect, kMVKCachedScissorCount> _mtlScissors, _mtlDynamicScissors;
+    MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors, _mtlDynamicScissors;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
@@ -20,7 +20,6 @@
 
 #include "MVKDevice.h"
 #include "MVKCommandBuffer.h"
-#include "MVKCommandResourceFactory.h"
 #include "MVKCommandEncodingPool.h"
 #include "MVKCommand.h"
 #include "MVKCmdPipeline.h"

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -67,8 +67,8 @@ class MVKCommandResourceFactory;
 const static uint32_t kMVKVertexContentBufferIndex = 0;
 
 // Parameters to define the sizing of inline collections
-const static uint32_t kMVKCachedViewportCount = 16;
-const static uint32_t kMVKCachedScissorCount = 16;
+const static uint32_t kMVKCachedViewportScissorCount = 16;
+const static uint32_t kMVKCachedColorAttachmentCount = 8;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1002,13 +1002,13 @@ void MVKPhysicalDevice::initProperties() {
 	// Limits
 #if MVK_IOS
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily2_v1] ) {
-        _properties.limits.maxColorAttachments = 8;
+        _properties.limits.maxColorAttachments = kMVKCachedColorAttachmentCount;
     } else {
-        _properties.limits.maxColorAttachments = 4;
+        _properties.limits.maxColorAttachments = 4;		// < kMVKCachedColorAttachmentCount
     }
 #endif
 #if MVK_MACOS
-    _properties.limits.maxColorAttachments = 8;
+    _properties.limits.maxColorAttachments = kMVKCachedColorAttachmentCount;
 #endif
 
     _properties.limits.maxFragmentOutputAttachments = _properties.limits.maxColorAttachments;
@@ -1038,7 +1038,7 @@ void MVKPhysicalDevice::initProperties() {
     float maxVPDim = max(_properties.limits.maxViewportDimensions[0], _properties.limits.maxViewportDimensions[1]);
     _properties.limits.viewportBoundsRange[0] = (-2.0 * maxVPDim);
     _properties.limits.viewportBoundsRange[1] = (2.0 * maxVPDim) - 1;
-    _properties.limits.maxViewports = _features.multiViewport ? 16 : 1;
+    _properties.limits.maxViewports = _features.multiViewport ? kMVKCachedViewportScissorCount : 1;
 
 	_properties.limits.maxImageDimension3D = (2 * KIBI);
 	_properties.limits.maxImageArrayLayers = (2 * KIBI);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -236,8 +236,8 @@ protected:
 	VkPipelineRasterizationStateCreateInfo _rasterInfo;
 	VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
 
-	MVKVectorInline<MTLViewport, kMVKCachedViewportCount> _mtlViewports;
-	MVKVectorInline<MTLScissorRect, kMVKCachedScissorCount> _mtlScissors;
+	MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports;
+	MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors;
 
 	MTLComputePipelineDescriptor* _mtlTessControlStageDesc = nil;
 


### PR DESCRIPTION
- Consolidate testing of subpass layered rendering.
- Add `MVKCommandEncoder::_isUsingLayeredRendering` member variable.
- Track layered rendering enabled in `MVKRPSKeyClearAtt`.
- Rename `MVKRPSKeyClearAtt::enable()` and `::isEnabled()` functions.
- Add `MVKRPSKeyClearAtt::reset()` function.
- Consolidate viewport, scissor & attachment limits.
- `MVKImage` add validation for layered rendering when used as attachment.