### PR TITLE
Fix Metal validation assertion on VkPhysicalDeviceLimits::minStorageBufferOffsetAlignment

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,8 @@ Released TBD
 - Fix issue where immutable samplers are removed during descriptor update.
 - Guard against Metal validation assertion from reuse of query number 
   within a single `MTLRenderEncoder`.
+- Increase value of `VkPhysicalDeviceLimits::minStorageBufferOffsetAlignment` 
+  to `16` to avoid Metal validation assertions.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1224,7 +1224,7 @@ void MVKPhysicalDevice::initProperties() {
 
     _properties.limits.minMemoryMapAlignment = _metalFeatures.mtlBufferAlignment;
     _properties.limits.minUniformBufferOffsetAlignment = _metalFeatures.mtlBufferAlignment;
-    _properties.limits.minStorageBufferOffsetAlignment = 4;
+    _properties.limits.minStorageBufferOffsetAlignment = 16;
     _properties.limits.bufferImageGranularity = _metalFeatures.mtlBufferAlignment;
     _properties.limits.nonCoherentAtomSize = _metalFeatures.mtlBufferAlignment;
 


### PR DESCRIPTION
Increase value of VkPhysicalDeviceLimits::minStorageBufferOffsetAlignment to 16 to avoid Metal validation assertions.

Fixes issue #829.