### PR TITLE
Fix image subresource sizing calculations for heap-based textures.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Support linear filtering when using `vkCmdBlitImage()`.
 - Clamp image copy extents to image extent.
 - Fix crash in `fetchDependencies` on build paths containing spaces.
+- Fix image subresource sizing calculations for heap-based textures.
 - Support *Xcode 11.2*.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -273,6 +273,7 @@ protected:
     id<MTLTexture> _mtlTexture;
     std::mutex _lock;
     IOSurfaceRef _ioSurface;
+	VkDeviceSize _rowByteAlignment;
     bool _isDepthStencilAttachment;
 	bool _canSupportMTLTextureView;
     bool _hasExpectedTexelSize;


### PR DESCRIPTION
Add `MVKImage::_rowByteAlignment` separate from `_byteAlignment`.

Fixes issue #768.