### PR TITLE
Improve performance of vkCmdFillBuffer().

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -29,9 +29,10 @@ Released TBD
 - Fix crash when `VkDeviceCreateInfo` specifies queue families out of numerical order.
 - Fix crash in `vkDestroyPipelineLayout()`.
 - Fix crash when signalling swapchain semaphore using `MTLEvent`.
-- `vkCmdBlitImage()` support format component swizzling.
-- `vkCmdClearImage()` set error if attempt made to clear 1D image, and fix validation of depth attachment formats.
-- `vkCreateRenderPass()` return `VK_ERROR_FORMAT_NOT_SUPPORTED` if format not supported.
+- `vkCmdBlitImage():` Support format component swizzling.
+- `vkCmdClearImage():` Set error if attempt made to clear 1D image, and fix validation of depth attachment formats.
+- `vkCreateRenderPass():` Return `VK_ERROR_FORMAT_NOT_SUPPORTED` if format not supported.
+- `vkCmdFillBuffer():` Improve performance 150x by using parallelism more effectively.
 - Remove error logging on `VK_TIMEOUT` of `VkSemaphore` and `VkFence`.
 - Consolidate the various linkable objects into a `MVKLinkableMixin` template base class.
 - Use `MVKVector` whenever possible in MoltenVK, especially within render loop.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -304,7 +304,7 @@ public:
 protected:
     MVKBuffer* _dstBuffer;
     VkDeviceSize _dstOffset;
-    VkDeviceSize _size;
+    uint32_t _wordCount;
     uint32_t _dataValue;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
@@ -93,16 +93,10 @@ kernel void cmdCopyBufferBytes(device uint8_t* src [[ buffer(0) ]],             
     }                                                                                                           \n\
 };                                                                                                              \n\
                                                                                                                 \n\
-typedef struct {                                                                                                \n\
-    uint32_t size;                                                                                              \n\
-    uint32_t data;                                                                                              \n\
-} FillInfo;                                                                                                     \n\
-                                                                                                                \n\
 kernel void cmdFillBuffer(device uint32_t* dst [[ buffer(0) ]],                                                 \n\
-                          constant FillInfo& info [[ buffer(1) ]]) {                                            \n\
-    for (uint32_t i = 0; i < info.size; i++) {                                                                  \n\
-        dst[i] = info.data;                                                                                     \n\
-    }                                                                                                           \n\
+                          constant uint32_t& fillValue [[ buffer(1) ]],                                         \n\
+                          uint pos [[thread_position_in_grid]]) {                                               \n\
+    dst[pos] = fillValue;                                                                                       \n\
 };                                                                                                              \n\
                                                                                                                 \n\
 typedef struct {                                                                                                \n\


### PR DESCRIPTION
Use  parallelism more effectively to massively cover buffer with
multiple full threadgroups, instead of serial looping in shader.
Performance improvement measured at 150x (yes...x not %) on macOS.
`MVKCmdFillBuffer` move validation test to `setContent()` instead of `encode()`.