### PR TITLE
VkSemaphore optionally uses MTLEvent, if available and MVK_ALLOW_METAL_EVENTS environment variable is enabled.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -33,6 +33,8 @@ Released TBD
 	- Fix tessellated indirect draws using wrong kernels to map parameters.
 	- Work around potential Metal bug with stage-in indirect buffers.
 	- Fix zero local threadgroup size in indirect tessellated rendering.
+- `VkSemaphore` optionally uses `MTLEvent`, if available and 
+  `MVK_ALLOW_METAL_EVENTS` environment variable is enabled.
 - Fix crash when clearing attachments using layered rendering on older macOS devices.
 - Fixes to Metal renderpass layered rendering settings.
 - Fix sporadic crash on `vkDestroySwapchainKHR()`.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -107,6 +107,10 @@ typedef unsigned long MTLLanguageVersion;
  *
  * 3. Setting the MVK_CONFIG_FORCE_LOW_POWER_GPU runtime environment variable or MoltenVK compile-time
  *    build setting to 1 will force MoltenVK to use a low-power GPU, if one is availble on the device.
+ *
+ * 4. Setting the MVK_ALLOW_METAL_EVENTS runtime environment variable or MoltenVK compile-time build
+ *    setting to 1 will cause MoltenVK to use Metal events, if they are available on the device, for
+ *    Vulkan sychronization components such as VkSemaphore. This is disabled by default.
  */
 typedef struct {
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -736,7 +736,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily1_v5] ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
-		_metalFeatures.events = true;
+		MVK_SET_FROM_ENV_OR_BUILD_BOOL(_metalFeatures.events, MVK_ALLOW_METAL_EVENTS);
 	}
 
 	if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily3_v1] ) {
@@ -793,7 +793,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     if ( [_mtlDevice supportsFeatureSet: MTLFeatureSet_macOS_GPUFamily1_v4] ) {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
         _metalFeatures.multisampleArrayTextures = true;
-        _metalFeatures.events = true;
+		MVK_SET_FROM_ENV_OR_BUILD_BOOL(_metalFeatures.events, MVK_ALLOW_METAL_EVENTS);
         _metalFeatures.memoryBarriers = true;
     }
 

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -146,6 +146,11 @@
 #   define MVK_CONFIG_FORCE_LOW_POWER_GPU    0
 #endif
 
+/** Allow the use of Metal events for Vulkan synchronizations such as VkSemaphores. Disabled by default. */
+#ifndef MVK_ALLOW_METAL_EVENTS
+#   define MVK_ALLOW_METAL_EVENTS    0
+#endif
+
 
 /**
  * IOSurfaces are supported on macOS, and on iOS starting with iOS 11.


### PR DESCRIPTION
Provides automatic workaround for issues #602 and #625.