### PR TITLE
Fix memory leaks when compiling shaders and pipelines without default OS autorelease pool

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
 - Add request for feedback from people who reject **MoltenVK** to `README.md` document.
 - Allow `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS` build setting to be overridden.
 - Fix memory leaks of system classes during `VkInstance` and `VkQueue` creation.
+- Fix memory leaks when compiling shaders and pipelines without default OS autorelease pool.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
@@ -310,7 +310,7 @@ void MVKMetalCompiler::compile(unique_lock<mutex>& lock, dispatch_block_t block)
 	MVKDevice* mvkDev = _owner->getDevice();
 	_startTime = mvkDev->getPerformanceTimestamp();
 
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{ @autoreleasepool { block(); } });
 
 	// Limit timeout to avoid overflow since wait_for() uses wait_until()
 	chrono::nanoseconds nanoTimeout(min(mvkDev->_pMVKConfig->metalCompileTimeout, kMVKUndefinedLargeUInt64));


### PR DESCRIPTION
Wrap MVKMetalCompiler compiling execution in an @autoreleasepool.

Fix for issue #746.