### PR TITLE
Take advantage of Metal 3.0's support for 3D compressed textures.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -540,6 +540,7 @@ typedef struct {
 	VkBool32 stencilFeedback;					/**< If true, fragment shaders that write to [[stencil]] outputs are supported. */
 	VkBool32 textureBuffers;					/**< If true, textures of type MTLTextureTypeBuffer are supported. */
 	VkBool32 postDepthCoverage;					/**< If true, coverage masks in fragment shaders post-depth-test are supported. */
+	VkBool32 native3DCompressedTextures;		/**< If true, 3D compressed images are supported natively, without manual decompression. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /**

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -758,7 +758,8 @@ void MVKCmdBufferImageCopy::encode(MVKCommandEncoder* cmdEncoder) {
 		// If we're copying to a compressed 3D image, the image data need to be decompressed.
 		// If we're copying to mip level 0, we can skip the copy and just decode
 		// directly into the image. Otherwise, we need to use an intermediate buffer.
-        if (_toImage && _image->getIsCompressed() && mtlTexture.textureType == MTLTextureType3D) {
+        if (_toImage && _image->getIsCompressed() && mtlTexture.textureType == MTLTextureType3D &&
+            !getDevice()->_pMetalFeatures->native3DCompressedTextures) {
             MVKCmdCopyBufferToImageInfo info;
             info.srcRowStride = bytesPerRow & 0xffffffff;
             info.srcRowStrideHigh = bytesPerRow >> 32;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -328,7 +328,7 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 			}
 #if MVK_MACOS
 			// If this is a compressed format and there's no codec, it isn't supported.
-			if ((mvkFmt == kMVKFormatCompressed) && !mvkCanDecodeFormat(format)) {
+			if ((mvkFmt == kMVKFormatCompressed) && !mvkCanDecodeFormat(format) && !_metalFeatures.native3DCompressedTextures) {
 				return VK_ERROR_FORMAT_NOT_SUPPORTED;
 			}
 #endif
@@ -888,6 +888,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 	if ( mvkOSVersion() >= 10.15 ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
+		_metalFeatures.native3DCompressedTextures = true;
 	}
 
 #endif


### PR DESCRIPTION
Mac-only for now. Mostly because I don't know which formats beyond DXTn
and ASTC support 3D textures. Also, the extension to support 3D ASTC
compression isn't ready yet.