### PR TITLE
Guard against Metal validation assertion from reuse of query number

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,8 @@ MoltenVK 1.0.41
 Released TBD
 
 - Fix issue where immutable samplers are removed during descriptor update.
+- Guard against Metal validation assertion from reuse of query number 
+  within a single `MTLRenderEncoder`.
 
 
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -103,8 +103,9 @@ typedef unsigned long MTLLanguageVersion;
  *    If none of these is set, errors and informational messages are logged.
  *
  * 2. The MVK_CONFIG_TRACE_VULKAN_CALLS runtime environment variable or MoltenVK compile-time build
- *    setting causes MoltenVK to log the name of each Vulkan call made by the application. The logging
- *    format options can be controlled by setting the value of MVK_CONFIG_TRACE_VULKAN_CALLS as follows:
+ *    setting causes MoltenVK to log the name of each Vulkan call made by the application, along with
+ *    the Mach thread ID, global system thread ID, and thread name. The logging format options can be
+ *    controlled by setting the value of MVK_CONFIG_TRACE_VULKAN_CALLS as follows:
  *        0: No Vulkan call logging.
  *        1: Log the name of each Vulkan call when the call is entered.
  *        2: Log the name of each Vulkan call when the call is entered and exited. This effectively

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -22,6 +22,7 @@
 #include "MVKCommandResourceFactory.h"
 #include "MVKDevice.h"
 #include "MVKVector.h"
+#include <unordered_map>
 
 class MVKCommandEncoder;
 class MVKOcclusionQueryPool;
@@ -562,10 +563,13 @@ public:
 protected:
     void encodeImpl(uint32_t) override;
     void resetImpl() override;
+	bool validateOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query);
+	void endCurrentOcclusionQuery();
 
     id<MTLBuffer> _visibilityResultMTLBuffer = nil;
     MTLVisibilityResultMode _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
     NSUInteger _mtlVisibilityResultOffset = 0;
+	std::unordered_map<MVKQueryKey, id<MTLRenderCommandEncoder>> _mtlEncodersUsed;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -563,13 +563,12 @@ public:
 protected:
     void encodeImpl(uint32_t) override;
     void resetImpl() override;
-	bool validateOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query);
-	void endCurrentOcclusionQuery();
 
     id<MTLBuffer> _visibilityResultMTLBuffer = nil;
     MTLVisibilityResultMode _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
     NSUInteger _mtlVisibilityResultOffset = 0;
-	std::unordered_map<MVKQueryKey, id<MTLRenderCommandEncoder>> _mtlEncodersUsed;
+	std::unordered_map<MVKQuerySpec, id<MTLRenderCommandEncoder>> _mtlEncodersUsed;
+	MVKQuerySpec _currentQuery;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -855,11 +855,7 @@ void MVKComputeResourcesCommandEncoderState::resetImpl() {
 
 void MVKOcclusionQueryCommandEncoderState::beginOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query, VkQueryControlFlags flags) {
 
-	// If the occlusion query is not valid, don't set it up, and end the current query
-	if ( !validateOcclusionQuery(pQueryPool, query) ) {
-		endCurrentOcclusionQuery();
-		return;
-	}
+	_currentQuery.set(pQueryPool, query);
 
     NSUInteger offset = pQueryPool->getVisibilityResultOffset(query);
     NSUInteger maxOffset = _cmdEncoder->_pDeviceMetalFeatures->maxQueryBufferSize - kMVKQuerySlotSizeInBytes;
@@ -874,42 +870,33 @@ void MVKOcclusionQueryCommandEncoderState::beginOcclusionQuery(MVKOcclusionQuery
 }
 
 void MVKOcclusionQueryCommandEncoderState::endOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query) {
-	endCurrentOcclusionQuery();
+	reset();
 }
 
-void MVKOcclusionQueryCommandEncoderState::endCurrentOcclusionQuery() {
-	_mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
-	_mtlVisibilityResultOffset = 0;
-
-	markDirty();
-}
-
-bool MVKOcclusionQueryCommandEncoderState::validateOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query) {
-
-	// If the query was already used for the current Metal render encoder, log an error and return the query as invalid
-	id<MTLRenderCommandEncoder> currMTLRendEnc = _cmdEncoder->_mtlRenderEncoder;
-	if (currMTLRendEnc) {
-		MVKQueryKey qKey = {pQueryPool, query};
-		if (_mtlEncodersUsed[qKey] == currMTLRendEnc) {
-			MVKLogError("vkCmdBeginQuery(): Metal does not support using the same query more than once within a single Vulkan render subpass.");
-			return false;
-		}
-		_mtlEncodersUsed[qKey] = currMTLRendEnc;	// Remember which MTLRenderEncoder was used for this query
-	}
-
-	return true;
-}
-
-// If the MTLBuffer has not yet been set, see if the command buffer is configured with it
 id<MTLBuffer> MVKOcclusionQueryCommandEncoderState::getVisibilityResultMTLBuffer() { return _visibilityResultMTLBuffer; }
 
 void MVKOcclusionQueryCommandEncoderState::encodeImpl(uint32_t stage) {
-    if (stage != kMVKGraphicsStageRasterization) { return; }
-    [_cmdEncoder->_mtlRenderEncoder setVisibilityResultMode: _mtlVisibilityResultMode
-                                                     offset: _mtlVisibilityResultOffset];
+	if (stage != kMVKGraphicsStageRasterization) { return; }
+
+	// Metal does not allow a query to be run twice on a single render encoder.
+	// If the query is active and was already used for the current Metal render encoder,
+	// log an error and terminate the current query. Remember which MTLRenderEncoder
+	// was used for this query to test for this situation on future queries.
+	if (_mtlVisibilityResultMode != MTLVisibilityResultModeDisabled) {
+		id<MTLRenderCommandEncoder> currMTLRendEnc = _cmdEncoder->_mtlRenderEncoder;
+		if (currMTLRendEnc == _mtlEncodersUsed[_currentQuery]) {
+			MVKLogError("vkCmdBeginQuery(): Metal does not support using the same occlusion query more than once within a single Vulkan render subpass.");
+			resetImpl();
+		}
+		_mtlEncodersUsed[_currentQuery] = currMTLRendEnc;
+	}
+
+	[_cmdEncoder->_mtlRenderEncoder setVisibilityResultMode: _mtlVisibilityResultMode
+													 offset: _mtlVisibilityResultOffset];
 }
 
 void MVKOcclusionQueryCommandEncoderState::resetImpl() {
+	_currentQuery.reset();
     _visibilityResultMTLBuffer = _cmdEncoder->_cmdBuffer->_initialVisibilityResultMTLBuffer;
     _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
     _mtlVisibilityResultOffset = 0;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -331,24 +331,29 @@ namespace std {
 }
 
 /**
- * Key for looking up query results.
+ * Spec for a query.
  *
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
-typedef struct MVKQueryKey {
-	MVKQueryPool* queryPool;
-	uint32_t query;
+typedef struct MVKQuerySpec {
+	MVKQueryPool* queryPool = nullptr;
+	uint32_t query = 0;
 
-	bool operator==(const MVKQueryKey& rhs) const {
+	inline void set(MVKQueryPool* qryPool, uint32_t qry) { queryPool = qryPool; query = qry; }
+	inline void reset() { set(nullptr, 0); }
+
+	bool operator==(const MVKQuerySpec& rhs) const {
 		return (queryPool == rhs.queryPool) && (query == rhs.query);
 	}
+
 	std::size_t hash() const { return (size_t)queryPool ^ query; }
-} MVKQueryKey;
+
+} MVKQuerySpec;
 
 namespace std {
 	template <>
-	struct hash<MVKQueryKey> {
-		std::size_t operator()(const MVKQueryKey& k) const { return k.hash(); }
+	struct hash<MVKQuerySpec> {
+		std::size_t operator()(const MVKQuerySpec& k) const { return k.hash(); }
 	};
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -25,6 +25,8 @@
 
 #import <Metal/Metal.h>
 
+class MVKQueryPool;
+
 
 #pragma mark -
 #pragma mark MVKRPSKeyBlitImg
@@ -34,14 +36,14 @@
  *
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
-typedef struct MVKRPSKeyBlitImg_t {
+typedef struct MVKRPSKeyBlitImg {
 	uint16_t srcMTLPixelFormat = 0;			/**< as MTLPixelFormat */
 	uint16_t srcMTLTextureType = 0;			/**< as MTLTextureType */
 	uint16_t dstMTLPixelFormat = 0;			/**< as MTLPixelFormat */
 	uint8_t srcFilter = 0;					/**< as MTLSamplerMinMagFilter */
 	uint8_t dstSampleCount = 0;
 
-	bool operator==(const MVKRPSKeyBlitImg_t& rhs) const {
+	bool operator==(const MVKRPSKeyBlitImg& rhs) const {
 		if (srcMTLPixelFormat != rhs.srcMTLPixelFormat) { return false; }
 		if (srcMTLTextureType != rhs.srcMTLTextureType) { return false; }
 		if (dstMTLPixelFormat != rhs.dstMTLPixelFormat) { return false; }
@@ -109,7 +111,7 @@ namespace std {
  *
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
-typedef struct MVKRPSKeyClearAtt_t {
+typedef struct MVKRPSKeyClearAtt {
     uint16_t attachmentMTLPixelFormats[kMVKClearAttachmentCount];
 	uint16_t mtlSampleCount;
     uint16_t flags;			// bitcount > kMVKClearAttachmentLayeredRenderingBitIndex
@@ -124,7 +126,7 @@ typedef struct MVKRPSKeyClearAtt_t {
 
 	bool isLayeredRenderingEnabled() { return mvkIsAnyFlagEnabled(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
 
-    bool operator==(const MVKRPSKeyClearAtt_t& rhs) const {
+    bool operator==(const MVKRPSKeyClearAtt& rhs) const {
         return ((flags == rhs.flags) &&
 				(mtlSampleCount == rhs.mtlSampleCount) &&
                 (memcmp(attachmentMTLPixelFormats, rhs.attachmentMTLPixelFormats, sizeof(attachmentMTLPixelFormats)) == 0));
@@ -141,7 +143,7 @@ typedef struct MVKRPSKeyClearAtt_t {
 		mtlSampleCount = mvkSampleCountFromVkSampleCountFlagBits(VK_SAMPLE_COUNT_1_BIT);
 	}
 
-	MVKRPSKeyClearAtt_t() { reset(); }
+	MVKRPSKeyClearAtt() { reset(); }
 
 } MVKRPSKeyClearAtt;
 
@@ -167,7 +169,7 @@ namespace std {
  * situated near the beginning of the structure so that a memory comparison will detect any
  * change as early as possible.
  */
-typedef struct MVKMTLStencilDescriptorData_t {
+typedef struct MVKMTLStencilDescriptorData {
     bool enabled;                       /**< Indicates whether stencil testing for this face is enabled. */
     uint8_t stencilCompareFunction;		/**< The stencil compare function (interpreted as MTLCompareFunction). */
     uint8_t stencilFailureOperation;	/**< The operation to take when the stencil test fails (interpreted as MTLStencilOperation). */
@@ -176,7 +178,7 @@ typedef struct MVKMTLStencilDescriptorData_t {
     uint32_t readMask;					/**< The bit-mask to apply when comparing the stencil buffer value to the reference value. */
     uint32_t writeMask;					/**< The bit-mask to apply when writing values to the stencil buffer. */
 
-    MVKMTLStencilDescriptorData_t() {
+    MVKMTLStencilDescriptorData() {
 
         // Start with all zeros to ensure memory comparisons will work,
         // even if the structure contains alignment gaps.
@@ -204,13 +206,13 @@ const MVKMTLStencilDescriptorData kMVKMTLStencilDescriptorDataDefault;
  * situated near the beginning of the structure so that a memory comparison will detect any
  * change as early as possible.
  */
-typedef struct MVKMTLDepthStencilDescriptorData_t {
+typedef struct MVKMTLDepthStencilDescriptorData {
     uint8_t depthCompareFunction;		/**< The depth compare function (interpreted as MTLCompareFunction). */
     bool depthWriteEnabled;				/**< Indicates whether depth writing is enabled. */
     MVKMTLStencilDescriptorData frontFaceStencilData;
     MVKMTLStencilDescriptorData backFaceStencilData;
 
-	bool operator==(const MVKMTLDepthStencilDescriptorData_t& rhs) const {
+	bool operator==(const MVKMTLDepthStencilDescriptorData& rhs) const {
 		return (memcmp(this, &rhs, sizeof(*this)) == 0);
 	}
 
@@ -230,7 +232,7 @@ typedef struct MVKMTLDepthStencilDescriptorData_t {
 		}
 	}
 
-	MVKMTLDepthStencilDescriptorData_t() {
+	MVKMTLDepthStencilDescriptorData() {
 		// Start with all zeros to ensure memory comparisons will work,
 		// even if the structure contains alignment gaps.
 		mvkClear(this);
@@ -259,7 +261,7 @@ namespace std {
  *
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
-typedef struct MVKImageDescriptorData_t {
+typedef struct MVKImageDescriptorData {
     VkImageType              imageType;
     VkFormat                 format;
     VkExtent3D               extent;
@@ -268,7 +270,7 @@ typedef struct MVKImageDescriptorData_t {
     VkSampleCountFlagBits    samples;
     VkImageUsageFlags        usage;
 
-    bool operator==(const MVKImageDescriptorData_t& rhs) const {
+    bool operator==(const MVKImageDescriptorData& rhs) const {
         return (memcmp(this, &rhs, sizeof(*this)) == 0);
     }
 
@@ -276,7 +278,7 @@ typedef struct MVKImageDescriptorData_t {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));
 	}
 
-    MVKImageDescriptorData_t() { mvkClear(this); }
+    MVKImageDescriptorData() { mvkClear(this); }
 
 } __attribute__((aligned(sizeof(uint64_t)))) MVKImageDescriptorData;
 
@@ -301,11 +303,11 @@ namespace std {
  *
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
-typedef struct MVKBufferDescriptorData_t {
+typedef struct MVKBufferDescriptorData {
     VkDeviceSize             size;
     VkBufferUsageFlags       usage;
 
-    bool operator==(const MVKBufferDescriptorData_t& rhs) const {
+    bool operator==(const MVKBufferDescriptorData& rhs) const {
         return (memcmp(this, &rhs, sizeof(*this)) == 0);
     }
 
@@ -313,7 +315,7 @@ typedef struct MVKBufferDescriptorData_t {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));
 	}
 
-    MVKBufferDescriptorData_t() { mvkClear(this); }
+    MVKBufferDescriptorData() { mvkClear(this); }
 
 } __attribute__((aligned(sizeof(uint64_t)))) MVKBufferDescriptorData;
 
@@ -326,6 +328,28 @@ namespace std {
     struct hash<MVKBufferDescriptorData> {
         std::size_t operator()(const MVKBufferDescriptorData& k) const { return k.hash(); }
     };
+}
+
+/**
+ * Key for looking up query results.
+ *
+ * This structure can be used as a key in a std::map and std::unordered_map.
+ */
+typedef struct MVKQueryKey {
+	MVKQueryPool* queryPool;
+	uint32_t query;
+
+	bool operator==(const MVKQueryKey& rhs) const {
+		return (queryPool == rhs.queryPool) && (query == rhs.query);
+	}
+	std::size_t hash() const { return (size_t)queryPool ^ query; }
+} MVKQueryKey;
+
+namespace std {
+	template <>
+	struct hash<MVKQueryKey> {
+		std::size_t operator()(const MVKQueryKey& k) const { return k.hash(); }
+	};
 }
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "MVKResource.h"
+#include "MVKCommandResourceFactory.h"
 #include "MVKSync.h"
 #include "MVKVector.h"
 #include <MoltenVKSPIRVToMSLConverter/SPIRVToMSLConverter.h>
@@ -30,8 +31,6 @@
 class MVKImageView;
 class MVKSwapchain;
 class MVKCommandEncoder;
-struct MVKImageDescriptorData_t;
-typedef MVKImageDescriptorData_t MVKImageDescriptorData;
 
 
 /** Tracks the state of an image subresource.  */
@@ -398,16 +397,6 @@ protected:
 
 #pragma mark -
 #pragma mark MVKSwapchainImage
-
-/** Indicates the relative availability of each image in the swapchain. */
-typedef struct MVKSwapchainImageAvailability_t {
-	uint64_t acquisitionID;			/**< When this image was last made available, relative to the other images in the swapchain. Smaller value is earlier. */
-	uint32_t waitCount;				/**< The number of semaphores already waiting for this image. */
-	bool isAvailable;				/**< Indicates whether this image is currently available. */
-
-	bool operator< (const MVKSwapchainImageAvailability_t& rhs) const;
-} MVKSwapchainImageAvailability;
-
 
 /** Represents a Vulkan image used as a rendering destination within a swapchain. */
 class MVKSwapchainImage : public MVKImage {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -158,15 +158,15 @@ protected:
 #pragma mark -
 #pragma mark MVKShaderModule
 
-typedef struct MVKShaderModuleKey_t {
+typedef struct MVKShaderModuleKey {
 	std::size_t codeSize;
 	std::size_t codeHash;
 
-	bool operator==(const MVKShaderModuleKey_t& rhs) const {
+	bool operator==(const MVKShaderModuleKey& rhs) const {
 		return ((codeSize == rhs.codeSize) && (codeHash == rhs.codeHash));
 	}
-	MVKShaderModuleKey_t(std::size_t codeSize, std::size_t codeHash) : codeSize(codeSize), codeHash(codeHash) {}
-	MVKShaderModuleKey_t() :  MVKShaderModuleKey_t(0, 0) {}
+	MVKShaderModuleKey(std::size_t codeSize, std::size_t codeHash) : codeSize(codeSize), codeHash(codeHash) {}
+	MVKShaderModuleKey() :  MVKShaderModuleKey(0, 0) {}
 } MVKShaderModuleKey;
 
 /**

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -27,6 +27,16 @@ class MVKWatermark;
 @class MVKBlockObserver;
 
 
+/** Indicates the relative availability of each image in the swapchain. */
+typedef struct MVKSwapchainImageAvailability {
+	uint64_t acquisitionID;			/**< When this image was last made available, relative to the other images in the swapchain. Smaller value is earlier. */
+	uint32_t waitCount;				/**< The number of semaphores already waiting for this image. */
+	bool isAvailable;				/**< Indicates whether this image is currently available. */
+
+	bool operator< (const MVKSwapchainImageAvailability& rhs) const;
+} MVKSwapchainImageAvailability;
+
+
 #pragma mark MVKSwapchain
 
 /** Tracks a semaphore and fence for later signaling. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -37,7 +37,7 @@ using namespace std;
 
 #pragma mark MVKSwapchain
 
-bool MVKSwapchainImageAvailability_t::operator< (const MVKSwapchainImageAvailability_t& rhs) const {
+bool MVKSwapchainImageAvailability::operator< (const MVKSwapchainImageAvailability& rhs) const {
 	if (  isAvailable && !rhs.isAvailable) { return true; }
 	if ( !isAvailable &&  rhs.isAvailable) { return false; }
 


### PR DESCRIPTION
Add thread ID when logging Vulkan calls during debugging.