### PR TITLE
Accurately populate Vulkan VkFormatProperties and capabilities.

### DIFF
--- a/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "API-Samples" */;
 			compatibilityVersion = "Xcode 8.0";

--- a/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-iOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-macOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/xcshareddata/xcschemes/API-Samples-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Cube" */;
 			compatibilityVersion = "Xcode 8.0";

--- a/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/xcshareddata/xcschemes/Cube-iOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/xcshareddata/xcschemes/Cube-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/xcshareddata/xcschemes/Cube-macOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/xcshareddata/xcschemes/Cube-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Hologram" */;
 			compatibilityVersion = "Xcode 8.0";

--- a/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/xcshareddata/xcschemes/Hologram-iOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/xcshareddata/xcschemes/Hologram-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/xcshareddata/xcschemes/Hologram-macOS.xcscheme
+++ b/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/xcshareddata/xcschemes/Hologram-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -30,6 +30,7 @@ Released 2020/03/30
 - Fix memory leak when pre-filling `MTLCommandBuffers` using `MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS`.
 - Update the `README.md` and `MoltenVK_Runtime_UserGuide.md` documents to clarify that 
   **MoltenVK** is not a fully-compliant implementation of *Vulkan*.
+- Support Xcode 11.4.
 
 
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,6 +21,7 @@ Released 2020/03/30
 
 - Accurately populate Vulkan `VkFormatProperties` from `MTLPixelFormat` capabilities, 
   taking into consideration variations across `MTLDevice` Features Sets.
+- Validate format capabilities for MSAA, renderpass attachments, and `vkCmdResolveImage()`.
 - Fix issue where immutable samplers are removed during descriptor update.
 - Guard against Metal validation assertion from reuse of query number within a single `MTLRenderEncoder`.
 - Increase value of `VkPhysicalDeviceLimits::minStorageBufferOffsetAlignment` 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,8 @@ MoltenVK 1.0.41
 
 Released 2020/03/30
 
+- Accurately populate Vulkan `VkFormatProperties` from `MTLPixelFormat` capabilities, 
+  taking into consideration variations across `MTLDevice` Features Sets.
 - Fix issue where immutable samplers are removed during descriptor update.
 - Guard against Metal validation assertion from reuse of query number within a single `MTLRenderEncoder`.
 - Increase value of `VkPhysicalDeviceLimits::minStorageBufferOffsetAlignment` 

--- a/ExternalDependencies.xcodeproj/project.pbxproj
+++ b/ExternalDependencies.xcodeproj/project.pbxproj
@@ -2966,7 +2966,7 @@
 		A9F55D25198BE6A7004EC31B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = "The Brenwill Workshop Ltd.";
 				TargetAttributes = {
 					A972A7E421CEC72F0013AB25 = {

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies (Debug).xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies (Debug).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/ExternalDependencies.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Cross-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/SPIRV-Tools-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-iOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-macOS.xcscheme
+++ b/ExternalDependencies.xcodeproj/xcshareddata/xcschemes/glslang-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -850,7 +850,7 @@
 		A9F55D25198BE6A7004EC31B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = "The Brenwill Workshop Ltd.";
 				TargetAttributes = {
 					A9B8EE091A98D796009C5A02 = {

--- a/MoltenVK/MoltenVK.xcodeproj/xcshareddata/xcschemes/MoltenVK-iOS.xcscheme
+++ b/MoltenVK/MoltenVK.xcodeproj/xcshareddata/xcschemes/MoltenVK-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVK/MoltenVK.xcodeproj/xcshareddata/xcschemes/MoltenVK-macOS.xcscheme
+++ b/MoltenVK/MoltenVK.xcodeproj/xcshareddata/xcschemes/MoltenVK-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -163,21 +163,8 @@ size_t mvkVkFormatBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t 
  */
 size_t mvkMTLPixelFormatBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
 
-/** 
- * Returns the default properties for the specified Vulkan format.
- *
- * Not all MTLPixelFormats returned by this function are supported by all GPU's, and, as a
- * result, MoltenVK may return a different value from the vkGetPhysicalDeviceFormatProperties()
- * function than is returned here. Use the vkGetPhysicalDeviceFormatProperties() function to
- * return the properties for a particular GPU.
- *
- * Setting assumeGPUSupportsDefault to true allows the default format properties to be returned.
- * The assumeGPUSupportsDefault flag can be set to false if it is already known that the format
- * is not supported by a particular GPU for images, in which case all of the returned properties
- * will be disabled, except possibly VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT, which may be supported
- * for the format even without image support.
- */
-VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat, bool assumeGPUSupportsDefault = true);
+/** Returns the default properties for the specified Vulkan format. */
+VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat);
 
 /** Returns the name of the specified Vulkan format. */
 const char* mvkVkFormatName(VkFormat vkFormat);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -467,6 +467,11 @@ void MVKCmdResolveImage::setContent(VkImage srcImage,
 
     _dstImage->getTransferDescriptorData(_transferImageData);
 	_transferImageData.samples = _srcImage->getSampleCount();
+
+	// Validate
+	if ( !mvkAreAllFlagsEnabled(getPixelFormats()->getMTLPixelFormatCapabilities(_dstImage->getMTLPixelFormat()), kMVKMTLFmtCapsResolve) ) {
+		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdResolveImage(): %s cannot be used as a resolve destination on this device.", getPixelFormats()->getVkFormatName(_dstImage->getVkFormat())));
+	}
 }
 
 /**

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -118,11 +118,11 @@ typedef struct MVKRPSKeyClearAtt {
 
     const static uint32_t bitFlag = 1;
 
-    void enableAttachment(uint32_t attIdx) { mvkEnableFlag(flags, bitFlag << attIdx); }
+    void enableAttachment(uint32_t attIdx) { mvkEnableFlags(flags, bitFlag << attIdx); }
 
     bool isAttachmentEnabled(uint32_t attIdx) { return mvkIsAnyFlagEnabled(flags, bitFlag << attIdx); }
 
-	void enableLayeredRendering() { mvkEnableFlag(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
+	void enableLayeredRendering() { mvkEnableFlags(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
 
 	bool isLayeredRenderingEnabled() { return mvkIsAnyFlagEnabled(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -112,9 +112,9 @@ namespace std {
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
 typedef struct MVKRPSKeyClearAtt {
-    uint16_t attachmentMTLPixelFormats[kMVKClearAttachmentCount];
+	uint16_t flags;				// bitcount > kMVKClearAttachmentLayeredRenderingBitIndex
 	uint16_t mtlSampleCount;
-    uint16_t flags;			// bitcount > kMVKClearAttachmentLayeredRenderingBitIndex
+	uint16_t attachmentMTLPixelFormats[kMVKClearAttachmentCount];
 
     const static uint32_t bitFlag = 1;
 
@@ -126,11 +126,7 @@ typedef struct MVKRPSKeyClearAtt {
 
 	bool isLayeredRenderingEnabled() { return mvkIsAnyFlagEnabled(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
 
-    bool operator==(const MVKRPSKeyClearAtt& rhs) const {
-        return ((flags == rhs.flags) &&
-				(mtlSampleCount == rhs.mtlSampleCount) &&
-                (memcmp(attachmentMTLPixelFormats, rhs.attachmentMTLPixelFormats, sizeof(attachmentMTLPixelFormats)) == 0));
-    }
+    bool operator==(const MVKRPSKeyClearAtt& rhs) const { return mvkAreEqual(this, &rhs); }
 
 	std::size_t hash() const {
 		std::size_t hash = mvkHash(&flags);
@@ -212,9 +208,7 @@ typedef struct MVKMTLDepthStencilDescriptorData {
     MVKMTLStencilDescriptorData frontFaceStencilData;
     MVKMTLStencilDescriptorData backFaceStencilData;
 
-	bool operator==(const MVKMTLDepthStencilDescriptorData& rhs) const {
-		return (memcmp(this, &rhs, sizeof(*this)) == 0);
-	}
+	bool operator==(const MVKMTLDepthStencilDescriptorData& rhs) const { return mvkAreEqual(this, &rhs); }
 
 	std::size_t hash() const {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));
@@ -270,9 +264,7 @@ typedef struct MVKImageDescriptorData {
     VkSampleCountFlagBits    samples;
     VkImageUsageFlags        usage;
 
-    bool operator==(const MVKImageDescriptorData& rhs) const {
-        return (memcmp(this, &rhs, sizeof(*this)) == 0);
-    }
+    bool operator==(const MVKImageDescriptorData& rhs) const { return mvkAreEqual(this, &rhs); }
 
 	std::size_t hash() const {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));
@@ -307,9 +299,7 @@ typedef struct MVKBufferDescriptorData {
     VkDeviceSize             size;
     VkBufferUsageFlags       usage;
 
-    bool operator==(const MVKBufferDescriptorData& rhs) const {
-        return (memcmp(this, &rhs, sizeof(*this)) == 0);
-    }
+    bool operator==(const MVKBufferDescriptorData& rhs) const { return mvkAreEqual(this, &rhs); }
 
 	std::size_t hash() const {
 		return mvkHash((uint64_t*)this, sizeof(*this) / sizeof(uint64_t));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -55,12 +55,12 @@ VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequireme
 #if MVK_MACOS
 	// Textures must not use shared memory
 	if (mvkIsAnyFlagEnabled(_usage, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)) {
-		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
 	}
 #endif
 #if MVK_IOS
 	// Memoryless storage is not allowed for buffers
-	mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+	mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
 #endif
 	return VK_SUCCESS;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -719,7 +719,6 @@ protected:
 
 /**
  * This mixin class adds the ability for an object to track the device that created it.
- * Implementation supports an instance where the device is null.
  *
  * As a mixin, this class should only be used as a component of multiple inheritance.
  * Any class that inherits from this class should also inherit from MVKBaseObject.
@@ -733,18 +732,19 @@ public:
 	inline MVKDevice* getDevice() { return _device; }
 
 	/** Returns the underlying Metal device. */
-	inline id<MTLDevice> getMTLDevice() { return _device ? _device->getMTLDevice() : nil; }
+	inline id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
 
 	/** Returns info about the pixel format supported by the physical device. */
-	inline MVKPixelFormats* getPixelFormats() { return _device ? _device->getPixelFormats() : mvkPlatformPixelFormats(); }
+	inline MVKPixelFormats* getPixelFormats() { return _device->getPixelFormats(); }
 
 	/** Constructs an instance for the specified device. */
-    MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) {}
+    MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) { assert(_device); }
 
 	virtual ~MVKDeviceTrackingMixin() {}
 
 protected:
 	virtual MVKBaseObject* getBaseObject() = 0;
+
 	MVKDevice* _device;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -223,11 +223,11 @@ void MVKPhysicalDevice::getFormatProperties(VkFormat format,
 }
 
 VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
-                                                     VkImageType type,
-                                                     VkImageTiling tiling,
-                                                     VkImageUsageFlags usage,
-                                                     VkImageCreateFlags flags,
-                                                     VkImageFormatProperties* pImageFormatProperties) {
+													 VkImageType type,
+													 VkImageTiling tiling,
+													 VkImageUsageFlags usage,
+													 VkImageCreateFlags flags,
+													 VkImageFormatProperties* pImageFormatProperties) {
 
 	if ( !_pixelFormats.vkFormatIsSupported(format) ) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
 
@@ -245,14 +245,16 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 														  VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
 														  VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
 
-    VkPhysicalDeviceLimits* pLimits = &_properties.limits;
-    VkExtent3D maxExt;
-	uint32_t maxLevels;
+	VkPhysicalDeviceLimits* pLimits = &_properties.limits;
+	VkExtent3D maxExt = { 1, 1, 1};
+	uint32_t maxLevels = 1;
 	uint32_t maxLayers = hasAttachmentUsage ? pLimits->maxFramebufferLayers : pLimits->maxImageArrayLayers;
 
-	VkSampleCountFlags sampleCounts = _metalFeatures.supportedSampleCounts;
-    switch (type) {
-        case VK_IMAGE_TYPE_1D:
+	bool supportsMSAA =  mvkAreAllFlagsEnabled(_pixelFormats.getVkFormatCapabilities(format), kMVKMTLFmtCapsMSAA);
+	VkSampleCountFlags sampleCounts = supportsMSAA ? _metalFeatures.supportedSampleCounts : VK_SAMPLE_COUNT_1_BIT;
+
+	switch (type) {
+		case VK_IMAGE_TYPE_1D:
 			maxExt.height = 1;
 			maxExt.depth = 1;
 			if (mvkTreatTexture1DAs2D()) {
@@ -273,16 +275,17 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 				if (mvkFmt == kMVKFormatDepthStencil) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
 				if (mvkFmt == kMVKFormatCompressed) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
 			}
-            break;
-        case VK_IMAGE_TYPE_2D:
-            if (mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ) {
-                maxExt.width = pLimits->maxImageDimensionCube;
-                maxExt.height = pLimits->maxImageDimensionCube;
-            } else {
-                maxExt.width = pLimits->maxImageDimension2D;
-                maxExt.height = pLimits->maxImageDimension2D;
-            }
-            maxExt.depth = 1;
+			break;
+
+		case VK_IMAGE_TYPE_2D:
+			if (mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ) {
+				maxExt.width = pLimits->maxImageDimensionCube;
+				maxExt.height = pLimits->maxImageDimensionCube;
+			} else {
+				maxExt.width = pLimits->maxImageDimension2D;
+				maxExt.height = pLimits->maxImageDimension2D;
+			}
+			maxExt.depth = 1;
 			if (tiling == VK_IMAGE_TILING_LINEAR) {
 				// Linear textures have additional restrictions under Metal:
 				// - They may not be depth/stencil or compressed textures.
@@ -310,12 +313,13 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 				}
 				maxLevels = mvkMipmapLevels3D(maxExt);
 			}
-            break;
-        case VK_IMAGE_TYPE_3D:
-            // Metal does not allow linear tiling on 3D textures
-            if (tiling == VK_IMAGE_TILING_LINEAR) {
-                return VK_ERROR_FORMAT_NOT_SUPPORTED;
-            }
+			break;
+
+		case VK_IMAGE_TYPE_3D:
+			// Metal does not allow linear tiling on 3D textures
+			if (tiling == VK_IMAGE_TILING_LINEAR) {
+				return VK_ERROR_FORMAT_NOT_SUPPORTED;
+			}
 			// Metal does not allow compressed or depth/stencil formats on 3D textures
 			if (mvkFmt == kMVKFormatDepthStencil
 #if MVK_IOS
@@ -330,35 +334,25 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 				return VK_ERROR_FORMAT_NOT_SUPPORTED;
 			}
 #endif
-            maxExt.width = pLimits->maxImageDimension3D;
-            maxExt.height = pLimits->maxImageDimension3D;
-            maxExt.depth = pLimits->maxImageDimension3D;
+			maxExt.width = pLimits->maxImageDimension3D;
+			maxExt.height = pLimits->maxImageDimension3D;
+			maxExt.depth = pLimits->maxImageDimension3D;
 			maxLevels = mvkMipmapLevels3D(maxExt);
-            maxLayers = 1;
-            sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-            break;
-        default:
-			// Metal does not allow linear tiling on anything but 2D textures
-			if (tiling == VK_IMAGE_TILING_LINEAR) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-
-			// Metal does not allow compressed or depth/stencil formats on anything but 2D textures
-			if (mvkFmt == kMVKFormatDepthStencil || mvkFmt == kMVKFormatCompressed) {
-				return VK_ERROR_FORMAT_NOT_SUPPORTED;
-			}
-            maxExt = { 1, 1, 1};
-            maxLayers = 1;
-			maxLevels = 1;
+			maxLayers = 1;
 			sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-            break;
-    }
+			break;
 
-    pImageFormatProperties->maxExtent = maxExt;
-    pImageFormatProperties->maxMipLevels = maxLevels;
-    pImageFormatProperties->maxArrayLayers = maxLayers;
-    pImageFormatProperties->sampleCounts = sampleCounts;
-    pImageFormatProperties->maxResourceSize = kMVKUndefinedLargeUInt64;
+		default:
+			return VK_ERROR_FORMAT_NOT_SUPPORTED;	// Illegal VkImageType
+	}
 
-    return VK_SUCCESS;
+	pImageFormatProperties->maxExtent = maxExt;
+	pImageFormatProperties->maxMipLevels = maxLevels;
+	pImageFormatProperties->maxArrayLayers = maxLayers;
+	pImageFormatProperties->sampleCounts = sampleCounts;
+	pImageFormatProperties->maxResourceSize = kMVKUndefinedLargeUInt64;
+
+	return VK_SUCCESS;
 }
 
 VkResult MVKPhysicalDevice::getImageFormatProperties(const VkPhysicalDeviceImageFormatInfo2KHR *pImageFormatInfo,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -323,6 +323,30 @@ public:
 	 */
 	void populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPassAttachmentDescriptor* mtlAttDesc);
 
+	/**
+	 * Returns, in mtlPixFmt, a MTLPixelFormat, based on the MTLPixelFormat converted from
+	 * the VkFormat, but possibly modified by the swizzles defined in the VkComponentMapping
+	 * of the VkImageViewCreateInfo.
+	 *
+	 * Metal prior to version 3.0 does not support native per-texture swizzles, so if the swizzle
+	 * is not an identity swizzle, this function attempts to find an alternate MTLPixelFormat that
+	 * coincidentally matches the swizzled format.
+	 *
+	 * If a replacement MTLFormat was found, it is returned and useSwizzle is set to false.
+	 * If a replacement MTLFormat could not be found, the original MTLPixelFormat is returned,
+	 * and the useSwizzle is set to true, indicating that either native or shader swizzling
+	 * should be used for this image view.
+	 *
+	 * This is a static function that can be used to validate image view formats prior to creating one.
+	 */
+	static VkResult validateSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo,
+												   MVKPixelFormats* mvkPixFmts,
+												   MVKVulkanAPIObject* apiObject,
+												   bool hasNativeSwizzleSupport,
+												   bool hasShaderSwizzleSupport,
+												   MTLPixelFormat& mtlPixFmt,
+												   bool& useSwizzle);
+
 
 #pragma mark Construction
 
@@ -336,10 +360,6 @@ protected:
 	void propogateDebugName() override;
 	id<MTLTexture> newMTLTexture();
 	void initMTLTextureViewSupport();
-    MTLPixelFormat getSwizzledMTLPixelFormat(VkFormat format,
-											 VkComponentMapping components,
-											 bool& useSwizzle,
-											 const MVKConfiguration* pMVKConfig);
 	void validateImageViewConfig(const VkImageViewCreateInfo* pCreateInfo);
 
     MVKImage* _image;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -178,13 +178,13 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
 #if MVK_MACOS
 	// Metal on macOS does not provide native support for host-coherent memory, but Vulkan requires it for Linear images
 	if ( !_isLinear ) {
-		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
 	}
 #endif
 #if MVK_IOS
 	// Only transient attachments may use memoryless storage
 	if (!mvkAreAllFlagsEnabled(_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ) {
-		mvkDisableFlag(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
 	}
 #endif
 	return VK_SUCCESS;
@@ -429,14 +429,14 @@ MTLTextureUsage MVKImage::getMTLTextureUsage() {
 		pixFmts->mtlPixelFormatIsDepthFormat(_mtlPixelFormat) &&
 		pixFmts->mtlPixelFormatIsStencilFormat(_mtlPixelFormat)) {
 
-		mvkDisableFlag(usage, MTLTextureUsagePixelFormatView);
+		mvkDisableFlags(usage, MTLTextureUsagePixelFormatView);
 	}
 
 	// If this format doesn't support being rendered to, disable MTLTextureUsageRenderTarget.
 	if ( !getSupportsAnyFormatFeature(VK_FORMAT_FEATURE_BLIT_DST_BIT |
 									  VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
 									  VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) ) {
-		mvkDisableFlag(usage, MTLTextureUsageRenderTarget);
+		mvkDisableFlags(usage, MTLTextureUsageRenderTarget);
 	}
 
 #if MVK_MACOS

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -442,7 +442,7 @@ MTLTextureUsage MVKImage::getMTLTextureUsage() {
 #if MVK_MACOS
 	// If this is a 3D compressed texture, tell Metal we might write to it.
 	if (_is3DCompressed) {
-		mvkEnableFlag(usage, MTLTextureUsageShaderWrite);
+		mvkEnableFlags(usage, MTLTextureUsageShaderWrite);
 	}
 #endif
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -634,7 +634,7 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
 	_mtlPixelFormat = pixFmts->getMTLPixelFormatFromVkFormat(pCreateInfo->format);
 	_usage = pCreateInfo->usage;
 
-	_is3DCompressed = (getImageType() == VK_IMAGE_TYPE_3D) && (pixFmts->getFormatTypeFromVkFormat(pCreateInfo->format) == kMVKFormatCompressed) && !getDevice()->_pMetalFeatures->native3DCompressedTextures;
+	_is3DCompressed = (getImageType() == VK_IMAGE_TYPE_3D) && (pixFmts->getFormatTypeFromVkFormat(pCreateInfo->format) == kMVKFormatCompressed) && !_device->_pMetalFeatures->native3DCompressedTextures;
 	_isDepthStencilAttachment = (mvkAreAllFlagsEnabled(pCreateInfo->usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ||
 								 mvkAreAllFlagsEnabled(pixFmts->getVkFormatProperties(pCreateInfo->format).optimalTilingFeatures, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT));
 	_canSupportMTLTextureView = !_isDepthStencilAttachment || _device->_pMetalFeatures->stencilViews;
@@ -705,7 +705,7 @@ void MVKImage::validateConfig(const VkImageCreateInfo* pCreateInfo, bool isAttac
 	if (isCompressed && !is2D) {
 		if (getImageType() != VK_IMAGE_TYPE_3D) {
 			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, compressed formats may only be used with 2D or 3D images."));
-		} else if (!getDevice()->_pMetalFeatures->native3DCompressedTextures && !mvkCanDecodeFormat(pCreateInfo->format)) {
+		} else if (!_device->_pMetalFeatures->native3DCompressedTextures && !mvkCanDecodeFormat(pCreateInfo->format)) {
 			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, the %s compressed format may only be used with 2D images.", getPixelFormats()->getVkFormatName(pCreateInfo->format)));
 		}
 	}
@@ -896,7 +896,7 @@ id<MTLTexture> MVKImageView::newMTLTexture() {
         mtlTextureType = MTLTextureType3D;
         sliceRange = NSMakeRange(0, 1);
     }
-    if (getDevice()->_pMetalFeatures->nativeTextureSwizzle && _packedSwizzle) {
+    if (_device->_pMetalFeatures->nativeTextureSwizzle && _packedSwizzle) {
         return [_image->getMTLTexture() newTextureViewWithPixelFormat: _mtlPixelFormat
                                                           textureType: mtlTextureType
                                                                levels: NSMakeRange(_subresourceRange.baseMipLevel, _subresourceRange.levelCount)
@@ -913,27 +913,24 @@ id<MTLTexture> MVKImageView::newMTLTexture() {
 
 #pragma mark Construction
 
-// device and _image may be nil when a temporary instance
-// is constructed to validate image view capabilities
 MVKImageView::MVKImageView(MVKDevice* device,
 						   const VkImageViewCreateInfo* pCreateInfo,
 						   const MVKConfiguration* pAltMVKConfig) : MVKVulkanAPIDeviceObject(device) {
 	_image = (MVKImage*)pCreateInfo->image;
-	_usage = _image ? _image->_usage : 0;
+	_usage = _image->_usage;
 
-	auto* next = (VkStructureType*)pCreateInfo->pNext;
+	auto* next = (MVKVkAPIStructHeader*)pCreateInfo->pNext;
 	while (next) {
-		switch (*next) {
-		case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO: {
-			auto* pViewUsageInfo = (VkImageViewUsageCreateInfo*)next;
-			if (!(pViewUsageInfo->usage & ~_usage))
-				_usage = pViewUsageInfo->usage;
-			next = (VkStructureType*)pViewUsageInfo->pNext;
-			break;
-		}
-		default:
-			next = (VkStructureType*)((VkImageViewCreateInfo*)next)->pNext;
-			break;
+		switch ((uint32_t)next->sType) {
+			case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO: {
+				auto* pViewUsageInfo = (VkImageViewUsageCreateInfo*)next;
+				if (!(pViewUsageInfo->usage & ~_usage)) { _usage = pViewUsageInfo->usage; }
+				next = (MVKVkAPIStructHeader*)next->pNext;
+				break;
+			}
+			default:
+				next = (MVKVkAPIStructHeader*)next->pNext;
+				break;
 		}
 	}
 
@@ -942,20 +939,21 @@ MVKImageView::MVKImageView(MVKDevice* device,
 	// Remember the subresource range, and determine the actual number of mip levels and texture slices
     _subresourceRange = pCreateInfo->subresourceRange;
 	if (_subresourceRange.levelCount == VK_REMAINING_MIP_LEVELS) {
-		_subresourceRange.levelCount = _image ? (_image->getMipLevelCount() - _subresourceRange.baseMipLevel) : 1;
+		_subresourceRange.levelCount = _image->getMipLevelCount() - _subresourceRange.baseMipLevel;
 	}
 	if (_subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS) {
-		_subresourceRange.layerCount = _image ? (_image->getLayerCount() - _subresourceRange.baseArrayLayer) : 1;
+		_subresourceRange.layerCount = _image->getLayerCount() - _subresourceRange.baseArrayLayer;
 	}
 
-	bool useSwizzle;
-	bool isMultisample = _image ? _image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT : false;
 	_mtlTexture = nil;
-    _mtlPixelFormat = getSwizzledMTLPixelFormat(pCreateInfo->format, pCreateInfo->components, useSwizzle,
-												(_device ? _device->_pMVKConfig : pAltMVKConfig));
+	bool useSwizzle;
+	setConfigurationResult(validateSwizzledMTLPixelFormat(pCreateInfo, getPixelFormats(), this,
+														  _device->_pMetalFeatures->nativeTextureSwizzle,
+														  _device->_pMVKConfig->fullImageViewSwizzle,
+														  _mtlPixelFormat, useSwizzle));
 	_packedSwizzle = useSwizzle ? mvkPackSwizzle(pCreateInfo->components) : 0;
-	_mtlTextureType = mvkMTLTextureTypeFromVkImageViewType(pCreateInfo->viewType, isMultisample);
-
+	_mtlTextureType = mvkMTLTextureTypeFromVkImageViewType(pCreateInfo->viewType,
+														   _image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT);
 	initMTLTextureViewSupport();
 }
 
@@ -982,71 +980,74 @@ void MVKImageView::validateImageViewConfig(const VkImageViewCreateInfo* pCreateI
 	}
 }
 
-// Returns a MTLPixelFormat, based on the MTLPixelFormat converted from the VkFormat, but possibly
-// modified by the swizzles defined in the VkComponentMapping of the VkImageViewCreateInfo.
-// Metal prior to version 3.0 does not support general per-texture swizzles, so if the swizzle is not an
-// identity swizzle, this function attempts to find an alternate MTLPixelFormat that coincidentally
-// matches the swizzled format.
-// If a replacement MTLFormat was found, it is returned and useSwizzle is set to false.
-// If a replacement MTLFormat could not be found, the original MTLPixelFormat is returned, and the
-// useSwizzle is set to true, indicating that either native or shader swizzling should be used for
-// this image view.
-// The config is used to test whether full shader swizzle support is available, and to report an error if not.
-MTLPixelFormat MVKImageView::getSwizzledMTLPixelFormat(VkFormat format,
-													   VkComponentMapping components,
-													   bool& useSwizzle,
-													   const MVKConfiguration* pMVKConfig) {
-
-	// Attempt to find a valid format transformation swizzle first.
-	MTLPixelFormat mtlPF = getPixelFormats()->getMTLPixelFormatFromVkFormat(format);
+VkResult MVKImageView::validateSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo,
+													  MVKPixelFormats* mvkPixFmts,
+													  MVKVulkanAPIObject* apiObject,
+													  bool hasNativeSwizzleSupport,
+													  bool hasShaderSwizzleSupport,
+													  MTLPixelFormat& mtlPixFmt,
+													  bool& useSwizzle) {
 	useSwizzle = false;
+	mtlPixFmt = mvkPixFmts->getMTLPixelFormatFromVkFormat(pCreateInfo->format);
+	VkComponentMapping components = pCreateInfo->components;
 
 	#define SWIZZLE_MATCHES(R, G, B, A)    mvkVkComponentMappingsMatch(components, {VK_COMPONENT_SWIZZLE_ ##R, VK_COMPONENT_SWIZZLE_ ##G, VK_COMPONENT_SWIZZLE_ ##B, VK_COMPONENT_SWIZZLE_ ##A} )
 	#define VK_COMPONENT_SWIZZLE_ANY       VK_COMPONENT_SWIZZLE_MAX_ENUM
 
-	switch (mtlPF) {
+	// If we have an identity swizzle, we're all good.
+	if (SWIZZLE_MATCHES(R, G, B, A)) {
+		return VK_SUCCESS;
+	}
+
+	switch (mtlPixFmt) {
 		case MTLPixelFormatR8Unorm:
 			if (SWIZZLE_MATCHES(ZERO, ANY, ANY, R)) {
-				return MTLPixelFormatA8Unorm;
+				mtlPixFmt = MTLPixelFormatA8Unorm;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatA8Unorm:
 			if (SWIZZLE_MATCHES(A, ANY, ANY, ZERO)) {
-				return MTLPixelFormatR8Unorm;
+				mtlPixFmt = MTLPixelFormatR8Unorm;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatRGBA8Unorm:
 			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				return MTLPixelFormatBGRA8Unorm;
+				mtlPixFmt = MTLPixelFormatBGRA8Unorm;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatRGBA8Unorm_sRGB:
 			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				return MTLPixelFormatBGRA8Unorm_sRGB;
+				mtlPixFmt = MTLPixelFormatBGRA8Unorm_sRGB;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatBGRA8Unorm:
 			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				return MTLPixelFormatRGBA8Unorm;
+				mtlPixFmt = MTLPixelFormatRGBA8Unorm;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatBGRA8Unorm_sRGB:
 			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				return MTLPixelFormatRGBA8Unorm_sRGB;
+				mtlPixFmt = MTLPixelFormatRGBA8Unorm_sRGB;
+				return VK_SUCCESS;
 			}
 			break;
 
 		case MTLPixelFormatDepth32Float_Stencil8:
 			// If aspect mask looking only for stencil then change to stencil-only format even if shader swizzling is needed
-			if (_subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
-				mtlPF = MTLPixelFormatX32_Stencil8;
+			if (pCreateInfo->subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
+				mtlPixFmt = MTLPixelFormatX32_Stencil8;
 				if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
-					return mtlPF;
+					return VK_SUCCESS;
 				}
 			}
 			break;
@@ -1054,10 +1055,10 @@ MTLPixelFormat MVKImageView::getSwizzledMTLPixelFormat(VkFormat format,
 #if MVK_MACOS
 		case MTLPixelFormatDepth24Unorm_Stencil8:
 			// If aspect mask looking only for stencil then change to stencil-only format even if shader swizzling is needed
-			if (_subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
-				mtlPF = MTLPixelFormatX24_Stencil8;
+			if (pCreateInfo->subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
+				mtlPixFmt = MTLPixelFormatX24_Stencil8;
 				if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
-					return mtlPF;
+					return VK_SUCCESS;
 				}
 			}
 			break;
@@ -1067,22 +1068,20 @@ MTLPixelFormat MVKImageView::getSwizzledMTLPixelFormat(VkFormat format,
 			break;
 	}
 
-	// No format transformation swizzles were found, so unless we have an identity swizzle, we'll need to use shader swizzling.
-	if ( !SWIZZLE_MATCHES(R, G, B, A)) {
-		useSwizzle = true;
-
-		if ( !pMVKConfig->fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle ) {
-			const char* vkCmd = _image ? "vkCreateImageView(VkImageViewCreateInfo" : "vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDeviceImageViewSupportEXTX";
-			const char* errMsg = ("The value of %s::components) (%s, %s, %s, %s), when applied to a VkImageView, requires full component swizzling to be enabled both at the"
-								  " time when the VkImageView is created and at the time any pipeline that uses that VkImageView is compiled. Full component swizzling can"
-								  " be enabled via the MVKConfiguration::fullImageViewSwizzle config parameter or MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable.");
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, errMsg, vkCmd,
-											   mvkVkComponentSwizzleName(components.r), mvkVkComponentSwizzleName(components.g),
-											   mvkVkComponentSwizzleName(components.b), mvkVkComponentSwizzleName(components.a)));
-		}
+	// No format transformation swizzles were found, so we'll need to use either native or shader swizzling.
+	useSwizzle = true;
+	if (hasNativeSwizzleSupport || hasShaderSwizzleSupport ) {
+		return VK_SUCCESS;
 	}
 
-	return mtlPF;
+	// Oh, oh. Neither native or shader swizzling is supported.
+	return apiObject->reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+								  "The value of %s::components) (%s, %s, %s, %s), when applied to a VkImageView, requires full component swizzling to be enabled both at the"
+								  " time when the VkImageView is created and at the time any pipeline that uses that VkImageView is compiled. Full component swizzling can"
+								  " be enabled via the MVKConfiguration::fullImageViewSwizzle config parameter or MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable.",
+								  pCreateInfo->image ? "vkCreateImageView(VkImageViewCreateInfo" : "vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDeviceImageViewSupportEXTX",
+								  mvkVkComponentSwizzleName(components.r), mvkVkComponentSwizzleName(components.g),
+								  mvkVkComponentSwizzleName(components.b), mvkVkComponentSwizzleName(components.a));
 }
 
 // Determine whether this image view should use a Metal texture view,
@@ -1104,7 +1103,7 @@ void MVKImageView::initMTLTextureViewSupport() {
 		 ((_mtlTextureType == MTLTextureType2D || _mtlTextureType == MTLTextureType2DArray) && is3D)) &&
 		_subresourceRange.levelCount == _image->_mipLevels &&
 		(is3D || _subresourceRange.layerCount == _image->_arrayLayers) &&
-		(!getDevice()->_pMetalFeatures->nativeTextureSwizzle || !_packedSwizzle)) {
+		(!_device->_pMetalFeatures->nativeTextureSwizzle || !_packedSwizzle)) {
 		_useMTLTextureView = false;
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1544,7 +1544,7 @@ void MVKPipelineCache::readData(const VkPipelineCacheCreateInfo* pCreateInfo) {
 		if (NSSwapLittleIntToHost(hdrComponent) !=  pDevProps->deviceID) { return; }
 
 		reader(pcUUID);			// Pipeline cache UUID
-		if (memcmp(pcUUID, pDevProps->pipelineCacheUUID, VK_UUID_SIZE) != 0) { return; }
+		if (mvkAreEqual(pcUUID, pDevProps->pipelineCacheUUID, VK_UUID_SIZE)) { return; }
 
 		bool done = false;
 		while ( !done ) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -284,6 +284,10 @@ protected:
 									   MTLFeatureSet mtlFeatSet,
 									   MTLPixelFormat mtlPixFmt,
 									   MVKMTLFmtCaps mtlFmtCaps);
+	void addMTLVertexFormatCapabilities(id<MTLDevice> mtlDevice,
+										MTLFeatureSet mtlFeatSet,
+										MTLVertexFormat mtlVtxFmt,
+										MVKMTLFmtCaps mtlFmtCaps);
 
 	template<typename T>
 	void testFmt(const T v1, const T v2, const char* fmtName, const char* funcName);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -38,71 +38,40 @@ static const uint32_t _mtlVertexFormatCount = MTLVertexFormatHalf + 1;
 #pragma mark Metal format capabilities
 
 typedef enum {
-	kMVKMTLFmtCapsNone               = 0,
-	kMVKMTLFmtCapsTexRead            = (1<<0),
-	kMVKMTLFmtCapsTexFilter          = (1<<1),
-	kMVKMTLFmtCapsTexColorAtt        = (1<<2),
-	kMVKMTLFmtCapsTexDepthStencilAtt = (1<<3),
-	kMVKMTLFmtCapsTexBlend           = (1<<4),
-	kMVKMTLFmtCapsTexMSAA            = (1<<5),
-	kMVKMTLFmtCapsTexResolve         = (1<<6),
-	kMVKMTLFmtCapsTexWrite           = (1<<7),
+	kMVKMTLFmtCapsNone        = 0,
+	kMVKMTLFmtCapsTexRead     = (1<<0),
+	kMVKMTLFmtCapsTexFilter   = (1<<1),
+	kMVKMTLFmtCapsTexColorAtt = (1<<2),
+	kMVKMTLFmtCapsTexDSAtt    = (1<<3),
+	kMVKMTLFmtCapsTexBlend    = (1<<4),
+	kMVKMTLFmtCapsTexMSAA     = (1<<5),
+	kMVKMTLFmtCapsTexResolve  = (1<<6),
+	kMVKMTLFmtCapsTexWrite    = (1<<7),
 
-	kMVKMTLFmtCapsBufRead            = (1<<8),
-	kMVKMTLFmtCapsBufVertex          = (1<<9),
-	kMVKMTLFmtCapsBufWrite           = (1<<10),
+	kMVKMTLFmtCapsBufRead     = (1<<8),
+	kMVKMTLFmtCapsBufVertex   = (1<<9),
+	kMVKMTLFmtCapsBufWrite    = (1<<10),
 
-	kMVKMTLFmtCapsTexRF              = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexFilter),
-	kMVKMTLFmtCapsTexRC              = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexColorAtt),
-	kMVKMTLFmtCapsTexRCM             = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexRCB             = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRCMB            = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA |
-										kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRWCM            = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexWrite |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexRFCMRB          = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexFilter |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA |
-										kMVKMTLFmtCapsTexResolve |
-										kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRFWCMB          = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexFilter |
-										kMVKMTLFmtCapsTexWrite |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA |
-										kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexDRM             = (kMVKMTLFmtCapsTexDepthStencilAtt |
-										kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexDRFMR           = (kMVKMTLFmtCapsTexDepthStencilAtt |
-										kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexFilter |
-										kMVKMTLFmtCapsTexMSAA |
-										kMVKMTLFmtCapsTexResolve),
-	kMVKMTLFmtCapsTexAll        = (kMVKMTLFmtCapsTexRead |
-										kMVKMTLFmtCapsTexFilter |
-										kMVKMTLFmtCapsTexWrite |
-										kMVKMTLFmtCapsTexColorAtt |
-										kMVKMTLFmtCapsTexMSAA |
-										kMVKMTLFmtCapsTexResolve |
-										kMVKMTLFmtCapsTexBlend),
+	kMVKMTLFmtCapsTexRF       = (kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexFilter),
+	kMVKMTLFmtCapsTexRC       = (kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexColorAtt),
+	kMVKMTLFmtCapsTexRCB      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexBlend),
+	kMVKMTLFmtCapsTexRCM      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexMSAA),
+	kMVKMTLFmtCapsTexRCMB     = (kMVKMTLFmtCapsTexRCM | kMVKMTLFmtCapsTexBlend),
+	kMVKMTLFmtCapsTexRWC      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexWrite),
+	kMVKMTLFmtCapsTexRWCB     = (kMVKMTLFmtCapsTexRWC | kMVKMTLFmtCapsTexBlend),
+	kMVKMTLFmtCapsTexRWCM     = (kMVKMTLFmtCapsTexRWC | kMVKMTLFmtCapsTexMSAA),
+	kMVKMTLFmtCapsTexRWCMB    = (kMVKMTLFmtCapsTexRWCM | kMVKMTLFmtCapsTexBlend),
+	kMVKMTLFmtCapsTexRFCMRB   = (kMVKMTLFmtCapsTexRCMB | kMVKMTLFmtCapsTexFilter | kMVKMTLFmtCapsTexResolve),
+	kMVKMTLFmtCapsTexRFWCMB   = (kMVKMTLFmtCapsTexRWCMB | kMVKMTLFmtCapsTexFilter),
+	kMVKMTLFmtCapsTexAll      = (kMVKMTLFmtCapsTexRFWCMB | kMVKMTLFmtCapsTexResolve),
 
-	kMVKMTLFmtCapsBufRW              = (kMVKMTLFmtCapsBufRead |
-										kMVKMTLFmtCapsBufWrite),
-	kMVKMTLFmtCapsBufAll             = (kMVKMTLFmtCapsBufRead |
-										kMVKMTLFmtCapsBufWrite |
-										kMVKMTLFmtCapsBufVertex),
+	kMVKMTLFmtCapsTexDRM      = (kMVKMTLFmtCapsTexDSAtt | kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexMSAA),
+	kMVKMTLFmtCapsTexDRMR     = (kMVKMTLFmtCapsTexDRM | kMVKMTLFmtCapsTexResolve),
+	kMVKMTLFmtCapsTexDRFMR    = (kMVKMTLFmtCapsTexDRMR | kMVKMTLFmtCapsTexFilter),
+
+	kMVKMTLFmtCapsBufRW       = (kMVKMTLFmtCapsBufRead | kMVKMTLFmtCapsBufWrite),
+	kMVKMTLFmtCapsBufAll      = (kMVKMTLFmtCapsBufRW | kMVKMTLFmtCapsBufVertex),
+
 } MVKMTLFmtCaps;
 
 
@@ -138,7 +107,7 @@ typedef struct {
 	};
 	VkFormat vkFormat;
 	MVKOSVersion sinceOSVersion;
-	MVKMTLFmtCaps mtlPixFmtCaps;
+	MVKMTLFmtCaps mtlFmtCaps;
 	const char* name;
 
 	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mvkOSVersion() >= sinceOSVersion); };
@@ -311,7 +280,10 @@ protected:
 	void initMTLVertexFormatCapabilities();
 	void buildFormatMaps();
 	void modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevice);
-	void disableMTLPixelFormat(MTLPixelFormat mtlFormat);
+	void addMTLPixelFormatCapabilities(id<MTLDevice> mtlDevice,
+									   MTLFeatureSet mtlFeatSet,
+									   MTLPixelFormat mtlPixFmt,
+									   MVKMTLFmtCaps mtlFmtCaps);
 
 	template<typename T>
 	void testFmt(const T v1, const T v2, const char* fmtName, const char* funcName);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -87,10 +87,14 @@ typedef struct {
 	bool hasReportedSubstitution;
 
 	inline double bytesPerTexel() const { return (double)bytesPerBlock / (double)(blockTexelSize.width * blockTexelSize.height); };
+
 	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid); };
 	inline bool isSupportedOrSubstitutable() const { return isSupported() || (mtlPixelFormatSubstitute != MTLPixelFormatInvalid); };
+	inline MTLPixelFormat getMTLPixelFormatOrSubstitute() const { return mtlPixelFormat ? mtlPixelFormat : mtlPixelFormatSubstitute; }
+
 	inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid); };
 	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); };
+	inline MTLVertexFormat getMTLVertexFormatOrSubstitute() const { return mtlVertexFormat ? mtlVertexFormat : mtlVertexFormatSubstitute; }
 } MVKVkFormatDesc;
 
 /** Describes the properties of a MTLPixelFormat or MTLVertexFormat. */
@@ -120,6 +124,9 @@ public:
 
 	/** Returns whether the VkFormat is supported by this implementation. */
 	bool vkFormatIsSupported(VkFormat vkFormat);
+
+	/** Returns whether the VkFormat is supported by this implementation, or can be substituted by one that is. */
+	bool vkFormatIsSupportedOrSubstitutable(VkFormat vkFormat);
 
 	/** Returns whether the MTLPixelFormat is supported by this implementation. */
 	bool mtlPixelFormatIsSupported(MTLPixelFormat mtlFormat);
@@ -225,6 +232,12 @@ public:
 	/** Returns the default properties for the specified Vulkan format. */
 	VkFormatProperties getVkFormatProperties(VkFormat vkFormat);
 
+	/** Returns the Metal format capabilities supported by the specified Vulkan format. */
+	MVKMTLFmtCaps getVkFormatCapabilities(VkFormat vkFormat);
+
+	/** Returns the Metal format capabilities supported by the specified Metal format. */
+	MVKMTLFmtCaps getMTLPixelFormatCapabilities(MTLPixelFormat mtlFormat);
+
 	/** Returns the name of the specified Vulkan format. */
 	const char* getVkFormatName(VkFormat vkFormat);
 
@@ -266,7 +279,9 @@ public:
 protected:
 	MVKVkFormatDesc& getVkFormatDesc(VkFormat vkFormat);
 	MVKVkFormatDesc& getVkFormatDesc(MTLPixelFormat mtlFormat);
+	MVKMTLFormatDesc& getMTLPixelFormatDesc(VkFormat vkFormat);
 	MVKMTLFormatDesc& getMTLPixelFormatDesc(MTLPixelFormat mtlFormat);
+	MVKMTLFormatDesc& getMTLVertexFormatDesc(VkFormat vkFormat);
 	MVKMTLFormatDesc& getMTLVertexFormatDesc(MTLVertexFormat mtlFormat);
 	VkFormatFeatureFlags getOptimalTilingFeatures(MVKMTLFmtCaps mtlFmtCaps);
 	VkFormatFeatureFlags getLinearTilingFeatures(MVKMTLFmtCaps mtlFmtCaps, MVKFormatType mvkFmtType);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -261,7 +261,7 @@ public:
 
 	MVKPixelFormats(MVKVulkanAPIObject* apiObject, id<MTLDevice> mtlDevice);
 
-	MVKPixelFormats() : MVKPixelFormats(nullptr, nil) {}
+	MVKPixelFormats();
 
 protected:
 	MVKVkFormatDesc& getVkFormatDesc(VkFormat vkFormat);
@@ -271,6 +271,7 @@ protected:
 	VkFormatFeatureFlags getOptimalTilingFeatures(MVKMTLFmtCaps mtlFmtCaps);
 	VkFormatFeatureFlags getLinearTilingFeatures(MVKMTLFmtCaps mtlFmtCaps, MVKFormatType mvkFmtType);
 	VkFormatFeatureFlags getBufferFeatures(MVKMTLFmtCaps mtlFmtTexCaps, MVKMTLFmtCaps mtlFmtVtxCaps, MVKFormatType mvkFmtType);
+	void init(id<MTLDevice> mtlDevice);
 	void initVkFormatCapabilities();
 	void initMTLPixelFormatCapabilities();
 	void initMTLVertexFormatCapabilities();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -36,40 +36,35 @@ static const uint32_t _mtlVertexFormatCount = MTLVertexFormatHalf + 1;
 #pragma mark -
 #pragma mark Metal format capabilities
 
-typedef enum {
-	kMVKMTLFmtCapsNone        = 0,
-	kMVKMTLFmtCapsTexRead     = (1<<0),
-	kMVKMTLFmtCapsTexFilter   = (1<<1),
-	kMVKMTLFmtCapsTexColorAtt = (1<<2),
-	kMVKMTLFmtCapsTexDSAtt    = (1<<3),
-	kMVKMTLFmtCapsTexBlend    = (1<<4),
-	kMVKMTLFmtCapsTexMSAA     = (1<<5),
-	kMVKMTLFmtCapsTexResolve  = (1<<6),
-	kMVKMTLFmtCapsTexWrite    = (1<<7),
+typedef enum : uint16_t {
 
-	kMVKMTLFmtCapsBufRead     = (1<<8),
-	kMVKMTLFmtCapsBufVertex   = (1<<9),
-	kMVKMTLFmtCapsBufWrite    = (1<<10),
+	kMVKMTLFmtCapsNone     = 0,
+	kMVKMTLFmtCapsRead     = (1<<0),
+	kMVKMTLFmtCapsFilter   = (1<<1),
+	kMVKMTLFmtCapsWrite    = (1<<2),
+	kMVKMTLFmtCapsColorAtt = (1<<3),
+	kMVKMTLFmtCapsDSAtt    = (1<<4),
+	kMVKMTLFmtCapsBlend    = (1<<5),
+	kMVKMTLFmtCapsMSAA     = (1<<6),
+	kMVKMTLFmtCapsResolve  = (1<<7),
+	kMVKMTLFmtCapsVertex   = (1<<8),
 
-	kMVKMTLFmtCapsTexRF       = (kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexFilter),
-	kMVKMTLFmtCapsTexRC       = (kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexColorAtt),
-	kMVKMTLFmtCapsTexRCB      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRCM      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexRCMB     = (kMVKMTLFmtCapsTexRCM | kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRWC      = (kMVKMTLFmtCapsTexRC | kMVKMTLFmtCapsTexWrite),
-	kMVKMTLFmtCapsTexRWCB     = (kMVKMTLFmtCapsTexRWC | kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRWCM     = (kMVKMTLFmtCapsTexRWC | kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexRWCMB    = (kMVKMTLFmtCapsTexRWCM | kMVKMTLFmtCapsTexBlend),
-	kMVKMTLFmtCapsTexRFCMRB   = (kMVKMTLFmtCapsTexRCMB | kMVKMTLFmtCapsTexFilter | kMVKMTLFmtCapsTexResolve),
-	kMVKMTLFmtCapsTexRFWCMB   = (kMVKMTLFmtCapsTexRWCMB | kMVKMTLFmtCapsTexFilter),
-	kMVKMTLFmtCapsTexAll      = (kMVKMTLFmtCapsTexRFWCMB | kMVKMTLFmtCapsTexResolve),
+	kMVKMTLFmtCapsRF       = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsFilter),
+	kMVKMTLFmtCapsRC       = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsColorAtt),
+	kMVKMTLFmtCapsRCB      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsBlend),
+	kMVKMTLFmtCapsRCM      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsMSAA),
+	kMVKMTLFmtCapsRCMB     = (kMVKMTLFmtCapsRCM | kMVKMTLFmtCapsBlend),
+	kMVKMTLFmtCapsRWC      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsWrite),
+	kMVKMTLFmtCapsRWCB     = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsBlend),
+	kMVKMTLFmtCapsRWCM     = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsMSAA),
+	kMVKMTLFmtCapsRWCMB    = (kMVKMTLFmtCapsRWCM | kMVKMTLFmtCapsBlend),
+	kMVKMTLFmtCapsRFCMRB   = (kMVKMTLFmtCapsRCMB | kMVKMTLFmtCapsFilter | kMVKMTLFmtCapsResolve),
+	kMVKMTLFmtCapsRFWCMB   = (kMVKMTLFmtCapsRWCMB | kMVKMTLFmtCapsFilter),
+	kMVKMTLFmtCapsAll      = (kMVKMTLFmtCapsRFWCMB | kMVKMTLFmtCapsResolve),
 
-	kMVKMTLFmtCapsTexDRM      = (kMVKMTLFmtCapsTexDSAtt | kMVKMTLFmtCapsTexRead | kMVKMTLFmtCapsTexMSAA),
-	kMVKMTLFmtCapsTexDRMR     = (kMVKMTLFmtCapsTexDRM | kMVKMTLFmtCapsTexResolve),
-	kMVKMTLFmtCapsTexDRFMR    = (kMVKMTLFmtCapsTexDRMR | kMVKMTLFmtCapsTexFilter),
-
-	kMVKMTLFmtCapsBufRW       = (kMVKMTLFmtCapsBufRead | kMVKMTLFmtCapsBufWrite),
-	kMVKMTLFmtCapsBufAll      = (kMVKMTLFmtCapsBufRW | kMVKMTLFmtCapsBufVertex),
+	kMVKMTLFmtCapsDRM      = (kMVKMTLFmtCapsDSAtt | kMVKMTLFmtCapsRead | kMVKMTLFmtCapsMSAA),
+	kMVKMTLFmtCapsDRMR     = (kMVKMTLFmtCapsDRM | kMVKMTLFmtCapsResolve),
+	kMVKMTLFmtCapsDRFMR    = (kMVKMTLFmtCapsDRMR | kMVKMTLFmtCapsFilter),
 
 } MVKMTLFmtCaps;
 
@@ -273,6 +268,9 @@ protected:
 	MVKVkFormatDesc& getVkFormatDesc(MTLPixelFormat mtlFormat);
 	MVKMTLFormatDesc& getMTLPixelFormatDesc(MTLPixelFormat mtlFormat);
 	MVKMTLFormatDesc& getMTLVertexFormatDesc(MTLVertexFormat mtlFormat);
+	VkFormatFeatureFlags getOptimalTilingFeatures(MVKMTLFmtCaps mtlFmtCaps);
+	VkFormatFeatureFlags getLinearTilingFeatures(MVKMTLFmtCaps mtlFmtCaps, MVKFormatType mvkFmtType);
+	VkFormatFeatureFlags getBufferFeatures(MVKMTLFmtCaps mtlFmtTexCaps, MVKMTLFmtCaps mtlFmtVtxCaps, MVKFormatType mvkFmtType);
 	void initVkFormatCapabilities();
 	void initMTLPixelFormatCapabilities();
 	void initMTLVertexFormatCapabilities();
@@ -290,6 +288,7 @@ protected:
 
 	template<typename T>
 	void testFmt(const T v1, const T v2, const char* fmtName, const char* funcName);
+	void testProps(const VkFormatProperties p1, const VkFormatProperties p2, const char* fmtName);
 	void test(id<MTLDevice> mtlDevice);
 
 	MVKVulkanAPIObject* _apiObject;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -20,14 +20,13 @@
 
 #include "mvk_datatypes.h"
 #include "MVKEnvironment.h"
-#include "MVKOSExtensions.h"
 #include "MVKBaseObject.h"
 #include <unordered_map>
 
 #import <Metal/Metal.h>
 
 
-/** Validate these values periodically as new formats are added over time. */
+// Validate these values periodically as new formats are added over time.
 static const uint32_t _vkFormatCount = 256;
 static const uint32_t _vkFormatCoreCount = VK_FORMAT_ASTC_12x12_SRGB_BLOCK + 1;
 static const uint32_t _mtlPixelFormatCount = MTLPixelFormatX32_Stencil8 + 2;     // The actual last enum value is not available on iOS
@@ -106,11 +105,10 @@ typedef struct {
 		MTLVertexFormat mtlVertexFormat;
 	};
 	VkFormat vkFormat;
-	MVKOSVersion sinceOSVersion;
 	MVKMTLFmtCaps mtlFmtCaps;
 	const char* name;
 
-	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mvkOSVersion() >= sinceOSVersion); };
+	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mtlFmtCaps != kMVKMTLFmtCapsNone); };
 } MVKMTLFormatDesc;
 
 
@@ -278,8 +276,9 @@ protected:
 	void initVkFormatCapabilities();
 	void initMTLPixelFormatCapabilities();
 	void initMTLVertexFormatCapabilities();
-	void buildFormatMaps();
-	void modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevice);
+	void buildMTLFormatMaps();
+	void buildVkFormatMaps();
+	void modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice);
 	void addMTLPixelFormatCapabilities(id<MTLDevice> mtlDevice,
 									   MTLFeatureSet mtlFeatSet,
 									   MTLPixelFormat mtlPixFmt,
@@ -291,7 +290,7 @@ protected:
 
 	template<typename T>
 	void testFmt(const T v1, const T v2, const char* fmtName, const char* funcName);
-	void test();
+	void test(id<MTLDevice> mtlDevice);
 
 	MVKVulkanAPIObject* _apiObject;
 	MVKVkFormatDesc _vkFormatDescriptions[_vkFormatCount];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -518,14 +518,14 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 	addVkFormatDesc( UNDEFINED, Invalid, Invalid, Invalid, Invalid, 1, 1, 0, None, NO_FEATS, NO_FEATS );
 
 	addVkFormatDesc( R4G4_UNORM_PACK8, Invalid, Invalid, Invalid, Invalid, 1, 1, 1, ColorFloat, NO_FEATS, NO_FEATS );
-	addVkFormatDesc( R4G4B4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( R4G4B4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 	addVkFormatDesc( B4G4R4A4_UNORM_PACK16, Invalid, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, NO_FEATS, NO_FEATS );
 
-	addVkFormatDesc( R5G6B5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( R5G6B5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 	addVkFormatDesc( B5G6R5_UNORM_PACK16, Invalid, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, NO_FEATS, NO_FEATS );
-	addVkFormatDesc( R5G5B5A1_UNORM_PACK16, A1BGR5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( R5G5B5A1_UNORM_PACK16, A1BGR5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 	addVkFormatDesc( B5G5R5A1_UNORM_PACK16, Invalid, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, NO_FEATS, NO_FEATS );
-	addVkFormatDesc( A1R5G5B5_UNORM_PACK16, BGR5A1Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( A1R5G5B5_UNORM_PACK16, BGR5A1Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 
 	addVkFormatDesc( R8_UNORM, R8Unorm, Invalid, UCharNormalized, UChar2Normalized, 1, 1, 1, ColorFloat, COLOR_FEATS, BUFFER_VTX_FEATS );
 	addVkFormatDesc( R8_SNORM, R8Snorm, Invalid, CharNormalized, Char2Normalized, 1, 1, 1, ColorFloat, COLOR_FEATS, BUFFER_VTX_FEATS );
@@ -583,18 +583,18 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 	addVkFormatDesc( A8B8G8R8_SINT_PACK32, RGBA8Sint, Invalid, Char4, Invalid, 1, 1, 4, ColorInt8, COLOR_INTEGER_FEATS, BUFFER_VTX_FEATS );
 	addVkFormatDesc( A8B8G8R8_SRGB_PACK32, RGBA8Unorm_sRGB, Invalid, UChar4Normalized, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 
-	addVkFormatDesc( A2R10G10B10_UNORM_PACK32, BGR10A2Unorm, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( A2R10G10B10_UNORM_PACK32, BGR10A2Unorm, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
 	addVkFormatDesc( A2R10G10B10_SNORM_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( A2R10G10B10_USCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( A2R10G10B10_SSCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( A2R10G10B10_UINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt16, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( A2R10G10B10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorInt16, NO_FEATS, NO_FEATS );
 
-	addVkFormatDesc( A2B10G10R10_UNORM_PACK32, RGB10A2Unorm, Invalid, UInt1010102Normalized, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_VTX_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( A2B10G10R10_UNORM_PACK32, RGB10A2Unorm, Invalid, UInt1010102Normalized, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_VTX_FEATS );
 	addVkFormatDesc( A2B10G10R10_SNORM_PACK32, Invalid, Invalid, Int1010102Normalized, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, BUFFER_VTX_FEATS );
 	addVkFormatDesc( A2B10G10R10_USCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( A2B10G10R10_SSCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, NO_FEATS, NO_FEATS );
-	addVkFormatDesc( A2B10G10R10_UINT_PACK32, RGB10A2Uint, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt16, COLOR_INTEGER_FEATS, BUFFER_FEATS );		// Vulkan packed is reversed
+	addVkFormatDesc( A2B10G10R10_UINT_PACK32, RGB10A2Uint, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt16, COLOR_INTEGER_FEATS, BUFFER_FEATS );
 	addVkFormatDesc( A2B10G10R10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorInt16, NO_FEATS, NO_FEATS );
 
 	addVkFormatDesc( R16_UNORM, R16Unorm, Invalid, UShortNormalized, UShort2Normalized, 1, 1, 2, ColorFloat, COLOR_FEATS, BUFFER_VTX_FEATS );
@@ -661,8 +661,8 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 	addVkFormatDesc( R64G64B64A64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat, NO_FEATS, NO_FEATS );
 	addVkFormatDesc( R64G64B64A64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat, NO_FEATS, NO_FEATS );
 
-	addVkFormatDesc( B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_FEATS );	// Vulkan packed is reversed
-	addVkFormatDesc( E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, E5B9G9R9_FEATS, E5B9G9R9_BUFFER_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, COLOR_FEATS, BUFFER_FEATS );
+	addVkFormatDesc( E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat, E5B9G9R9_FEATS, E5B9G9R9_BUFFER_FEATS );
 
 	addVkFormatDesc( D32_SFLOAT, Depth32Float, Invalid, Invalid, Invalid, 1, 1, 4, DepthStencil, DEPTH_FEATS, NO_FEATS );
 	addVkFormatDesc( D32_SFLOAT_S8_UINT, Depth32Float_Stencil8, Invalid, Invalid, Invalid, 1, 1, 5, DepthStencil, DEPTH_FEATS, NO_FEATS );
@@ -673,7 +673,7 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 	addVkFormatDesc( D16_UNORM_S8_UINT, Invalid, Depth16Unorm_Stencil8, Invalid, Invalid, 1, 1, 3, DepthStencil, DEPTH_FEATS, NO_FEATS );
 	addVkFormatDesc( D24_UNORM_S8_UINT, Depth24Unorm_Stencil8, Depth32Float_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil, DEPTH_FEATS, NO_FEATS );
 
-	addVkFormatDesc( X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil, DEPTH_FEATS, NO_FEATS );	// Vulkan packed is reversed
+	addVkFormatDesc( X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil, DEPTH_FEATS, NO_FEATS );
 
 	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed, COMPRESSED_FEATS, NO_FEATS );
 	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed, COMPRESSED_FEATS, NO_FEATS );
@@ -913,10 +913,10 @@ void MVKPixelFormats::initMTLPixelFormatCapabilities() {
 	addMTLPixelFormatDesc( BGRG422, 8.0, 10.11, TexRF, TexRF );
 
 	// Depth and stencil pixel formats
-	addMTLPixelFormatDesc( Depth16Unorm, kMTLFmtNA, 10.12, None, TexDRFMR );
+	addMTLPixelFormatDesc( Depth16Unorm, kMTLFmtNA, 10.12, None, None );
 	addMTLPixelFormatDesc( Depth32Float, 8.0, 10.11, TexDRM, TexDRFMR );
 	addMTLPixelFormatDesc( Stencil8, 8.0, 10.11, TexDRM, TexDRM );
-	addMTLPixelFormatDesc( Depth24Unorm_Stencil8, kMTLFmtNA, 10.11, None, TexDRFMR );
+	addMTLPixelFormatDesc( Depth24Unorm_Stencil8, kMTLFmtNA, 10.11, None, None );
 	addMTLPixelFormatDesc( Depth32Float_Stencil8, 9.0, 10.11, TexDRM, TexDRFMR );
 	addMTLPixelFormatDesc( X24_Stencil8, kMTLFmtNA, 10.11, None, TexDRM );
 	addMTLPixelFormatDesc( X32_Stencil8, 8.0, 10.11, TexDRM, TexDRM );
@@ -926,7 +926,7 @@ void MVKPixelFormats::initMTLPixelFormatCapabilities() {
 	addMTLPixelFormatDesc( BGRA10_XR_sRGB, 10.0, kMTLFmtNA, None, None );
 	addMTLPixelFormatDesc( BGR10_XR, 10.0, kMTLFmtNA, None, None );
 	addMTLPixelFormatDesc( BGR10_XR_sRGB, 10.0, kMTLFmtNA, None, None );
-	addMTLPixelFormatDesc( BGR10A2Unorm, 11.0, 10.13, TexAll, TexRFCMRB );
+	addMTLPixelFormatDesc( BGR10A2Unorm, 11.0, 10.13, None, None );
 
 	// When adding to this list, be sure to ensure _mtlPixelFormatCount is large enough for the format count
 }
@@ -948,11 +948,6 @@ void MVKPixelFormats::initMTLVertexFormatCapabilities() {
 	// MTLVertexFormatInvalid must come first.
 	addMTLVertexFormatDesc( Invalid, kMTLFmtNA, kMTLFmtNA, None, None );
 
-	addMTLVertexFormatDesc( UCharNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( CharNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( UChar, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Char, 11.0, 10.13, BufVertex, BufVertex );
-
 	addMTLVertexFormatDesc( UChar2Normalized, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Char2Normalized, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( UChar2, 8.0, 10.11, BufVertex, BufVertex );
@@ -968,16 +963,8 @@ void MVKPixelFormats::initMTLVertexFormatCapabilities() {
 	addMTLVertexFormatDesc( UChar4, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Char4, 8.0, 10.11, BufVertex, BufVertex );
 
-	addMTLVertexFormatDesc( UChar4Normalized_BGRA, 11.0, 10.13, BufVertex, BufVertex );
-
 	addMTLVertexFormatDesc( UInt1010102Normalized, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Int1010102Normalized, 8.0, 10.11, BufVertex, BufVertex );
-
-	addMTLVertexFormatDesc( UShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( ShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( UShort, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Short, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Half, 11.0, 10.13, BufVertex, BufVertex );
 
 	addMTLVertexFormatDesc( UShort2Normalized, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Short2Normalized, 8.0, 10.11, BufVertex, BufVertex );
@@ -1012,6 +999,19 @@ void MVKPixelFormats::initMTLVertexFormatCapabilities() {
 	addMTLVertexFormatDesc( UInt4, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Int4, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Float4, 8.0, 10.11, BufVertex, BufVertex );
+
+	addMTLVertexFormatDesc( UCharNormalized, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( CharNormalized, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( UChar, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( Char, 11.0, 10.13, BufVertex, BufVertex );
+
+	addMTLVertexFormatDesc( UShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( ShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( UShort, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( Short, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( Half, 11.0, 10.13, BufVertex, BufVertex );
+
+	addMTLVertexFormatDesc( UChar4Normalized_BGRA, 11.0, 10.13, BufVertex, BufVertex );
 
 	// When adding to this list, be sure to ensure _mtlVertexFormatCount is large enough for the format count
 }
@@ -1076,20 +1076,115 @@ void MVKPixelFormats::buildFormatMaps() {
 	}
 }
 
+// If the device supports the feature set, add additional capabilities to a MTLPixelFormat
+void MVKPixelFormats::addMTLPixelFormatCapabilities(id<MTLDevice> mtlDevice,
+													MTLFeatureSet mtlFeatSet,
+													MTLPixelFormat mtlPixFmt,
+													MVKMTLFmtCaps mtlFmtCaps) {
+	if ( [mtlDevice supportsFeatureSet: mtlFeatSet] ) {
+		auto& fmtDesc = getMTLPixelFormatDesc(mtlPixFmt);
+		fmtDesc.mtlFmtCaps = (MVKMTLFmtCaps)(fmtDesc.mtlFmtCaps | mtlFmtCaps);
+	}
+}
+
+#define addMTLPixelFormatCapabilities(FEAT_SET, MTL_FMT, CAPS)  \
+	addMTLPixelFormatCapabilities(mtlDevice, MTLFeatureSet_ ##FEAT_SET, MTLPixelFormat ##MTL_FMT, kMVKMTLFmtCaps ##CAPS)
+
 // Modifies the format capability tables based on the capabilities of the specific MTLDevice
+#if MVK_MACOS
 void MVKPixelFormats::modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevice) {
 	if ( !mtlDevice ) { return; }
 
-#if MVK_MACOS
-	if ( !mtlDevice.isDepth24Stencil8PixelFormatSupported ) {
-		disableMTLPixelFormat(MTLPixelFormatDepth24Unorm_Stencil8);
+	if (mtlDevice.isDepth24Stencil8PixelFormatSupported) {
+		addMTLPixelFormatCapabilities( macOS_GPUFamily1_v1, Depth24Unorm_Stencil8, TexDRFMR );
 	}
-#endif
-}
 
-void MVKPixelFormats::disableMTLPixelFormat(MTLPixelFormat mtlFormat) {
-	getVkFormatDesc(mtlFormat).mtlPixelFormat = MTLPixelFormatInvalid;
+	addMTLPixelFormatCapabilities( macOS_GPUFamily1_v2, Depth16Unorm, TexDRFMR );
+
+	addMTLPixelFormatCapabilities( macOS_GPUFamily1_v3, BGR10A2Unorm, TexRFCMRB );
 }
+#endif
+#if MVK_IOS
+void MVKPixelFormats::modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevice) {
+	if ( !mtlDevice ) { return; }
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v3, R8Unorm_sRGB, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, R8Unorm_sRGB, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v1, R8Snorm, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v3, RG8Unorm_sRGB, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RG8Unorm_sRGB, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v1, RG8Snorm, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, R32Uint, TexRWC );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, R32Sint, TexRWC );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, R32Float, TexRWCMB );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v3, RGBA8Unorm_sRGB, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RGBA8Unorm_sRGB, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v1, RGBA8Snorm, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily2_v3, BGRA8Unorm_sRGB, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, BGRA8Unorm_sRGB, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RGB10A2Unorm, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RGB10A2Uint, TexRWCM );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RG11B10Float, TexAll );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, RGB9E5Float, TexAll );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RG32Uint, TexRWC );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RG32Sint, TexRWC );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RG32Float, TexRWCB );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RGBA32Uint, TexRWC );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RGBA32Sint, TexRWC );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily1_v2, RGBA32Float, TexRWC );
+
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_4x4_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_4x4_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_5x4_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_5x4_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_5x5_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_5x5_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_6x5_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_6x5_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_6x6_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_6x6_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x5_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x5_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x6_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x6_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x8_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_8x8_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x5_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x5_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x6_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x6_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x8_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x8_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x10_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_10x10_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_12x10_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_12x10_sRGB, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_12x12_LDR, TexRF );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily2_v1, ASTC_12x12_sRGB, TexRF );
+
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, Depth32Float, TexDRMR );
+	addMTLPixelFormatCapabilities( iOS_GPUFamily3_v1, Depth32Float_Stencil8, TexDRMR );
+
+	addMTLPixelFormatCapabilities(iOS_GPUFamily3_v2, BGRA10_XR, TexAll );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily3_v2, BGRA10_XR_sRGB, TexAll );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily3_v2, BGR10_XR, TexAll );
+	addMTLPixelFormatCapabilities(iOS_GPUFamily3_v2, BGR10_XR_sRGB, TexAll );
+
+	addMTLPixelFormatCapabilities(iOS_GPUFamily1_v4, BGR10A2Unorm, TexAll );
+}
+#endif
+#undef addMTLPixelFormatCapabilities
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -360,24 +360,24 @@ uint32_t MVKPixelFormats::getMTLClearStencilFromVkClearValue(VkClearValue vkClea
 }
 
 VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsage mtlUsage,
-																	  MTLPixelFormat mtlFormat) {
+																		   MTLPixelFormat mtlFormat) {
     VkImageUsageFlags vkImageUsageFlags = 0;
 
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderRead) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_SAMPLED_BIT);
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_SAMPLED_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     }
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageRenderTarget) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
         if (mtlPixelFormatIsDepthFormat(mtlFormat) || mtlPixelFormatIsStencilFormat(mtlFormat)) {
-            mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         } else {
-            mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
         }
     }
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderWrite) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_STORAGE_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_STORAGE_BIT);
     }
 
     return vkImageUsageFlags;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -432,7 +432,7 @@ void MVKPixelFormats::init(id<MTLDevice> mtlDevice) {
 	initVkFormatCapabilities();
 	buildVkFormatMaps();
 
-	test(mtlDevice);
+//	test(mtlDevice);
 }
 
 #define addVkFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE)  \
@@ -1271,66 +1271,69 @@ void MVKPixelFormats::testProps(const VkFormatProperties p1, const VkFormatPrope
 // Validate the functionality of this class against the previous format data within MoltenVK.
 // This is a temporary function to confirm that converting to using this class matches existing behaviour at first.
 void MVKPixelFormats::test(id<MTLDevice> mtlDevice) {
-	if ( !mtlDevice || mtlDevice.isLowPower ) { return; }	// Only test primary device platform formats
+	@autoreleasepool {
+		// Don't test a static instance, and only test the default MTLDevice if more than one GPU.
+		if ( !_apiObject || mtlDevice != [MTLCreateSystemDefaultDevice() autorelease] ) { return; }
 
-	MVKLogInfo("Starting testing formats");
-	for (uint32_t fmtIdx = 0; fmtIdx < _vkFormatCount; fmtIdx++) {
-		auto& fd = _vkFormatDescriptions[fmtIdx];
-		VkFormat vkFmt = fd.vkFormat;
-		MTLPixelFormat mtlFmt = fd.mtlPixelFormat;
+		MVKLogInfo("Starting testing formats");
+		for (uint32_t fmtIdx = 0; fmtIdx < _vkFormatCount; fmtIdx++) {
+			auto& fd = _vkFormatDescriptions[fmtIdx];
+			VkFormat vkFmt = fd.vkFormat;
+			MTLPixelFormat mtlFmt = fd.mtlPixelFormat;
 
-		if (fd.vkFormat) {
-			if (fd.isSupportedOrSubstitutable()) {
-				MVKLogInfo("Testing %s", fd.name);
+			if (fd.vkFormat) {
+				if (fd.isSupportedOrSubstitutable()) {
+					MVKLogInfo("Testing %s", fd.name);
 
-#				define testFmt(V1, V2)	  testFmt(V1, V2, fd.name, #V1)
-#				define testProps(V1, V2)  testProps(V1, V2, fd.name)
+#					define testFmt(V1, V2)	  testFmt(V1, V2, fd.name, #V1)
+#					define testProps(V1, V2)  testProps(V1, V2, fd.name)
 
-				testFmt(vkFormatIsSupported(vkFmt), mvkVkFormatIsSupported(vkFmt));
-				testFmt(mtlPixelFormatIsSupported(mtlFmt), mvkMTLPixelFormatIsSupported(mtlFmt));
-				testFmt(mtlPixelFormatIsDepthFormat(mtlFmt), mvkMTLPixelFormatIsDepthFormat(mtlFmt));
-				testFmt(mtlPixelFormatIsStencilFormat(mtlFmt), mvkMTLPixelFormatIsStencilFormat(mtlFmt));
-				testFmt(mtlPixelFormatIsPVRTCFormat(mtlFmt), mvkMTLPixelFormatIsPVRTCFormat(mtlFmt));
-				testFmt(getFormatTypeFromVkFormat(vkFmt), mvkFormatTypeFromVkFormat(vkFmt));
-				testFmt(getFormatTypeFromMTLPixelFormat(mtlFmt), mvkFormatTypeFromMTLPixelFormat(mtlFmt));
-				testFmt(getMTLPixelFormatFromVkFormat(vkFmt), mvkMTLPixelFormatFromVkFormat(vkFmt));
-				testFmt(getVkFormatFromMTLPixelFormat(mtlFmt), mvkVkFormatFromMTLPixelFormat(mtlFmt));
-				testFmt(getVkFormatBytesPerBlock(vkFmt), mvkVkFormatBytesPerBlock(vkFmt));
-				testFmt(getMTLPixelFormatBytesPerBlock(mtlFmt), mvkMTLPixelFormatBytesPerBlock(mtlFmt));
-				testFmt(getVkFormatBlockTexelSize(vkFmt), mvkVkFormatBlockTexelSize(vkFmt));
-				testFmt(getMTLPixelFormatBlockTexelSize(mtlFmt), mvkMTLPixelFormatBlockTexelSize(mtlFmt));
-				testFmt(getVkFormatBytesPerTexel(vkFmt), mvkVkFormatBytesPerTexel(vkFmt));
-				testFmt(getMTLPixelFormatBytesPerTexel(mtlFmt), mvkMTLPixelFormatBytesPerTexel(mtlFmt));
-				testFmt(getVkFormatBytesPerRow(vkFmt, 4), mvkVkFormatBytesPerRow(vkFmt, 4));
-				testFmt(getMTLPixelFormatBytesPerRow(mtlFmt, 4), mvkMTLPixelFormatBytesPerRow(mtlFmt, 4));
-				testFmt(getVkFormatBytesPerLayer(vkFmt, 256, 4), mvkVkFormatBytesPerLayer(vkFmt, 256, 4));
-				testFmt(getMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4), mvkMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4));
-				testProps(getVkFormatProperties(vkFmt), mvkVkFormatProperties(vkFmt));
-				testFmt(strcmp(getVkFormatName(vkFmt), mvkVkFormatName(vkFmt)), 0);
-				testFmt(strcmp(getMTLPixelFormatName(mtlFmt), mvkMTLPixelFormatName(mtlFmt)), 0);
-				testFmt(getMTLClearColorFromVkClearValue(VkClearValue(), vkFmt),
-						mvkMTLClearColorFromVkClearValue(VkClearValue(), vkFmt));
+					testFmt(vkFormatIsSupported(vkFmt), mvkVkFormatIsSupported(vkFmt));
+					testFmt(mtlPixelFormatIsSupported(mtlFmt), mvkMTLPixelFormatIsSupported(mtlFmt));
+					testFmt(mtlPixelFormatIsDepthFormat(mtlFmt), mvkMTLPixelFormatIsDepthFormat(mtlFmt));
+					testFmt(mtlPixelFormatIsStencilFormat(mtlFmt), mvkMTLPixelFormatIsStencilFormat(mtlFmt));
+					testFmt(mtlPixelFormatIsPVRTCFormat(mtlFmt), mvkMTLPixelFormatIsPVRTCFormat(mtlFmt));
+					testFmt(getFormatTypeFromVkFormat(vkFmt), mvkFormatTypeFromVkFormat(vkFmt));
+					testFmt(getFormatTypeFromMTLPixelFormat(mtlFmt), mvkFormatTypeFromMTLPixelFormat(mtlFmt));
+					testFmt(getMTLPixelFormatFromVkFormat(vkFmt), mvkMTLPixelFormatFromVkFormat(vkFmt));
+					testFmt(getVkFormatFromMTLPixelFormat(mtlFmt), mvkVkFormatFromMTLPixelFormat(mtlFmt));
+					testFmt(getVkFormatBytesPerBlock(vkFmt), mvkVkFormatBytesPerBlock(vkFmt));
+					testFmt(getMTLPixelFormatBytesPerBlock(mtlFmt), mvkMTLPixelFormatBytesPerBlock(mtlFmt));
+					testFmt(getVkFormatBlockTexelSize(vkFmt), mvkVkFormatBlockTexelSize(vkFmt));
+					testFmt(getMTLPixelFormatBlockTexelSize(mtlFmt), mvkMTLPixelFormatBlockTexelSize(mtlFmt));
+					testFmt(getVkFormatBytesPerTexel(vkFmt), mvkVkFormatBytesPerTexel(vkFmt));
+					testFmt(getMTLPixelFormatBytesPerTexel(mtlFmt), mvkMTLPixelFormatBytesPerTexel(mtlFmt));
+					testFmt(getVkFormatBytesPerRow(vkFmt, 4), mvkVkFormatBytesPerRow(vkFmt, 4));
+					testFmt(getMTLPixelFormatBytesPerRow(mtlFmt, 4), mvkMTLPixelFormatBytesPerRow(mtlFmt, 4));
+					testFmt(getVkFormatBytesPerLayer(vkFmt, 256, 4), mvkVkFormatBytesPerLayer(vkFmt, 256, 4));
+					testFmt(getMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4), mvkMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4));
+					testProps(getVkFormatProperties(vkFmt), mvkVkFormatProperties(vkFmt));
+					testFmt(strcmp(getVkFormatName(vkFmt), mvkVkFormatName(vkFmt)), 0);
+					testFmt(strcmp(getMTLPixelFormatName(mtlFmt), mvkMTLPixelFormatName(mtlFmt)), 0);
+					testFmt(getMTLClearColorFromVkClearValue(VkClearValue(), vkFmt),
+							mvkMTLClearColorFromVkClearValue(VkClearValue(), vkFmt));
 
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt),
-						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt),
-						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt),
-						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt),
-						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt),
-						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt));
+					testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt),
+							mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt));
+					testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt),
+							mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt));
+					testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt),
+							mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt));
+					testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt),
+							mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt));
+					testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt),
+							mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt));
 
-				testFmt(getMTLVertexFormatFromVkFormat(vkFmt), mvkMTLVertexFormatFromVkFormat(vkFmt));
+					testFmt(getMTLVertexFormatFromVkFormat(vkFmt), mvkMTLVertexFormatFromVkFormat(vkFmt));
 
-#				undef testFmt
-#				undef testProps
+#					undef testFmt
+#					undef testProps
 
-			} else {
-				MVKLogInfo("%s not supported or substitutable on this device.", fd.name);
+				} else {
+					MVKLogInfo("%s not supported or substitutable on this device.", fd.name);
+				}
 			}
 		}
+		MVKLogInfo("Finished testing formats.\n");
 	}
-	MVKLogInfo("Finished testing formats.\n");
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1000,18 +1000,18 @@ void MVKPixelFormats::initMTLVertexFormatCapabilities() {
 	addMTLVertexFormatDesc( Int4, 8.0, 10.11, BufVertex, BufVertex );
 	addMTLVertexFormatDesc( Float4, 8.0, 10.11, BufVertex, BufVertex );
 
-	addMTLVertexFormatDesc( UCharNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( CharNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( UChar, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Char, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( UCharNormalized, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( CharNormalized, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( UChar, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( Char, 11.0, 10.13, None, None );
 
-	addMTLVertexFormatDesc( UShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( ShortNormalized, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( UShort, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Short, 11.0, 10.13, BufVertex, BufVertex );
-	addMTLVertexFormatDesc( Half, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( UShortNormalized, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( ShortNormalized, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( UShort, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( Short, 11.0, 10.13, None, None );
+	addMTLVertexFormatDesc( Half, 11.0, 10.13, None, None );
 
-	addMTLVertexFormatDesc( UChar4Normalized_BGRA, 11.0, 10.13, BufVertex, BufVertex );
+	addMTLVertexFormatDesc( UChar4Normalized_BGRA, 11.0, 10.13, None, None );
 
 	// When adding to this list, be sure to ensure _mtlVertexFormatCount is large enough for the format count
 }
@@ -1087,8 +1087,22 @@ void MVKPixelFormats::addMTLPixelFormatCapabilities(id<MTLDevice> mtlDevice,
 	}
 }
 
+// If the device supports the feature set, add additional capabilities to a MTLVertexFormat
+void MVKPixelFormats::addMTLVertexFormatCapabilities(id<MTLDevice> mtlDevice,
+													 MTLFeatureSet mtlFeatSet,
+													 MTLVertexFormat mtlVtxFmt,
+													 MVKMTLFmtCaps mtlFmtCaps) {
+	if ( [mtlDevice supportsFeatureSet: mtlFeatSet] ) {
+		auto& fmtDesc = getMTLVertexFormatDesc(mtlVtxFmt);
+		fmtDesc.mtlFmtCaps = (MVKMTLFmtCaps)(fmtDesc.mtlFmtCaps | mtlFmtCaps);
+	}
+}
+
 #define addMTLPixelFormatCapabilities(FEAT_SET, MTL_FMT, CAPS)  \
 	addMTLPixelFormatCapabilities(mtlDevice, MTLFeatureSet_ ##FEAT_SET, MTLPixelFormat ##MTL_FMT, kMVKMTLFmtCaps ##CAPS)
+
+#define addMTLVertexFormatCapabilities(FEAT_SET, MTL_FMT, CAPS)  \
+	addMTLVertexFormatCapabilities(mtlDevice, MTLFeatureSet_ ##FEAT_SET, MTLVertexFormat ##MTL_FMT, kMVKMTLFmtCaps ##CAPS)
 
 // Modifies the format capability tables based on the capabilities of the specific MTLDevice
 #if MVK_MACOS
@@ -1102,6 +1116,17 @@ void MVKPixelFormats::modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevi
 	addMTLPixelFormatCapabilities( macOS_GPUFamily1_v2, Depth16Unorm, TexDRFMR );
 
 	addMTLPixelFormatCapabilities( macOS_GPUFamily1_v3, BGR10A2Unorm, TexRFCMRB );
+
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, UCharNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, CharNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, UChar, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, Char, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, UShortNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, ShortNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, UShort, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, Short, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, Half, BufVertex );
+	addMTLVertexFormatCapabilities( macOS_GPUFamily1_v3, UChar4Normalized_BGRA, BufVertex );
 }
 #endif
 #if MVK_IOS
@@ -1182,9 +1207,21 @@ void MVKPixelFormats::modifyFormatCapabilitiesForMTLDevice(id<MTLDevice> mtlDevi
 	addMTLPixelFormatCapabilities(iOS_GPUFamily3_v2, BGR10_XR_sRGB, TexAll );
 
 	addMTLPixelFormatCapabilities(iOS_GPUFamily1_v4, BGR10A2Unorm, TexAll );
+
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, UCharNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, CharNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, UChar, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, Char, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, UShortNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, ShortNormalized, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, UShort, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, Short, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, Half, BufVertex );
+	addMTLVertexFormatCapabilities( iOS_GPUFamily1_v4, UChar4Normalized_BGRA, BufVertex );
 }
 #endif
 #undef addMTLPixelFormatCapabilities
+#undef addMTLVertexFormatCapabilities
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -16,13 +16,11 @@
  * limitations under the License.
  */
 
-#include "mvk_datatypes.hpp"
 #include "MVKPixelFormats.h"
 #include "MVKVulkanAPIObject.h"
 #include "MVKFoundation.h"
 #include "MVKLogging.h"
 #include <string>
-#include <limits>
 
 using namespace std;
 
@@ -412,6 +410,17 @@ MVKVkFormatDesc& MVKPixelFormats::getVkFormatDesc(MTLPixelFormat mtlFormat) {
 #pragma mark Construction
 
 MVKPixelFormats::MVKPixelFormats(MVKVulkanAPIObject* apiObject, id<MTLDevice> mtlDevice) : _apiObject(apiObject) {
+	init(mtlDevice);
+}
+
+//	Retrieves the default MTLDevice, which needs to be released after use.
+MVKPixelFormats::MVKPixelFormats() : _apiObject(nullptr) {
+	id<MTLDevice> mtlDevice = MTLCreateSystemDefaultDevice();	// retained
+	init(mtlDevice);
+	[mtlDevice release];	// Release temp instance
+}
+
+void MVKPixelFormats::init(id<MTLDevice> mtlDevice) {
 
 	// Build and update the Metal formats
 	initMTLPixelFormatCapabilities();
@@ -423,7 +432,7 @@ MVKPixelFormats::MVKPixelFormats(MVKVulkanAPIObject* apiObject, id<MTLDevice> mt
 	initVkFormatCapabilities();
 	buildVkFormatMaps();
 
-//	test(mtlDevice);
+	test(mtlDevice);
 }
 
 #define addVkFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE)  \

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -84,7 +84,7 @@ private:
 	friend class MVKRenderPass;
 	friend class MVKRenderPassAttachment;
 
-	bool isUsingAttachmentAt(uint32_t rpAttIdx);
+	MVKMTLFmtCaps getRequiredFormatCapabilitiesForAttachmentAt(uint32_t rpAttIdx);
 
 	MVKRenderPass* _renderPass;
 	uint32_t _subpassIndex;
@@ -134,8 +134,6 @@ public:
 							const VkAttachmentDescription* pCreateInfo);
 
 protected:
-	VkAttachmentDescription validate(const VkAttachmentDescription* pCreateInfo);
-
 	VkAttachmentDescription _info;
 	MVKRenderPass* _renderPass;
 	uint32_t _attachmentIndex;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -503,11 +503,11 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
     };
 
 	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)) {
-		mvkEnableFlag(imgInfo.flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+		mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
 	}
 	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR)) {
 		// We don't really support this, but set the flag anyway.
-		mvkEnableFlag(imgInfo.flags, VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT);
+		mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT);
 	}
 
 	_surfaceImages.reserve(imgCnt);

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -496,15 +496,9 @@ bool mvkSetOrClear(T* pDest, const T* pSrc) {
 
 #pragma mark Boolean flags
 
-/**
- * Enables the flag (set the bit to 1) within the value parameter specified by the bitMask parameter.
- *
- * Typically, you call this function with only a single bit of the bitMask parameter set to 1.
- * However, you may also call this function with more than one bit of the bitMask parameter set
- * to 1, in which case, this function will set all corresponding bits in the value parameter to 1.
- */
+/** Enables the flags (sets bits to 1) within the value parameter specified by the bitMask parameter. */
 template<typename T1, typename T2>
-void mvkEnableFlag(T1& value, const T2 bitMask) { value |= bitMask; }
+void mvkEnableFlags(T1& value, const T2 bitMask) { value |= bitMask; }
 
 /** Disables the flags (sets bits to 0) within the value parameter specified by the bitMask parameter. */
 template<typename T1, typename T2>

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -506,15 +506,9 @@ bool mvkSetOrClear(T* pDest, const T* pSrc) {
 template<typename T1, typename T2>
 void mvkEnableFlag(T1& value, const T2 bitMask) { value |= bitMask; }
 
-/**
- * Disables the flag (set the bit to 0) within the value parameter specified by the bitMask parameter.
- *
- * Typically, you call this function with only a single bit of the bitMask parameter set to 1.
- * However, you may also call this function with more than one bit of the bitMask parameter set
- * to 1, in which case, this function will set all corresponding bits in the value parameter to 0.
- */
+/** Disables the flags (sets bits to 0) within the value parameter specified by the bitMask parameter. */
 template<typename T1, typename T2>
-void mvkDisableFlag(T1& value, const T2 bitMask) { value &= ~bitMask; }
+void mvkDisableFlags(T1& value, const T2 bitMask) { value &= ~bitMask; }
 
 /** Returns whether the specified value has ANY of the flags specified in bitMask enabled (set to 1). */
 template<typename T1, typename T2>

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -20,6 +20,7 @@
 #pragma once
 
 
+#include "MVKCommonEnvironment.h"
 #include "mvk_vulkan.h"
 #include <algorithm>
 #include <string>
@@ -330,6 +331,8 @@ static inline bool mvkVkComponentMappingsMatch(VkComponentMapping cm1, VkCompone
 #pragma mark -
 #pragma mark Template functions
 
+#pragma mark Math
+
 /** Returns whether the value will fit inside the numeric type. */
 template<typename T, typename Tval>
 const bool mvkFits(const Tval& val) {
@@ -349,6 +352,9 @@ T mvkCeilingDivide(T numerator, T denominator) {
 	return (denominator == 1) ? numerator : (numerator + denominator - 1) / denominator;
 }
 
+
+#pragma mark Hashing
+
 /**
  * Returns a hash value calculated from the specified array of numeric elements,
  * using the DJB2a algorithm:  hash = (hash * 33) ^ value.
@@ -363,6 +369,9 @@ std::size_t mvkHash(const N* pVals, std::size_t count = 1, std::size_t seed = 53
     for (std::size_t i = 0; i < count; i++) { hash = ((hash << 5) + hash) ^ pVals[i]; }
     return hash;
 }
+
+
+#pragma mark Containers
 
 /** Ensures the size of the specified container is at least the specified size. */
 template<typename C, typename S>
@@ -414,6 +423,20 @@ void mvkRemoveFirstOccurance(C& container, T val) {
 template<class C, class T>
 void mvkRemoveAllOccurances(C& container, T val) {
     container.erase(remove(container.begin(), container.end(), val), container.end());
+}
+
+
+#pragma mark Values and structs
+
+/** Selects and returns one of the values, based on the platform OS. */
+template<typename T>
+const T& mvkSelectPlatformValue(const T& macOSVal, const T& iOSVal) {
+#if MVK_IOS
+	return iOSVal;
+#endif
+#if MVK_MACOS
+	return macOSVal;
+#endif
 }
 
 /**
@@ -469,6 +492,9 @@ bool mvkSetOrClear(T* pDest, const T* pSrc) {
     if (pDest) { mvkClear(pDest); }
     return false;
 }
+
+
+#pragma mark Boolean flags
 
 /**
  * Enables the flag (set the bit to 1) within the value parameter specified by the bitMask parameter.

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -497,26 +497,26 @@ bool mvkSetOrClear(T* pDest, const T* pSrc) {
 #pragma mark Boolean flags
 
 /** Enables the flags (sets bits to 1) within the value parameter specified by the bitMask parameter. */
-template<typename T1, typename T2>
-void mvkEnableFlags(T1& value, const T2 bitMask) { value |= bitMask; }
+template<typename Tv, typename Tm>
+void mvkEnableFlags(Tv& value, const Tm bitMask) { value = (Tv)(value | bitMask); }
 
 /** Disables the flags (sets bits to 0) within the value parameter specified by the bitMask parameter. */
-template<typename T1, typename T2>
-void mvkDisableFlags(T1& value, const T2 bitMask) { value &= ~bitMask; }
+template<typename Tv, typename Tm>
+void mvkDisableFlags(Tv& value, const Tm bitMask) { value = (Tv)(value & ~(Tv)bitMask); }
 
 /** Returns whether the specified value has ANY of the flags specified in bitMask enabled (set to 1). */
-template<typename T1, typename T2>
-bool mvkIsAnyFlagEnabled(T1 value, const T2 bitMask) { return !!(value & bitMask); }
+template<typename Tv, typename Tm>
+bool mvkIsAnyFlagEnabled(Tv value, const Tm bitMask) { return !!(value & bitMask); }
 
 /** Returns whether the specified value has ALL of the flags specified in bitMask enabled (set to 1). */
-template<typename T1, typename T2>
-bool mvkAreAllFlagsEnabled(T1 value, const T2 bitMask) { return ((value & bitMask) == bitMask); }
+template<typename Tv, typename Tm>
+bool mvkAreAllFlagsEnabled(Tv value, const Tm bitMask) { return ((value & bitMask) == bitMask); }
 
 /** Returns whether the specified value has ONLY one or more of the flags specified in bitMask enabled (set to 1), and none others. */
-template<typename T1, typename T2>
-bool mvkIsOnlyAnyFlagEnabled(T1 value, const T2 bitMask) { return (mvkIsAnyFlagEnabled(value, bitMask) && ((value | bitMask) == bitMask)); }
+template<typename Tv, typename Tm>
+bool mvkIsOnlyAnyFlagEnabled(Tv value, const Tm bitMask) { return (mvkIsAnyFlagEnabled(value, bitMask) && ((value | bitMask) == bitMask)); }
 
 /** Returns whether the specified value has ONLY ALL of the flags specified in bitMask enabled (set to 1), and none others. */
-template<typename T1, typename T2>
-bool mvkAreOnlyAllFlagsEnabled(T1 value, const T2 bitMask) { return (value == bitMask); }
+template<typename Tv, typename Tm>
+bool mvkAreOnlyAllFlagsEnabled(Tv value, const Tm bitMask) { return (value == bitMask); }
 

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.hpp
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.hpp
@@ -75,14 +75,6 @@ MTLTessellationPartitionMode mvkMTLTessellationPartitionModeFromSpvExecutionMode
 #pragma mark -
 #pragma mark Image properties
 
-#pragma mark Texture formats
-
-/**
- * Returns info about the default pixel formats supported by the platform,
- * without taking into consideration support at the MTLDevice level.
- */
-MVKPixelFormats* mvkPlatformPixelFormats();
-
 /** Returns whether 1D textures should be treated as Metal 2D textures with height 1. */
 bool mvkTreatTexture1DAs2D();
 

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -268,19 +268,19 @@ MVK_PUBLIC_SYMBOL MTLTextureUsage mvkMTLTextureUsageFromVkImageUsageFlags(VkImag
 												VK_IMAGE_USAGE_SAMPLED_BIT |
 												VK_IMAGE_USAGE_STORAGE_BIT |
 												VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT))) {
-		mvkEnableFlag(mtlUsage, MTLTextureUsageShaderRead);
+		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderRead);
 	}
 
 	// Write to...
 	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_STORAGE_BIT))) {
-		mvkEnableFlag(mtlUsage, MTLTextureUsageShaderWrite);
+		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
 	}
 
 	// Render to...
 	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
 												VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
 												VK_IMAGE_USAGE_TRANSFER_DST_BIT))) {				// Scaling a BLIT may use rendering.
-		mvkEnableFlag(mtlUsage, MTLTextureUsageRenderTarget);
+		mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
 	}
 
 	// Create view on...
@@ -290,7 +290,7 @@ MVK_PUBLIC_SYMBOL MTLTextureUsage mvkMTLTextureUsageFromVkImageUsageFlags(VkImag
 												VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
 												VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
 												VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT))) {	// D/S may be filtered out after device check
-		mvkEnableFlag(mtlUsage, MTLTextureUsagePixelFormatView);
+		mvkEnableFlags(mtlUsage, MTLTextureUsagePixelFormatView);
 	}
 
     return mtlUsage;
@@ -300,20 +300,20 @@ MVK_PUBLIC_SYMBOL VkImageUsageFlags mvkVkImageUsageFlagsFromMTLTextureUsage(MTLT
     VkImageUsageFlags vkImageUsageFlags = 0;
 
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderRead) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_SAMPLED_BIT);
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_SAMPLED_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     }
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageRenderTarget) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
         if (mvkMTLPixelFormatIsDepthFormat(mtlFormat) || mvkMTLPixelFormatIsStencilFormat(mtlFormat)) {
-            mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         } else {
-            mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
         }
     }
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderWrite) ) {
-        mvkEnableFlag(vkImageUsageFlags, VK_IMAGE_USAGE_STORAGE_BIT);
+        mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_STORAGE_BIT);
     }
 
     return vkImageUsageFlags;
@@ -447,10 +447,10 @@ MVK_PUBLIC_SYMBOL MTLSamplerMipFilter mvkMTLSamplerMipFilterFromVkSamplerMipmapM
 
 MVK_PUBLIC_SYMBOL MTLColorWriteMask mvkMTLColorWriteMaskFromVkChannelFlags(VkColorComponentFlags vkWriteFlags) {
 	MTLColorWriteMask mtlWriteMask = MTLColorWriteMaskNone;
-	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_R_BIT)) { mvkEnableFlag(mtlWriteMask, MTLColorWriteMaskRed); }
-	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_G_BIT)) { mvkEnableFlag(mtlWriteMask, MTLColorWriteMaskGreen); }
-	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_B_BIT)) { mvkEnableFlag(mtlWriteMask, MTLColorWriteMaskBlue); }
-	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_A_BIT)) { mvkEnableFlag(mtlWriteMask, MTLColorWriteMaskAlpha); }
+	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_R_BIT)) { mvkEnableFlags(mtlWriteMask, MTLColorWriteMaskRed); }
+	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_G_BIT)) { mvkEnableFlags(mtlWriteMask, MTLColorWriteMaskGreen); }
+	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_B_BIT)) { mvkEnableFlags(mtlWriteMask, MTLColorWriteMaskBlue); }
+	if (mvkAreAllFlagsEnabled(vkWriteFlags, VK_COLOR_COMPONENT_A_BIT)) { mvkEnableFlags(mtlWriteMask, MTLColorWriteMaskAlpha); }
 	return mtlWriteMask;
 }
 

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -34,8 +34,6 @@ using namespace std;
 
 static MVKPixelFormats _platformPixelFormats;
 
-MVKPixelFormats* mvkPlatformPixelFormats() { return &_platformPixelFormats; }
-
 MVK_PUBLIC_SYMBOL bool mvkVkFormatIsSupported(VkFormat vkFormat) {
 	return _platformPixelFormats.vkFormatIsSupported(vkFormat);
 }

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -30,672 +30,90 @@
 using namespace std;
 
 
-#pragma mark -
-#pragma mark Image properties
-
-#define MVK_FMT_IMAGE_FEATS			(VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                    \
-									| VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT                   \
-                                    | VK_FORMAT_FEATURE_BLIT_SRC_BIT                        \
-									| VK_FORMAT_FEATURE_TRANSFER_SRC_BIT                    \
-									| VK_FORMAT_FEATURE_TRANSFER_DST_BIT)
-
-#define MVK_FMT_COLOR_INTEGER_FEATS	(MVK_FMT_IMAGE_FEATS                                    \
-									| VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT                \
-									| VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT          \
-                                    | VK_FORMAT_FEATURE_BLIT_DST_BIT)
-
-#define MVK_FMT_COLOR_FEATS			(MVK_FMT_COLOR_INTEGER_FEATS | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
-
-#if MVK_IOS
-// iOS does not support filtering of float32 values.
-#	define MVK_FMT_COLOR_FLOAT32_FEATS	MVK_FMT_COLOR_INTEGER_FEATS
-#else
-#	define MVK_FMT_COLOR_FLOAT32_FEATS	MVK_FMT_COLOR_FEATS
-#endif
-
-#define MVK_FMT_STENCIL_FEATS		(MVK_FMT_IMAGE_FEATS | VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
-
-#if MVK_IOS
-// iOS does not support filtering of depth values.
-#	define MVK_FMT_DEPTH_FEATS		MVK_FMT_STENCIL_FEATS
-#else
-#	define MVK_FMT_DEPTH_FEATS		(MVK_FMT_STENCIL_FEATS | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
-#endif
-
-#define MVK_FMT_COMPRESSED_FEATS	(VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT                    \
-									| VK_FORMAT_FEATURE_TRANSFER_SRC_BIT                    \
-									| VK_FORMAT_FEATURE_TRANSFER_DST_BIT                    \
-									| VK_FORMAT_FEATURE_BLIT_SRC_BIT                        \
-									| VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
-
-#if MVK_MACOS
-// macOS does not support linear images as framebuffer attachments.
-#define MVK_FMT_LINEAR_TILING_FEATS	(MVK_FMT_IMAGE_FEATS | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
-
-// macOS also does not support E5B9G9R9 for anything but filtering.
-#define MVK_FMT_E5B9G9R9_FEATS 		MVK_FMT_COMPRESSED_FEATS
-#else
-#define MVK_FMT_LINEAR_TILING_FEATS	MVK_FMT_COLOR_FEATS
-#define MVK_FMT_E5B9G9R9_FEATS		MVK_FMT_COLOR_FEATS
-#endif
-
-#define MVK_FMT_BUFFER_FEATS		(VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT             \
-									| VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)
-
-#define MVK_FMT_BUFFER_VTX_FEATS	(MVK_FMT_BUFFER_FEATS | VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)
-
-#define MVK_FMT_BUFFER_RDONLY_FEATS	(VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)
-
-#if MVK_MACOS
-#define MVK_FMT_E5B9G9R9_BUFFER_FEATS 		MVK_FMT_BUFFER_RDONLY_FEATS
-#else
-#define MVK_FMT_E5B9G9R9_BUFFER_FEATS 		MVK_FMT_BUFFER_FEATS
-#endif
-
-#define MVK_FMT_NO_FEATS			0
-
-#define MVK_MAKE_FMT_STRUCT(VK_FMT, MTL_FMT, MTL_FMT_ALT, IOS_SINCE, MACOS_SINCE, BLK_W, BLK_H, BLK_BYTE_CNT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, VTX_IOS_SINCE, VTX_MACOS_SINCE, CLR_TYPE, PIXEL_FEATS, BUFFER_FEATS)  \
-        { VK_FMT, MTL_FMT, MTL_FMT_ALT, IOS_SINCE, MACOS_SINCE, { BLK_W, BLK_H }, BLK_BYTE_CNT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, VTX_IOS_SINCE, VTX_MACOS_SINCE, CLR_TYPE, { (PIXEL_FEATS & MVK_FMT_LINEAR_TILING_FEATS), PIXEL_FEATS, BUFFER_FEATS }, #VK_FMT, #MTL_FMT, false }
-
-
-#pragma mark Texture formats
+#pragma mark Pixel formats
 
 static MVKPixelFormats _platformPixelFormats;
 
 MVKPixelFormats* mvkPlatformPixelFormats() { return &_platformPixelFormats; }
 
-static const MVKOSVersion kMTLFmtNA = numeric_limits<MVKOSVersion>::max();
-
-/** Describes the properties of each VkFormat, including the corresponding Metal pixel format. */
-typedef struct {
-	VkFormat vk;
-	MTLPixelFormat mtl;
-    MTLPixelFormat mtlSubstitute;
-    MVKOSVersion sinceIOSVersion;
-    MVKOSVersion sinceMacOSVersion;
-    VkExtent2D blockTexelSize;
-	uint32_t bytesPerBlock;
-	MTLVertexFormat mtlVertexFormat;
-	MTLVertexFormat mtlVertexFormatSubstitute;
-	MVKOSVersion vertexSinceIOSVersion;
-	MVKOSVersion vertexSinceMacOSVersion;
-	MVKFormatType formatType;
-	VkFormatProperties properties;
-    const char* vkName;
-    const char* mtlName;
-	bool hasReportedSubstitution;
-
-    inline double bytesPerTexel() const { return (double)bytesPerBlock / (double)(blockTexelSize.width * blockTexelSize.height); };
-
-    inline MVKOSVersion sinceOSVersion() const {
-#if MVK_IOS
-        return sinceIOSVersion;
-#endif
-#if MVK_MACOS
-        return sinceMacOSVersion;
-#endif
-    }
-    inline bool isSupported() const { return (mtl != MTLPixelFormatInvalid) && (mvkOSVersion() >= sinceOSVersion()); };
-    inline bool isSupportedOrSubstitutable() const { return isSupported() || (mtlSubstitute != MTLPixelFormatInvalid); };
-
-    inline MVKOSVersion vertexSinceOSVersion() const {
-#if MVK_IOS
-        return vertexSinceIOSVersion;
-#endif
-#if MVK_MACOS
-        return vertexSinceMacOSVersion;
-#endif
-    }
-    inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid) && (mvkOSVersion() >= vertexSinceOSVersion()); };
-    inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); };
-} MVKPlatformFormatDesc;
-
-/** Mapping between Vulkan and Metal pixel formats. */
-#if MVK_MACOS
-#   define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
-#   define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
-#   define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
-#   define MTLPixelFormatBGR5A1Unorm            MTLPixelFormatInvalid
-#   define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
-#   define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
-
-#   define MTLPixelFormatETC2_RGB8              MTLPixelFormatInvalid
-#   define MTLPixelFormatETC2_RGB8_sRGB         MTLPixelFormatInvalid
-#   define MTLPixelFormatETC2_RGB8A1            MTLPixelFormatInvalid
-#   define MTLPixelFormatETC2_RGB8A1_sRGB       MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_RGBA8              MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_RGBA8_sRGB         MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_R11Unorm           MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_R11Snorm           MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_RG11Unorm          MTLPixelFormatInvalid
-#   define MTLPixelFormatEAC_RG11Snorm          MTLPixelFormatInvalid
-
-#   define MTLPixelFormatASTC_4x4_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_4x4_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_5x4_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_5x4_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_5x5_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_5x5_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_6x5_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_6x5_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_6x6_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_6x6_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x5_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x5_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x6_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x6_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x8_LDR           MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_8x8_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x5_LDR          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x5_sRGB         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x6_LDR          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x6_sRGB         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x8_LDR          MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x8_sRGB         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x10_LDR         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_10x10_sRGB        MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_12x10_LDR         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_12x10_sRGB        MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_12x12_LDR         MTLPixelFormatInvalid
-#   define MTLPixelFormatASTC_12x12_sRGB        MTLPixelFormatInvalid
-
-#   define MTLPixelFormatPVRTC_RGB_2BPP         MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGB_2BPP_sRGB    MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGB_4BPP         MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGB_4BPP_sRGB    MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGBA_2BPP        MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGBA_2BPP_sRGB   MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGBA_4BPP        MTLPixelFormatInvalid
-#   define MTLPixelFormatPVRTC_RGBA_4BPP_sRGB   MTLPixelFormatInvalid
-
-#   define MTLPixelFormatDepth16Unorm_Stencil8  MTLPixelFormatDepth24Unorm_Stencil8
-#endif
-
-#if MVK_IOS
-#   define MTLPixelFormatDepth16Unorm           MTLPixelFormatInvalid
-#   define MTLPixelFormatDepth24Unorm_Stencil8  MTLPixelFormatInvalid
-#   define MTLPixelFormatBC1_RGBA               MTLPixelFormatInvalid
-#   define MTLPixelFormatBC1_RGBA_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatBC2_RGBA               MTLPixelFormatInvalid
-#   define MTLPixelFormatBC2_RGBA_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatBC3_RGBA               MTLPixelFormatInvalid
-#   define MTLPixelFormatBC3_RGBA_sRGB          MTLPixelFormatInvalid
-#   define MTLPixelFormatBC4_RUnorm             MTLPixelFormatInvalid
-#   define MTLPixelFormatBC4_RSnorm             MTLPixelFormatInvalid
-#   define MTLPixelFormatBC5_RGUnorm            MTLPixelFormatInvalid
-#   define MTLPixelFormatBC5_RGSnorm            MTLPixelFormatInvalid
-#   define MTLPixelFormatBC6H_RGBUfloat         MTLPixelFormatInvalid
-#   define MTLPixelFormatBC6H_RGBFloat          MTLPixelFormatInvalid
-#   define MTLPixelFormatBC7_RGBAUnorm          MTLPixelFormatInvalid
-#   define MTLPixelFormatBC7_RGBAUnorm_sRGB     MTLPixelFormatInvalid
-
-#   define MTLPixelFormatDepth16Unorm_Stencil8  MTLPixelFormatDepth32Float_Stencil8
-#endif
-
-// This cannot be const, because we write to MVKPlatformFormatDesc::hasReportedSubstitution
-static MVKPlatformFormatDesc _formatDescriptions[] {
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_UNDEFINED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 0, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatNone, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R4G4_UNORM_PACK8, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 1, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R4G4B4A4_UNORM_PACK16, MTLPixelFormatABGR4Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B4G4R4A4_UNORM_PACK16, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R5G6B5_UNORM_PACK16, MTLPixelFormatB5G6R5Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B5G6R5_UNORM_PACK16, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R5G5B5A1_UNORM_PACK16, MTLPixelFormatA1BGR5Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B5G5R5A1_UNORM_PACK16, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A1R5G5B5_UNORM_PACK16, MTLPixelFormatBGR5A1Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_UNORM, MTLPixelFormatR8Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 1, MTLVertexFormatUCharNormalized, MTLVertexFormatUChar2Normalized, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_SNORM, MTLPixelFormatR8Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 1, MTLVertexFormatCharNormalized, MTLVertexFormatChar2Normalized, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 1, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 1, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_UINT, MTLPixelFormatR8Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 1, MTLVertexFormatUChar, MTLVertexFormatUChar2, 11.0, 10.13, kMVKFormatColorUInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_SINT, MTLPixelFormatR8Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 1, MTLVertexFormatChar, MTLVertexFormatChar2, 11.0, 10.13, kMVKFormatColorInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8_SRGB, MTLPixelFormatR8Unorm_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 1, MTLVertexFormatUCharNormalized, MTLVertexFormatUChar2Normalized, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_UNORM, MTLPixelFormatRG8Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatUChar2Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_SNORM, MTLPixelFormatRG8Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatChar2Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_UINT, MTLPixelFormatRG8Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatUChar2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_SINT, MTLPixelFormatRG8Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatChar2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8_SRGB, MTLPixelFormatRG8Unorm_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 1, 1, 2, MTLVertexFormatUChar2Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_UNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatUChar3Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_SNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatChar3Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatUChar3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatChar3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8_SRGB, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatUChar3Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_UNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_SNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorUInt8, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorInt8, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8_SRGB, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_UNORM, MTLPixelFormatRGBA8Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_SNORM, MTLPixelFormatRGBA8Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_UINT, MTLPixelFormatRGBA8Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_SINT, MTLPixelFormatRGBA8Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatChar4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R8G8B8A8_SRGB, MTLPixelFormatRGBA8Unorm_sRGB, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_UNORM, MTLPixelFormatBGRA8Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4Normalized_BGRA, MTLVertexFormatInvalid, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_SNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorUInt8, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorInt8, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B8G8R8A8_SRGB, MTLPixelFormatBGRA8Unorm_sRGB, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_UNORM_PACK32, MTLPixelFormatRGBA8Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_SNORM_PACK32, MTLPixelFormatRGBA8Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_USCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_SSCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_UINT_PACK32, MTLPixelFormatRGBA8Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_SINT_PACK32, MTLPixelFormatRGBA8Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatChar4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt8, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A8B8G8R8_SRGB_PACK32, MTLPixelFormatRGBA8Unorm_sRGB, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUChar4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_UNORM_PACK32, MTLPixelFormatBGR10A2Unorm, MTLPixelFormatInvalid, 11.0, 10.13, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_SNORM_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_USCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_SSCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_UINT_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorUInt16, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2R10G10B10_SINT_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorInt16, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-  
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_UNORM_PACK32, MTLPixelFormatRGB10A2Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUInt1010102Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_SNORM_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInt1010102Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_USCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_SSCALED_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_UINT_PACK32, MTLPixelFormatRGB10A2Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorUInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_FEATS ),		// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_A2B10G10R10_SINT_PACK32, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorInt16, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_UNORM, MTLPixelFormatR16Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatUShortNormalized, MTLVertexFormatUShort2Normalized, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_SNORM, MTLPixelFormatR16Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatShortNormalized, MTLVertexFormatShort2Normalized, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_UINT, MTLPixelFormatR16Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatUShort, MTLVertexFormatUShort2, 11.0, 10.13, kMVKFormatColorUInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_SINT, MTLPixelFormatR16Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatShort, MTLVertexFormatShort2, 11.0, 10.13, kMVKFormatColorInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16_SFLOAT, MTLPixelFormatR16Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 2, MTLVertexFormatHalf, MTLVertexFormatHalf2, 11.0, 10.13, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_UNORM, MTLPixelFormatRG16Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUShort2Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_SNORM, MTLPixelFormatRG16Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatShort2Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_UINT, MTLPixelFormatRG16Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUShort2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_SINT, MTLPixelFormatRG16Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatShort2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16_SFLOAT, MTLPixelFormatRG16Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatHalf2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_UNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatUShort3Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_SNORM, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatShort3Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatUShort3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatShort3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 6, MTLVertexFormatHalf3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_UNORM, MTLPixelFormatRGBA16Unorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatUShort4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_SNORM, MTLPixelFormatRGBA16Snorm, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatShort4Normalized, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_USCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_SSCALED, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_UINT, MTLPixelFormatRGBA16Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatUShort4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_SINT, MTLPixelFormatRGBA16Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatShort4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt16, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R16G16B16A16_SFLOAT, MTLPixelFormatRGBA16Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatHalf4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32_UINT, MTLPixelFormatR32Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatUInt, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32_SINT, MTLPixelFormatR32Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInt, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32_SFLOAT, MTLPixelFormatR32Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatFloat, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FLOAT32_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32_UINT, MTLPixelFormatRG32Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatUInt2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32_SINT, MTLPixelFormatRG32Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatInt2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32_SFLOAT, MTLPixelFormatRG32Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 8, MTLVertexFormatFloat2, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FLOAT32_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 12, MTLVertexFormatUInt3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 12, MTLVertexFormatInt3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 12, MTLVertexFormatFloat3, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FLOAT32_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32A32_UINT, MTLPixelFormatRGBA32Uint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 16, MTLVertexFormatUInt4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorUInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32A32_SINT, MTLPixelFormatRGBA32Sint, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 16, MTLVertexFormatInt4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorInt32, MVK_FMT_COLOR_INTEGER_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R32G32B32A32_SFLOAT, MTLPixelFormatRGBA32Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 16, MTLVertexFormatFloat4, MTLVertexFormatInvalid, 8.0, 10.11, kMVKFormatColorFloat, MVK_FMT_COLOR_FLOAT32_FEATS, MVK_FMT_BUFFER_VTX_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 24, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 24, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 24, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64A64_UINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 32, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64A64_SINT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 32, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_R64G64B64A64_SFLOAT, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 1, 1, 32, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_B10G11R11_UFLOAT_PACK32, MTLPixelFormatRG11B10Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),	// Vulkan packed is reversed
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, MTLPixelFormatRGB9E5Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_E5B9G9R9_FEATS, MVK_FMT_E5B9G9R9_BUFFER_FEATS ),	// Vulkan packed is reversed
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_D32_SFLOAT, MTLPixelFormatDepth32Float, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_D32_SFLOAT_S8_UINT, MTLPixelFormatDepth32Float_Stencil8, MTLPixelFormatInvalid, 9.0, 10.11, 1, 1, 5, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),
-
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_S8_UINT, MTLPixelFormatStencil8, MTLPixelFormatInvalid, 8.0, 10.11, 1, 1, 1, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_STENCIL_FEATS, MVK_FMT_NO_FEATS ),
-
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_D16_UNORM, MTLPixelFormatDepth16Unorm, MTLPixelFormatDepth32Float, kMTLFmtNA, 10.12, 1, 1, 2, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_D16_UNORM_S8_UINT, MTLPixelFormatInvalid, MTLPixelFormatDepth16Unorm_Stencil8, kMTLFmtNA, kMTLFmtNA, 1, 1, 3, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_D24_UNORM_S8_UINT, MTLPixelFormatDepth24Unorm_Stencil8, MTLPixelFormatDepth32Float_Stencil8, kMTLFmtNA, 10.11, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),
-
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_X8_D24_UNORM_PACK32, MTLPixelFormatInvalid, MTLPixelFormatDepth24Unorm_Stencil8, kMTLFmtNA, kMTLFmtNA, 1, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatDepthStencil, MVK_FMT_DEPTH_FEATS, MVK_FMT_NO_FEATS ),	// Vulkan packed is reversed
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC1_RGB_UNORM_BLOCK, MTLPixelFormatBC1_RGBA, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC1_RGB_SRGB_BLOCK, MTLPixelFormatBC1_RGBA_sRGB, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC1_RGBA_UNORM_BLOCK, MTLPixelFormatBC1_RGBA, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC1_RGBA_SRGB_BLOCK, MTLPixelFormatBC1_RGBA_sRGB, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC2_UNORM_BLOCK, MTLPixelFormatBC2_RGBA, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC2_SRGB_BLOCK, MTLPixelFormatBC2_RGBA_sRGB, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC3_UNORM_BLOCK, MTLPixelFormatBC3_RGBA, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC3_SRGB_BLOCK, MTLPixelFormatBC3_RGBA_sRGB, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC4_UNORM_BLOCK, MTLPixelFormatBC4_RUnorm, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC4_SNORM_BLOCK, MTLPixelFormatBC4_RSnorm, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC5_UNORM_BLOCK, MTLPixelFormatBC5_RGUnorm, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC5_SNORM_BLOCK, MTLPixelFormatBC5_RGSnorm, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC6H_UFLOAT_BLOCK, MTLPixelFormatBC6H_RGBUfloat, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC6H_SFLOAT_BLOCK, MTLPixelFormatBC6H_RGBFloat, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC7_UNORM_BLOCK, MTLPixelFormatBC7_RGBAUnorm, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_BC7_SRGB_BLOCK, MTLPixelFormatBC7_RGBAUnorm_sRGB, MTLPixelFormatInvalid, kMTLFmtNA, 10.11, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK, MTLPixelFormatETC2_RGB8, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK, MTLPixelFormatETC2_RGB8_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK, MTLPixelFormatETC2_RGB8A1, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK, MTLPixelFormatETC2_RGB8A1_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK, MTLPixelFormatEAC_RGBA8, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK, MTLPixelFormatEAC_RGBA8_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_EAC_R11_UNORM_BLOCK, MTLPixelFormatEAC_R11Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_EAC_R11_SNORM_BLOCK, MTLPixelFormatEAC_R11Snorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_EAC_R11G11_UNORM_BLOCK, MTLPixelFormatEAC_RG11Unorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_EAC_R11G11_SNORM_BLOCK, MTLPixelFormatEAC_RG11Snorm, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_4x4_UNORM_BLOCK, MTLPixelFormatASTC_4x4_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_4x4_SRGB_BLOCK, MTLPixelFormatASTC_4x4_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_5x4_UNORM_BLOCK, MTLPixelFormatASTC_5x4_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 5, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_5x4_SRGB_BLOCK, MTLPixelFormatASTC_5x4_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 5, 4, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_5x5_UNORM_BLOCK, MTLPixelFormatASTC_5x5_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 5, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_5x5_SRGB_BLOCK, MTLPixelFormatASTC_5x5_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 5, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_6x5_UNORM_BLOCK, MTLPixelFormatASTC_6x5_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 6, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_6x5_SRGB_BLOCK, MTLPixelFormatASTC_6x5_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 6, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_6x6_UNORM_BLOCK, MTLPixelFormatASTC_6x6_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 6, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_6x6_SRGB_BLOCK, MTLPixelFormatASTC_6x6_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 6, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x5_UNORM_BLOCK, MTLPixelFormatASTC_8x5_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x5_SRGB_BLOCK, MTLPixelFormatASTC_8x5_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x6_UNORM_BLOCK, MTLPixelFormatASTC_8x6_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x6_SRGB_BLOCK, MTLPixelFormatASTC_8x6_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x8_UNORM_BLOCK, MTLPixelFormatASTC_8x8_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 8, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_8x8_SRGB_BLOCK, MTLPixelFormatASTC_8x8_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 8, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x5_UNORM_BLOCK, MTLPixelFormatASTC_10x5_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x5_SRGB_BLOCK, MTLPixelFormatASTC_10x5_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 5, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x6_UNORM_BLOCK, MTLPixelFormatASTC_10x6_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x6_SRGB_BLOCK, MTLPixelFormatASTC_10x6_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 6, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x8_UNORM_BLOCK, MTLPixelFormatASTC_10x8_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 8, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x8_SRGB_BLOCK, MTLPixelFormatASTC_10x8_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 8, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x10_UNORM_BLOCK, MTLPixelFormatASTC_10x10_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 10, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_10x10_SRGB_BLOCK, MTLPixelFormatASTC_10x10_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 10, 10, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_12x10_UNORM_BLOCK, MTLPixelFormatASTC_12x10_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 12, 10, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_12x10_SRGB_BLOCK, MTLPixelFormatASTC_12x10_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 12, 10, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_12x12_UNORM_BLOCK, MTLPixelFormatASTC_12x12_LDR, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 12, 12, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_ASTC_12x12_SRGB_BLOCK, MTLPixelFormatASTC_12x12_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 12, 12, 16, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-
-	// Extension VK_IMG_format_pvrtc
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC1_2BPP_UNORM_BLOCK_IMG, MTLPixelFormatPVRTC_RGBA_2BPP, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC1_4BPP_UNORM_BLOCK_IMG, MTLPixelFormatPVRTC_RGBA_4BPP, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC2_2BPP_UNORM_BLOCK_IMG, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 8, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC2_4BPP_UNORM_BLOCK_IMG, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG, MTLPixelFormatPVRTC_RGBA_2BPP_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 8, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG, MTLPixelFormatPVRTC_RGBA_4BPP_sRGB, MTLPixelFormatInvalid, 8.0, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_COMPRESSED_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 8, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-	MVK_MAKE_FMT_STRUCT( VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG, MTLPixelFormatInvalid, MTLPixelFormatInvalid, kMTLFmtNA, kMTLFmtNA, 4, 4, 8, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatCompressed, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS ),
-
-    // Future extension VK_KHX_color_conversion and Vulkan 1.1.
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_UNDEFINED, MTLPixelFormatGBGR422, MTLPixelFormatInvalid, 8.0, 10.11, 2, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-    MVK_MAKE_FMT_STRUCT( VK_FORMAT_UNDEFINED, MTLPixelFormatBGRG422, MTLPixelFormatInvalid, 8.0, 10.11, 2, 1, 4, MTLVertexFormatInvalid, MTLVertexFormatInvalid, kMTLFmtNA, kMTLFmtNA, kMVKFormatColorFloat, MVK_FMT_COLOR_FEATS, MVK_FMT_BUFFER_FEATS ),
-};
-
-// Map for mapping large VkFormat values to an index.
-typedef unordered_map<uint32_t, uint32_t> MVKFormatIndexByVkFormatMap;
-
-// Vulkan core formats have small values and are mapped by simple lookup array.
-// Vulkan extension formats have larger values and are mapped by a map.
-// MVKFormatIndexByVkFormatMap held as global pointer to allow it to be populated during global init functions.
-static uint16_t _fmtDescIndicesByVkFormatsCore[_vkFormatCoreCount];
-static MVKFormatIndexByVkFormatMap* _pFmtDescIndicesByVkFormatsExt;
-
-// Metal formats have small values and are mapped by simple lookup array.
-static uint16_t _fmtDescIndicesByMTLPixelFormats[_mtlPixelFormatCount];
-static uint16_t _fmtDescIndicesByMTLVertexFormats[_mtlVertexFormatCount];
-
-/**
- * Populates the lookup maps that map Vulkan and Metal pixel formats to one-another.
- *
- * Because both Metal and core Vulkan format value are enumerations that start at zero and are 
- * more or less consecutively enumerated, we can use a simple lookup array in each direction
- * to map the value in one architecture (as an array index) to the corresponding value in the
- * other architecture. Values that exist in one API but not the other are given a default value.
- *
- * Vulkan extension formats have very large values, and are tracked in a separate map.
- */
-static void MVKInitFormatMaps() {
-
-    // Set all VkFormats and MTLPixelFormats to undefined/invalid
-    mvkClear(_fmtDescIndicesByVkFormatsCore, _vkFormatCoreCount);
-    mvkClear(_fmtDescIndicesByMTLPixelFormats, _mtlPixelFormatCount);
-    mvkClear(_fmtDescIndicesByMTLVertexFormats, _mtlVertexFormatCount);
-
-	_pFmtDescIndicesByVkFormatsExt = new MVKFormatIndexByVkFormatMap();
-
-	// Iterate through the format descriptions and populate the lookup maps.
-	uint32_t fmtCnt = sizeof(_formatDescriptions) / sizeof(MVKPlatformFormatDesc);
-	for (uint32_t fmtIdx = 0; fmtIdx < fmtCnt; fmtIdx++) {
-
-		// Access the mapping
-		const MVKPlatformFormatDesc& tfm = _formatDescriptions[fmtIdx];
-
-		// If the Vulkan format is defined, create a lookup between the Vulkan format
-        // and an index to the format info. For core Vulkan formats, which are small
-        // and consecutive, use a simple lookup array. For extension formats, use a map.
-        if (tfm.vk != VK_FORMAT_UNDEFINED) {
-            if (tfm.vk < _vkFormatCoreCount) {
-                _fmtDescIndicesByVkFormatsCore[tfm.vk] = fmtIdx;
-            } else {
-				(*_pFmtDescIndicesByVkFormatsExt)[tfm.vk] = fmtIdx;
-            }
-        }
-
-        // If the Metal format is defined, create a lookup between the Metal format and an
-        // index to the format info. Metal formats are small, so use a simple lookup array.
-		if (tfm.mtl != MTLPixelFormatInvalid && !_fmtDescIndicesByMTLPixelFormats[tfm.mtl]) {
-			_fmtDescIndicesByMTLPixelFormats[tfm.mtl] = fmtIdx;
-		}
-		if (tfm.mtlVertexFormat != MTLVertexFormatInvalid && !_fmtDescIndicesByMTLVertexFormats[tfm.mtlVertexFormat]) {
-			_fmtDescIndicesByMTLVertexFormats[tfm.mtlVertexFormat] = fmtIdx;
-		}
-	}
-}
-
-// Return a reference to the format description corresponding to the VkFormat.
-inline const MVKPlatformFormatDesc& formatDescForVkFormat(VkFormat vkFormat) {
-	uint16_t fmtIdx = (vkFormat < _vkFormatCoreCount) ? _fmtDescIndicesByVkFormatsCore[vkFormat] : (*_pFmtDescIndicesByVkFormatsExt)[vkFormat];
-    return _formatDescriptions[fmtIdx];
-}
-
-// Return a reference to the format description corresponding to the MTLPixelFormat.
-inline const MVKPlatformFormatDesc& formatDescForMTLPixelFormat(MTLPixelFormat mtlFormat) {
-    uint16_t fmtIdx = (mtlFormat < _mtlPixelFormatCount) ? _fmtDescIndicesByMTLPixelFormats[mtlFormat] : 0;
-    return _formatDescriptions[fmtIdx];
-}
-
-// Return a reference to the format description corresponding to the MTLVertexFormat.
-inline const MVKPlatformFormatDesc& formatDescForMTLVertexFormat(MTLVertexFormat mtlFormat) {
-    uint16_t fmtIdx = (mtlFormat < _mtlVertexFormatCount) ? _fmtDescIndicesByMTLVertexFormats[mtlFormat] : 0;
-    return _formatDescriptions[fmtIdx];
-}
-
 MVK_PUBLIC_SYMBOL bool mvkVkFormatIsSupported(VkFormat vkFormat) {
-	return formatDescForVkFormat(vkFormat).isSupported();
+	return _platformPixelFormats.vkFormatIsSupported(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL bool mvkMTLPixelFormatIsSupported(MTLPixelFormat mtlFormat) {
-	return formatDescForMTLPixelFormat(mtlFormat).isSupported();
+	return _platformPixelFormats.mtlPixelFormatIsSupported(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MVKFormatType mvkFormatTypeFromVkFormat(VkFormat vkFormat) {
-	return formatDescForVkFormat(vkFormat).formatType;
+	return _platformPixelFormats.getFormatTypeFromVkFormat(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL MVKFormatType mvkFormatTypeFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
-	return formatDescForMTLPixelFormat(mtlFormat).formatType;
+	return _platformPixelFormats.getFormatTypeFromMTLPixelFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLPixelFormat mvkMTLPixelFormatFromVkFormat(VkFormat vkFormat) {
-	MTLPixelFormat mtlPixFmt = MTLPixelFormatInvalid;
-
-	const MVKPlatformFormatDesc& fmtDesc = formatDescForVkFormat(vkFormat);
-	if (fmtDesc.isSupported()) {
-		mtlPixFmt = fmtDesc.mtl;
-	} else if (vkFormat != VK_FORMAT_UNDEFINED) {
-		// If the MTLPixelFormat is not supported but VkFormat is valid, attempt to substitute a different format.
-		mtlPixFmt = fmtDesc.mtlSubstitute;
-
-		// Report an error if there is no substitute, or the first time a substitution is made.
-		if ( !mtlPixFmt || !fmtDesc.hasReportedSubstitution ) {
-			string errMsg;
-			errMsg += "VkFormat ";
-			errMsg += (fmtDesc.vkName) ? fmtDesc.vkName : to_string(fmtDesc.vk);
-			errMsg += " is not supported on this device.";
-
-			if (mtlPixFmt) {
-				((MVKPlatformFormatDesc*)&fmtDesc)->hasReportedSubstitution = true;
-
-				const MVKPlatformFormatDesc& fmtDescSubs = formatDescForMTLPixelFormat(mtlPixFmt);
-				errMsg += " Using VkFormat ";
-				errMsg += (fmtDescSubs.vkName) ? fmtDescSubs.vkName : to_string(fmtDescSubs.vk);
-				errMsg += " instead.";
-			}
-			MVKBaseObject::reportError(nullptr, VK_ERROR_FORMAT_NOT_SUPPORTED, "%s", errMsg.c_str());
-		}
-	}
-
-	return mtlPixFmt;
+	return _platformPixelFormats.getMTLPixelFormatFromVkFormat(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkFormat mvkVkFormatFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
-    return formatDescForMTLPixelFormat(mtlFormat).vk;
+	return _platformPixelFormats.getVkFormatFromMTLPixelFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkVkFormatBytesPerBlock(VkFormat vkFormat) {
-    return formatDescForVkFormat(vkFormat).bytesPerBlock;
+	return _platformPixelFormats.getVkFormatBytesPerBlock(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkMTLPixelFormatBytesPerBlock(MTLPixelFormat mtlFormat) {
-    return formatDescForMTLPixelFormat(mtlFormat).bytesPerBlock;
+	return _platformPixelFormats.getMTLPixelFormatBytesPerBlock(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkExtent2D mvkVkFormatBlockTexelSize(VkFormat vkFormat) {
-    return formatDescForVkFormat(vkFormat).blockTexelSize;
+	return _platformPixelFormats.getVkFormatBlockTexelSize(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkExtent2D mvkMTLPixelFormatBlockTexelSize(MTLPixelFormat mtlFormat) {
-    return formatDescForMTLPixelFormat(mtlFormat).blockTexelSize;
+	return _platformPixelFormats.getMTLPixelFormatBlockTexelSize(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL float mvkVkFormatBytesPerTexel(VkFormat vkFormat) {
-    return formatDescForVkFormat(vkFormat).bytesPerTexel();
+	return _platformPixelFormats.getVkFormatBytesPerTexel(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL float mvkMTLPixelFormatBytesPerTexel(MTLPixelFormat mtlFormat) {
-    return formatDescForMTLPixelFormat(mtlFormat).bytesPerTexel();
+	return _platformPixelFormats.getMTLPixelFormatBytesPerTexel(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkVkFormatBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow) {
-    const MVKPlatformFormatDesc& fmtDesc = formatDescForVkFormat(vkFormat);
-    return mvkCeilingDivide(texelsPerRow, fmtDesc.blockTexelSize.width) * fmtDesc.bytesPerBlock;
+	return _platformPixelFormats.getVkFormatBytesPerRow(vkFormat, texelsPerRow);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkMTLPixelFormatBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow) {
-    const MVKPlatformFormatDesc& fmtDesc = formatDescForMTLPixelFormat(mtlFormat);
-    return mvkCeilingDivide(texelsPerRow, fmtDesc.blockTexelSize.width) * fmtDesc.bytesPerBlock;
+	return _platformPixelFormats.getMTLPixelFormatBytesPerRow(mtlFormat, texelsPerRow);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkVkFormatBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-    return mvkCeilingDivide(texelRowsPerLayer, formatDescForVkFormat(vkFormat).blockTexelSize.height) * bytesPerRow;
+	return _platformPixelFormats.getVkFormatBytesPerLayer(vkFormat, bytesPerRow, texelRowsPerLayer);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkMTLPixelFormatBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-    return mvkCeilingDivide(texelRowsPerLayer, formatDescForMTLPixelFormat(mtlFormat).blockTexelSize.height) * bytesPerRow;
+	return _platformPixelFormats.getMTLPixelFormatBytesPerLayer(mtlFormat, bytesPerRow, texelRowsPerLayer);
 }
 
-MVK_PUBLIC_SYMBOL VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat, bool assumeGPUSupportsDefault) {
-	VkFormatProperties fmtProps = {MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS, MVK_FMT_NO_FEATS};
-	const MVKPlatformFormatDesc& fmtDesc = formatDescForVkFormat(vkFormat);
-	if (assumeGPUSupportsDefault && fmtDesc.isSupported()) {
-		fmtProps = fmtDesc.properties;
-		if (!fmtDesc.vertexIsSupportedOrSubstitutable()) {
-			fmtProps.bufferFeatures &= ~VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
-		}
-	} else {
-		// If texture format is unsupported, vertex buffer format may still be.
-		fmtProps.bufferFeatures |= fmtDesc.properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT;
-	}
-	return fmtProps;
+MVK_PUBLIC_SYMBOL VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat) {
+	return _platformPixelFormats.getVkFormatProperties(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL const char* mvkVkFormatName(VkFormat vkFormat) {
-    return formatDescForVkFormat(vkFormat).vkName;
+	return _platformPixelFormats.getVkFormatName(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL const char* mvkMTLPixelFormatName(MTLPixelFormat mtlFormat) {
-    return formatDescForMTLPixelFormat(mtlFormat).mtlName;
+	return _platformPixelFormats.getMTLPixelFormatName(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLVertexFormat mvkMTLVertexFormatFromVkFormat(VkFormat vkFormat) {
-    MTLVertexFormat mtlVtxFmt = MTLVertexFormatInvalid;
-    const MVKPlatformFormatDesc& fmtDesc = formatDescForVkFormat(vkFormat);
-    if (fmtDesc.vertexIsSupported()) {
-        mtlVtxFmt = fmtDesc.mtlVertexFormat;
-    } else if (vkFormat != VK_FORMAT_UNDEFINED) {
-        // If the MTLVertexFormat is not supported but VkFormat is valid,
-        // report an error, and possibly substitute a different MTLVertexFormat.
-        string errMsg;
-        errMsg += "VkFormat ";
-        errMsg += (fmtDesc.vkName) ? fmtDesc.vkName : to_string(fmtDesc.vk);
-        errMsg += " is not supported for vertex buffers on this device.";
-
-        if (fmtDesc.vertexIsSupportedOrSubstitutable()) {
-            mtlVtxFmt = fmtDesc.mtlVertexFormatSubstitute;
-
-            const MVKPlatformFormatDesc& fmtDescSubs = formatDescForMTLVertexFormat(mtlVtxFmt);
-            errMsg += " Using VkFormat ";
-            errMsg += (fmtDescSubs.vkName) ? fmtDescSubs.vkName : to_string(fmtDescSubs.vk);
-            errMsg += " instead.";
-        }
-		MVKBaseObject::reportError(nullptr, VK_ERROR_FORMAT_NOT_SUPPORTED, "%s", errMsg.c_str());
-    }
-
-    return mtlVtxFmt;
+	return _platformPixelFormats.getMTLVertexFormatFromVkFormat(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLClearColor mvkMTLClearColorFromVkClearValue(VkClearValue vkClearValue,
@@ -1436,23 +854,4 @@ bool mvkTreatTexture1DAs2D() {
 	}
 	return _mvkTexture1DAs2D;
 }
-
-
-#pragma mark -
-#pragma mark Library initialization
-
-/**
- * Called automatically when the framework is loaded and initialized.
- *
- * Initialize various data type lookups.
- */
-static bool _mvkDataTypesInitialized = false;
-__attribute__((constructor)) static void MVKInitDataTypes() {
-	if (_mvkDataTypesInitialized ) { return; }
-	_mvkDataTypesInitialized = true;
-
-	MVKInitFormatMaps();
-}
-
-	
 

--- a/MoltenVKPackaging.xcodeproj/project.pbxproj
+++ b/MoltenVKPackaging.xcodeproj/project.pbxproj
@@ -248,7 +248,7 @@
 		A90B2B1D1A9B6170008EE819 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 				TargetAttributes = {
 					A9FEADBC1F3517480010240E = {
 						DevelopmentTeam = VU3TCKU48B;

--- a/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (Debug).xcscheme
+++ b/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (Debug).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (iOS only).xcscheme
+++ b/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (iOS only).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (macOS only).xcscheme
+++ b/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package (macOS only).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package.xcscheme
+++ b/MoltenVKPackaging.xcodeproj/xcshareddata/xcschemes/MoltenVK Package.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -415,7 +415,7 @@
 		A9F55D25198BE6A7004EC31B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = "The Brenwill Workshop Ltd.";
 				TargetAttributes = {
 					A9092A8C1A81717B00051823 = {

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKGLSLToSPIRVConverter-iOS.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKGLSLToSPIRVConverter-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKGLSLToSPIRVConverter-macOS.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKGLSLToSPIRVConverter-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKSPIRVToMSLConverter-iOS.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKSPIRVToMSLConverter-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKSPIRVToMSLConverter-macOS.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKSPIRVToMSLConverter-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1140"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Accurately populate Vulkan `VkFormatProperties` and capabilities from documented `MTLPixelFormat` capabilities, taking into consideration variations across `MTLDevice` Features Sets.

Fixes reporting requirement of #828.