### PR TITLE
Fixes to issues found during CTS testing

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -512,8 +512,6 @@ This section documents the known limitations in this version of **MoltenVK**.
   In order to use Vulkan layers such as the validation layers, use the Vulkan loader and layers from the
   [LunarG Vulkan SDK](https://vulkan.lunarg.com).
 
-- `VkEvents` are not supported.
-
 - Application-controlled memory allocations using `VkAllocationCallbacks` are ignored.
 
 - Pipeline statistics query pool using `VK_QUERY_TYPE_PIPELINE_STATISTICS` is not supported.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 - Add support for `VkEvent`, using either native `MTLEvent` or emulation when `MTLEvent` not available.
 - `vkInvalidateMappedMemoryRanges()` synchronizes managed device memory to CPU.
 - Revert to supporting host-coherent memory for linear images on macOS.
+- Disable depth and/or stencil testing if corresponding attachment is missing.
 - Ensure Vulkan loader magic number is set every time before returning any dispatchable Vulkan handle.
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.
 - Fix crash in `vkDestroyPipelineLayout()`.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,7 @@ Released TBD
 - Fix crash in `vkDestroyPipelineLayout()`.
 - `vkCmdBlitImage()` support format component swizzling.
 - `vkCmdClearImage()` set error if attempt made to clear 1D image, and fix validation of depth attachment formats.
+- `vkCreateRenderPass()` return `VK_ERROR_FORMAT_NOT_SUPPORTED` if format not supported.
 - Remove error logging on `VK_TIMEOUT` of `VkSemaphore` and `VkFence`.
 - Consolidate the various linkable objects into a `MVKLinkableMixin` template base class.
 - Use `MVKVector` whenever possible in MoltenVK, especially within render loop.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -62,7 +62,7 @@ public:
      * will be encoded to Metal, otherwise it is marked as clean, so the contents will NOT
      * be encoded. Default state can be left unencoded on a new Metal encoder.
      */
-    void beginMetalRenderPass() { if (_isModified) { markDirty(); } }
+	virtual void beginMetalRenderPass() { if (_isModified) { markDirty(); } }
 
     /**
      * If the content of this instance is dirty, marks this instance as no longer dirty
@@ -237,6 +237,8 @@ public:
      */
     void setStencilWriteMask(VkStencilFaceFlags faceMask, uint32_t stencilWriteMask);
 
+	void beginMetalRenderPass() override;
+
     /** Constructs this instance for the specified command encoder. */
     MVKDepthStencilCommandEncoderState(MVKCommandEncoder* cmdEncoder)
         : MVKCommandEncoderState(cmdEncoder) {}
@@ -248,7 +250,9 @@ protected:
                          const VkStencilOpState& vkStencil,
                          bool enabled);
 
-    MVKMTLDepthStencilDescriptorData _depthStencilData;
+    MVKMTLDepthStencilDescriptorData _depthStencilData = kMVKMTLDepthStencilDescriptorDataDefault;
+	bool _hasDepthAttachment = false;
+	bool _hasStencilAttachment = false;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -207,18 +207,24 @@ typedef struct MVKMTLDepthStencilDescriptorData_t {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));
 	}
 
-    MVKMTLDepthStencilDescriptorData_t() {
+	/** Disable depth and/or stencil testing. */
+	void disable(bool disableDepth, bool disableStencil) {
+		if (disableDepth) {
+			depthCompareFunction = MTLCompareFunctionAlways;
+			depthWriteEnabled = false;
+		}
+		if (disableStencil) {
+			frontFaceStencilData = kMVKMTLStencilDescriptorDataDefault;
+			backFaceStencilData = kMVKMTLStencilDescriptorDataDefault;
+		}
+	}
 
-        // Start with all zeros to ensure memory comparisons will work,
-        // even if the structure contains alignment gaps.
-        memset(this, 0, sizeof(*this));
-
-        depthCompareFunction = MTLCompareFunctionAlways;
-        depthWriteEnabled = false;
-
-        frontFaceStencilData = kMVKMTLStencilDescriptorDataDefault;
-        backFaceStencilData = kMVKMTLStencilDescriptorDataDefault;
-    }
+	MVKMTLDepthStencilDescriptorData_t() {
+		// Start with all zeros to ensure memory comparisons will work,
+		// even if the structure contains alignment gaps.
+		memset(this, 0, sizeof(*this));
+		disable(true, true);
+	}
 
 } __attribute__((aligned(sizeof(uint64_t)))) MVKMTLDepthStencilDescriptorData;
 
@@ -345,10 +351,7 @@ public:
 	id<MTLRenderPipelineState> newCmdClearMTLRenderPipelineState(MVKRPSKeyClearAtt& attKey,
 																 MVKVulkanAPIDeviceObject* owner);
 
-	/**
-	 * Returns a new MTLDepthStencilState dedicated to rendering to several 
-	 * attachments to support clearing regions of those attachments.
-	 */
+	/** Returns a new MTLDepthStencilState that always writes to the depth and/or stencil attachments. */
 	id<MTLDepthStencilState> newMTLDepthStencilState(bool useDepth, bool useStencil);
 
     /**

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -134,6 +134,8 @@ public:
 							const VkAttachmentDescription* pCreateInfo);
 
 protected:
+	VkAttachmentDescription validate(const VkAttachmentDescription* pCreateInfo);
+
 	VkAttachmentDescription _info;
 	MVKRenderPass* _renderPass;
 	uint32_t _attachmentIndex;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -321,9 +321,19 @@ MVKRenderPassAttachment::MVKRenderPassAttachment(MVKRenderPass* renderPass,
 		}
 	}
 
-    _info = *pCreateInfo;
+	_info = validate(pCreateInfo);
 }
 
+// Validate and potentially modify the create info
+VkAttachmentDescription MVKRenderPassAttachment::validate(const VkAttachmentDescription* pCreateInfo) {
+	VkAttachmentDescription info = *pCreateInfo;
+
+	if ( !_renderPass->getMTLPixelFormatFromVkFormat(info.format) ) {
+		_renderPass->setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateRenderPass(): Attachment format %s is not supported on this device.", mvkVkFormatName(info.format)));
+	}
+
+	return info;
+}
 
 #pragma mark -
 #pragma mark MVKRenderPass

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -580,7 +580,7 @@ MTLPixelFormat mvkMTLPixelFormatFromVkFormatInObj(VkFormat vkFormat, MVKBaseObje
         string errMsg;
         errMsg += "VkFormat ";
         errMsg += (fmtDesc.vkName) ? fmtDesc.vkName : to_string(fmtDesc.vk);
-        errMsg += " is not supported on this platform.";
+        errMsg += " is not supported on this device.";
 
         if (fmtDesc.isSupportedOrSubstitutable()) {
             mtlPixFmt = fmtDesc.mtlSubstitute;
@@ -702,7 +702,7 @@ MTLVertexFormat mvkMTLVertexFormatFromVkFormatInObj(VkFormat vkFormat, MVKBaseOb
         string errMsg;
         errMsg += "VkFormat ";
         errMsg += (fmtDesc.vkName) ? fmtDesc.vkName : to_string(fmtDesc.vk);
-        errMsg += " is not supported for vertex buffers on this platform.";
+        errMsg += " is not supported for vertex buffers on this device.";
 
         if (fmtDesc.vertexIsSupportedOrSubstitutable()) {
             mtlVtxFmt = fmtDesc.mtlVertexFormatSubstitute;


### PR DESCRIPTION
- `vkCreateRenderPass()` return `VK_ERROR_FORMAT_NOT_SUPPORTED` if format not supported.
- Disable depth and/or stencil testing if corresponding attachment is missing.