### PR TITLE
Fix implementation of VK_EXT_texel_buffer_alignment.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1107,7 +1107,11 @@ void MVKPhysicalDevice::initProperties() {
 	_properties.limits.maxDescriptorSetStorageImages = (_properties.limits.maxPerStageDescriptorStorageImages * 4);
 	_properties.limits.maxDescriptorSetInputAttachments = (_properties.limits.maxPerStageDescriptorInputAttachments * 4);
 
-	_properties.limits.maxTexelBufferElements = _properties.limits.maxImageDimension2D * _properties.limits.maxImageDimension2D;
+	if (_metalFeatures.textureBuffers) {
+		_properties.limits.maxTexelBufferElements = (uint32_t)_metalFeatures.maxMTLBufferSize;
+	} else {
+		_properties.limits.maxTexelBufferElements = _properties.limits.maxImageDimension2D * _properties.limits.maxImageDimension2D;
+	}
 	_properties.limits.maxUniformBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
 	_properties.limits.maxStorageBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
 	_properties.limits.maxPushConstantsSize = (4 * KIBI);
@@ -1170,6 +1174,7 @@ void MVKPhysicalDevice::initProperties() {
             }
             return true;
         });
+        _texelBuffAlignProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT;
         _texelBuffAlignProperties.storageTexelBufferOffsetAlignmentBytes = maxStorage;
         _texelBuffAlignProperties.storageTexelBufferOffsetSingleTexelAlignment = singleTexelStorage;
         _texelBuffAlignProperties.uniformTexelBufferOffsetAlignmentBytes = maxUniform;

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -667,6 +667,7 @@ MVK_PUBLIC_SYMBOL const char* mvkMTLPixelFormatName(MTLPixelFormat mtlFormat) {
 
 void mvkEnumerateSupportedFormats(VkFormatProperties properties, bool any, std::function<bool(VkFormat)> func) {
     static const auto areFeaturesSupported = [any](uint32_t a, uint32_t b) {
+        if (b == 0) return true;
         if (any)
             return mvkIsAnyFlagEnabled(a, b);
         else


### PR DESCRIPTION
Correct maximum number of texel buffer elements for the native texture
buffer case. With an 8-bit format, I assume it's possible to create a
texture buffer spanning the entire 3.5 GiB (the maximum size of a buffer
on my GPU).

Set the structure type in the physical device's
`_texelBuffAlignProperties` struct. Otherwise, when it gets written out
to a chain, the structure type will be lost, and it wouldn't e.g. show
up in `vulkaninfo`.

Fix enumeration of formats when one of the members of the
`VkFormatProperties` is zero. I intended that to mean "don't care," but
it was erroneously filtering out, well, everything. Now we actually
accurately report the minimum alignment requirements.