### PR TITLE
Fix crash on pipeline cache merge after VkShaderModule destroyed.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -177,7 +177,7 @@ void MVKCommandBuffer::clearPrefilledMTLCommandBuffer() {
 
 #pragma mark Construction
 
-// Initializes this instance after it has been created retrieved from a pool.
+// Initializes this instance after it has been created or retrieved from a pool.
 void MVKCommandBuffer::init(const VkCommandBufferAllocateInfo* pAllocateInfo) {
 	_commandPool = (MVKCommandPool*)pAllocateInfo->commandPool;
 	_isSecondary = (pAllocateInfo->level == VK_COMMAND_BUFFER_LEVEL_SECONDARY);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1839,7 +1839,7 @@ VkResult MVKDevice::createPipelines(VkPipelineCache pipelineCache,
 }
 
 // Create concrete implementations of the two variations of the mvkCreatePipelines() function
-// that we will be using. This is required since the template definition is location in this
+// that we will be using. This is required since the template definition is located in this
 // implementation file instead of in the header file. This is a realistic approach if the
 // universe of possible template implementation variations is small and known in advance.
 template VkResult MVKDevice::createPipelines<MVKGraphicsPipeline, VkGraphicsPipelineCreateInfo>(VkPipelineCache pipelineCache,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -365,7 +365,7 @@ public:
 	~MVKPipelineCache() override;
 
 protected:
-	void propogateDebugName() override;
+	void propogateDebugName() override {}
 	MVKShaderLibraryCache* getShaderLibraryCache(MVKShaderModuleKey smKey);
 	void readData(const VkPipelineCacheCreateInfo* pCreateInfo);
 	void writeData(std::ostream& outstream, bool isCounting = false);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1268,20 +1268,12 @@ MVKComputePipeline::~MVKComputePipeline() {
 #pragma mark -
 #pragma mark MVKPipelineCache
 
-
-void MVKPipelineCache::propogateDebugName() {
-	lock_guard<mutex> lock(_shaderCacheLock);
-
-	for (auto& slPair : _shaderCache) { slPair.second->propogateDebugName(); }
-}
-
 // Return a shader library from the specified shader context sourced from the specified shader module.
 MVKShaderLibrary* MVKPipelineCache::getShaderLibrary(SPIRVToMSLConverterContext* pContext, MVKShaderModule* shaderModule) {
 	lock_guard<mutex> lock(_shaderCacheLock);
 
 	bool wasAdded = false;
 	MVKShaderLibraryCache* slCache = getShaderLibraryCache(shaderModule->getKey());
-	slCache->setShaderModule(shaderModule);
 	MVKShaderLibrary* shLib = slCache->getShaderLibrary(pContext, shaderModule, &wasAdded);
 	if (wasAdded) { markDirty(); }
 	return shLib;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -75,15 +75,11 @@ protected:
 	friend MVKShaderLibraryCache;
 	friend MVKShaderModule;
 
-	void propogateDebugName();
-	NSString* getDebugName();
-	void setShaderModule(MVKShaderModule* shaderModule);
-	MVKMTLFunction getMTLFunction(const VkSpecializationInfo* pSpecializationInfo);
+	MVKMTLFunction getMTLFunction(const VkSpecializationInfo* pSpecializationInfo, MVKShaderModule* shaderModule);
 	void handleCompilationError(NSError* err, const char* opDesc);
     MTLFunctionConstant* getFunctionConstant(NSArray<MTLFunctionConstant*>* mtlFCs, NSUInteger mtlFCID);
 
 	MVKVulkanAPIDeviceObject* _owner;
-	MVKShaderModule* _shaderModule = nullptr;
 	id<MTLLibrary> _mtlLibrary;
 	SPIRVEntryPoint _entryPoint;
 	std::string _msl;
@@ -111,11 +107,6 @@ public:
 	MVKShaderLibrary* getShaderLibrary(SPIRVToMSLConverterContext* pContext,
 									   MVKShaderModule* shaderModule,
 									   bool* pWasAdded = nullptr);
-	/**
-	 * Sets the shader module associated with this library cache.
-	 * This is set after creation because libraries can be loaded from a pipeline cache.
-	 */
-	void setShaderModule(MVKShaderModule* shaderModule);
 
 	MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner) : _owner(owner) {};
 
@@ -126,7 +117,6 @@ protected:
 	friend MVKPipelineCache;
 	friend MVKShaderModule;
 
-	void propogateDebugName();
 	MVKShaderLibrary* findShaderLibrary(SPIRVToMSLConverterContext* pContext);
 	MVKShaderLibrary* addShaderLibrary(SPIRVToMSLConverterContext* pContext,
 									   const std::string& mslSourceCode,
@@ -134,7 +124,6 @@ protected:
 	void merge(MVKShaderLibraryCache* other);
 
 	MVKVulkanAPIDeviceObject* _owner;
-	MVKShaderModule* _shaderModule = nullptr;
 	std::vector<std::pair<SPIRVToMSLConverterContext, MVKShaderLibrary*>> _shaderLibraries;
 };
 
@@ -208,7 +197,7 @@ public:
 protected:
 	friend MVKShaderCacheIterator;
 
-	void propogateDebugName() override;
+	void propogateDebugName() override {}
 	MVKGLSLConversionShaderStage getMVKGLSLConversionShaderStage(SPIRVToMSLConverterContext* pContext);
 
 	MVKShaderLibraryCache _shaderLibraryCache;


### PR DESCRIPTION
- Set `MTLFunction` label immediately after creation from `MVKShaderModule`.
- Remove `_shaderModule` reference from `MVKShaderLibrary` & `MVKShaderLibraryCache`.
- No-op `propogateDebugName()` function in `MVKShaderModule` & `MVKPipelineCache`.