### PR TITLE
Host-coherent memory for linear images again, plus Vulkan loader magic number fix.

### DIFF
--- a/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-macOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-macOS.xcscheme
@@ -42,9 +42,9 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Demos/LunarG-VulkanSamples/Cube/macOS/DemoViewController.m
+++ b/Demos/LunarG-VulkanSamples/Cube/macOS/DemoViewController.m
@@ -43,11 +43,8 @@
 
 	self.view.wantsLayer = YES;		// Back the view with a layer created by the makeBackingLayer method.
 
-	uint32_t argc = 2;
-	const char* argv[argc];
-	argv[0] = "cube";
-	argv[1] = "--use_staging";
-	demo_main(&demo, self.view.layer, argc, argv);
+	const char* arg = "cube";
+	demo_main(&demo, self.view.layer, 1, &arg);
 
 	CVDisplayLinkCreateWithActiveCGDisplays(&_displayLink);
 	CVDisplayLinkSetOutputCallback(_displayLink, &DisplayLinkCallback, &demo);

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,15 @@ For best results, use a Markdown reader.*
 
 
 
+MoltenVK 1.0.37
+---------------
+
+Released TBD
+
+- Revert to supporting host-coherent memory for linear images on macOS.
+
+
+
 MoltenVK 1.0.36
 ---------------
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.0.37
 Released TBD
 
 - Revert to supporting host-coherent memory for linear images on macOS.
+- Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -175,8 +175,10 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
 										   ? _device->getPhysicalDevice()->getPrivateMemoryTypes()
 										   : _device->getPhysicalDevice()->getAllMemoryTypes());
 #if MVK_MACOS
-	// Textures must not use shared memory
-	mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+	// Metal on macOS does not provide native support for host-coherent memory, but Vulkan requires it for Linear images
+	if ( !_isLinear ) {
+		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+	}
 #endif
 #if MVK_IOS
 	// Only transient attachments may use memoryless storage

--- a/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.h
@@ -122,21 +122,30 @@ class MVKDispatchableVulkanAPIObject : public MVKVulkanAPIObject {
 public:
 
     /**
-     * Returns a reference to this object suitable for use as a Vulkan API handle.
-     * This is the compliment of the getDispatchableObject() method.
+     * Returns a reference to this object suitable for use as a dispatchable Vulkan API handle.
+	 *
+	 * Establishes the loader magic number every time, in case the loader
+	 * overwrote it for some reason before passing the object back,
+	 * particularly in pooled objects that the loader might consider freed.
+	 *
+	 * This is the compliment of the getDispatchableObject() function.
      */
-    void* getVkHandle() override { return &_icdRef; }
+    void* getVkHandle() override {
+		set_loader_magic_value(&_icdRef);
+		return &_icdRef;
+	}
 
     /**
      * Retrieves the MVKDispatchableVulkanAPIObject instance referenced by the dispatchable Vulkan handle.
-     * This is the compliment of the getVkHandle() method.
+	 *
+     * This is the compliment of the getVkHandle() function.
      */
     static inline MVKDispatchableVulkanAPIObject* getDispatchableObject(void* vkHandle) {
 		return vkHandle ? ((MVKDispatchableObjectICDRef*)vkHandle)->mvkObject : nullptr;
     }
 
 protected:
-    MVKDispatchableObjectICDRef _icdRef = { ICD_LOADER_MAGIC, this };
+    MVKDispatchableObjectICDRef _icdRef = { VK_NULL_HANDLE, this };
 
 };
 


### PR DESCRIPTION
- Revert to supporting host-coherent memory for linear images on macOS.
    - `MVKImage::getMemoryRequirements()` include host-coherent for linear images.
    - Cube demo on macOS not use staging buffers for loading images.
    - Fixes #687 

- Ensure Vulkan loader magic number persists in objects pooled by MoltenVK.
    - `MVKDispatchableVulkanAPIObject::getVkHandle()` re-establishes the loader magic number
before returning, in case the loader overwrote it before returning the object.
    - Fixes #689 
