### PR TITLE
Allow MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS build setting to be overridden.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,6 +21,7 @@ Released TBD
 
 - Clarify static linking as the recommended linking approach for *iOS* app store distribution.
 - Add request for feedback from people who reject **MoltenVK** to `README.md` document.
+- Allow `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS` build setting to be overridden.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -647,21 +647,6 @@ void MVKInstance::logVersions() {
 }
 
 void MVKInstance::initConfig() {
-
-// The default value for MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS actually depends on whether
-// MTLEvents are supported, becuase if MTLEvents are not supported, then synchronous queues
-// should be turned off by default to ensure , whereas if MTLEvents are supported, we want
-// sychronous queues for better behaviour. The app can of course still override this default
-// behaviour by setting the env var, or the config directly.
-#undef MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS
-#define MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS	syncQueueSubmits
-#if MVK_MACOS
-	bool syncQueueSubmits = mvkOSVersion() >= 10.14;	// Support for MTLEvents
-#endif
-#if MVK_IOS
-	bool syncQueueSubmits = mvkOSVersion() >= 12.0;		// Support for MTLEvents
-#endif
-
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.debugMode,                              MVK_DEBUG);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.shaderConversionFlipVertexY,            MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL( _mvkConfig.synchronousQueueSubmits,                MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS);

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -56,9 +56,23 @@
 #   define MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y    1
 #endif
 
-/** Process command queue submissions on the same thread on which the submission call was made. Enable by default. */
+/**
+ * Process command queue submissions on the same thread on which the submission call was made.
+ * The default value actually depends on whether MTLEvents are supported, becuase if MTLEvents
+ * are not supported, then synchronous queues should be turned off by default to ensure the
+ * CPU emulation of VkEvent behaviour does not deadlock a queue submission, whereas if MTLEvents
+ * are supported, we want sychronous queues for better, and more performant, behaviour.
+ * The app can of course still override this default behaviour by setting the
+ * MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS env var, or the config directly.
+ */
+#if MVK_MACOS
+#   define MVK_MTLEVENT_MIN_OS  10.14
+#endif
+#if MVK_IOS
+#   define MVK_MTLEVENT_MIN_OS  12.0
+#endif
 #ifndef MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS
-#   define MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS    1
+#   define MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS    (mvkOSVersion() >= MVK_MTLEVENT_MIN_OS)
 #endif
 
 /** Fill a Metal command buffers when each Vulkan command buffer is filled. */


### PR DESCRIPTION
Fixes issue #737.