### PR TITLE
Added missing texelBufferTextureWidth setting in MVKComputePipeline::getMTLFunction.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1196,6 +1196,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	shaderContext.options.entryPointName = pCreateInfo->stage.pName;
 	shaderContext.options.entryPointStage = spv::ExecutionModelGLCompute;
     shaderContext.options.mslVersion = _device->_pMetalFeatures->mslVersion;
+    shaderContext.options.texelBufferTextureWidth = _device->_pMetalFeatures->maxTextureDimension;
 	shaderContext.options.shouldSwizzleTextureSamples = _fullImageViewSwizzle;
 
     MVKPipelineLayout* layout = (MVKPipelineLayout*)pCreateInfo->layout;


### PR DESCRIPTION
Fixes #589.