### PR TITLE
MVKDevice: Remove usage of MTLSoftwareVersion.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -281,9 +281,6 @@ public:
 	
 #pragma mark Metal
 
-	/** Returns whether the underlying MTLDevice supports the Metal version. */
-	bool getSupportsMetalVersion(MTLSoftwareVersion mtlVersion);
-
 	/** Returns whether the underlying MTLDevice supports the GPU family. */
 	bool getSupportsGPUFamily(MTLGPUFamily gpuFamily);
 


### PR DESCRIPTION
Apple removed this from all SDKs as of Xcode 11 beta 5.