### PR TITLE
Fix [[attribute]] assignment for tessellation evaluation shaders.

### DIFF
--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
@@ -272,6 +272,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverter::convert(SPIRVToMSLConverterContext& 
 			SPIRV_CROSS_NAMESPACE::MSLVertexAttr va;
 			for (auto& ctxVA : context.vertexAttributes) {
 				va.location = ctxVA.location;
+				va.builtin = ctxVA.builtin;
 				va.msl_buffer = ctxVA.mslBuffer;
 				va.msl_offset = ctxVA.mslOffset;
 				va.msl_stride = ctxVA.mslStride;


### PR DESCRIPTION
This is needed for TessLevelInner and TessLevelOuter in tessellation evaluation
shaders.

Fixes dEQP-VK.tessellation.shader_input_output.tess_level_inner_0_tes.