### PR TITLE
Guard against null _debugNames being used to build name strings.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -29,7 +29,8 @@ using namespace std;
 #pragma mark MVKBuffer
 
 void MVKBuffer::propogateDebugName() {
-	if (_deviceMemory &&
+	if (_debugName &&
+		_deviceMemory &&
 		_deviceMemory->isDedicatedAllocation() &&
 		_deviceMemory->_debugName.length == 0) {
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -429,6 +429,9 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::getMTLRenderPipelineDescriptor
 	// Output
 	addFragmentOutputToPipeline(plDesc, reflectData, pCreateInfo);
 
+	// Metal does not allow the name of the pipeline to be changed after it has been created,
+	// and we need to create the Metal pipeline immediately to provide error feedback to app.
+	// The best we can do at this point is set the pipeline name from the layout.
 	setLabelIfNotNil(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
 
 	return plDesc;
@@ -580,6 +583,9 @@ MTLComputePipelineDescriptor* MVKGraphicsPipeline::getMTLTessControlStageDescrip
 	}
 	plDesc.stageInputDescriptor.indexBufferIndex = kMVKTessCtlIndexBufferIndex;
 
+	// Metal does not allow the name of the pipeline to be changed after it has been created,
+	// and we need to create the Metal pipeline immediately to provide error feedback to app.
+	// The best we can do at this point is set the pipeline name from the layout.
 	setLabelIfNotNil(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
 
 	return plDesc;
@@ -1172,6 +1178,10 @@ MVKComputePipeline::MVKComputePipeline(MVKDevice* device,
 	if (shaderFunc.mtlFunction) {
 		MTLComputePipelineDescriptor* plDesc = [[MTLComputePipelineDescriptor new] autorelease];
 		plDesc.computeFunction = shaderFunc.mtlFunction;
+
+		// Metal does not allow the name of the pipeline to be changed after it has been created,
+		// and we need to create the Metal pipeline immediately to provide error feedback to app.
+		// The best we can do at this point is set the pipeline name from the layout.
 		setLabelIfNotNil(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
 
 		MVKComputePipelineCompiler* plc = new MVKComputePipelineCompiler(this);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -35,9 +35,11 @@ using namespace std;
 #pragma mark MVKSwapchain
 
 void MVKSwapchain::propogateDebugName() {
-	size_t imgCnt = _surfaceImages.size();
-	for (size_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
-		_surfaceImages[imgIdx]->setDebugName([NSString stringWithFormat: @"%@(%lu)", _debugName, imgIdx].UTF8String);
+	if (_debugName) {
+		size_t imgCnt = _surfaceImages.size();
+		for (size_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
+			_surfaceImages[imgIdx]->setDebugName([NSString stringWithFormat: @"%@(%lu)", _debugName, imgIdx].UTF8String);
+		}
 	}
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
@@ -55,9 +55,11 @@ bool MVKVulkanAPIObject::markDestroyed() {
 }
 
 VkResult MVKVulkanAPIObject::setDebugName(const char* pObjectName) {
-	[_debugName release];
-	_debugName = [[NSString stringWithUTF8String: pObjectName] retain];		// retained
-	propogateDebugName();
+	if (pObjectName) {
+		[_debugName release];
+		_debugName = [[NSString stringWithUTF8String: pObjectName] retain];		// retained
+		propogateDebugName();
+	}
 	return VK_SUCCESS;
 }
 


### PR DESCRIPTION
Replaces #611.