### PR TITLE
Guard against missing Metal pipeline states when pipeline compilation fails.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,8 +23,8 @@ Released TBD
 	- `VK_EXT_debug_marker`
 	- `VK_EXT_debug_utils`
 	- `VK_NV_glsl_shader`
-- Change log indication of error in logs from `[***MoltenVK ERROR***]` to 
-  `[mvk-error]`, for consistency with other log level indications. 
+- Support setting workgroup size for shader modules that use 
+  MSL directly instead of converting from SPIR-V.
 - Tessellation fixes:
 	- Don't use `setVertexBytes()` for passing tessellation vertex counts.
 	- Fix intermediate Metal renderpasses load and store actions maintaining 
@@ -35,10 +35,13 @@ Released TBD
 	- Fix zero local threadgroup size in indirect tessellated rendering.
 - `VkSemaphore` optionally uses `MTLEvent`, if available and 
   `MVK_ALLOW_METAL_EVENTS` environment variable is enabled.
+- Change log indication of error in logs from `[***MoltenVK ERROR***]` to 
+  `[mvk-error]`, for consistency with other log level indications. 
 - Fix crash when clearing attachments using layered rendering on older macOS devices.
 - Fixes to Metal renderpass layered rendering settings.
 - Fix sporadic crash on `vkDestroySwapchainKHR()`.
 - `MoltenVKShaderConverter` tool: Add MSL version and platform command-line options.
+- Guard against missing Metal pipeline states when pipeline compilation fails.
 - Allow building external dependency libraries in `Debug` mode.
 - Enable AMD and NV GLSL extensions when building `glslang` for `MoltenVKGLSLToSPIRVConverter`.
 - Make external library header references consistent and add `MVK_EXCLUDE_SPIRV_TOOLS` option.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -117,9 +117,12 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
         if (stage == kMVKGraphicsStageVertex)
             cmdEncoder->_depthStencilState.markDirty();
         cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
-        id<MTLComputeCommandEncoder> mtlTessCtlEncoder = nil;
 
-        switch (stage) {
+		if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
+
+		id<MTLComputeCommandEncoder> mtlTessCtlEncoder = nil;
+
+		switch (stage) {
             case kMVKGraphicsStageVertex:
                 if (pipeline->needsVertexOutputBuffer()) {
                     vtxOutBuff = cmdEncoder->getTempMTLBuffer(_vertexCount * _instanceCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxVertexOutputComponents);
@@ -347,6 +350,8 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
         if (stage == kMVKGraphicsStageVertex)
             cmdEncoder->_depthStencilState.markDirty();
         cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
+
+		if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
 
         switch (stage) {
             case kMVKGraphicsStageVertex:
@@ -617,6 +622,8 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                 cmdEncoder->_depthStencilState.markDirty();
             cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
 
+			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
+
             switch (stage) {
                 case kMVKGraphicsStageVertex:
                     if (pipeline->needsVertexOutputBuffer()) {
@@ -867,6 +874,8 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
             if (stage == kMVKGraphicsStageVertex)
                 cmdEncoder->_depthStencilState.markDirty();
 	        cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
+
+			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
 
             switch (stage) {
                 case kMVKGraphicsStageVertex:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -153,6 +153,9 @@ public:
 	/** Returns whether or not full image view swizzling is enabled for this pipeline. */
 	bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
 
+	/** Returns whether all internal Metal pipeline states are valid. */
+	bool hasValidMTLPipelineStates() { return _hasValidMTLPipelineStates; }
+
 	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
 	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipeline* parent) : MVKVulkanAPIDeviceObject(device),
 																						   _pipelineCache(pipelineCache),
@@ -165,6 +168,7 @@ protected:
 	MVKShaderImplicitRezBinding _swizzleBufferIndex;
 	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
 	bool _fullImageViewSwizzle;
+	bool _hasValidMTLPipelineStates = true;
 
 };
 
@@ -226,7 +230,7 @@ public:
 
 protected:
     id<MTLRenderPipelineState> getOrCompilePipeline(MTLRenderPipelineDescriptor* plDesc, id<MTLRenderPipelineState>& plState);
-    id<MTLComputePipelineState> getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc, id<MTLComputePipelineState>& plState);
+    id<MTLComputePipelineState> getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc, id<MTLComputePipelineState>& plState, const char* compilerType);
     void initMTLRenderPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo, const SPIRVTessReflectionData& reflectData);
     void initMVKShaderConverterContext(SPIRVToMSLConverterContext& _shaderContext,
                                        const VkGraphicsPipelineCreateInfo* pCreateInfo,
@@ -445,8 +449,8 @@ public:
 
 #pragma mark Construction
 
-	MVKComputePipelineCompiler(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
-		_compilerType = "Compute pipeline";
+	MVKComputePipelineCompiler(MVKVulkanAPIDeviceObject* owner, const char* compilerType = nullptr) : MVKMetalCompiler(owner) {
+		_compilerType = compilerType ? compilerType : "Compute pipeline";
 		_pPerformanceTracker = &_owner->getDevice()->_performanceStatistics.shaderCompilation.pipelineCompile;
 	}
 


### PR DESCRIPTION
- MVKPipeline records whether Metal pipelines are successfully compiled.
- Pipeline and draw commands check for valid Metal pipeline state before encoding.
- Compute compilation operations can have custom names.
- Name Tessellation control stage compute compiler for logging.