### PR TITLE
Fix crash when app does not use queue family zero.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -14,6 +14,15 @@ For best results, use a Markdown reader.*
 
 
 
+MoltenVK 1.0.40
+---------------
+
+Released TBD
+
+- Fix crash when app does not use queue family zero.
+
+
+
 MoltenVK 1.0.39
 ---------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -50,7 +50,7 @@ typedef unsigned long MTLLanguageVersion;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   39
+#define MVK_VERSION_PATCH   40
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -402,8 +402,11 @@ public:
 	/** Returns the function pointer corresponding to the specified named entry point. */
 	PFN_vkVoidFunction getProcAddr(const char* pName);
 
-	/** Retrieves a queue at the specified index within the specified family. */
-	MVKQueue* getQueue(uint32_t queueFamilyIndex = 0, uint32_t queueIndex = 0);
+	/** Returns the queue at the specified index within the specified family. */
+	MVKQueue* getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex);
+
+	/** Retrieves the queue at the lowest queue and queue family indices used by the app. */
+	MVKQueue* getAnyQueue();
 
 	/** Block the current thread until all queues in this device are idle. */
 	VkResult waitIdle();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2030,6 +2030,15 @@ MVKQueue* MVKDevice::getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex) {
 	return _queuesByQueueFamilyIndex[queueFamilyIndex][queueIndex];
 }
 
+MVKQueue* MVKDevice::getAnyQueue() {
+	for (auto& queues : _queuesByQueueFamilyIndex) {
+		for (MVKQueue* q : queues) {
+			if (q) { return q; };
+		}
+	}
+	return nullptr;
+}
+
 VkResult MVKDevice::waitIdle() {
 	for (auto& queues : _queuesByQueueFamilyIndex) {
 		for (MVKQueue* q : queues) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -110,7 +110,7 @@ VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset,
 
 #if MVK_MACOS
 		if (pBlitEnc && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {
-			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = [_device->getQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]; }
+			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = [_device->getAnyQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]; }
 			if ( !pBlitEnc->mtlBlitEncoder) { pBlitEnc->mtlBlitEncoder = [pBlitEnc->mtlCmdBuffer blitCommandEncoder]; }
 			[pBlitEnc->mtlBlitEncoder synchronizeResource: _mtlBuffer];
 		}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -172,7 +172,7 @@ void MVKSwapchain::signalWhenAvailable(uint32_t imageIndex, MVKSemaphore* semaph
 		@autoreleasepool {
 			MVKSemaphore* mvkSem = signaler.first;
 			id<MTLCommandBuffer> mtlCmdBuff = (mvkSem && mvkSem->isUsingCommandEncoding()
-											   ? [_device->getQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]
+											   ? [_device->getAnyQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]
 											   : nil);
 			signal(signaler, mtlCmdBuff);
 			[mtlCmdBuff commit];


### PR DESCRIPTION
- Add `MVKDevice::getAnyQueue()` to safely find the first available queue.
- Update MoltenVK version to 1.0.40.

Fixes issue #791 and maybe #779.