### PR TITLE
Mark stencil reference value as dirty in MVKCmdClearAttachment command.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -962,6 +962,8 @@ void MVKCmdClearAttachments::encode(MVKCommandEncoder* cmdEncoder) {
     cmdEncoder->setVertexBytes(mtlRendEnc, _vertices.data(), vtxCnt * sizeof(_vertices[0]), vtxBuffIdx);
     [mtlRendEnc drawPrimitives: MTLPrimitiveTypeTriangle vertexStart: 0 vertexCount: vtxCnt];
     [mtlRendEnc popDebugGroup];
+
+	cmdEncoder->_stencilReferenceValueState.markDirty();
 }
 
 


### PR DESCRIPTION
MVKCmdClearAttachment sets the stencil reference value to 0 and the stencil
reference value is not properly restored for subsequent draw calls.

I'm affraid there might be more similar bugs in MoltenVK.