### PR TITLE
MVKBuffer: Support texel buffers in "host-coherent" memory on Mac.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -72,7 +72,7 @@ public:
 	id<MTLBuffer> getMTLBuffer();
 
 	/** Returns the offset at which the contents of this instance starts within the underlying Metal buffer. */
-	inline NSUInteger getMTLBufferOffset() { return _deviceMemory && _deviceMemory->getMTLHeap() ? 0 : _deviceMemoryOffset; }
+	inline NSUInteger getMTLBufferOffset() { return _deviceMemory && _deviceMemory->getMTLHeap() && !_isHostCoherentTexelBuffer ? 0 : _deviceMemoryOffset; }
 
 
 #pragma mark Construction
@@ -82,14 +82,19 @@ public:
 	~MVKBuffer() override;
 
 protected:
+	friend class MVKDeviceMemory;
 	using MVKResource::needsHostReadSync;
 
 	void propogateDebugName() override;
 	bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
 						   VkPipelineStageFlags dstStageMask,
 						   VkBufferMemoryBarrier* pBufferMemoryBarrier);
+	bool shouldFlushHostMemory();
+	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
+	VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);
 
 	VkBufferUsageFlags _usage;
+	bool _isHostCoherentTexelBuffer = false;
 	id<MTLBuffer> _mtlBuffer = nil;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -93,6 +93,7 @@ VkResult MVKDeviceMemory::flushToDevice(VkDeviceSize offset, VkDeviceSize size, 
 		if (!_mtlHeap) {
 			lock_guard<mutex> lock(_rezLock);
 			for (auto& img : _images) { img->flushToDevice(offset, memSize); }
+			for (auto& buf : _buffers) { buf->flushToDevice(offset, memSize); }
 		}
 	}
 	return VK_SUCCESS;
@@ -107,6 +108,7 @@ VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset,
 	if (memSize > 0 && isMemoryHostAccessible() && (evenIfCoherent || !isMemoryHostCoherent()) && !_mtlHeap) {
 		lock_guard<mutex> lock(_rezLock);
         for (auto& img : _images) { img->pullFromDevice(offset, memSize); }
+        for (auto& buf : _buffers) { buf->pullFromDevice(offset, memSize); }
 
 #if MVK_MACOS
 		if (pBlitEnc && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {


### PR DESCRIPTION
According to the Vulkan spec:

> * If `buffer` is a `VkBuffer` not created with the
>   `VK_BUFFER_CREATE_SPARSE_BINDING_BIT` bit set[...] then the
>   `memoryTypeBits` member always contains at least one bit set
>   corresponding to a `VkMemoryType` with a `propertyFlags` that has
>   both the `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT` bit and the
>   `VK_MEMORY_PROPERTY_HOST_COHERENT_BIT` bit set. In other words,
>   mappable coherent memory **can** always be attached to these
>   objects.

There is no exception for texel buffers. Even though desktop Metal
disallows textures in shared memory, even linear textures created from a
buffer, we have to advertise host-coherent memory for texel buffers.
Some applications actually depend on this behavior, so it's not just a
theoretical concern.

To support host-coherent texel buffers, we implicitly create a managed
buffer and copy data between the device memory and the managed buffer,
just like for a linear image.