### PR TITLE
Fixes to VK_EXT_debug_marker extension.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDebug.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDebug.mm
@@ -41,9 +41,14 @@ MVKCmdDebugMarker::~MVKCmdDebugMarker() {
 #pragma mark MVKCmdDebugMarkerBegin
 
 // Vulkan debug groups are more general than Metal's.
-// Always push on command buffer instead of the encoder.
+// If a renderpass is active, push on the render command encoder, otherwise push on the command buffer.
 void MVKCmdDebugMarkerBegin::encode(MVKCommandEncoder* cmdEncoder) {
-	[cmdEncoder->_mtlCmdBuffer pushDebugGroup: _markerName];
+	id<MTLRenderCommandEncoder> mtlCmdEnc = cmdEncoder->_mtlRenderEncoder;
+	if (mtlCmdEnc) {
+		[mtlCmdEnc pushDebugGroup: _markerName];
+	} else {
+		[cmdEncoder->_mtlCmdBuffer pushDebugGroup: _markerName];
+	}
 }
 
 MVKCmdDebugMarkerBegin::MVKCmdDebugMarkerBegin(MVKCommandTypePool<MVKCmdDebugMarkerBegin>* pool)
@@ -54,9 +59,14 @@ MVKCmdDebugMarkerBegin::MVKCmdDebugMarkerBegin(MVKCommandTypePool<MVKCmdDebugMar
 #pragma mark MVKCmdDebugMarkerEnd
 
 // Vulkan debug groups are more general than Metal's.
-// Always pop from command buffer instead of the encoder.
+// If a renderpass is active, pop from the render command encoder, otherwise pop from the command buffer.
 void MVKCmdDebugMarkerEnd::encode(MVKCommandEncoder* cmdEncoder) {
-	[cmdEncoder->_mtlCmdBuffer popDebugGroup];
+	id<MTLRenderCommandEncoder> mtlCmdEnc = cmdEncoder->_mtlRenderEncoder;
+	if (mtlCmdEnc) {
+		[mtlCmdEnc popDebugGroup];
+	} else {
+		[cmdEncoder->_mtlCmdBuffer popDebugGroup];
+	}
 }
 
 MVKCmdDebugMarkerEnd::MVKCmdDebugMarkerEnd(MVKCommandTypePool<MVKCmdDebugMarkerEnd>* pool)

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -74,7 +74,7 @@ MVKCmdNextSubpass::MVKCmdNextSubpass(MVKCommandTypePool<MVKCmdNextSubpass>* pool
 
 void MVKCmdEndRenderPass::encode(MVKCommandEncoder* cmdEncoder) {
 //	MVKLogDebug("Encoding vkCmdEndRenderPass(). Elapsed time: %.6f ms.", mvkGetElapsedMilliseconds());
-	cmdEncoder->endMetalRenderEncoding();
+	cmdEncoder->endRenderpass();
 }
 
 MVKCmdEndRenderPass::MVKCmdEndRenderPass(MVKCommandTypePool<MVKCmdEndRenderPass>* pool)

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -301,6 +301,9 @@ public:
     /** Called by each compute dispatch command to establish any outstanding state just prior to performing the dispatch. */
     void finalizeDispatchState();
 
+	/** Ends the current renderpass. */
+	void endRenderpass();
+
 	/** 
 	 * Ends all encoding operations on the current Metal command encoder.
 	 *

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -332,7 +332,12 @@ MVKRenderSubpass* MVKCommandEncoder::getSubpass() { return _renderPass->getSubpa
 
 // Returns a name for use as a MTLRenderCommandEncoder label
 NSString* MVKCommandEncoder::getMTLRenderCommandEncoderName() {
-	NSString* rpName = _renderPass ? _renderPass->getDebugName() : nil;
+	NSString* rpName;
+
+	rpName = _renderPass->getDebugName();
+	if (rpName) { return rpName; }
+
+	rpName = _cmdBuffer->getDebugName();
 	if (rpName) { return rpName; }
 
 	MVKCommandUse cmdUse = (_renderSubpassIndex == 0) ? kMVKCommandUseBeginRenderPass : kMVKCommandUseNextSubpass;
@@ -416,6 +421,14 @@ void MVKCommandEncoder::finalizeDispatchState() {
     _computePipelineState.encode();    // Must do first..it sets others
     _computeResourcesState.encode();
     _computePushConstants.encode();
+}
+
+void MVKCommandEncoder::endRenderpass() {
+	endMetalRenderEncoding();
+
+	_renderPass = nullptr;
+	_framebuffer = nullptr;
+	_renderSubpassIndex = 0;
 }
 
 void MVKCommandEncoder::endMetalRenderEncoding() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1241,6 +1241,7 @@ MVKShaderLibrary* MVKPipelineCache::getShaderLibrary(SPIRVToMSLConverterContext*
 
 	bool wasAdded = false;
 	MVKShaderLibraryCache* slCache = getShaderLibraryCache(shaderModule->getKey());
+	slCache->setShaderModule(shaderModule);
 	MVKShaderLibrary* shLib = slCache->getShaderLibrary(pContext, shaderModule, &wasAdded);
 	if (wasAdded) { markDirty(); }
 	return shLib;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -55,9 +55,6 @@ public:
 	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return _owner->getVulkanAPIObject(); };
 
-	/** Returns the Metal shader function, possibly specialized. */
-	MVKMTLFunction getMTLFunction(const VkSpecializationInfo* pSpecializationInfo);
-
 	/** Constructs an instance from the specified MSL source code. */
 	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
 					 const std::string& mslSourceCode,
@@ -79,10 +76,14 @@ protected:
 	friend MVKShaderModule;
 
 	void propogateDebugName();
+	NSString* getDebugName();
+	void setShaderModule(MVKShaderModule* shaderModule);
+	MVKMTLFunction getMTLFunction(const VkSpecializationInfo* pSpecializationInfo);
 	void handleCompilationError(NSError* err, const char* opDesc);
     MTLFunctionConstant* getFunctionConstant(NSArray<MTLFunctionConstant*>* mtlFCs, NSUInteger mtlFCID);
 
 	MVKVulkanAPIDeviceObject* _owner;
+	MVKShaderModule* _shaderModule = nullptr;
 	id<MTLLibrary> _mtlLibrary;
 	SPIRVEntryPoint _entryPoint;
 	std::string _msl;
@@ -110,6 +111,11 @@ public:
 	MVKShaderLibrary* getShaderLibrary(SPIRVToMSLConverterContext* pContext,
 									   MVKShaderModule* shaderModule,
 									   bool* pWasAdded = nullptr);
+	/**
+	 * Sets the shader module associated with this library cache.
+	 * This is set after creation because libraries can be loaded from a pipeline cache.
+	 */
+	void setShaderModule(MVKShaderModule* shaderModule);
 
 	MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner) : _owner(owner) {};
 
@@ -128,6 +134,7 @@ protected:
 	void merge(MVKShaderLibraryCache* other);
 
 	MVKVulkanAPIDeviceObject* _owner;
+	MVKShaderModule* _shaderModule = nullptr;
 	std::vector<std::pair<SPIRVToMSLConverterContext, MVKShaderLibrary*>> _shaderLibraries;
 };
 


### PR DESCRIPTION
- `vkCmdDebugMarkerBegin()` and `vkCmdDebugMarkerEnd()` attach debug
groups to render encoder if available, or command buffer if not.
- Name `MTLRenderCommandEncoder` first after renderpass,
if named, then command buffer, if named, then usage name.
- Add `MVKCommandEncoder::endRenderpass()` to clean up renderpass components.
- `MVKShaderLibrary` and `MVKShaderLibraryCache` track shader module to
retrieve name for `MTLLibrary` and `MTLFunction`, even when cached offline.