### PR TITLE
Add more supported color spaces as of the latest OS versions.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -484,8 +484,8 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 
 	MVKVectorInline<VkColorSpaceKHR, 16> colorSpaces;
 	colorSpaces.push_back(VK_COLOR_SPACE_SRGB_NONLINEAR_KHR);
-#if MVK_MACOS
 	if (getInstance()->_enabledExtensions.vk_EXT_swapchain_colorspace.enabled) {
+#if MVK_MACOS
 		// 10.11 supports some but not all of the color spaces specified by VK_EXT_swapchain_colorspace.
 		colorSpaces.push_back(VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT);
 		colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT);
@@ -496,8 +496,38 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 			colorSpaces.push_back(VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT);
 		}
-	}
+		if (mvkOSVersion() >= 10.14) {
+			colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_LINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_BT2020_LINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
+		}
 #endif
+#if MVK_IOS
+		// iOS 8 doesn't support anything but sRGB.
+		if (mvkOSVersion() >= 9.0) {
+			colorSpaces.push_back(VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_BT709_NONLINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_PASS_THROUGH_EXT);
+		}
+		if (mvkOSVersion() >= 10.0) {
+			colorSpaces.push_back(VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT);
+		}
+		if (mvkOSVersion() >= 12.0) {
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
+		}
+		if (mvkOSVersion() >= 12.3) {
+			colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_LINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_BT2020_LINEAR_EXT);
+		}
+		if (mvkOSVersion() >= 13.0) {
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
+		}
+#endif
+	}
 
 	uint mtlFmtsCnt = sizeof(mtlFormats) / sizeof(MTLPixelFormat);
 	if (!mvkMTLPixelFormatIsSupported(MTLPixelFormatBGR10A2Unorm)) { mtlFmtsCnt--; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -226,7 +226,6 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 																			   VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 																			   VK_IMAGE_USAGE_SAMPLED_BIT |
 																			   VK_IMAGE_USAGE_STORAGE_BIT));
-#if MVK_MACOS
 	switch (pCreateInfo->imageColorSpace) {
 		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
@@ -237,24 +236,35 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 		case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearSRGB);
 			break;
+		case VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT:
+			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
+			break;
+		case VK_COLOR_SPACE_DCI_P3_LINEAR_EXT:
+			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearDisplayP3);
+			break;
 		case VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceDCIP3);
 			break;
 		case VK_COLOR_SPACE_BT709_NONLINEAR_EXT:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_709);
 			break;
+		case VK_COLOR_SPACE_BT2020_LINEAR_EXT:
+			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearITUR_2020);
+			break;
+		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ_EOTF);
+			break;
+		case VK_COLOR_SPACE_HDR10_HLG_EXT:
+			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_HLG);
+			break;
 		case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceAdobeRGB1998);
-			break;
-		case VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
 			break;
 		case VK_COLOR_SPACE_PASS_THROUGH_EXT:
 		default:
 			// Nothing - the default is not to do color matching.
 			break;
 	}
-#endif
 	_mtlLayerOrigDrawSize = _mtlLayer.updatedDrawableSizeMVK;
 
 	// TODO: set additional CAMetalLayer properties before extracting drawables:

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
@@ -75,7 +75,9 @@ static bool mvkIsSupportedOnPlatform(VkExtensionProperties* pProperties) {
 	if (pProperties == &kVkExtProps_EXT_SHADER_STENCIL_EXPORT) {
 		return mvkOSVersion() >= 12.0;
 	}
-	if (pProperties == &kVkExtProps_EXT_SWAPCHAIN_COLOR_SPACE) { return false; }
+	if (pProperties == &kVkExtProps_EXT_SWAPCHAIN_COLOR_SPACE) {
+		return mvkOSVersion() >= 9.0;
+	}
 	if (pProperties == &kVkExtProps_EXT_TEXEL_BUFFER_ALIGNMENT) {
 		return mvkOSVersion() >= 11.0;
 	}

--- a/Scripts/create_dylib.sh
+++ b/Scripts/create_dylib.sh
@@ -35,7 +35,7 @@ ${MVK_SAN} \
 ${MVK_LINK_WARN} \
 -isysroot ${SDK_DIR} \
 -iframework ${MVK_SYS_FWK_DIR}  \
--framework Metal ${MVK_IOSURFACE_FWK} -framework ${MVK_UX_FWK} -framework QuartzCore -framework IOKit -framework Foundation \
+-framework Metal ${MVK_IOSURFACE_FWK} -framework ${MVK_UX_FWK} -framework QuartzCore -framework CoreGraphics -framework IOKit -framework Foundation \
 --library-directory ${MVK_USR_LIB_DIR} \
 -o "${BUILT_PRODUCTS_DIR}/dynamic/${MVK_DYLIB_NAME}" \
 -force_load "${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a"


### PR DESCRIPTION
Support `VK_EXT_swapchain_colorspace` on iOS as well. The 13.0 headers
add the `colorspace` property needed for this.