### PR TITLE
Fix buffer offset in vkCmdPushDescriptorSet() for non-dedicated buffer memory

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ MoltenVK 1.0.40
 Released TBD
 
 - Fix crash when app does not use queue family zero.
+- Fix buffer offset in `vkCmdPushDescriptorSet()` for non-dedicated buffer memory.
 
 
 
@@ -120,7 +121,6 @@ Released 2019/10/30
 	- Do not consider aliased struct types if the master is not a block.
 	- Fix `OpVectorExtractDynamic` with spec constant op index.
 	- Update SPIR-V headers to SPIR-V 1.5.
-	 
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -258,7 +258,7 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
                 const auto& bufferInfo = get<VkDescriptorBufferInfo>(pData, stride, rezIdx - dstArrayElement);
                 MVKBuffer* buffer = (MVKBuffer*)bufferInfo.buffer;
                 bb.mtlBuffer = buffer->getMTLBuffer();
-                bb.offset = bufferInfo.offset;
+                bb.offset = buffer->getMTLBufferOffset() + bufferInfo.offset;
 				bb.size = (uint32_t)buffer->getByteCount();
                 for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
                     if (_applyToStage[i]) {


### PR DESCRIPTION
Fixes issue #797.