### PR TITLE
In MVKCommand subclasses, replace holding Metal content with holding smaller Vulkan equivalents.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.h
@@ -40,7 +40,12 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-    MTLRegion  _mtlThreadgroupCount;
+	uint32_t _baseGroupX;
+	uint32_t _baseGroupY;
+	uint32_t _baseGroupZ;
+	uint32_t _groupCountX;
+	uint32_t _groupCountY;
+	uint32_t _groupCountZ;
 };
 
 
@@ -59,6 +64,6 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	id<MTLBuffer> _mtlIndirectBuffer;
-	NSUInteger _mtlIndirectBufferOffset;
+	VkDeviceSize _mtlIndirectBufferOffset;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
@@ -139,7 +139,7 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	id<MTLBuffer> _mtlIndirectBuffer;
-	NSUInteger _mtlIndirectBufferOffset;
+	VkDeviceSize _mtlIndirectBufferOffset;
 	uint32_t _mtlIndirectBufferStride;
 	uint32_t _drawCount;
 };

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -125,7 +125,7 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	uint32_t _firstViewport;
-	MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports;
+	MVKVectorInline<VkViewport, kMVKCachedViewportScissorCount> _viewports;
 };
 
 
@@ -147,7 +147,7 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	uint32_t _firstScissor;
-	MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors;
+	MVKVectorInline<VkRect2D, kMVKCachedViewportScissorCount> _scissors;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -124,17 +124,17 @@ VkResult MVKCmdSetViewport::setContent(MVKCommandBuffer* cmdBuff,
 									   uint32_t viewportCount,
 									   const VkViewport* pViewports) {
 	_firstViewport = firstViewport;
-	_mtlViewports.clear();	// Clear for reuse
-	_mtlViewports.reserve(viewportCount);
-	for (uint32_t i = 0; i < viewportCount; i++) {
-		_mtlViewports.push_back(mvkMTLViewportFromVkViewport(pViewports[i]));
+	_viewports.clear();	// Clear for reuse
+	_viewports.reserve(viewportCount);
+	for (uint32_t vpIdx = 0; vpIdx < viewportCount; vpIdx++) {
+		_viewports.push_back(pViewports[vpIdx]);
 	}
 
 	return VK_SUCCESS;
 }
 
 void MVKCmdSetViewport::encode(MVKCommandEncoder* cmdEncoder) {
-    cmdEncoder->_viewportState.setViewports(_mtlViewports, _firstViewport, true);
+    cmdEncoder->_viewportState.setViewports(_viewports, _firstViewport, true);
 }
 
 
@@ -148,17 +148,17 @@ VkResult MVKCmdSetScissor::setContent(MVKCommandBuffer* cmdBuff,
 									  uint32_t scissorCount,
 									  const VkRect2D* pScissors) {
 	_firstScissor = firstScissor;
-	_mtlScissors.clear();	// Clear for reuse
-	_mtlScissors.reserve(scissorCount);
-	for (uint32_t i = 0; i < scissorCount; i++) {
-		_mtlScissors.push_back(mvkMTLScissorRectFromVkRect2D(pScissors[i]));
+	_scissors.clear();	// Clear for reuse
+	_scissors.reserve(scissorCount);
+	for (uint32_t sIdx = 0; sIdx < scissorCount; sIdx++) {
+		_scissors.push_back(pScissors[sIdx]);
 	}
 
 	return VK_SUCCESS;
 }
 
 void MVKCmdSetScissor::encode(MVKCommandEncoder* cmdEncoder) {
-    cmdEncoder->_scissorState.setScissors(_mtlScissors, _firstScissor, true);
+    cmdEncoder->_scissorState.setScissors(_scissors, _firstScissor, true);
 }
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -64,8 +64,6 @@ protected:
 	VkImageLayout _srcLayout;
 	MVKImage* _dstImage;
 	VkImageLayout _dstLayout;
-	MTLPixelFormat _srcMTLPixFmt;
-	MTLPixelFormat _dstMTLPixFmt;
 	uint32_t _srcSampleCount;
 	uint32_t _dstSampleCount;
 	bool _isSrcCompressed;
@@ -131,8 +129,8 @@ protected:
 
 /** Describes Metal texture resolve parameters. */
 typedef struct {
-    NSUInteger	level;
-    NSUInteger	slice;
+    uint32_t	level;
+    uint32_t	slice;
 } MVKMetalResolveSlice;
 
 /** Vulkan command to resolve image regions. */
@@ -282,9 +280,7 @@ protected:
     MVKImage* _image;
     VkImageLayout _imgLayout;
 	MVKVectorInline<VkImageSubresourceRange, 4> _subresourceRanges;
-	MTLClearColor _mtlColorClearValue;
-	double _mtlDepthClearValue;
-    uint32_t _mtlStencilClearValue;
+	VkClearValue _clearValue;
     bool _isDepthStencilClear;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -295,7 +295,7 @@ public:
     bool supportsDynamicState(VkDynamicState state);
 
 	/** Clips the scissor to ensure it fits inside the render area.  */
-	MTLScissorRect clipToRenderArea(MTLScissorRect mtlScissor);
+	VkRect2D clipToRenderArea(VkRect2D scissor);
 
 	/** Called by each graphics draw command to establish any outstanding state just prior to performing the draw. */
 	void finalizeDrawState(MVKGraphicsStage stage);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -373,19 +373,19 @@ bool MVKCommandEncoder::supportsDynamicState(VkDynamicState state) {
     return !gpl || gpl->supportsDynamicState(state);
 }
 
-MTLScissorRect MVKCommandEncoder::clipToRenderArea(MTLScissorRect mtlScissor) {
+VkRect2D MVKCommandEncoder::clipToRenderArea(VkRect2D scissor) {
 
-	NSUInteger raLeft = _renderArea.offset.x;
-	NSUInteger raRight = raLeft + _renderArea.extent.width;
-	NSUInteger raBottom = _renderArea.offset.y;
-	NSUInteger raTop = raBottom + _renderArea.extent.height;
+	int32_t raLeft = _renderArea.offset.x;
+	int32_t raRight = raLeft + _renderArea.extent.width;
+	int32_t raBottom = _renderArea.offset.y;
+	int32_t raTop = raBottom + _renderArea.extent.height;
 
-	mtlScissor.x		= mvkClamp(mtlScissor.x, raLeft, max(raRight - 1, raLeft));
-	mtlScissor.y		= mvkClamp(mtlScissor.y, raBottom, max(raTop - 1, raBottom));
-	mtlScissor.width	= min(mtlScissor.width, raRight - mtlScissor.x);
-	mtlScissor.height	= min(mtlScissor.height, raTop - mtlScissor.y);
+	scissor.offset.x		= mvkClamp(scissor.offset.x, raLeft, max(raRight - 1, raLeft));
+	scissor.offset.y		= mvkClamp(scissor.offset.y, raBottom, max(raTop - 1, raBottom));
+	scissor.extent.width	= min<int32_t>(scissor.extent.width, raRight - scissor.offset.x);
+	scissor.extent.height	= min<int32_t>(scissor.extent.height, raTop - scissor.offset.y);
 
-	return mtlScissor;
+	return scissor;
 }
 
 void MVKCommandEncoder::finalizeDrawState(MVKGraphicsStage stage) {

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -140,7 +140,7 @@ public:
 	 * The isSettingDynamically indicates that the scissor is being changed dynamically,
 	 * which is only allowed if the pipeline was created as VK_DYNAMIC_STATE_SCISSOR.
 	 */
-	void setViewports(const MVKVector<MTLViewport> &mtlViewports,
+	void setViewports(const MVKVector<VkViewport> &viewports,
 					  uint32_t firstViewport,
 					  bool isSettingDynamically);
 
@@ -152,7 +152,7 @@ protected:
     void encodeImpl(uint32_t stage) override;
     void resetImpl() override;
 
-    MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports, _mtlDynamicViewports;
+    MVKVectorInline<VkViewport, kMVKCachedViewportScissorCount> _viewports, _dynamicViewports;
 };
 
 
@@ -169,7 +169,7 @@ public:
 	 * The isSettingDynamically indicates that the scissor is being changed dynamically,
 	 * which is only allowed if the pipeline was created as VK_DYNAMIC_STATE_SCISSOR.
 	 */
-	void setScissors(const MVKVector<MTLScissorRect> &mtlScissors,
+	void setScissors(const MVKVector<VkRect2D> &scissors,
 					 uint32_t firstScissor,
 					 bool isSettingDynamically);
 
@@ -181,7 +181,7 @@ protected:
     void encodeImpl(uint32_t stage) override;
     void resetImpl() override;
 
-    MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors, _mtlDynamicScissors;
+    MVKVectorInline<VkRect2D, kMVKCachedViewportScissorCount> _scissors, _dynamicScissors;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -269,8 +269,8 @@ protected:
 	VkPipelineRasterizationStateCreateInfo _rasterInfo;
 	VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
 
-	MVKVectorInline<MTLViewport, kMVKCachedViewportScissorCount> _mtlViewports;
-	MVKVectorInline<MTLScissorRect, kMVKCachedViewportScissorCount> _mtlScissors;
+	MVKVectorInline<VkViewport, kMVKCachedViewportScissorCount> _viewports;
+	MVKVectorInline<VkRect2D, kMVKCachedViewportScissorCount> _scissors;
 
 	MTLComputePipelineDescriptor* _mtlTessControlStageDesc = nil;
 


### PR DESCRIPTION
Use just in time convert to Metal values.