### PR TITLE
Fixes to vkCmdBlitImage() & vkCmdClearImage().

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -26,6 +26,7 @@ Released TBD
 - Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.
 - Fix crash in `vkDestroyPipelineLayout()`.
+- `vkCmdBlitImage()` support format component swizzling.
 - `vkCmdClearImage()` set error if attempt made to clear 1D image, and fix validation of depth attachment formats.
 - Remove error logging on `VK_TIMEOUT` of `VkSemaphore` and `VkFence`.
 - Consolidate the various linkable objects into a `MVKLinkableMixin` template base class.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -26,7 +26,7 @@ Released TBD
 - Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.
 - Fix crash in `vkDestroyPipelineLayout()`.
-- `vkCmdClearImage()` set error if attempt made to clear 1D image.
+- `vkCmdClearImage()` set error if attempt made to clear 1D image, and fix validation of depth attachment formats.
 - Remove error logging on `VK_TIMEOUT` of `VkSemaphore` and `VkFence`.
 - Consolidate the various linkable objects into a `MVKLinkableMixin` template base class.
 - Use `MVKVector` whenever possible in MoltenVK, especially within render loop.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -52,7 +52,8 @@ public:
 
 protected:
 	void setContent(VkImage srcImage, VkImageLayout srcImageLayout,
-					VkImage dstImage, VkImageLayout dstImageLayout, MVKCommandUse commandUse);
+					VkImage dstImage, VkImageLayout dstImageLayout,
+					bool formatsMustMatch, MVKCommandUse commandUse);
 	void addImageCopyRegion(const VkImageCopy& region);
 	void addTempBufferImageCopyRegion(const VkImageCopy& region);
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1058,7 +1058,8 @@ void MVKCmdClearImage::setContent(VkImage image,
 	if (_image->getImageType() == VK_IMAGE_TYPE_1D) {
 		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdClearImage(): 1D images cannot be cleared on this device."));
 	}
-	if ( !_image->getSupportsAllFormatFeatures(VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) ) {
+	if ((_isDepthStencilClear && !_image->getSupportsAllFormatFeatures(VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) ||
+		(!_isDepthStencilClear && !_image->getSupportsAllFormatFeatures(VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT))) {
 		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdClearImage(): Format %s cannot be cleared on this device.", mvkVkFormatName(_image->getVkFormat())));
 	}
 }


### PR DESCRIPTION
`vkCmdBlitImage()` support format component swizzling.
`vkCmdClearImage()` fix validation of depth attachment formats.

Fixes issues #694 & #704.