### PR TITLE
Rename `vkSetThreadgroupSizeMVK` to `vkSetWorkgroupSizeMVK` to be con…

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -796,13 +796,13 @@ VKAPI_ATTR void VKAPI_CALL vkGetVersionStringsMVK(
     uint32_t                                    vulkanVersionStringBufferLength);
 
 /**
- * Sets the number of threads in a threadgroup for a compute kernel.
+ * Sets the number of threads in a workgroup for a compute kernel.
  *
  * This needs to be called if you are creating compute shader modules from MSL
- * source code or MSL compiled code. Threadgroup size is determined automatically
+ * source code or MSL compiled code. Workgroup size is determined automatically
  * if you're using SPIR-V.
  */
-VKAPI_ATTR void VKAPI_CALL vkSetThreadgroupSizeMVK(
+VKAPI_ATTR void VKAPI_CALL vkSetWorkgroupSizeMVK(
     VkShaderModule                              shaderModule,
     uint32_t                                    x,
     uint32_t                                    y,

--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -149,7 +149,7 @@ MVK_PUBLIC_SYMBOL void vkGetIOSurfaceMVK(
     *pIOSurface = mvkImg->getIOSurface();
 }
 
-MVK_PUBLIC_SYMBOL void vkSetThreadgroupSizeMVK(
+MVK_PUBLIC_SYMBOL void vkSetWorkgroupSizeMVK(
     VkShaderModule                              shaderModule,
     uint32_t                                    x,
     uint32_t                                    y,


### PR DESCRIPTION
…sistent with Vulkan terminology