### PR TITLE
Enable use of MTLFence for Vulkan semaphores, by default.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -37,6 +37,7 @@ Released 2019/10/28
 - Allow `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS` build setting to be overridden.
 - Fix memory leaks of system classes during `VkInstance` and `VkQueue` creation.
 - Fix memory leaks when compiling shaders and pipelines without default OS autorelease pool.
+- Log format substitution error when `MTLPixelFormatDepth24Unorm_Stencil8` is not supported.
 - Reduce memory usage by adjusting default memory allocs for many `MVKVectorInline` uses and 
   replacing use of `MVKVectorDefault` with `std::vector` in descriptor set bindings.
 	 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -17,13 +17,15 @@ For best results, use a Markdown reader.*
 MoltenVK 1.0.38
 ---------------
 
-Released 2019/10/31
+Released 2019/10/28
 
 - Add support for Metal 3.0 capabilities.
 - Add support for extensions:
 	- `VK_EXT_swapchain_colorspace` (*iOS*, already supported on *macOS*).
 	- `VK_EXT_hdr_metadata` (*macOS*)
 - Use native texture swizzling when available.
+- Set default value of the `MVK_ALLOW_METAL_FENCES` environment variable to `1 (true)`, 
+  to enable use of `MTLFence` for Vulkan semaphores, by default.
 - Use placement `MTLHeaps` for `VkDeviceMemory` when possible.
 - Report heap sizes accurately when possible.
 - Add support for additional colorspace options.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -116,10 +116,14 @@ typedef unsigned long MTLLanguageVersion;
  *    build setting to 1 will force MoltenVK to use a low-power GPU, if one is availble on the device.
  *
  * 4. Setting the MVK_ALLOW_METAL_FENCES or MVK_ALLOW_METAL_EVENTS runtime environment variable
- *    or MoltenVK compile-time build setting to 1 will cause MoltenVK to use MTLFence or MTLEvent
- *    if they are available on the device, for VkSemaphore sychronization behaviour.
+ *    or MoltenVK compile-time build setting to 1 will cause MoltenVK to use MTLFence or MTLEvent,
+ *    respectively, if it is available on the device, for VkSemaphore synchronization behaviour.
  *    If both variables are set, MVK_ALLOW_METAL_FENCES takes priority over MVK_ALLOW_METAL_EVENTS.
- *    Both options are disabled by default.
+ *    If both are disabled, or if MTLFence or MTLEvent is not available on the device, MoltenVK
+ *    will use CPU synchronization to control VkSemaphore synchronization behaviour.
+ *    By default, MVK_ALLOW_METAL_FENCES is enabled and MVK_ALLOW_METAL_EVENTS is disabled,
+ *    meaning MoltenVK will use MTLFences, if they are available, to control VkSemaphore
+ *    synchronization behaviour, by default.
  *
  * 5. The MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE runtime environment variable or MoltenVK compile-time
  *    build setting controls whether Xcode should run an automatic GPU capture without the user

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2653,7 +2653,7 @@ void MVKDevice::initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDe
 	if (_pMetalFeatures->events) {
 		MVK_SET_FROM_ENV_OR_BUILD_BOOL(_useMTLEventForSemaphores, MVK_ALLOW_METAL_EVENTS);
 	}
-	MVKLogInfo("Using %s for semaphores.", _useMTLFenceForSemaphores ? "MTLFence" : (_useMTLEventForSemaphores ? "MTLEvent" : "emulation"));
+	MVKLogInfo("Using %s for Vulkan semaphores.", _useMTLFenceForSemaphores ? "MTLFence" : (_useMTLEventForSemaphores ? "MTLEvent" : "emulation"));
 
 #if MVK_MACOS
 	// If we have selected a high-power GPU and want to force the window system

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -211,8 +211,6 @@ bool MVKPhysicalDevice::getFormatIsSupported(VkFormat format) {
 	switch (mvkMTLPixelFormatFromVkFormat(format)) {
 		case MTLPixelFormatDepth24Unorm_Stencil8:
 			return getMTLDevice().isDepth24Stencil8PixelFormatSupported;
-			break;
-
 		default:
 			break;
 	}
@@ -2512,7 +2510,7 @@ MTLPixelFormat MVKDevice::getMTLPixelFormatFromVkFormat(VkFormat vkFormat, MVKBa
 #if MVK_MACOS
 	if (mtlPixFmt == MTLPixelFormatDepth24Unorm_Stencil8 &&
 		!getMTLDevice().isDepth24Stencil8PixelFormatSupported) {
-		return MTLPixelFormatDepth32Float_Stencil8;
+		return mvkMTLPixelFormatFromVkFormatInObj(vkFormat, mvkObj, MTLPixelFormatDepth24Unorm_Stencil8);
 	}
 #endif
 	return mtlPixFmt;

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -171,14 +171,18 @@
 #   define MVK_CONFIG_FORCE_LOW_POWER_GPU    0
 #endif
 
-/** Allow the use of MTLFence or MTLEvent for VkSemaphore synchronization behaviour. Disabled by default. */
+/**
+ * Allow the use of MTLFence or MTLEvent for VkSemaphore synchronization behaviour.
+ * By default:
+ *   - MVK_ALLOW_METAL_FENCES is enabled
+ *   - MVK_ALLOW_METAL_EVENTS is disabled
+ * */
 #ifndef MVK_ALLOW_METAL_FENCES
-#   define MVK_ALLOW_METAL_FENCES    0
+#   define MVK_ALLOW_METAL_FENCES    1
 #endif
 #ifndef MVK_ALLOW_METAL_EVENTS
 #   define MVK_ALLOW_METAL_EVENTS    0
 #endif
-
 
 /**
  * IOSurfaces are supported on macOS, and on iOS starting with iOS 11.

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.hpp
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.hpp
@@ -47,7 +47,9 @@ class MVKBaseObject;
  * of an MVKBaseObject subclass, which is true for all but static calling functions.
  */
 
-MTLPixelFormat mvkMTLPixelFormatFromVkFormatInObj(VkFormat vkFormat, MVKBaseObject* mvkObj);
+MTLPixelFormat mvkMTLPixelFormatFromVkFormatInObj(VkFormat vkFormat,
+												  MVKBaseObject* mvkObj,
+												  MTLPixelFormat mtlPixelFormatKnownUnsupported = MTLPixelFormatInvalid);
 #define mvkMTLPixelFormatFromVkFormat(vkFormat)	mvkMTLPixelFormatFromVkFormatInObj(vkFormat, this)
 
 MTLVertexFormat mvkMTLVertexFormatFromVkFormatInObj(VkFormat vkFormat, MVKBaseObject* mvkObj);

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -569,11 +569,13 @@ MVK_PUBLIC_SYMBOL MTLPixelFormat mvkMTLPixelFormatFromVkFormat(VkFormat vkFormat
 	return mvkMTLPixelFormatFromVkFormatInObj(vkFormat, nullptr);
 }
 
-MTLPixelFormat mvkMTLPixelFormatFromVkFormatInObj(VkFormat vkFormat, MVKBaseObject* mvkObj) {
+MTLPixelFormat mvkMTLPixelFormatFromVkFormatInObj(VkFormat vkFormat,
+												  MVKBaseObject* mvkObj,
+												  MTLPixelFormat mtlPixelFormatKnownUnsupported) {
 	MTLPixelFormat mtlPixFmt = MTLPixelFormatInvalid;
 
 	const MVKFormatDesc& fmtDesc = formatDescForVkFormat(vkFormat);
-	if (fmtDesc.isSupported()) {
+	if (fmtDesc.isSupported() && (fmtDesc.mtl != mtlPixelFormatKnownUnsupported)) {
 		mtlPixFmt = fmtDesc.mtl;
 	} else if (vkFormat != VK_FORMAT_UNDEFINED) {
 		// If the MTLPixelFormat is not supported but VkFormat is valid, attempt to substitute a different format.


### PR DESCRIPTION
- Enable use of MTLFence for Vulkan semaphores, by default.
- Log format substitution error when `MTLPixelFormatDepth24Unorm_Stencil8` is not supported

Fixes issue #593.