### PR TITLE
Add shader linking capability to GLSLToSPIRVConverter

### DIFF
--- a/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
@@ -70,8 +70,8 @@ MVK_PUBLIC_SYMBOL bool GLSLToSPIRVConverter::convert(MVKGLSLConversionShaderStag
 	configureGLSLCompilerResources(&glslCompilerResources);
 	std::vector<std::unique_ptr<glslang::TShader>> glslShaders;
 	const char *glslStrings[1];
-    glslang::TProgram glslProgram;
-    
+	glslang::TProgram glslProgram;
+
 	for (const auto& glsl : _glsls) {
 		glslStrings[0] = glsl.data();
 

--- a/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.cpp
@@ -39,14 +39,12 @@ EShLanguage eshLanguageFromMVKGLSLConversionShaderStage(const MVKGLSLConversionS
 
 MVK_PUBLIC_SYMBOL void GLSLToSPIRVConverter::setGLSL(const std::string& glslSrc) {
 	_glsls.clear();
-	if (glslSrc.size())
-		_glsls.push_back(glslSrc);
+	if (glslSrc.size()) { _glsls.push_back(glslSrc); }
 }
 
 MVK_PUBLIC_SYMBOL void GLSLToSPIRVConverter::setGLSL(const char* glslSrc, size_t length) {
 	_glsls.clear();
-	if (length > 0)
-		_glsls.push_back(std::string(glslSrc, length));
+	if (length > 0) { _glsls.push_back(std::string(glslSrc, length)); }
 }
 
 MVK_PUBLIC_SYMBOL void GLSLToSPIRVConverter::setGLSLs(const std::vector<std::string>& glslSrcs) {
@@ -147,7 +145,7 @@ bool GLSLToSPIRVConverter::validateSPIRV() {
 void GLSLToSPIRVConverter::logGLSL(const char* opDesc) {
 	_resultLog += opDesc;
 	_resultLog += " GLSL:\n";
-	for (const auto& glsl : _glsls) _resultLog += glsl + "\n";
+	for (const auto& glsl : _glsls) { _resultLog += glsl + "\n"; }
 	_resultLog += "End GLSL\n\n";
 }
 

--- a/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKGLSLToSPIRVConverter/GLSLToSPIRVConverter.h
@@ -36,19 +36,30 @@ namespace mvk {
 	public:
 
 		/** Sets the GLSL source code that is to be converted to the specified string. */
-		void setGLSL(const std::string& glslSrc) { _glsl = glslSrc; }
+		void setGLSL(const std::string& glslSrc);
 
 		/**
 		 * Sets the GLSL source code that is to be converted from the first length characters
 		 * of the buffer, and ensuring the resulting string is null-terminated.
 		 */
-		void setGLSL(const char* glslSrc, size_t length) { _glsl.assign(glslSrc, length); }
+		void setGLSL(const char* glslSrc, size_t length);
 
 		/** Returns the GLSL source code that was set using the setGLSL() function. */
-		const std::string& getGLSL() { return _glsl; }
+		const std::string& getGLSL() { return _glsls.front(); }
+
+		/**
+		 * Sets the GLSL source code that is to be converted to the specified strings.
+		 * 
+		 * A separate shader will be compiled for each source and linked together into a single
+		 * program.
+		 */
+		void setGLSLs(const std::vector<std::string>& glslSrcs);
+
+		/** Returns the GLSL source code that was set using the setGLSLs() function. */
+		const std::vector<std::string>& getGLSLs() { return _glsls; }
 
 		/** Returns whether the SPIR-V code has been set. */
-		bool hasGLSL() { return !_glsl.empty(); }
+		bool hasGLSL() { return !_glsls.empty(); }
 
 		/**
 		 * Converts GLSL code, set with setGLSL(), to SPIR-V code, which can be retrieved using getSPIRV().
@@ -82,7 +93,7 @@ namespace mvk {
 		bool validateSPIRV();
 		void initGLSLCompilerResources();
 
-		std::string _glsl;
+		std::vector<std::string> _glsls;
 		std::vector<uint32_t> _spirv;
 		std::string _resultLog;
 		bool _wasConverted = false;


### PR DESCRIPTION
This is a PR for this [issue](https://github.com/KhronosGroup/MoltenVK/issues/755). Simple change to make it so that you can use the linking feature in [glslang ](https://github.com/KhronosGroup/glslang)

Thanks