### PR TITLE
MVKImage: Swapchain images do support texture views.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1374,7 +1374,6 @@ MVKSwapchainImage::MVKSwapchainImage(MVKDevice* device,
 	_availability.isAvailable = true;
 	_preSignaled = make_pair(nullptr, nullptr);
 	_mtlDrawable = nil;
-    _canSupportMTLTextureView = false;		// Override...swapchains never support Metal image view.
 }
 
 MVKSwapchainImage::~MVKSwapchainImage() {


### PR DESCRIPTION
I forgot to make this change when I added support for
`VK_KHR_swapchain_mutable_format`. The extension isn't very useful
without this.