### PR TITLE
 vkInvalidateMappedMemoryRanges() synchronizes managed device memory to CPU.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,6 +21,7 @@ Released TBD
 - Add support for extensions:
 	- `VK_KHR_device_group`
 - Add support for `VkEvent`, using either native `MTLEvent` or emulation when `MTLEvent` not available.
+- `vkInvalidateMappedMemoryRanges()` synchronizes managed device memory to CPU.
 - Revert to supporting host-coherent memory for linear images on macOS.
 - Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,6 +32,7 @@ Released TBD
 - No longer prefer dedicated allocations for buffer memory, including buffer-backed images.
 - Handle the `compositeAlpha` member of `VkSwapchainCreateInfoKHR`.
 - `VkPhysicalDevicePortabilitySubsetFeaturesEXTX::events` set to `true`.
+- Add ability to automatically cause an *Xcode* GPU capture without developer intervention.
 
 
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -102,8 +102,8 @@ typedef unsigned long MTLLanguageVersion;
  *      2: Log errors and informational messages.
  *    If neither is set, errors and informational messages are logged.
  *
- * 2. Setting the MVK_CONFIG_TRACE_VULKAN_CALLS runtime environment variable or MoltenVK compile-time build
- *    setting will cause MoltenVK to log the name of each Vulkan call made by the application. The logging
+ * 2. The MVK_CONFIG_TRACE_VULKAN_CALLS runtime environment variable or MoltenVK compile-time build
+ *    setting causes MoltenVK to log the name of each Vulkan call made by the application. The logging
  *    format options can be controlled by setting the value of MVK_CONFIG_TRACE_VULKAN_CALLS as follows:
  *        0: No Vulkan call logging.
  *        1: Log the name of each Vulkan call when the call is entered.
@@ -117,6 +117,18 @@ typedef unsigned long MTLLanguageVersion;
  * 4. Setting the MVK_ALLOW_METAL_EVENTS runtime environment variable or MoltenVK compile-time build
  *    setting to 1 will cause MoltenVK to use Metal events, if they are available on the device, for
  *    for VkSemaphore sychronization behaviour. This is disabled by default.
+ *
+ * 5. The MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE runtime environment variable or MoltenVK compile-time
+ *    build setting controls whether Xcode should run an automatic GPU capture without the user
+ *    having to trigger it manually via the Xcode user interface, and controls the scope under
+ *    which that GPU capture will occur. This is useful when trying to capture a one-shot GPU
+ *    trace, such as when running a Vulkan CTS test case. For the automatic GPU capture to occur,
+ *    the Xcode scheme under which the app is run must have the Metal GPU capture option turned on.
+ *    MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE should not be set to manually trigger a GPU capture via the
+ *    Xcode user interface.
+ *      0: No automatic GPU capture.
+ *      1: Capture all GPU commands issued during the lifetime of the VkDevice.
+ *    If none of these is set, no automatic GPU capture will occur.
  */
 typedef struct {
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -110,10 +110,8 @@ void MVKBuffer::applyBufferMemoryBarrier(VkPipelineStageFlags srcStageMask,
 #endif
 }
 
-/**
- * Returns whether the specified buffer memory barrier requires a sync between this
- * buffer and host memory for the purpose of the host reading texture memory.
- */
+// Returns whether the specified buffer memory barrier requires a sync between this
+// buffer and host memory for the purpose of the host reading texture memory.
 bool MVKBuffer::needsHostReadSync(VkPipelineStageFlags srcStageMask,
 								  VkPipelineStageFlags dstStageMask,
 								  VkBufferMemoryBarrier* pBufferMemoryBarrier) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -360,6 +360,11 @@ protected:
 #pragma mark -
 #pragma mark MVKDevice
 
+typedef struct {
+	id<MTLBlitCommandEncoder> mtlBlitEncoder = nil;
+	id<MTLCommandBuffer> mtlCmdBuffer = nil;
+} MVKMTLBlitEncoder;
+
 /** Represents a Vulkan logical GPU device, associated with a physical device. */
 class MVKDevice : public MVKDispatchableVulkanAPIObject {
 
@@ -387,7 +392,7 @@ public:
 	PFN_vkVoidFunction getProcAddr(const char* pName);
 
 	/** Retrieves a queue at the specified index within the specified family. */
-	MVKQueue* getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex);
+	MVKQueue* getQueue(uint32_t queueFamilyIndex = 0, uint32_t queueIndex = 0);
 
 	/** Block the current thread until all queues in this device are idle. */
 	VkResult waitIdle();
@@ -528,6 +533,9 @@ public:
 	void freeMemory(MVKDeviceMemory* mvkDevMem,
 					const VkAllocationCallbacks* pAllocator);
 
+
+#pragma mark Operations
+
 	/** Applies the specified global memory barrier to all resource issued by this device. */
 	void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
 							VkPipelineStageFlags dstStageMask,
@@ -564,6 +572,9 @@ public:
 
     /** Populates the specified statistics structure from the current activity performance statistics. */
     void getPerformanceStatistics(MVKPerformanceStatistics* pPerf);
+
+	/** Invalidates the memory regions. */
+	VkResult invalidateMappedMemoryRanges(uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
 
 
 #pragma mark Metal

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2122,6 +2122,9 @@ void MVKDevice::freeMemory(MVKDeviceMemory* mvkDevMem,
 	mvkDevMem->destroy();
 }
 
+
+#pragma mark Operations
+
 // Adds the specified resource for tracking, and returns the added resource.
 MVKResource* MVKDevice::addResource(MVKResource* rez) {
 	lock_guard<mutex> lock(_rezLock);
@@ -2195,6 +2198,25 @@ void MVKDevice::getPerformanceStatistics(MVKPerformanceStatistics* pPerf) {
     lock_guard<mutex> lock(_perfLock);
 
     if (pPerf) { *pPerf = _performanceStatistics; }
+}
+
+VkResult MVKDevice::invalidateMappedMemoryRanges(uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges) {
+	@autoreleasepool {
+		VkResult rslt = VK_SUCCESS;
+		MVKMTLBlitEncoder mvkBlitEnc;
+		for (uint32_t i = 0; i < memRangeCount; i++) {
+			const VkMappedMemoryRange* pMem = &pMemRanges[i];
+			MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
+			VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size, false, &mvkBlitEnc);
+			if (rslt == VK_SUCCESS) { rslt = r; }
+		}
+		if (mvkBlitEnc.mtlBlitEncoder) { [mvkBlitEnc.mtlBlitEncoder endEncoding]; }
+		if (mvkBlitEnc.mtlCmdBuffer) {
+			[mvkBlitEnc.mtlCmdBuffer commit];
+			[mvkBlitEnc.mtlCmdBuffer waitUntilCompleted];
+		}
+		return rslt;
+	}
 }
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2279,6 +2279,10 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 
 	initQueues(pCreateInfo);
 
+	if (getInstance()->_autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE) {
+		[[MTLCaptureManager sharedCaptureManager] startCaptureWithDevice: getMTLDevice()];
+	}
+
 	MVKLogInfo("Created VkDevice to run on GPU %s with the following %d Vulkan extensions enabled:%s",
 			   _pProperties->deviceName,
 			   _enabledExtensions.getEnabledCount(),
@@ -2562,6 +2566,10 @@ MVKDevice::~MVKDevice() {
 
 	[_mtlCompileOptions release];
     [_globalVisibilityResultMTLBuffer release];
+
+	if (getInstance()->_autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE) {
+		[[MTLCaptureManager sharedCaptureManager] stopCapture];
+	}
 }
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -85,8 +85,18 @@ public:
 	 * If this memory is host-visible, pulls the specified memory range from the device.
 	 * Normally, pulling will only occur if the device memory is non-coherent, but pulling
 	 * to coherent memory can be forced by setting evenIfCoherent to true.
+	 *
+	 * If pBlitEnc is not null, it points to a holder for a MTLBlitCommandEncoder and its
+	 * assocated MTLCommandBuffer. If this instance has a MTLBuffer using managed memory,
+	 * this function may call synchronizeResource: on the MTLBlitCommandEncoder to
+	 * synchronize the GPU contents to the CPU. If the contents of the pBlitEnc do not
+	 * include a MTLBlitCommandEncoder and MTLCommandBuffer, this function will create
+	 * them and populate the contents into the MVKMTLBlitEncoder struct.
 	 */
-	VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size, bool evenIfCoherent = false);
+	VkResult pullFromDevice(VkDeviceSize offset,
+							VkDeviceSize size,
+							bool evenIfCoherent = false,
+							MVKMTLBlitEncoder* pBlitEnc = nullptr);
 
 
 #pragma mark Metal

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -196,6 +196,7 @@ protected:
 	bool _hasDebugUtilsMessengers;
 	bool _useCreationCallbacks;
 	const char* _debugReportCallbackLayerPrefix;
+	int32_t _autoGPUCaptureScope;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -679,6 +679,8 @@ void MVKInstance::initConfig() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.fullImageViewSwizzle,                   MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.defaultGPUCaptureScopeQueueFamilyIndex, MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.defaultGPUCaptureScopeQueueIndex,       MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX);
+
+	MVK_SET_FROM_ENV_OR_BUILD_INT32(_autoGPUCaptureScope, MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE);
 }
 
 VkResult MVKInstance::verifyLayers(uint32_t count, const char* const* names) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -166,14 +166,10 @@ void MVKSwapchain::signalWhenAvailable(uint32_t imageIndex, MVKSemaphore* semaph
 		signal(signaler);
 		if (_device->_useMTLEventsForSemaphores) {
 			// Unfortunately, we can't assume we have an MTLSharedEvent here.
-			// This means we need to execute a command on the device to signal
-			// the semaphore. Alternatively, we could always use an MTLSharedEvent,
-			// but that might impose unacceptable performance costs just to handle
-			// this one case.
-			MVKQueue* queue = _device->getQueue(0, 0);	
-			id<MTLCommandQueue> mtlQ = queue->getMTLCommandQueue();
-			id<MTLCommandBuffer> mtlCmdBuff = [mtlQ commandBufferWithUnretainedReferences];
-			[mtlCmdBuff enqueue];
+			// This means we need to execute a command on the device to signal the semaphore.
+			// Alternatively, we could always use an MTLSharedEvent, but that might impose
+			// unacceptable performance costs just to handle this one case.
+			id<MTLCommandBuffer> mtlCmdBuff = [_device->getQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences];
 			signaler.first->encodeSignal(mtlCmdBuff);
 			[mtlCmdBuff commit];
 		}

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -141,6 +141,17 @@
 #   define MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX    0
 #endif
 
+/**
+ * The scope under which to automatically run a GPU capture within Xcode, without the
+ * developer having to trigger it manually via the Xcode UI. This is useful when trying
+ * to capture a one-shot trace, such as when running a Vulkan CTS test case.
+ */
+#define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE		0
+#define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE	1
+#ifndef MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE
+#   define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE    	MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE
+#endif
+
 /** Force the use of a low-power GPU if it exists. Disabled by default. */
 #ifndef MVK_CONFIG_FORCE_LOW_POWER_GPU
 #   define MVK_CONFIG_FORCE_LOW_POWER_GPU    0

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -429,15 +429,10 @@ MVK_PUBLIC_SYMBOL VkResult vkInvalidateMappedMemoryRanges(
     VkDevice                                    device,
     uint32_t                                    memRangeCount,
     const VkMappedMemoryRange*                  pMemRanges) {
-	
+
 	MVKTraceVulkanCallStart();
-	VkResult rslt = VK_SUCCESS;
-	for (uint32_t i = 0; i < memRangeCount; i++) {
-		const VkMappedMemoryRange* pMem = &pMemRanges[i];
-		MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
-		VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size);
-		if (rslt == VK_SUCCESS) { rslt = r; }
-	}
+	MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
+	VkResult rslt = mvkDev->invalidateMappedMemoryRanges(memRangeCount, pMemRanges);
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }


### PR DESCRIPTION
Hard to imagine we've got this far without the basic ability to invalidate `VkBuffers` using Metal managed memory to keep the CPU synchronized! 

I guess most devs who want to read `VkBuffers` use shared memory for them. This was exposed by CTS testing.

- Uses dynamically created `MTLCommandBuffer` & `MTLBlitCommandEncoder`.
- Add `MVKDevice::invalidateMappedMemoryRanges()`.
- Add `MVKMTLBlitEncoder` struct.
- `MVKDevice::getQueue()` defaults to queue family zero and queue zero.

While working on this...I've also added the ability to generate an automatic one-shot GPU capture in Xcode...which is useful for viewing and debugging the GPU activity and resources in a CTS test case.


- Add ability to automatically cause an Xcode GPU capture without developer intervention.
- Add `MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE` env var and build setting.
