### PR TITLE
Fix severe FPS degradation caused by certain swapchain recreation situations.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -40,6 +40,7 @@ Released 2019/10/29
 - Allow `MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS` build setting to be overridden.
 - Fix memory leaks of system classes during `VkInstance` and `VkQueue` creation.
 - Fix memory leaks when compiling shaders and pipelines without default OS autorelease pool.
+- Fix severe FPS degradation caused by certain swapchain recreation situations.
 - Log format substitution error when `MTLPixelFormatDepth24Unorm_Stencil8` is not supported.
 - Reduce memory usage by adjusting default memory allocs for many `MVKVectorInline` uses and 
   replacing use of `MVKVectorDefault` with `std::vector` in descriptor set bindings.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -446,6 +446,8 @@ public:
 					  const VkImageCreateInfo* pCreateInfo,
 					  MVKSwapchain* swapchain);
 
+	~MVKSwapchainImage() override;
+
 protected:
 	id<MTLTexture> newMTLTexture() override;
 	id<CAMetalDrawable> getCAMetalDrawable();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1348,4 +1348,7 @@ MVKSwapchainImage::MVKSwapchainImage(MVKDevice* device,
 	_swapchainIndex = uint32_t(-1);
 }
 
+MVKSwapchainImage::~MVKSwapchainImage() {
+	resetMetalSurface();	// remove drawable from swapchain
+}
 


### PR DESCRIPTION
Ensure swapchain clears all cached `CAMetalDrawables` when destroyed.

Fixes issue #756.