### PR TITLE
MVKDevice: Report a second heap for non-UMA devices.

### DIFF
--- a/Common/MVKOSExtensions.h
+++ b/Common/MVKOSExtensions.h
@@ -111,3 +111,17 @@ bool mvkGetEnvVarBool(std::string varName, bool* pWasFound = nullptr);
 		int64_t val = wasFound ? ev : EV;						\
 		cfgVal = (int32_t)std::min(std::max(val, (int64_t)INT32_MIN), (int64_t)INT32_MAX);	\
 	} while(false)
+
+
+#pragma mark -
+#pragma mark System memory
+
+/** Returns the total amount of physical RAM in the system. */
+uint64_t mvkGetSystemMemorySize();
+
+/** Returns the amount of memory available to this process. */
+uint64_t mvkGetAvailableMemorySize();
+
+/** Returns the amount of memory currently used by this process. */
+uint64_t mvkGetUsedMemorySize();
+

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -278,6 +278,9 @@ public:
 	 */
 	inline uint32_t getLazilyAllocatedMemoryTypes() { return _lazilyAllocatedMemoryTypes; }
 
+	/** Returns whether this is a unified memory device. */
+	bool getHasUnifiedMemory();
+
 	
 #pragma mark Metal
 
@@ -330,7 +333,9 @@ protected:
 	void initProperties();
 	void initGPUInfoProperties();
 	void initMemoryProperties();
+	uint64_t getVRAMSize();
 	uint64_t getRecommendedMaxWorkingSetSize();
+	uint64_t getCurrentAllocatedSize();
 	void initExtensions();
 	MVKExtensionList* getSupportedExtensions(const char* pLayerName = nullptr);
 	std::vector<MVKQueueFamily*>& getQueueFamilies();


### PR DESCRIPTION
This is the heap representing system memory. The memory type
corresponding to `MTLStorageModeShared` is reported as belonging to this
heap.

I've tried to correct the reported size of the heaps as well while I'm
at it. UMA GPUs and the system heap for NUMA GPUs use the system memory
size as the heap size, and the amount of available memory as the budget.
iOS 13 uses the new `os_proc_available_memory()` API for this purpose.
NUMA GPUs additionally use the memory used by the process as a crude
measure of system heap usage.