### PR TITLE
Add support for VkEvent.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.0.37
 
 Released TBD
 
+- Add support for `VkEvent`, using either native `MTLEvent` or emulation when `MTLEvent` not available.
 - Revert to supporting host-coherent memory for linear images on macOS.
 - Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -116,7 +116,7 @@ typedef unsigned long MTLLanguageVersion;
  *
  * 4. Setting the MVK_ALLOW_METAL_EVENTS runtime environment variable or MoltenVK compile-time build
  *    setting to 1 will cause MoltenVK to use Metal events, if they are available on the device, for
- *    Vulkan sychronization components such as VkSemaphore. This is disabled by default.
+ *    for VkSemaphore sychronization behaviour. This is disabled by default.
  */
 typedef struct {
 
@@ -167,7 +167,10 @@ typedef struct {
 	 * The initial value or this parameter is set by the
 	 * MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS
 	 * runtime environment variable or MoltenVK compile-time build setting.
-	 * If neither is set, the value of this parameter defaults to true.
+	 * If neither is set, the value of this parameter defaults to true for macOS 10.14
+	 * and above or iOS 12 and above, and false otherwise. The reason for this distinction
+	 * is that this feature should be disabled when emulation is required to support VkEvents
+	 * because native support for events (MTLEvent) is not available.
 	 */
 	VkBool32 synchronousQueueSubmits;
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -190,6 +190,54 @@ private:
 
 
 #pragma mark -
+#pragma mark MVKCmdSetResetEvent
+
+/** Vulkan command to set or reset an event. */
+class MVKCmdSetResetEvent : public MVKCommand {
+
+public:
+	void setContent(VkEvent event, VkPipelineStageFlags stageMask, bool status);
+
+	void encode(MVKCommandEncoder* cmdEncoder) override;
+
+	MVKCmdSetResetEvent(MVKCommandTypePool<MVKCmdSetResetEvent>* pool);
+
+private:
+	MVKEvent* _mvkEvent;
+	bool _status;
+
+};
+
+
+#pragma mark -
+#pragma mark MVKCmdWaitEvents
+
+/** Vulkan command to wait for an event to be signaled. */
+class MVKCmdWaitEvents : public MVKCommand {
+
+public:
+	void setContent(uint32_t eventCount,
+					const VkEvent* pEvents,
+					VkPipelineStageFlags srcStageMask,
+					VkPipelineStageFlags dstStageMask,
+					uint32_t memoryBarrierCount,
+					const VkMemoryBarrier* pMemoryBarriers,
+					uint32_t bufferMemoryBarrierCount,
+					const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+					uint32_t imageMemoryBarrierCount,
+					const VkImageMemoryBarrier* pImageMemoryBarriers);
+
+	void encode(MVKCommandEncoder* cmdEncoder) override;
+
+	MVKCmdWaitEvents(MVKCommandTypePool<MVKCmdWaitEvents>* pool);
+
+private:
+	MVKVectorInline<MVKEvent*, 4> _mvkEvents;
+
+};
+
+
+#pragma mark -
 #pragma mark Command creation functions
 
 /** Adds commands to the specified command buffer that insert the specified pipeline barriers. */
@@ -241,3 +289,27 @@ void mvkCmdPushDescriptorSetWithTemplate(MVKCommandBuffer* cmdBuff,
 										 VkPipelineLayout layout,
 										 uint32_t set,
 										 const void* pData);
+
+/** Adds a set event command to the specified command buffer. */
+void mvkCmdSetEvent(MVKCommandBuffer* cmdBuff,
+					VkEvent event,
+					VkPipelineStageFlags stageMask);
+
+/** Adds a reset event command to the specified command buffer. */
+void mvkCmdResetEvent(MVKCommandBuffer* cmdBuff,
+					  VkEvent event,
+					  VkPipelineStageFlags stageMask);
+
+
+/** Adds a wait events command to the specified command buffer. */
+void mvkCmdWaitEvents(MVKCommandBuffer* cmdBuff,
+					  uint32_t eventCount,
+					  const VkEvent* pEvents,
+					  VkPipelineStageFlags srcStageMask,
+					  VkPipelineStageFlags dstStageMask,
+					  uint32_t memoryBarrierCount,
+					  const VkMemoryBarrier* pMemoryBarriers,
+					  uint32_t bufferMemoryBarrierCount,
+					  const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+					  uint32_t imageMemoryBarrierCount,
+					  const VkImageMemoryBarrier* pImageMemoryBarriers);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -283,6 +283,9 @@ public:
     /** Binds a pipeline to a bind point. */
     void bindPipeline(VkPipelineBindPoint pipelineBindPoint, MVKPipeline* pipeline);
 
+	/** Encodes an operation to signal an event to a status. */
+	void signalEvent(MVKEvent* mvkEvent, bool status);
+
     /**
      * If a pipeline is currently bound, returns whether the current pipeline permits dynamic
      * setting of the specified state. If no pipeline is currently bound, returns true.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -359,6 +359,11 @@ void MVKCommandEncoder::bindPipeline(VkPipelineBindPoint pipelineBindPoint, MVKP
     }
 }
 
+void MVKCommandEncoder::signalEvent(MVKEvent* mvkEvent, bool status) {
+	endCurrentMetalEncoding();
+	mvkEvent->encodeSignal(_mtlCmdBuffer, status);
+}
+
 bool MVKCommandEncoder::supportsDynamicState(VkDynamicState state) {
     MVKGraphicsPipeline* gpl = (MVKGraphicsPipeline*)_graphicsPipelineState.getPipeline();
     return !gpl || gpl->supportsDynamicState(state);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
@@ -149,6 +149,10 @@ public:
 
 	MVKCommandTypePool<MVKCmdDebugMarkerInsert> _cmdDebugMarkerInsertPool;
 
+	MVKCommandTypePool<MVKCmdSetResetEvent> _cmdSetResetEventPool;
+
+	MVKCommandTypePool<MVKCmdWaitEvents> _cmdWaitEventsPool;
+
 
 #pragma mark Command resources
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -126,6 +126,8 @@ void MVKCommandPool::trim() {
 	_cmdDebugMarkerBeginPool.clear();
 	_cmdDebugMarkerEndPool.clear();
 	_cmdDebugMarkerInsertPool.clear();
+	_cmdSetResetEventPool.clear();
+	_cmdWaitEventsPool.clear();
 }
 
 
@@ -180,7 +182,9 @@ MVKCommandPool::MVKCommandPool(MVKDevice* device,
 	_cmdPushSetWithTemplatePool(this),
 	_cmdDebugMarkerBeginPool(this),
 	_cmdDebugMarkerEndPool(this),
-	_cmdDebugMarkerInsertPool(this)
+	_cmdDebugMarkerInsertPool(this),
+	_cmdSetResetEventPool(this),
+	_cmdWaitEventsPool(this)
 // when extending be sure to add to trim() as well
 {}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -47,6 +47,7 @@ class MVKSwapchain;
 class MVKDeviceMemory;
 class MVKFence;
 class MVKSemaphore;
+class MVKEvent;
 class MVKQueryPool;
 class MVKShaderModule;
 class MVKPipelineCache;
@@ -445,6 +446,11 @@ public:
 	void destroySemaphore(MVKSemaphore* mvkSem4,
 						  const VkAllocationCallbacks* pAllocator);
 
+	MVKEvent* createEvent(const VkEventCreateInfo* pCreateInfo,
+						  const VkAllocationCallbacks* pAllocator);
+	void destroyEvent(MVKEvent* mvkEvent,
+					  const VkAllocationCallbacks* pAllocator);
+
 	MVKQueryPool* createQueryPool(const VkQueryPoolCreateInfo* pCreateInfo,
 								  const VkAllocationCallbacks* pAllocator);
 	void destroyQueryPool(MVKQueryPool* mvkQP,
@@ -639,6 +645,11 @@ public:
 
     /** Performance statistics. */
     MVKPerformanceStatistics _performanceStatistics;
+
+	// Indicates whether semaphores should use MTLEvents if available.
+	// Set by the MVK_ALLOW_METAL_EVENTS environment variable if MTLEvents are available.
+	// This should be a temporary fix after some repair to semaphore handling.
+	bool _useMTLEventsForSemaphores;
 
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1286,7 +1286,7 @@ void MVKSwapchainImage::signalWhenAvailable(MVKSemaphore* semaphore, MVKFence* f
 	if (_availability.isAvailable) {
 		_availability.isAvailable = false;
 		signal(signaler);
-		if (_device->_pMetalFeatures->events) {
+		if (_device->_useMTLEventsForSemaphores) {
 			// Unfortunately, we can't assume we have an MTLSharedEvent here.
 			// This means we need to execute a command on the device to signal
 			// the semaphore. Alternatively, we could always use an MTLSharedEvent,
@@ -1310,7 +1310,7 @@ void MVKSwapchainImage::signalWhenAvailable(MVKSemaphore* semaphore, MVKFence* f
 
 // Signal either or both of the semaphore and fence in the specified tracker pair.
 void MVKSwapchainImage::signal(MVKSwapchainSignaler& signaler) {
-	if (signaler.first && !_device->_pMetalFeatures->events) { signaler.first->signal(); }
+	if (signaler.first && !_device->_useMTLEventsForSemaphores) { signaler.first->signal(); }
 	if (signaler.second) { signaler.second->signal(); }
 }
 
@@ -1367,7 +1367,7 @@ void MVKSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffer> mtlCmdBuff) 
 		if (scName) { [mtlCmdBuff popDebugGroup]; }
 
 		resetMetalSurface();
-        if (_device->_pMetalFeatures->events && !_availabilitySignalers.empty()) {
+        if (_device->_useMTLEventsForSemaphores && !_availabilitySignalers.empty()) {
             // Signal the semaphore device-side.
             _availabilitySignalers.front().first->encodeSignal(mtlCmdBuff);
         }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -644,6 +644,21 @@ void MVKInstance::logVersions() {
 }
 
 void MVKInstance::initConfig() {
+
+// The default value for MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS actually depends on whether
+// MTLEvents are supported, becuase if MTLEvents are not supported, then synchronous queues
+// should be turned off by default to ensure , whereas if MTLEvents are supported, we want
+// sychronous queues for better behaviour. The app can of course still override this default
+// behaviour by setting the env var, or the config directly.
+#undef MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS
+#define MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS	syncQueueSubmits
+#if MVK_MACOS
+	bool syncQueueSubmits = mvkOSVersion() >= 10.14;	// Support for MTLEvents
+#endif
+#if MVK_IOS
+	bool syncQueueSubmits = mvkOSVersion() >= 12.0;		// Support for MTLEvents
+#endif
+
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.debugMode,                              MVK_DEBUG);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.shaderConversionFlipVertexY,            MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.synchronousQueueSubmits,                MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -224,7 +224,7 @@ void MVKQueueCommandBufferSubmission::execute() {
 	MVKDevice* mvkDev = _queue->getDevice();
 
 	// If the device supports it, wait for any semaphores on the device.
-	if (mvkDev->_pMetalFeatures->events && _isAwaitingSemaphores) {
+	if (mvkDev->_useMTLEventsForSemaphores && _isAwaitingSemaphores) {
 		_isAwaitingSemaphores = false;
 		for (auto* ws : _waitSemaphores) {
 			ws->encodeWait(getActiveMTLCommandBuffer());
@@ -239,7 +239,7 @@ void MVKQueueCommandBufferSubmission::execute() {
 	if (_fence || _isSignalingSemaphores) { getActiveMTLCommandBuffer(); }
 
 	// If the device supports it, signal all semaphores on the device.
-	if (mvkDev->_pMetalFeatures->events && _isSignalingSemaphores) {
+	if (mvkDev->_useMTLEventsForSemaphores && _isSignalingSemaphores) {
 		_isSignalingSemaphores = false;
 		for (auto* ss : _signalSemaphores) {
 			ss->encodeSignal(getActiveMTLCommandBuffer());
@@ -354,7 +354,7 @@ void MVKQueuePresentSurfaceSubmission::execute() {
 	// If there are semaphores and this device supports MTLEvent, we must present
 	// with a command buffer in order to synchronize with the semaphores.
 	MVKDevice* mvkDev = _queue->getDevice();
-	if (mvkDev->_pMetalFeatures->events && !_waitSemaphores.empty()) {
+	if (mvkDev->_useMTLEventsForSemaphores && !_waitSemaphores.empty()) {
 		// Create a command buffer, have it wait for the semaphores, then present
 		// surfaces via the command buffer.
 		id<MTLCommandBuffer> mtlCmdBuff = getMTLCommandBuffer();

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -146,7 +146,7 @@
 #   define MVK_CONFIG_FORCE_LOW_POWER_GPU    0
 #endif
 
-/** Allow the use of Metal events for Vulkan synchronizations such as VkSemaphores. Disabled by default. */
+/** Allow the use of Metal events for VkSemaphore synchronization behaviour. Disabled by default. */
 #ifndef MVK_ALLOW_METAL_EVENTS
 #   define MVK_ALLOW_METAL_EVENTS    0
 #endif

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -651,9 +651,10 @@ MVK_PUBLIC_SYMBOL VkResult vkCreateEvent(
     VkEvent*                                    pEvent) {
 	
 	MVKTraceVulkanCallStart();
-	//VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT
 	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-	VkResult rslt = mvkDev->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateEvent(): Vukan events are not supported.");
+	MVKEvent* mvkEvent = mvkDev->createEvent(pCreateInfo, pAllocator);
+	*pEvent = (VkEvent)mvkEvent;
+	VkResult rslt = mvkEvent->getConfigurationResult();
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -666,7 +667,7 @@ MVK_PUBLIC_SYMBOL void vkDestroyEvent(
 	MVKTraceVulkanCallStart();
 	if ( !event ) { return; }
 	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-	mvkDev->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkDestroyEvent(): Vukan events are not supported.");
+	mvkDev->destroyEvent((MVKEvent*)event, pAllocator);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -675,8 +676,8 @@ MVK_PUBLIC_SYMBOL VkResult vkGetEventStatus(
     VkEvent                                     event) {
 	
 	MVKTraceVulkanCallStart();
-	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-	VkResult rslt = mvkDev->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkGetEventStatus(): Vukan events are not supported.");
+	MVKEvent* mvkEvent = (MVKEvent*)event;
+	VkResult rslt = mvkEvent->isSet() ? VK_EVENT_SET : VK_EVENT_RESET;
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -686,10 +687,10 @@ MVK_PUBLIC_SYMBOL VkResult vkSetEvent(
     VkEvent                                     event) {
 	
 	MVKTraceVulkanCallStart();
-	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-	VkResult rslt = mvkDev->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkSetEvent(): Vukan events are not supported.");
+	MVKEvent* mvkEvent = (MVKEvent*)event;
+	mvkEvent->signal(true);
 	MVKTraceVulkanCallEnd();
-	return rslt;
+	return VK_SUCCESS;
 }
 
 MVK_PUBLIC_SYMBOL VkResult vkResetEvent(
@@ -697,10 +698,10 @@ MVK_PUBLIC_SYMBOL VkResult vkResetEvent(
     VkEvent                                     event) {
 	
 	MVKTraceVulkanCallStart();
-	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-	VkResult rslt = mvkDev->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkResetEvent(): Vukan events are not supported.");
+	MVKEvent* mvkEvent = (MVKEvent*)event;
+	mvkEvent->signal(false);
 	MVKTraceVulkanCallEnd();
-	return rslt;
+	return VK_SUCCESS;
 }
 
 MVK_PUBLIC_SYMBOL VkResult vkCreateQueryPool(
@@ -1709,7 +1710,7 @@ MVK_PUBLIC_SYMBOL void vkCmdSetEvent(
 	
 	MVKTraceVulkanCallStart();
 	MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-	cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdSetEvent(): Vukan events are not supported.");
+	mvkCmdSetEvent(cmdBuff, event, stageMask);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -1720,7 +1721,7 @@ MVK_PUBLIC_SYMBOL void vkCmdResetEvent(
 	
 	MVKTraceVulkanCallStart();
 	MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-	cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdResetEvent(): Vukan events are not supported.");
+	mvkCmdResetEvent(cmdBuff, event, stageMask);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -1739,7 +1740,11 @@ MVK_PUBLIC_SYMBOL void vkCmdWaitEvents(
 
 	MVKTraceVulkanCallStart();
 	MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-	cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdWaitEvents(): Vukan events are not supported.");
+	mvkCmdWaitEvents(cmdBuff, eventCount, pEvents,
+					 srcStageMask, dstStageMask,
+					 memoryBarrierCount, pMemoryBarriers,
+					 bufferMemoryBarrierCount, pBufferMemoryBarriers,
+					 imageMemoryBarrierCount, pImageMemoryBarriers);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -1757,8 +1762,8 @@ MVK_PUBLIC_SYMBOL void vkCmdPipelineBarrier(
 
 	MVKTraceVulkanCallStart();
     MVKCommandBuffer* cmdBuff = MVKCommandBuffer::getMVKCommandBuffer(commandBuffer);
-	mvkCmdPipelineBarrier(cmdBuff, srcStageMask, dstStageMask,
-						  dependencyFlags, memoryBarrierCount, pMemoryBarriers,
+	mvkCmdPipelineBarrier(cmdBuff, srcStageMask, dstStageMask, dependencyFlags,
+						  memoryBarrierCount, pMemoryBarriers,
 						  bufferMemoryBarrierCount, pBufferMemoryBarriers,
 						  imageMemoryBarrierCount, pImageMemoryBarriers);
 	MVKTraceVulkanCallEnd();


### PR DESCRIPTION
- Add `MVKEvent` class. `MVKEventNative` subclass uses native `MTLEvent`. `MVKEventEmulated`
subclass uses emulation using CPU blocking and `MTLCommandBuffer` completion handling.
- `MVKConfiguration::synchronousQueueSubmits` now disabled by default if `MTLEvents` are not supported.
- Document updated use of `MVK_ALLOW_METAL_EVENTS` and `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS`
environment variables and `synchronousQueueSubmits` config setting, in `vk_mvk_moltenvk.h`.