### PR TITLE
Fix sporadic crash on vkDestroySwapchainKHR().

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,6 +32,7 @@ Released TBD
 	- Fix zero local threadgroup size in indirect tessellated rendering.
 - Fix crash when clearing attachments using layered rendering on older macOS devices.
 - Fixes to Metal renderpass layered rendering settings.
+- Fix sporadic crash on `vkDestroySwapchainKHR()`.
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
 - Allow building external dependency libraries in `Debug` mode.
 - Enable AMD and NV GLSL extensions when building `glslang` for `MoltenVKGLSLToSPIRVConverter`.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
@@ -45,6 +45,8 @@ MVKSurface::MVKSurface(MVKInstance* mvkInstance,
 		obj = ((PLATFORM_VIEW_CLASS*)obj).layer;
 	}
 
+	_layerObserver = nil;
+
 	// Confirm that we were provided with a CAMetalLayer
 	if ([obj isKindOfClass: [CAMetalLayer class]]) {
 		_mtlCAMetalLayer = (CAMetalLayer*)[obj retain];		// retained

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -179,6 +179,7 @@ id<CAMetalDrawable> MVKSwapchain::getNextCAMetalDrawable() {
 MVKSwapchain::MVKSwapchain(MVKDevice* device,
 						   const VkSwapchainCreateInfoKHR* pCreateInfo) : MVKVulkanAPIDeviceObject(device), _surfaceLost(false) {
 	_currentAcquisitionID = 0;
+	_layerObserver = nil;
 
 	// If applicable, release any surfaces (not currently being displayed) from the old swapchain.
 	MVKSwapchain* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;


### PR DESCRIPTION
`MVKSwapchain` & `MVKSurface` init `_layerObserver` to nil.

Fixes issue #584.

