### PR TITLE
MVKDescriptor: Pass buffers to shaders that do atomic image accesses.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -291,9 +291,9 @@ protected:
 	MVKMTLFormatDesc& getMTLPixelFormatDesc(MTLPixelFormat mtlFormat);
 	MVKMTLFormatDesc& getMTLVertexFormatDesc(VkFormat vkFormat);
 	MVKMTLFormatDesc& getMTLVertexFormatDesc(MTLVertexFormat mtlFormat);
-	VkFormatFeatureFlags getOptimalTilingFeatures(MVKMTLFmtCaps mtlFmtCaps);
-	VkFormatFeatureFlags getLinearTilingFeatures(MVKMTLFmtCaps mtlFmtCaps, MVKFormatType mvkFmtType);
-	VkFormatFeatureFlags getBufferFeatures(MVKMTLFmtCaps mtlFmtTexCaps, MVKMTLFmtCaps mtlFmtVtxCaps, MVKFormatType mvkFmtType);
+	VkFormatFeatureFlags getOptimalTilingFeatures(VkFormat vkFormat, MVKMTLFmtCaps mtlFmtCaps);
+	VkFormatFeatureFlags getLinearTilingFeatures(VkFormat vkFormat, MVKMTLFmtCaps mtlFmtCaps, MVKFormatType mvkFmtType);
+	VkFormatFeatureFlags getBufferFeatures(VkFormat vkFormat, MVKMTLFmtCaps mtlFmtTexCaps, MVKMTLFmtCaps mtlFmtVtxCaps, MVKFormatType mvkFmtType);
 	void initVkFormatCapabilities();
 	void initMTLPixelFormatCapabilities();
 	void initMTLVertexFormatCapabilities();


### PR DESCRIPTION
Special thanks to Epic Games for contributing the underlying support to
SPIRV-Cross.

Metal does not support atomic image accesses, but we can work around
that. For buffer views, and for linear image views, we can pass the
underlying buffer to the shader and do atomic accesses on that. For now,
we only support this for `VK_FORMAT_R32_UINT` and `VK_FORMAT_R32_SINT`,
as required by the Vulkan standard; it should theoretically be possible
to extend this to any format where the size of a pixel is 32 bits. Metal
does not yet support 16-bit or 8-bit atomic access, so those formats are
out for now.

Unfortunately, we cannot yet support this for optimal-tiled images, even
though Vulkan requires it. These images do not have a buffer backing
them. Possible alternatives and their downsides:

* Pass a buffer, probably the buffer backing the device memory, for
  these images. But this would defeat the purpose of atomic access--the
  buffer and image would not be consistent until afterward when their
  contents were sync'd. Using a heap with aliased resources would
  eliminate this problem... but, optimal tiling.
* Lie and create a linear image for a format supporting atomic image
  access. But that only works for 1D and 2D images with one array slice
  and one mip level. Also, this would likely hurt performance, because
  the GPU can no longer rely on optimal layout.