### PR TITLE
Fixes and consolidation of external library header references.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -38,6 +38,7 @@ Released TBD
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
 - Allow building external dependency libraries in `Debug` mode.
 - Enable AMD and NV GLSL extensions when building `glslang` for `MoltenVKGLSLToSPIRVConverter`.
+- Make external library header references consistent and add `MVK_EXCLUDE_SPIRV_TOOLS` option.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to 20.
 - Update to latest SPIRV-Cross version:
 	- MSL: Only use constant address space for tessellation control shader.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1393,7 +1393,7 @@ MTLFeatureSet MVKPhysicalDevice::getHighestMTLFeatureSet() {
 // Retrieve the SPIRV-Cross Git revision hash from a derived header file that was created in the fetchDependencies script.
 uint64_t MVKPhysicalDevice::getSpirvCrossRevision() {
 
-#include "../External/SPIRV-Cross/mvkSpirvCrossRevisionDerived.h"
+#include <SPIRV-Cross/mvkSpirvCrossRevisionDerived.h>
 
 	static const string revStr(spirvCrossRevisionString, 0, 16);	// We just need the first 16 chars
 	static const string lut("0123456789ABCDEF");

--- a/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
@@ -21,9 +21,7 @@
 #include "SPIRVToMSLConverter.h"
 #include "SPIRVSupport.h"
 #include "MVKStrings.h"
-#include "../glslang/SPIRV/GlslangToSpv.h"
-#include "../glslang/SPIRV/disassemble.h"
-#include "../glslang/SPIRV/doc.h"
+#include <glslang/SPIRV/GlslangToSpv.h>
 #include <sstream>
 
 using namespace std;

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVReflection.cpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVReflection.cpp
@@ -17,8 +17,8 @@
  */
 
 #include "SPIRVReflection.h"
-#include "../SPIRV-Cross/spirv_parser.hpp"
-#include "../SPIRV-Cross/spirv_reflect.hpp"
+#include <SPIRV-Cross/spirv_parser.hpp>
+#include <SPIRV-Cross/spirv_reflect.hpp>
 
 namespace mvk {
 

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVReflection.h
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVReflection.h
@@ -19,8 +19,8 @@
 #ifndef __SPIRVReflection_h_
 #define __SPIRVReflection_h_ 1
 
-#include "../SPIRV-Cross/spirv.hpp"
-#include "../SPIRV-Cross/spirv_common.hpp"
+#include <SPIRV-Cross/spirv.hpp>
+#include <SPIRV-Cross/spirv_common.hpp>
 #include <string>
 #include <vector>
 

--- a/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.cpp
@@ -20,8 +20,8 @@
 #include "MVKCommonEnvironment.h"
 #include "MVKStrings.h"
 #include "FileSupport.h"
-#include "spirv_msl.hpp"
 #include "SPIRVSupport.h"
+#include <SPIRV-Cross/spirv_msl.hpp>
 #include <fstream>
 
 using namespace mvk;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -752,10 +752,6 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/macOS\"";
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -770,10 +766,6 @@
 				GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO;
 				GCC_WARN_CHECK_SWITCH_STATEMENTS = NO;
 				GCC_WARN_UNUSED_PARAMETER = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/macOS\"";
 				PRODUCT_NAME = MoltenVKGLSLToSPIRVConverter;
 				SDKROOT = macosx;
@@ -790,12 +782,6 @@
 					"SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross",
 				);
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/SPIRV-Cross\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
-					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/iOS\"";
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -814,12 +800,6 @@
 					"SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross",
 				);
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/SPIRV-Cross\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
-					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/iOS\"";
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = iphoneos;
@@ -836,12 +816,6 @@
 					"SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross",
 				);
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/SPIRV-Cross\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
-					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/macOS\"";
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;
@@ -856,12 +830,6 @@
 					"SPIRV_CROSS_NAMESPACE_OVERRIDE=MVK_spirv_cross",
 				);
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/SPIRV-Cross\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/\"",
-					"\"$(SRCROOT)/glslang/build/External/spirv-tools\"",
-				);
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../External/build/Latest/macOS\"";
 				PRODUCT_NAME = MoltenVKSPIRVToMSLConverter;
 				SDKROOT = macosx;
@@ -911,7 +879,6 @@
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACH_O_TYPE = staticlib;
@@ -965,7 +932,6 @@
 					"$(inherited)",
 					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
-					"\"$(SRCROOT)/glslang/External/spirv-tools/external/spirv-headers/include\"",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACH_O_TYPE = staticlib;

--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ Building from the command line creates the same `Package` folder structure descr
 from within *Xcode*.
 
 
+### Building Within a Larger External Build Environment
+
+If you build **MoltenVK** as part of a larger build environment, that does not use the scripts or *Xcode* 
+projects provided by **MoltenVK**, you may be interested in certain build options designed to allow you to 
+customize the use of **MoltenVK** within your custom build environment. These options are not available
+in the default **MoltenVK** build environment described in the previous sections.
+
+- `MoltenVKShaderConverter` uses the `SPIRV-Tools` external library to log SPIR-V code for diagnostics. 
+  If this is not useful to you, you can define the `MVK_EXCLUDE_SPIRV_TOOLS` when building the 
+  `MoltenVKShaderConverter` code base, and **MoltenVK** will not attempt to use code from the `SPIRV-Tools` 
+  repository. In this way, you will not need to retrieve or build the `SPIRV-Tools` repository, or link to 
+  a `SPIRV-Tools` external library.
+
+
+
 <a name="demos"></a>
 Running the **MoltenVK** Demo Applications
 ------------------------------------------


### PR DESCRIPTION
- All external library header references consistently include framework references.
- Cleanup references to external library headers that are no longer required.
- Simplify and consolidate external library header paths in Xcode projects.
- Add `MVK_EXCLUDE_SPIRV_TOOLS` build option to avoid use of SPIRV-Tools library.
- Remove all other references to headers within SPIRV-Tools library.

- Fix #607. 
- Fix #610.