### PR TITLE
Take advantage of native texture swizzling support.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -234,6 +234,12 @@ uint32_t mvkSampleCountFromVkSampleCountFlagBits(VkSampleCountFlagBits vkSampleC
 /** Returns the Vulkan bit flags corresponding to the numeric sample count, which must be a PoT value. */
 VkSampleCountFlagBits mvkVkSampleCountFlagBitsFromSampleCount(NSUInteger sampleCount);
 
+/** Returns the Metal texture swizzle from the Vulkan component swizzle. */
+MTLTextureSwizzle mvkMTLTextureSwizzleFromVkComponentSwizzle(VkComponentSwizzle vkSwizzle);
+
+/** Returns all four Metal texture swizzles from the Vulkan component mapping. */
+MTLTextureSwizzleChannels mvkMTLTextureSwizzleChannelsFromVkComponentMapping(VkComponentMapping vkMapping);
+
 
 #pragma mark Mipmaps
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -541,6 +541,7 @@ typedef struct {
 	VkBool32 textureBuffers;					/**< If true, textures of type MTLTextureTypeBuffer are supported. */
 	VkBool32 postDepthCoverage;					/**< If true, coverage masks in fragment shaders post-depth-test are supported. */
 	VkBool32 native3DCompressedTextures;		/**< If true, 3D compressed images are supported natively, without manual decompression. */
+	VkBool32 nativeTextureSwizzle;				/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /**

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -574,7 +574,7 @@ void MVKGraphicsResourcesCommandEncoderState::markDirty() {
 void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
 
     MVKPipeline* pipeline = _cmdEncoder->_graphicsPipelineState.getPipeline();
-    bool fullImageViewSwizzle = pipeline->fullImageViewSwizzle();
+    bool fullImageViewSwizzle = pipeline->fullImageViewSwizzle() || _cmdEncoder->getDevice()->_pMetalFeatures->nativeTextureSwizzle;
     bool forTessellation = ((MVKGraphicsPipeline*)pipeline)->isTessellationPipeline();
 
     if (stage == (forTessellation ? kMVKGraphicsStageVertex : kMVKGraphicsStageRasterization)) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -129,7 +129,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
                     portabilityFeatures->triangleFans = false;
                     portabilityFeatures->separateStencilMaskRef = true;
                     portabilityFeatures->events = false;
-                    portabilityFeatures->standardImageViews = _mvkInstance->getMoltenVKConfiguration()->fullImageViewSwizzle;
+                    portabilityFeatures->standardImageViews = _mvkInstance->getMoltenVKConfiguration()->fullImageViewSwizzle || _metalFeatures.nativeTextureSwizzle;
                     portabilityFeatures->samplerMipLodBias = false;
                     break;
                 }
@@ -840,6 +840,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 	if ( mvkOSVersion() >= 13.0 ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
+		if ( getSupportsGPUFamily(MTLGPUFamilyApple4) ) {
+			_metalFeatures.nativeTextureSwizzle = true;
+		}
 	}
 
 #endif
@@ -889,6 +892,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	if ( mvkOSVersion() >= 10.15 ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.native3DCompressedTextures = true;
+		if ( getSupportsGPUFamily(MTLGPUFamilyMac2) ) {
+			_metalFeatures.nativeTextureSwizzle = true;
+		}
 	}
 
 #endif

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -862,15 +862,25 @@ id<MTLTexture> MVKImageView::getMTLTexture() {
 // overlay on the Metal texture of the underlying image.
 id<MTLTexture> MVKImageView::newMTLTexture() {
     MTLTextureType mtlTextureType = _mtlTextureType;
+    NSRange sliceRange = NSMakeRange(_subresourceRange.baseArrayLayer, _subresourceRange.layerCount);
     // Fake support for 2D views of 3D textures.
     if (_image->getImageType() == VK_IMAGE_TYPE_3D &&
-		(mtlTextureType == MTLTextureType2D || mtlTextureType == MTLTextureType2DArray)) {
+        (mtlTextureType == MTLTextureType2D || mtlTextureType == MTLTextureType2DArray)) {
         mtlTextureType = MTLTextureType3D;
-	}
-    return [_image->getMTLTexture() newTextureViewWithPixelFormat: _mtlPixelFormat
-                                                      textureType: mtlTextureType
-                                                           levels: NSMakeRange(_subresourceRange.baseMipLevel, _subresourceRange.levelCount)
-                                                           slices: NSMakeRange(_subresourceRange.baseArrayLayer, _subresourceRange.layerCount)];	// retained
+        sliceRange = NSMakeRange(0, 1);
+    }
+    if (getDevice()->_pMetalFeatures->nativeTextureSwizzle && _packedSwizzle) {
+        return [_image->getMTLTexture() newTextureViewWithPixelFormat: _mtlPixelFormat
+                                                          textureType: mtlTextureType
+                                                               levels: NSMakeRange(_subresourceRange.baseMipLevel, _subresourceRange.levelCount)
+                                                               slices: sliceRange
+                                                              swizzle: mvkMTLTextureSwizzleChannelsFromVkComponentMapping(mvkUnpackSwizzle(_packedSwizzle))];	// retained
+    } else {
+        return [_image->getMTLTexture() newTextureViewWithPixelFormat: _mtlPixelFormat
+                                                          textureType: mtlTextureType
+                                                               levels: NSMakeRange(_subresourceRange.baseMipLevel, _subresourceRange.levelCount)
+                                                               slices: sliceRange];	// retained
+    }
 }
 
 
@@ -911,12 +921,12 @@ MVKImageView::MVKImageView(MVKDevice* device,
 		_subresourceRange.layerCount = _image ? (_image->getLayerCount() - _subresourceRange.baseArrayLayer) : 1;
 	}
 
-	bool useShaderSwizzle;
+	bool useSwizzle;
 	bool isMultisample = _image ? _image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT : false;
 	_mtlTexture = nil;
-    _mtlPixelFormat = getSwizzledMTLPixelFormat(pCreateInfo->format, pCreateInfo->components, useShaderSwizzle,
+    _mtlPixelFormat = getSwizzledMTLPixelFormat(pCreateInfo->format, pCreateInfo->components, useSwizzle,
 												(_device ? _device->_pMVKConfig : pAltMVKConfig));
-	_packedSwizzle = useShaderSwizzle ? mvkPackSwizzle(pCreateInfo->components) : 0;
+	_packedSwizzle = useSwizzle ? mvkPackSwizzle(pCreateInfo->components) : 0;
 	_mtlTextureType = mvkMTLTextureTypeFromVkImageViewType(pCreateInfo->viewType, isMultisample);
 
 	initMTLTextureViewSupport();
@@ -947,20 +957,22 @@ void MVKImageView::validateImageViewConfig(const VkImageViewCreateInfo* pCreateI
 
 // Returns a MTLPixelFormat, based on the MTLPixelFormat converted from the VkFormat, but possibly
 // modified by the swizzles defined in the VkComponentMapping of the VkImageViewCreateInfo.
-// Metal does not support general per-texture swizzles, so if the swizzle is not an identity swizzle, this
-// function attempts to find an alternate MTLPixelFormat that coincidentally matches the swizzled format.
-// If a replacement MTLFormat was found, it is returned and useShaderSwizzle is set to false.
+// Metal prior to version 3.0 does not support general per-texture swizzles, so if the swizzle is not an
+// identity swizzle, this function attempts to find an alternate MTLPixelFormat that coincidentally
+// matches the swizzled format.
+// If a replacement MTLFormat was found, it is returned and useSwizzle is set to false.
 // If a replacement MTLFormat could not be found, the original MTLPixelFormat is returned, and the
-// useShaderSwizzle is set to true, indicating that shader swizzling should be used for this image view.
+// useSwizzle is set to true, indicating that either native or shader swizzling should be used for
+// this image view.
 // The config is used to test whether full shader swizzle support is available, and to report an error if not.
 MTLPixelFormat MVKImageView::getSwizzledMTLPixelFormat(VkFormat format,
 													   VkComponentMapping components,
-													   bool& useShaderSwizzle,
+													   bool& useSwizzle,
 													   const MVKConfiguration* pMVKConfig) {
 
 	// Attempt to find a valid format transformation swizzle first.
 	MTLPixelFormat mtlPF = getMTLPixelFormatFromVkFormat(format);
-	useShaderSwizzle = false;
+	useSwizzle = false;
 
 	#define SWIZZLE_MATCHES(R, G, B, A)    mvkVkComponentMappingsMatch(components, {VK_COMPONENT_SWIZZLE_ ##R, VK_COMPONENT_SWIZZLE_ ##G, VK_COMPONENT_SWIZZLE_ ##B, VK_COMPONENT_SWIZZLE_ ##A} )
 	#define VK_COMPONENT_SWIZZLE_ANY       VK_COMPONENT_SWIZZLE_MAX_ENUM
@@ -1030,9 +1042,9 @@ MTLPixelFormat MVKImageView::getSwizzledMTLPixelFormat(VkFormat format,
 
 	// No format transformation swizzles were found, so unless we have an identity swizzle, we'll need to use shader swizzling.
 	if ( !SWIZZLE_MATCHES(R, G, B, A)) {
-		useShaderSwizzle = true;
+		useSwizzle = true;
 
-		if ( !pMVKConfig->fullImageViewSwizzle ) {
+		if ( !pMVKConfig->fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle ) {
 			const char* vkCmd = _image ? "vkCreateImageView(VkImageViewCreateInfo" : "vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDeviceImageViewSupportEXTX";
 			const char* errMsg = ("The value of %s::components) (%s, %s, %s, %s), when applied to a VkImageView, requires full component swizzling to be enabled both at the"
 								  " time when the VkImageView is created and at the time any pipeline that uses that VkImageView is compiled. Full component swizzling can"
@@ -1064,12 +1076,8 @@ void MVKImageView::initMTLTextureViewSupport() {
 		(_mtlTextureType == _image->_mtlTextureType ||
 		 ((_mtlTextureType == MTLTextureType2D || _mtlTextureType == MTLTextureType2DArray) && is3D)) &&
 		_subresourceRange.levelCount == _image->_mipLevels &&
-		_subresourceRange.layerCount == (is3D ? _image->_extent.depth : _image->_arrayLayers)) {
-		_useMTLTextureView = false;
-	}
-
-	// Never use views for subsets of 3D textures. Metal doesn't support them yet.
-	if (is3D && _subresourceRange.layerCount != _image->_extent.depth) {
+		(is3D || _subresourceRange.layerCount == _image->_arrayLayers) &&
+		(!getDevice()->_pMetalFeatures->nativeTextureSwizzle || !_packedSwizzle)) {
 		_useMTLTextureView = false;
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1155,7 +1155,7 @@ void MVKGraphicsPipeline::initMVKShaderConverterContext(SPIRVToMSLConversionConf
 
     shaderContext.options.mslOptions.enable_point_size_builtin = isRenderingPoints(pCreateInfo, reflectData);
     shaderContext.options.shouldFlipVertexY = _device->_pMVKConfig->shaderConversionFlipVertexY;
-    shaderContext.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle;
+    shaderContext.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle;
     shaderContext.options.mslOptions.tess_domain_origin_lower_left = pTessDomainOriginState && pTessDomainOriginState->domainOrigin == VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
 
     shaderContext.options.tessPatchKind = reflectData.patchKind;
@@ -1337,7 +1337,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	shaderContext.options.entryPointStage = spv::ExecutionModelGLCompute;
     shaderContext.options.mslOptions.msl_version = _device->_pMetalFeatures->mslVersion;
     shaderContext.options.mslOptions.texel_buffer_texture_width = _device->_pMetalFeatures->maxTextureDimension;
-	shaderContext.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle;
+	shaderContext.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle;
 	shaderContext.options.mslOptions.texture_buffer_native = _device->_pMetalFeatures->textureBuffers;
 
     MVKPipelineLayout* layout = (MVKPipelineLayout*)pCreateInfo->layout;

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -927,6 +927,25 @@ MVK_PUBLIC_SYMBOL VkSampleCountFlagBits mvkVkSampleCountFlagBitsFromSampleCount(
     return VkSampleCountFlagBits(sampleCount);
 }
 
+MVK_PUBLIC_SYMBOL MTLTextureSwizzle mvkMTLTextureSwizzleFromVkComponentSwizzle(VkComponentSwizzle vkSwizzle) {
+    switch (vkSwizzle) {
+    case VK_COMPONENT_SWIZZLE_ZERO: return MTLTextureSwizzleZero;
+    case VK_COMPONENT_SWIZZLE_ONE:  return MTLTextureSwizzleOne;
+    case VK_COMPONENT_SWIZZLE_R:    return MTLTextureSwizzleRed;
+    case VK_COMPONENT_SWIZZLE_G:    return MTLTextureSwizzleGreen;
+    case VK_COMPONENT_SWIZZLE_B:    return MTLTextureSwizzleBlue;
+    case VK_COMPONENT_SWIZZLE_A:    return MTLTextureSwizzleAlpha;
+    }
+    return MTLTextureSwizzleRed;
+}
+
+MVK_PUBLIC_SYMBOL MTLTextureSwizzleChannels mvkMTLTextureSwizzleChannelsFromVkComponentMapping(VkComponentMapping vkMapping) {
+#define convert(v, d) \
+    v == VK_COMPONENT_SWIZZLE_IDENTITY ? MTLTextureSwizzle##d : mvkMTLTextureSwizzleFromVkComponentSwizzle(v)
+    return MTLTextureSwizzleChannelsMake(convert(vkMapping.r, Red), convert(vkMapping.g, Green), convert(vkMapping.b, Blue), convert(vkMapping.a, Alpha));
+#undef convert
+}
+
 
 #pragma mark Mipmaps
 


### PR DESCRIPTION
When available, use it instead of doing it manually in the shaders.
Unfortunately, it's only available on Apple GPU family 4 and up, and
desktop GPU family 2. Should still provide a nice boost.