### PR TITLE
Fix issue where immutable samplers are removed during descriptor update.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -14,6 +14,15 @@ For best results, use a Markdown reader.*
 
 
 
+MoltenVK 1.0.41
+---------------
+
+Released TBD
+
+- Fix issue where immutable samplers are removed during descriptor update.
+
+
+
 MoltenVK 1.0.40
 ---------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -50,7 +50,7 @@ typedef unsigned long MTLLanguageVersion;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   0
-#define MVK_VERSION_PATCH   40
+#define MVK_VERSION_PATCH   41
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -189,7 +189,7 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		[msl appendLineMVK];
 		[msl appendLineMVK: @"}"];
 
-		MVKLogDebug("\n%s", msl.UTF8String);
+//		MVKLogDebug("\n%s", msl.UTF8String);
 
 		return newMTLFunction(msl, funcName);
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -700,7 +700,7 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 					break;
 				}
 			}
-	}
+		}
 
 		const void* pData = getWriteParameters(pDescWrite->descriptorType, pDescWrite->pImageInfo,
 											   pDescWrite->pBufferInfo, pDescWrite->pTexelBufferView,


### PR DESCRIPTION
Suppress spurious debug message.
Minor syntax fix.
Update MoltenVK version to 1.0.41.