### PR TITLE
Fix name of Display-P3 linear color space.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -497,7 +497,7 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 			colorSpaces.push_back(VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT);
 		}
 		if (mvkOSVersion() >= 10.14) {
-			colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_LINEAR_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_BT2020_LINEAR_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -308,7 +308,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
-		case VK_COLOR_SPACE_DCI_P3_LINEAR_EXT:
+		case VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT:
 			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearDisplayP3);
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;


### PR DESCRIPTION
The old `DCI_P3_LINEAR` enum is deprecated. Use
`VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT` instead. This is a closer match
for the Core Graphics name anyhow.