### PR TITLE
Fix memory leaks of system classes during VkInstance and VkQueue creation.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 - Clarify static linking as the recommended linking approach for *iOS* app store distribution.
 - Add request for feedback from people who reject **MoltenVK** to `README.md` document.
 - Allow `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS` build setting to be overridden.
+- Fix memory leaks of system classes during `VkInstance` and `VkQueue` creation.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -38,9 +38,11 @@ id<MTLCommandQueue> MVKQueueFamily::getMTLCommandQueue(uint32_t queueIndex) {
 	lock_guard<mutex> lock(_qLock);
 	id<MTLCommandQueue> mtlQ = _mtlQueues[queueIndex];
 	if ( !mtlQ ) {
-		uint32_t maxCmdBuffs = _physicalDevice->getInstance()->getMoltenVKConfiguration()->maxActiveMetalCommandBuffersPerQueue;
-		mtlQ = [_physicalDevice->getMTLDevice() newCommandQueueWithMaxCommandBufferCount: maxCmdBuffs];		// retained
-		_mtlQueues[queueIndex] = mtlQ;
+		@autoreleasepool {		// Catch any autoreleased objects created during MTLCommandQueue creation
+			uint32_t maxCmdBuffs = _physicalDevice->getInstance()->getMoltenVKConfiguration()->maxActiveMetalCommandBuffersPerQueue;
+			mtlQ = [_physicalDevice->getMTLDevice() newCommandQueueWithMaxCommandBufferCount: maxCmdBuffs];		// retained
+			_mtlQueues[queueIndex] = mtlQ;
+		}
 	}
 	return mtlQ;
 }


### PR DESCRIPTION
Wrap retrieval of MTLDevice and MTLCommandQueue in an @autoreleasepool.

Fixes issue #725.