### PR TITLE
Avoid calling stringWithUTF8String with NULL.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
@@ -56,7 +56,7 @@ bool MVKVulkanAPIObject::markDestroyed() {
 
 VkResult MVKVulkanAPIObject::setDebugName(const char* pObjectName) {
 	[_debugName release];
-	_debugName = [[NSString stringWithUTF8String: pObjectName] retain];		// retained
+	_debugName = pObjectName ? [[NSString stringWithUTF8String: pObjectName] retain] : nil;
 	propogateDebugName();
 	return VK_SUCCESS;
 }


### PR DESCRIPTION
It raises an exception when bytes is NULL.