### PR TITLE
MVKDevice: Constant buffer bindings on macOS cannot exceed 64k.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1136,7 +1136,12 @@ void MVKPhysicalDevice::initProperties() {
 	} else {
 		_properties.limits.maxTexelBufferElements = _properties.limits.maxImageDimension2D * _properties.limits.maxImageDimension2D;
 	}
+#if MVK_MACOS
+	_properties.limits.maxUniformBufferRange = (64 * KIBI);
+#endif
+#if MVK_IOS
 	_properties.limits.maxUniformBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
+#endif
 	_properties.limits.maxStorageBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
 	_properties.limits.maxPushConstantsSize = (4 * KIBI);
 


### PR DESCRIPTION
This limitation appears to be have been present all along (cf. Metal
Feature Set Tables, under "Maximum function memory allocation for a
buffer in the constant address space"). I guess we never ran into it
before.

Prompted by #730.