### PR TITLE
Fix a few issues with EXT_inline_uniform_block

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -253,6 +253,25 @@ void MVKCmdPushDescriptorSet::setContent(VkPipelineBindPoint pipelineBindPoint,
 			std::copy_n(descWrite.pTexelBufferView, descWrite.descriptorCount, pNewTexelBufferView);
 			descWrite.pTexelBufferView = pNewTexelBufferView;
 		}
+        if (getDevice()->_enabledExtensions.vk_EXT_inline_uniform_block.enabled) {
+            const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock = nullptr;
+            for (auto* next = (VkWriteDescriptorSetInlineUniformBlockEXT*)descWrite.pNext; next; next = (VkWriteDescriptorSetInlineUniformBlockEXT*)next->pNext)
+            {
+                switch (next->sType) {
+                case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: {
+                    pInlineUniformBlock = next;
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            if (pInlineUniformBlock != nullptr) {
+                auto *pNewInlineUniformBlock = new VkWriteDescriptorSetInlineUniformBlockEXT(*pInlineUniformBlock);
+                pNewInlineUniformBlock->pNext = nullptr; // clear pNext just in case, no other extensions are supported at this time
+                descWrite.pNext = pNewInlineUniformBlock;
+            }
+        }
 	}
 
 	// Validate by encoding on a null encoder
@@ -276,6 +295,22 @@ void MVKCmdPushDescriptorSet::clearDescriptorWrites() {
 		if (descWrite.pImageInfo) delete[] descWrite.pImageInfo;
 		if (descWrite.pBufferInfo) delete[] descWrite.pBufferInfo;
 		if (descWrite.pTexelBufferView) delete[] descWrite.pTexelBufferView;
+        if (getDevice()->_enabledExtensions.vk_EXT_inline_uniform_block.enabled) {
+            const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock = nullptr;
+            for (auto* next = (VkWriteDescriptorSetInlineUniformBlockEXT*)descWrite.pNext; next; next = (VkWriteDescriptorSetInlineUniformBlockEXT*)next->pNext)
+            {
+                switch (next->sType) {
+                case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: {
+                    pInlineUniformBlock = next;
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+            if (pInlineUniformBlock != nullptr)
+                delete pInlineUniformBlock;
+        }
 	}
 	_descriptorWrites.clear();
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -424,9 +424,6 @@ public:
     /** Binds the specified buffer for the specified shader stage. */
     void bindBuffer(MVKShaderStage stage, const MVKMTLBufferBinding& binding);
 
-    /** Binds the specified buffer for the specified shader stage. */
-    void bindInline(MVKShaderStage stage, const MVKMTLInlineBinding& binding);
-
     /** Binds the specified texture for the specified shader stage. */
     void bindTexture(MVKShaderStage stage, const MVKMTLTextureBinding& binding);
 
@@ -461,8 +458,7 @@ public:
                         std::function<void(MVKCommandEncoder*, MVKMTLBufferBinding&)> bindBuffer,
                         std::function<void(MVKCommandEncoder*, MVKMTLBufferBinding&, MVKVector<uint32_t>&)> bindImplicitBuffer,
                         std::function<void(MVKCommandEncoder*, MVKMTLTextureBinding&)> bindTexture,
-                        std::function<void(MVKCommandEncoder*, MVKMTLSamplerStateBinding&)> bindSampler,
-                        std::function<void(MVKCommandEncoder*, MVKMTLInlineBinding&)> bindInline);
+                        std::function<void(MVKCommandEncoder*, MVKMTLSamplerStateBinding&)> bindSampler);
 
 #pragma mark Construction
     
@@ -478,7 +474,6 @@ protected:
         MVKVectorInline<MVKMTLBufferBinding, 8> bufferBindings;
         MVKVectorInline<MVKMTLTextureBinding, 8> textureBindings;
         MVKVectorInline<MVKMTLSamplerStateBinding, 8> samplerStateBindings;
-        MVKVectorInline<MVKMTLInlineBinding, 8> inlineBindings;
         MVKVectorInline<uint32_t, 8> swizzleConstants;
         MVKVectorInline<uint32_t, 8> bufferSizes;
         MVKMTLBufferBinding swizzleBufferBinding;
@@ -487,7 +482,6 @@ protected:
         bool areBufferBindingsDirty = false;
         bool areTextureBindingsDirty = false;
         bool areSamplerStateBindingsDirty = false;
-        bool areInlineBindingsDirty = false;
 
         bool needsSwizzle = false;
     };
@@ -506,9 +500,6 @@ public:
 
     /** Binds the specified buffer. */
     void bindBuffer(const MVKMTLBufferBinding& binding);
-
-    /** Binds the specified buffer. */
-    void bindInline(const MVKMTLInlineBinding& binding);
 
     /** Binds the specified texture. */
     void bindTexture(const MVKMTLTextureBinding& binding);
@@ -535,7 +526,6 @@ protected:
     MVKVectorInline<MVKMTLBufferBinding, 4> _bufferBindings;
     MVKVectorInline<MVKMTLTextureBinding, 4> _textureBindings;
     MVKVectorInline<MVKMTLSamplerStateBinding, 4> _samplerStateBindings;
-    MVKVectorInline<MVKMTLInlineBinding, 4> _inlineBindings;
     MVKVectorInline<uint32_t, 4> _swizzleConstants;
     MVKVectorInline<uint32_t, 4> _bufferSizes;
     MVKMTLBufferBinding _swizzleBufferBinding;
@@ -544,7 +534,6 @@ protected:
     bool _areBufferBindingsDirty = false;
     bool _areTextureBindingsDirty = false;
     bool _areSamplerStateBindingsDirty = false;
-    bool _areInlineBindingsDirty = false;
 
     bool _needsSwizzle = false;
 };

--- a/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
@@ -37,11 +37,12 @@ typedef struct {
 
 /** Describes a MTLBuffer resource binding. */
 typedef struct {
-    union { id<MTLBuffer> mtlBuffer = nil; id<MTLBuffer> mtlResource; }; // aliases
+    union { id<MTLBuffer> mtlBuffer = nil; id<MTLBuffer> mtlResource; const void* mtlBytes; }; // aliases
     NSUInteger offset = 0;
     uint32_t index = 0;
     uint32_t size = 0;
     bool isDirty = true;
+    bool isInline = false;
 } MVKMTLBufferBinding;
 
 /** Describes a MTLBuffer resource binding as used for an index buffer. */
@@ -51,12 +52,3 @@ typedef struct {
     MTLIndexType mtlIndexType;
     bool isDirty = true;
 } MVKIndexMTLBufferBinding;
-
-/** Describes host bytes resource binding. */
-typedef struct {
-    union { const void* mtlBytes = nil; const void* mtlResource; }; // aliases
-    uint32_t index = 0;
-    uint32_t size = 0;
-    bool isDirty = true;
-} MVKMTLInlineBinding;
-


### PR DESCRIPTION
The separate `bufferBindings` and `inlineBindings` members proved troublesome, and using `set[Vertex/Fragment/Compute]Bytes` always was unnecessary overhead, so replaced with an `MTLBuffer`. Unfortunately I still don't have a proper test of `vkCmdPushDescriptorSets` though, but spotted what I could for now.