### PR TITLE
Advertise VK_FORMAT_A2R10G10B10_UNORM_PACK32 as a surface format.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -469,6 +469,7 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 		MTLPixelFormatBGRA8Unorm,
 		MTLPixelFormatBGRA8Unorm_sRGB,
 		MTLPixelFormatRGBA16Float,
+		MTLPixelFormatBGR10A2Unorm,
 	};
 
 	MVKVectorInline<VkColorSpaceKHR, 16> colorSpaces;
@@ -488,7 +489,9 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 	}
 #endif
 
-	const uint mtlFmtsCnt = sizeof(mtlFormats) / sizeof(MTLPixelFormat);
+	uint mtlFmtsCnt = sizeof(mtlFormats) / sizeof(MTLPixelFormat);
+	if (!mvkMTLPixelFormatIsSupported(MTLPixelFormatBGR10A2Unorm)) { mtlFmtsCnt--; }
+
 	const uint vkFmtsCnt = mtlFmtsCnt * (uint)colorSpaces.size();
 
 	// If properties aren't actually being requested yet, simply update the returned count


### PR DESCRIPTION
The documentation for the corresponding Metal format recommends using it
on displays with wide-color output to reduce banding artifacts, and thus
implies that it is possible to use it with a CAMetalLayer.

My investigation found that, surprisingly, `MTLPixelFormatRGB10A2Unorm` is
*also* supported.