### PR TITLE
MVKSwapchain: Add handling for compositeAlpha.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -457,8 +457,8 @@ VkResult MVKPhysicalDevice::getSurfaceCapabilities(MVKSurface* surface,
 	pSurfaceCapabilities->supportedTransforms = (VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
 	pSurfaceCapabilities->currentTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
     pSurfaceCapabilities->supportedCompositeAlpha = (VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR |
-                                                     VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR |
-                                                     VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR);
+                                                     VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR |
+                                                     VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR);
 	pSurfaceCapabilities->supportedUsageFlags = (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
                                                  VK_IMAGE_USAGE_STORAGE_BIT |
                                                  VK_IMAGE_USAGE_TRANSFER_SRC_BIT |

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -226,6 +226,9 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 																			   VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 																			   VK_IMAGE_USAGE_SAMPLED_BIT |
 																			   VK_IMAGE_USAGE_STORAGE_BIT));
+	if (pCreateInfo->compositeAlpha != VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
+		_mtlLayer.opaque = pCreateInfo->compositeAlpha == VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+	}
 #if MVK_MACOS
 	switch (pCreateInfo->imageColorSpace) {
 		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:


### PR DESCRIPTION
Set the `opaque` property of the `CAMetalLayer` based on this. In the
past, we did nothing; this actually corresponds to
`VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR`.

Drop support for premultiplied alpha. In Core Animation, this is managed
by the `contents` of the layer. Most layers use a `CGImage` or an
`NSImage` for their contents; the `AlphaInfo` property of a `CGImage`
determines whether or not it uses premultiplied alpha. However,
`CAMetalLayer` doesn't use a `CGImage`, but a custom opaque Core
Foundation object which ostensibly vends images to be displayed by the
layer. I don't know which kind of alpha it uses, but since most
applications render postmultiplied colors I'm going to assume that
premultiplied alpha isn't supported yet.