### PR TITLE
Add support for uncached, host-coherent memory.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -447,16 +447,19 @@ static inline VkExtent3D mvkVkExtent3DFromMTLSize(MTLSize mtlSize) {
 #pragma mark Memory options
 
 /** Macro indicating the Vulkan memory type bits corresponding to Metal private memory (not host visible). */
-#define MVK_VK_MEMORY_TYPE_METAL_PRIVATE	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+#define MVK_VK_MEMORY_TYPE_METAL_PRIVATE				(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
 
 /** Macro indicating the Vulkan memory type bits corresponding to Metal managed memory (host visible and non-coherent). */
-#define MVK_VK_MEMORY_TYPE_METAL_MANAGED	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
+#define MVK_VK_MEMORY_TYPE_METAL_MANAGED				(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
+
+/** Macro indicating the Vulkan memory type bits corresponding to Metal shared write-combined memory (host visible, coherent, but uncached). */
+#define MVK_VK_MEMORY_TYPE_METAL_SHARED_WRITE_COMBINED	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
 
 /** Macro indicating the Vulkan memory type bits corresponding to Metal shared memory (host visible and coherent). */
-#define MVK_VK_MEMORY_TYPE_METAL_SHARED		(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
+#define MVK_VK_MEMORY_TYPE_METAL_SHARED					(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
 
 /** Macro indicating the Vulkan memory type bits corresponding to Metal memoryless memory (not host visible and lazily allocated). */
-#define MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+#define MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS				(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
 
 /** Returns the Metal storage mode corresponding to the specified Vulkan memory flags. */
 MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1597,6 +1597,10 @@ void MVKPhysicalDevice::initMemoryProperties() {
 #endif
             {
                 .heapIndex = 0,
+                .propertyFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED_WRITE_COMBINED,    // Shared storage, write-combined caching
+            },
+            {
+                .heapIndex = 0,
                 .propertyFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED,    // Shared storage
             },
 #if MVK_IOS
@@ -1609,25 +1613,25 @@ void MVKPhysicalDevice::initMemoryProperties() {
     };
 
 #if MVK_MACOS
-	_memoryProperties.memoryTypeCount = 3;
+	_memoryProperties.memoryTypeCount = 4;
 	_privateMemoryTypes			= 0x1;			// Private only
 	_lazilyAllocatedMemoryTypes	= 0x0;			// Not supported on macOS
-	_hostCoherentMemoryTypes 	= 0x4;			// Shared only
-	_hostVisibleMemoryTypes		= 0x6;			// Shared & managed
-	_allMemoryTypes				= 0x7;			// Private, shared, & managed
+	_hostCoherentMemoryTypes 	= 0xc;			// Shared only
+	_hostVisibleMemoryTypes		= 0xe;			// Shared & managed
+	_allMemoryTypes				= 0xf;			// Private, shared, & managed
 #endif
 #if MVK_IOS
-	_memoryProperties.memoryTypeCount = 2;		// Managed storage not available on iOS
+	_memoryProperties.memoryTypeCount = 3;		// Managed storage not available on iOS
 	_privateMemoryTypes			= 0x1;			// Private only
 	_lazilyAllocatedMemoryTypes	= 0x0;			// Not supported on this version
-	_hostCoherentMemoryTypes 	= 0x2;			// Shared only
-	_hostVisibleMemoryTypes		= 0x2;			// Shared only
-	_allMemoryTypes				= 0x3;			// Private & shared
+	_hostCoherentMemoryTypes 	= 0x6;			// Shared only
+	_hostVisibleMemoryTypes		= 0x6;			// Shared only
+	_allMemoryTypes				= 0x7;			// Private & shared
 	if ([getMTLDevice() supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily1_v3]) {
-		_memoryProperties.memoryTypeCount = 3;	// Memoryless storage available
-		_privateMemoryTypes			= 0x5;		// Private & memoryless
-		_lazilyAllocatedMemoryTypes	= 0x4;		// Memoryless only
-		_allMemoryTypes				= 0x7;		// Private, shared & memoryless
+		_memoryProperties.memoryTypeCount = 4;	// Memoryless storage available
+		_privateMemoryTypes			= 0x9;		// Private & memoryless
+		_lazilyAllocatedMemoryTypes	= 0x8;		// Memoryless only
+		_allMemoryTypes				= 0xf;		// Private, shared & memoryless
 	}
 #endif
 }

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -1412,7 +1412,7 @@ MVK_PUBLIC_SYMBOL MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMe
 }
 
 MVK_PUBLIC_SYMBOL MTLCPUCacheMode mvkMTLCPUCacheModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags) {
-	return MTLCPUCacheModeDefaultCache;
+	return mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_CACHED_BIT) ? MTLCPUCacheModeDefaultCache : MTLCPUCacheModeWriteCombined;
 }
 
 MVK_PUBLIC_SYMBOL MTLResourceOptions mvkMTLResourceOptions(MTLStorageMode mtlStorageMode,


### PR DESCRIPTION
In Metal, this roughly corresponds to `MTLStorageModeShared` and
`MTLCPUCacheModeWriteCombined`. Vulkan requires that host-visible memory
must have either or both of the `HOST_COHERENT` and `HOST_CACHED` bits
set, so no write-combined managed here.

Shared write-combined memory is placed before regular shared memory, as
it must be by the Vulkan rules for sorting memory types; but after
managed memory. Apple warns that write-combined memory "can have
surprising performance pitfalls," so managed memory is preferred.

I notice that `mvkMTLCPUCacheModeFromVkMemoryPropertyFlags()`
already exists, but it just returned `MTLCPUCacheModeDefaultCache`. Is
there a reason for that? Was this supported once, but the support was
removed? (I've marked this draft, because I don't want this merged
until those questions are answered.)