### PR TITLE
Rename most MVKPixelFormats member functions to eliminate naming redundancy.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -328,14 +328,14 @@ void MVKDepthStencilCommandEncoderState::setStencilWriteMask(VkStencilFaceFlags 
 void MVKDepthStencilCommandEncoderState::beginMetalRenderPass() {
 	MVKRenderSubpass* mvkSubpass = _cmdEncoder->getSubpass();
 	MVKPixelFormats* pixFmts = _cmdEncoder->getPixelFormats();
-	MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormatFromVkFormat(mvkSubpass->getDepthStencilFormat());
+	MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(mvkSubpass->getDepthStencilFormat());
 
 	bool prevHasDepthAttachment = _hasDepthAttachment;
-	_hasDepthAttachment = pixFmts->mtlPixelFormatIsDepthFormat(mtlDSFormat);
+	_hasDepthAttachment = pixFmts->isDepthFormat(mtlDSFormat);
 	if (_hasDepthAttachment != prevHasDepthAttachment) { markDirty(); }
 
 	bool prevHasStencilAttachment = _hasStencilAttachment;
-	_hasStencilAttachment = pixFmts->mtlPixelFormatIsStencilFormat(mtlDSFormat);
+	_hasStencilAttachment = pixFmts->isStencilFormat(mtlDSFormat);
 	if (_hasStencilAttachment != prevHasStencilAttachment) { markDirty(); }
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -118,8 +118,8 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
     }
 	MVKPixelFormats* pixFmts = getPixelFormats();
     MTLPixelFormat mtlDSFormat = (MTLPixelFormat)attKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex];
-    if (pixFmts->mtlPixelFormatIsDepthFormat(mtlDSFormat)) { plDesc.depthAttachmentPixelFormat = mtlDSFormat; }
-    if (pixFmts->mtlPixelFormatIsStencilFormat(mtlDSFormat)) { plDesc.stencilAttachmentPixelFormat = mtlDSFormat; }
+    if (pixFmts->isDepthFormat(mtlDSFormat)) { plDesc.depthAttachmentPixelFormat = mtlDSFormat; }
+    if (pixFmts->isStencilFormat(mtlDSFormat)) { plDesc.stencilAttachmentPixelFormat = mtlDSFormat; }
 
     MTLVertexDescriptor* vtxDesc = plDesc.vertexDescriptor;
 
@@ -277,7 +277,7 @@ id<MTLFunction> MVKCommandResourceFactory::newClearFragFunction(MVKRPSKeyClearAt
 }
 
 NSString* MVKCommandResourceFactory::getMTLFormatTypeString(MTLPixelFormat mtlPixFmt) {
-	switch (getPixelFormats()->getFormatTypeFromMTLPixelFormat(mtlPixFmt)) {
+	switch (getPixelFormats()->getFormatType(mtlPixFmt)) {
 		case kMVKFormatColorHalf:		return @"half";
 		case kMVKFormatColorFloat:		return @"float";
 		case kMVKFormatColorInt8:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -251,9 +251,9 @@ MVKBufferView::MVKBufferView(MVKDevice* device, const VkBufferViewCreateInfo* pC
 	MVKPixelFormats* pixFmts = getPixelFormats();
     _buffer = (MVKBuffer*)pCreateInfo->buffer;
     _mtlBufferOffset = _buffer->getMTLBufferOffset() + pCreateInfo->offset;
-    _mtlPixelFormat = pixFmts->getMTLPixelFormatFromVkFormat(pCreateInfo->format);
-    VkExtent2D fmtBlockSize = pixFmts->getVkFormatBlockTexelSize(pCreateInfo->format);  // Pixel size of format
-    size_t bytesPerBlock = pixFmts->getVkFormatBytesPerBlock(pCreateInfo->format);
+    _mtlPixelFormat = pixFmts->getMTLPixelFormat(pCreateInfo->format);
+    VkExtent2D fmtBlockSize = pixFmts->getBlockTexelSize(pCreateInfo->format);  // Pixel size of format
+    size_t bytesPerBlock = pixFmts->getBytesPerBlock(pCreateInfo->format);
 	_mtlTexture = nil;
 
     // Layout texture as a 1D array of texel blocks (which are texels for non-compressed textures) that covers the bytes

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -126,76 +126,76 @@ public:
 	MVKVulkanAPIObject* getVulkanAPIObject() override;
 
 	/** Returns whether the VkFormat is supported by this implementation. */
-	bool vkFormatIsSupported(VkFormat vkFormat);
+	bool isSupported(VkFormat vkFormat);
 
 	/** Returns whether the VkFormat is supported by this implementation, or can be substituted by one that is. */
-	bool vkFormatIsSupportedOrSubstitutable(VkFormat vkFormat);
+	bool isSupportedOrSubstitutable(VkFormat vkFormat);
 
 	/** Returns whether the MTLPixelFormat is supported by this implementation. */
-	bool mtlPixelFormatIsSupported(MTLPixelFormat mtlFormat);
+	bool isSupported(MTLPixelFormat mtlFormat);
 
 	/** Returns whether the specified Metal MTLPixelFormat can be used as a depth format. */
-	bool mtlPixelFormatIsDepthFormat(MTLPixelFormat mtlFormat);
+	bool isDepthFormat(MTLPixelFormat mtlFormat);
 
 	/** Returns whether the specified Metal MTLPixelFormat can be used as a stencil format. */
-	bool mtlPixelFormatIsStencilFormat(MTLPixelFormat mtlFormat);
+	bool isStencilFormat(MTLPixelFormat mtlFormat);
 
 	/** Returns whether the specified Metal MTLPixelFormat is a PVRTC format. */
-	bool mtlPixelFormatIsPVRTCFormat(MTLPixelFormat mtlFormat);
+	bool isPVRTCFormat(MTLPixelFormat mtlFormat);
 
 	/** Returns the format type corresponding to the specified Vulkan VkFormat, */
-	MVKFormatType getFormatTypeFromVkFormat(VkFormat vkFormat);
+	MVKFormatType getFormatType(VkFormat vkFormat);
 
 	/** Returns the format type corresponding to the specified Metal MTLPixelFormat, */
-	MVKFormatType getFormatTypeFromMTLPixelFormat(MTLPixelFormat mtlFormat);
+	MVKFormatType getFormatType(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the Metal MTLPixelFormat corresponding to the specified Vulkan VkFormat,
 	 * or returns MTLPixelFormatInvalid if no corresponding MTLPixelFormat exists.
 	 */
-	MTLPixelFormat getMTLPixelFormatFromVkFormat(VkFormat vkFormat);
+	MTLPixelFormat getMTLPixelFormat(VkFormat vkFormat);
 
 	/**
 	 * Returns the Vulkan VkFormat corresponding to the specified Metal MTLPixelFormat,
 	 * or returns VK_FORMAT_UNDEFINED if no corresponding VkFormat exists.
 	 */
-	VkFormat getVkFormatFromMTLPixelFormat(MTLPixelFormat mtlFormat);
+	VkFormat getVkFormat(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the size, in bytes, of a texel block of the specified Vulkan format.
 	 * For uncompressed formats, the returned value corresponds to the size in bytes of a single texel.
 	 */
-	uint32_t getVkFormatBytesPerBlock(VkFormat vkFormat);
+	uint32_t getBytesPerBlock(VkFormat vkFormat);
 
 	/**
 	 * Returns the size, in bytes, of a texel block of the specified Metal format.
 	 * For uncompressed formats, the returned value corresponds to the size in bytes of a single texel.
 	 */
-	uint32_t getMTLPixelFormatBytesPerBlock(MTLPixelFormat mtlFormat);
+	uint32_t getBytesPerBlock(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the size of the compression block, measured in texels for a Vulkan format.
 	 * The returned value will be {1, 1} for non-compressed formats.
 	 */
-	VkExtent2D getVkFormatBlockTexelSize(VkFormat vkFormat);
+	VkExtent2D getBlockTexelSize(VkFormat vkFormat);
 
 	/**
 	 * Returns the size of the compression block, measured in texels for a Metal format.
 	 * The returned value will be {1, 1} for non-compressed formats.
 	 */
-	VkExtent2D getMTLPixelFormatBlockTexelSize(MTLPixelFormat mtlFormat);
+	VkExtent2D getBlockTexelSize(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the size, in bytes, of a texel of the specified Vulkan format.
 	 * The returned value may be fractional for certain compressed formats.
 	 */
-	float getVkFormatBytesPerTexel(VkFormat vkFormat);
+	float getBytesPerTexel(VkFormat vkFormat);
 
 	/**
 	 * Returns the size, in bytes, of a texel of the specified Metal format.
 	 * The returned value may be fractional for certain compressed formats.
 	 */
-	float getMTLPixelFormatBytesPerTexel(MTLPixelFormat mtlFormat);
+	float getBytesPerTexel(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the size, in bytes, of a row of texels of the specified Vulkan format.
@@ -204,7 +204,7 @@ public:
 	 * and texelsPerRow should specify the width in texels, not blocks. The result is rounded
 	 * up if texelsPerRow is not an integer multiple of the compression block width.
 	 */
-	size_t getVkFormatBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow);
+	size_t getBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow);
 
 	/**
 	 * Returns the size, in bytes, of a row of texels of the specified Metal format.
@@ -213,7 +213,7 @@ public:
 	 * and texelsPerRow should specify the width in texels, not blocks. The result is rounded
 	 * up if texelsPerRow is not an integer multiple of the compression block width.
 	 */
-	size_t getMTLPixelFormatBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow);
+	size_t getBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow);
 
 	/**
 	 * Returns the size, in bytes, of a texture layer of the specified Vulkan format.
@@ -222,7 +222,7 @@ public:
 	 * and texelRowsPerLayer should specify the height in texels, not blocks. The result is
 	 * rounded up if texelRowsPerLayer is not an integer multiple of the compression block height.
 	 */
-	size_t getVkFormatBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
+	size_t getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
 
 	/**
 	 * Returns the size, in bytes, of a texture layer of the specified Metal format.
@@ -230,46 +230,45 @@ public:
 	 * and texelRowsPerLayer should specify the height in texels, not blocks. The result is
 	 * rounded up if texelRowsPerLayer is not an integer multiple of the compression block height.
 	 */
-	size_t getMTLPixelFormatBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
+	size_t getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
 
 	/** Returns the default properties for the specified Vulkan format. */
 	VkFormatProperties getVkFormatProperties(VkFormat vkFormat);
 
 	/** Returns the Metal format capabilities supported by the specified Vulkan format. */
-	MVKMTLFmtCaps getVkFormatCapabilities(VkFormat vkFormat);
+	MVKMTLFmtCaps getCapabilities(VkFormat vkFormat);
 
 	/** Returns the Metal format capabilities supported by the specified Metal format. */
-	MVKMTLFmtCaps getMTLPixelFormatCapabilities(MTLPixelFormat mtlFormat);
+	MVKMTLFmtCaps getCapabilities(MTLPixelFormat mtlFormat);
 
 	/** Returns the name of the specified Vulkan format. */
-	const char* getVkFormatName(VkFormat vkFormat);
+	const char* getName(VkFormat vkFormat);
 
 	/** Returns the name of the specified Metal pixel format. */
-	const char* getMTLPixelFormatName(MTLPixelFormat mtlFormat);
+	const char* getName(MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the MTLClearColor value corresponding to the color value in the VkClearValue,
 	 * extracting the color value that is VkFormat for the VkFormat.
 	 */
-	MTLClearColor getMTLClearColorFromVkClearValue(VkClearValue vkClearValue,
-												   VkFormat vkFormat);
+	MTLClearColor getMTLClearColor(VkClearValue vkClearValue, VkFormat vkFormat);
 
 	/** Returns the Metal depth value corresponding to the depth value in the specified VkClearValue. */
-	double getMTLClearDepthFromVkClearValue(VkClearValue vkClearValue);
+	double getMTLClearDepthValue(VkClearValue vkClearValue);
 
 	/** Returns the Metal stencil value corresponding to the stencil value in the specified VkClearValue. */
-	uint32_t getMTLClearStencilFromVkClearValue(VkClearValue vkClearValue);
+	uint32_t getMTLClearStencilValue(VkClearValue vkClearValue);
 
 	/** Returns the Vulkan image usage from the Metal texture usage and format. */
-	VkImageUsageFlags getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsage mtlUsage, MTLPixelFormat mtlFormat);
+	VkImageUsageFlags getVkImageUsageFlags(MTLTextureUsage mtlUsage, MTLPixelFormat mtlFormat);
 
 	/**
 	 * Returns the Metal texture usage from the Vulkan image usage and Metal format, ensuring that at least the
 	 * usages in minUsage are included, even if they wouldn't naturally be included based on the other two parameters.
 	 */
-	MTLTextureUsage getMTLTextureUsageFromVkImageUsageFlags(VkImageUsageFlags vkImageUsageFlags,
-															MTLPixelFormat mtlFormat,
-															MTLTextureUsage minUsage = MTLTextureUsageUnknown);
+	MTLTextureUsage getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
+									   MTLPixelFormat mtlFormat,
+									   MTLTextureUsage minUsage = MTLTextureUsageUnknown);
 
 	/** Enumerates all formats that support the given features, calling a specified function for each one. */
 	void enumerateSupportedFormats(VkFormatProperties properties, bool any, std::function<bool(VkFormat)> func);
@@ -278,7 +277,7 @@ public:
 	 * Returns the Metal MTLVertexFormat corresponding to the specified
 	 * Vulkan VkFormat as used as a vertex attribute format.
 	 */
-	MTLVertexFormat getMTLVertexFormatFromVkFormat(VkFormat vkFormat);
+	MTLVertexFormat getMTLVertexFormat(VkFormat vkFormat);
 
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -118,19 +118,19 @@ using namespace std;
 
 MVKVulkanAPIObject* MVKPixelFormats::getVulkanAPIObject() { return _physicalDevice; };
 
-bool MVKPixelFormats::vkFormatIsSupported(VkFormat vkFormat) {
+bool MVKPixelFormats::isSupported(VkFormat vkFormat) {
 	return getVkFormatDesc(vkFormat).isSupported();
 }
 
-bool MVKPixelFormats::vkFormatIsSupportedOrSubstitutable(VkFormat vkFormat) {
+bool MVKPixelFormats::isSupportedOrSubstitutable(VkFormat vkFormat) {
 	return getVkFormatDesc(vkFormat).isSupportedOrSubstitutable();
 }
 
-bool MVKPixelFormats::mtlPixelFormatIsSupported(MTLPixelFormat mtlFormat) {
+bool MVKPixelFormats::isSupported(MTLPixelFormat mtlFormat) {
 	return getMTLPixelFormatDesc(mtlFormat).isSupported();
 }
 
-bool MVKPixelFormats::mtlPixelFormatIsDepthFormat(MTLPixelFormat mtlFormat) {
+bool MVKPixelFormats::isDepthFormat(MTLPixelFormat mtlFormat) {
 	switch (mtlFormat) {
 		case MTLPixelFormatDepth32Float:
 #if MVK_MACOS
@@ -144,7 +144,7 @@ bool MVKPixelFormats::mtlPixelFormatIsDepthFormat(MTLPixelFormat mtlFormat) {
 	}
 }
 
-bool MVKPixelFormats::mtlPixelFormatIsStencilFormat(MTLPixelFormat mtlFormat) {
+bool MVKPixelFormats::isStencilFormat(MTLPixelFormat mtlFormat) {
 	switch (mtlFormat) {
 		case MTLPixelFormatStencil8:
 #if MVK_MACOS
@@ -159,7 +159,7 @@ bool MVKPixelFormats::mtlPixelFormatIsStencilFormat(MTLPixelFormat mtlFormat) {
 	}
 }
 
-bool MVKPixelFormats::mtlPixelFormatIsPVRTCFormat(MTLPixelFormat mtlFormat) {
+bool MVKPixelFormats::isPVRTCFormat(MTLPixelFormat mtlFormat) {
 	switch (mtlFormat) {
 #if MVK_IOS
 		case MTLPixelFormatPVRTC_RGBA_2BPP:
@@ -177,15 +177,15 @@ bool MVKPixelFormats::mtlPixelFormatIsPVRTCFormat(MTLPixelFormat mtlFormat) {
 	}
 }
 
-MVKFormatType MVKPixelFormats::getFormatTypeFromVkFormat(VkFormat vkFormat) {
+MVKFormatType MVKPixelFormats::getFormatType(VkFormat vkFormat) {
 	return getVkFormatDesc(vkFormat).formatType;
 }
 
-MVKFormatType MVKPixelFormats::getFormatTypeFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
+MVKFormatType MVKPixelFormats::getFormatType(MTLPixelFormat mtlFormat) {
 	return getVkFormatDesc(mtlFormat).formatType;
 }
 
-MTLPixelFormat MVKPixelFormats::getMTLPixelFormatFromVkFormat(VkFormat vkFormat) {
+MTLPixelFormat MVKPixelFormats::getMTLPixelFormat(VkFormat vkFormat) {
 	auto& vkDesc = getVkFormatDesc(vkFormat);
 	MTLPixelFormat mtlPixFmt = vkDesc.mtlPixelFormat;
 
@@ -216,49 +216,49 @@ MTLPixelFormat MVKPixelFormats::getMTLPixelFormatFromVkFormat(VkFormat vkFormat)
 	return mtlPixFmt;
 }
 
-VkFormat MVKPixelFormats::getVkFormatFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
+VkFormat MVKPixelFormats::getVkFormat(MTLPixelFormat mtlFormat) {
     return getMTLPixelFormatDesc(mtlFormat).vkFormat;
 }
 
-uint32_t MVKPixelFormats::getVkFormatBytesPerBlock(VkFormat vkFormat) {
+uint32_t MVKPixelFormats::getBytesPerBlock(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).bytesPerBlock;
 }
 
-uint32_t MVKPixelFormats::getMTLPixelFormatBytesPerBlock(MTLPixelFormat mtlFormat) {
+uint32_t MVKPixelFormats::getBytesPerBlock(MTLPixelFormat mtlFormat) {
     return getVkFormatDesc(mtlFormat).bytesPerBlock;
 }
 
-VkExtent2D MVKPixelFormats::getVkFormatBlockTexelSize(VkFormat vkFormat) {
+VkExtent2D MVKPixelFormats::getBlockTexelSize(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).blockTexelSize;
 }
 
-VkExtent2D MVKPixelFormats::getMTLPixelFormatBlockTexelSize(MTLPixelFormat mtlFormat) {
+VkExtent2D MVKPixelFormats::getBlockTexelSize(MTLPixelFormat mtlFormat) {
     return getVkFormatDesc(mtlFormat).blockTexelSize;
 }
 
-float MVKPixelFormats::getVkFormatBytesPerTexel(VkFormat vkFormat) {
+float MVKPixelFormats::getBytesPerTexel(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).bytesPerTexel();
 }
 
-float MVKPixelFormats::getMTLPixelFormatBytesPerTexel(MTLPixelFormat mtlFormat) {
+float MVKPixelFormats::getBytesPerTexel(MTLPixelFormat mtlFormat) {
     return getVkFormatDesc(mtlFormat).bytesPerTexel();
 }
 
-size_t MVKPixelFormats::getVkFormatBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow) {
+size_t MVKPixelFormats::getBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow) {
     auto& vkDesc = getVkFormatDesc(vkFormat);
     return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) * vkDesc.bytesPerBlock;
 }
 
-size_t MVKPixelFormats::getMTLPixelFormatBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow) {
+size_t MVKPixelFormats::getBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow) {
 	auto& vkDesc = getVkFormatDesc(mtlFormat);
     return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) * vkDesc.bytesPerBlock;
 }
 
-size_t MVKPixelFormats::getVkFormatBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
+size_t MVKPixelFormats::getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
     return mvkCeilingDivide(texelRowsPerLayer, getVkFormatDesc(vkFormat).blockTexelSize.height) * bytesPerRow;
 }
 
-size_t MVKPixelFormats::getMTLPixelFormatBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
+size_t MVKPixelFormats::getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
     return mvkCeilingDivide(texelRowsPerLayer, getVkFormatDesc(mtlFormat).blockTexelSize.height) * bytesPerRow;
 }
 
@@ -266,19 +266,19 @@ VkFormatProperties MVKPixelFormats::getVkFormatProperties(VkFormat vkFormat) {
 	return	getVkFormatDesc(vkFormat).properties;
 }
 
-MVKMTLFmtCaps MVKPixelFormats::getVkFormatCapabilities(VkFormat vkFormat) {
+MVKMTLFmtCaps MVKPixelFormats::getCapabilities(VkFormat vkFormat) {
 	return getMTLPixelFormatDesc(vkFormat).mtlFmtCaps;
 }
 
-MVKMTLFmtCaps MVKPixelFormats::getMTLPixelFormatCapabilities(MTLPixelFormat mtlFormat) {
+MVKMTLFmtCaps MVKPixelFormats::getCapabilities(MTLPixelFormat mtlFormat) {
 	return getMTLPixelFormatDesc(mtlFormat).mtlFmtCaps;
 }
 
-const char* MVKPixelFormats::getVkFormatName(VkFormat vkFormat) {
+const char* MVKPixelFormats::getName(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).name;
 }
 
-const char* MVKPixelFormats::getMTLPixelFormatName(MTLPixelFormat mtlFormat) {
+const char* MVKPixelFormats::getName(MTLPixelFormat mtlFormat) {
     return getMTLPixelFormatDesc(mtlFormat).name;
 }
 
@@ -302,7 +302,7 @@ void MVKPixelFormats::enumerateSupportedFormats(VkFormatProperties properties, b
 	}
 }
 
-MTLVertexFormat MVKPixelFormats::getMTLVertexFormatFromVkFormat(VkFormat vkFormat) {
+MTLVertexFormat MVKPixelFormats::getMTLVertexFormat(VkFormat vkFormat) {
 	auto& vkDesc = getVkFormatDesc(vkFormat);
 	MTLVertexFormat mtlVtxFmt = vkDesc.mtlVertexFormat;
 
@@ -328,10 +328,9 @@ MTLVertexFormat MVKPixelFormats::getMTLVertexFormatFromVkFormat(VkFormat vkForma
 	return mtlVtxFmt;
 }
 
-MTLClearColor MVKPixelFormats::getMTLClearColorFromVkClearValue(VkClearValue vkClearValue,
-														   VkFormat vkFormat) {
+MTLClearColor MVKPixelFormats::getMTLClearColor(VkClearValue vkClearValue, VkFormat vkFormat) {
 	MTLClearColor mtlClr;
-	switch (getFormatTypeFromVkFormat(vkFormat)) {
+	switch (getFormatType(vkFormat)) {
 		case kMVKFormatColorHalf:
 		case kMVKFormatColorFloat:
 			mtlClr.red		= vkClearValue.color.float32[0];
@@ -365,16 +364,16 @@ MTLClearColor MVKPixelFormats::getMTLClearColorFromVkClearValue(VkClearValue vkC
 	return mtlClr;
 }
 
-double MVKPixelFormats::getMTLClearDepthFromVkClearValue(VkClearValue vkClearValue) {
+double MVKPixelFormats::getMTLClearDepthValue(VkClearValue vkClearValue) {
 	return vkClearValue.depthStencil.depth;
 }
 
-uint32_t MVKPixelFormats::getMTLClearStencilFromVkClearValue(VkClearValue vkClearValue) {
+uint32_t MVKPixelFormats::getMTLClearStencilValue(VkClearValue vkClearValue) {
 	return vkClearValue.depthStencil.stencil;
 }
 
-VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsage mtlUsage,
-																		   MTLPixelFormat mtlFormat) {
+VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlags(MTLTextureUsage mtlUsage,
+														MTLPixelFormat mtlFormat) {
     VkImageUsageFlags vkImageUsageFlags = 0;
 
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderRead) ) {
@@ -384,7 +383,7 @@ VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlagsFromMTLTextureUsage(MTLTe
     }
     if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageRenderTarget) ) {
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-        if (mtlPixelFormatIsDepthFormat(mtlFormat) || mtlPixelFormatIsStencilFormat(mtlFormat)) {
+        if (isDepthFormat(mtlFormat) || isStencilFormat(mtlFormat)) {
             mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         } else {
             mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -397,15 +396,15 @@ VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlagsFromMTLTextureUsage(MTLTe
     return vkImageUsageFlags;
 }
 
-MTLTextureUsage MVKPixelFormats::getMTLTextureUsageFromVkImageUsageFlags(VkImageUsageFlags vkImageUsageFlags,
-																		 MTLPixelFormat mtlFormat,
-																		 MTLTextureUsage minUsage) {
-	bool isDepthFmt = mtlPixelFormatIsDepthFormat(mtlFormat);
-	bool isStencilFmt = mtlPixelFormatIsStencilFormat(mtlFormat);
+MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
+													MTLPixelFormat mtlFormat,
+													MTLTextureUsage minUsage) {
+	bool isDepthFmt = isDepthFormat(mtlFormat);
+	bool isStencilFmt = isStencilFormat(mtlFormat);
 	bool isCombinedDepthStencilFmt = isDepthFmt && isStencilFmt;
 	bool isColorFormat = !(isDepthFmt || isStencilFmt);
 	bool supportsStencilViews = _physicalDevice ? _physicalDevice->getMetalFeatures()->stencilViews : false;
-	MVKMTLFmtCaps mtlFmtCaps = getMTLPixelFormatCapabilities(mtlFormat);
+	MVKMTLFmtCaps mtlFmtCaps = getCapabilities(mtlFormat);
 
 	MTLTextureUsage mtlUsage = minUsage;
 
@@ -1353,50 +1352,50 @@ void MVKPixelFormats::test() {
 			if (fd.isSupportedOrSubstitutable()) {
 				MVKLogInfo("Testing %s", fd.name);
 
-				testFmt(vkFormatIsSupported(vkFmt), mvkVkFormatIsSupported(vkFmt));
-				testFmt(mtlPixelFormatIsSupported(mtlFmt), mvkMTLPixelFormatIsSupported(mtlFmt));
-				testFmt(mtlPixelFormatIsDepthFormat(mtlFmt), mvkMTLPixelFormatIsDepthFormat(mtlFmt));
-				testFmt(mtlPixelFormatIsStencilFormat(mtlFmt), mvkMTLPixelFormatIsStencilFormat(mtlFmt));
-				testFmt(mtlPixelFormatIsPVRTCFormat(mtlFmt), mvkMTLPixelFormatIsPVRTCFormat(mtlFmt));
-				testFmt(getFormatTypeFromVkFormat(vkFmt), mvkFormatTypeFromVkFormat(vkFmt));
-				testFmt(getFormatTypeFromMTLPixelFormat(mtlFmt), mvkFormatTypeFromMTLPixelFormat(mtlFmt));
-				testFmt(getMTLPixelFormatFromVkFormat(vkFmt), mvkMTLPixelFormatFromVkFormat(vkFmt));
-				testFmt(getVkFormatFromMTLPixelFormat(mtlFmt), mvkVkFormatFromMTLPixelFormat(mtlFmt));
-				testFmt(getVkFormatBytesPerBlock(vkFmt), mvkVkFormatBytesPerBlock(vkFmt));
-				testFmt(getMTLPixelFormatBytesPerBlock(mtlFmt), mvkMTLPixelFormatBytesPerBlock(mtlFmt));
-				testFmt(getVkFormatBlockTexelSize(vkFmt), mvkVkFormatBlockTexelSize(vkFmt));
-				testFmt(getMTLPixelFormatBlockTexelSize(mtlFmt), mvkMTLPixelFormatBlockTexelSize(mtlFmt));
-				testFmt(getVkFormatBytesPerTexel(vkFmt), mvkVkFormatBytesPerTexel(vkFmt));
-				testFmt(getMTLPixelFormatBytesPerTexel(mtlFmt), mvkMTLPixelFormatBytesPerTexel(mtlFmt));
-				testFmt(getVkFormatBytesPerRow(vkFmt, 4), mvkVkFormatBytesPerRow(vkFmt, 4));
-				testFmt(getMTLPixelFormatBytesPerRow(mtlFmt, 4), mvkMTLPixelFormatBytesPerRow(mtlFmt, 4));
-				testFmt(getVkFormatBytesPerLayer(vkFmt, 256, 4), mvkVkFormatBytesPerLayer(vkFmt, 256, 4));
-				testFmt(getMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4), mvkMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4));
+				testFmt(isSupported(vkFmt), mvkVkFormatIsSupported(vkFmt));
+				testFmt(isSupported(mtlFmt), mvkMTLPixelFormatIsSupported(mtlFmt));
+				testFmt(isDepthFormat(mtlFmt), mvkMTLPixelFormatIsDepthFormat(mtlFmt));
+				testFmt(isStencilFormat(mtlFmt), mvkMTLPixelFormatIsStencilFormat(mtlFmt));
+				testFmt(isPVRTCFormat(mtlFmt), mvkMTLPixelFormatIsPVRTCFormat(mtlFmt));
+				testFmt(getFormatType(vkFmt), mvkFormatTypeFromVkFormat(vkFmt));
+				testFmt(getFormatType(mtlFmt), mvkFormatTypeFromMTLPixelFormat(mtlFmt));
+				testFmt(getMTLPixelFormat(vkFmt), mvkMTLPixelFormatFromVkFormat(vkFmt));
+				testFmt(getVkFormat(mtlFmt), mvkVkFormatFromMTLPixelFormat(mtlFmt));
+				testFmt(getBytesPerBlock(vkFmt), mvkVkFormatBytesPerBlock(vkFmt));
+				testFmt(getBytesPerBlock(mtlFmt), mvkMTLPixelFormatBytesPerBlock(mtlFmt));
+				testFmt(getBlockTexelSize(vkFmt), mvkVkFormatBlockTexelSize(vkFmt));
+				testFmt(getBlockTexelSize(mtlFmt), mvkMTLPixelFormatBlockTexelSize(mtlFmt));
+				testFmt(getBytesPerTexel(vkFmt), mvkVkFormatBytesPerTexel(vkFmt));
+				testFmt(getBytesPerTexel(mtlFmt), mvkMTLPixelFormatBytesPerTexel(mtlFmt));
+				testFmt(getBytesPerRow(vkFmt, 4), mvkVkFormatBytesPerRow(vkFmt, 4));
+				testFmt(getBytesPerRow(mtlFmt, 4), mvkMTLPixelFormatBytesPerRow(mtlFmt, 4));
+				testFmt(getBytesPerLayer(vkFmt, 256, 4), mvkVkFormatBytesPerLayer(vkFmt, 256, 4));
+				testFmt(getBytesPerLayer(mtlFmt, 256, 4), mvkMTLPixelFormatBytesPerLayer(mtlFmt, 256, 4));
 				testProps(getVkFormatProperties(vkFmt), mvkVkFormatProperties(vkFmt));
-				testFmt(strcmp(getVkFormatName(vkFmt), mvkVkFormatName(vkFmt)), 0);
-				testFmt(strcmp(getMTLPixelFormatName(mtlFmt), mvkMTLPixelFormatName(mtlFmt)), 0);
-				testFmt(getMTLClearColorFromVkClearValue(VkClearValue(), vkFmt),
+				testFmt(strcmp(getName(vkFmt), mvkVkFormatName(vkFmt)), 0);
+				testFmt(strcmp(getName(mtlFmt), mvkMTLPixelFormatName(mtlFmt)), 0);
+				testFmt(getMTLClearColor(VkClearValue(), vkFmt),
 						mvkMTLClearColorFromVkClearValue(VkClearValue(), vkFmt));
 
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt),
+				testFmt(getVkImageUsageFlags(MTLTextureUsageUnknown, mtlFmt),
 						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageUnknown, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt),
+				testFmt(getVkImageUsageFlags(MTLTextureUsageShaderRead, mtlFmt),
 						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderRead, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt),
+				testFmt(getVkImageUsageFlags(MTLTextureUsageShaderWrite, mtlFmt),
 						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageShaderWrite, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt),
+				testFmt(getVkImageUsageFlags(MTLTextureUsageRenderTarget, mtlFmt),
 						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsageRenderTarget, mtlFmt));
-				testFmt(getVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt),
+				testFmt(getVkImageUsageFlags(MTLTextureUsagePixelFormatView, mtlFmt),
 						mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsagePixelFormatView, mtlFmt));
 
 				VkImageUsageFlags vkUsage;
 				vkUsage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-				testFmt(getMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt), mvkMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt));
+				testFmt(getMTLTextureUsage(vkUsage, mtlFmt), mvkMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt));
 
 				vkUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
-				testFmt(getMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt), mvkMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt));
+				testFmt(getMTLTextureUsage(vkUsage, mtlFmt), mvkMTLTextureUsageFromVkImageUsageFlags(vkUsage, mtlFmt));
 
-				testFmt(getMTLVertexFormatFromVkFormat(vkFmt), mvkMTLVertexFormatFromVkFormat(vkFmt));
+				testFmt(getMTLVertexFormat(vkFmt), mvkMTLVertexFormatFromVkFormat(vkFmt));
 
 			} else {
 				MVKLogInfo("%s not supported or substitutable on this device.", fd.name);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -126,7 +126,7 @@ void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffe
                                                        __watermarkTextureWidth,
                                                        __watermarkTextureHeight,
                                                        __watermarkTextureFormat,
-                                                       getPixelFormats()->getMTLPixelFormatBytesPerRow(__watermarkTextureFormat, __watermarkTextureWidth),
+                                                       getPixelFormats()->getBytesPerRow(__watermarkTextureFormat, __watermarkTextureWidth),
                                                        __watermarkShaderSource);
         }
 		_licenseWatermark->render(mtlTexture, mtlCmdBuff, 0.02f);
@@ -260,7 +260,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 
 	_mtlLayer = mvkSrfc->getCAMetalLayer();
 	_mtlLayer.device = getMTLDevice();
-	_mtlLayer.pixelFormat = getPixelFormats()->getMTLPixelFormatFromVkFormat(pCreateInfo->imageFormat);
+	_mtlLayer.pixelFormat = getPixelFormats()->getMTLPixelFormat(pCreateInfo->imageFormat);
 	_mtlLayer.maximumDrawableCountMVK = imgCnt;
 	_mtlLayer.displaySyncEnabledMVK = (pCreateInfo->presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
 	_mtlLayer.magnificationFilter = _device->_pMVKConfig->swapchainMagFilterUseNearest ? kCAFilterNearest : kCAFilterLinear;
@@ -349,7 +349,7 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
         .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
         .pNext = VK_NULL_HANDLE,
         .imageType = VK_IMAGE_TYPE_2D,
-        .format = getPixelFormats()->getVkFormatFromMTLPixelFormat(_mtlLayer.pixelFormat),
+        .format = getPixelFormats()->getVkFormat(_mtlLayer.pixelFormat),
         .extent = { imgExtent.width, imgExtent.height, 1 },
         .mipLevels = 1,
         .arrayLayers = 1,

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -35,67 +35,67 @@ using namespace std;
 static MVKPixelFormats _platformPixelFormats;
 
 MVK_PUBLIC_SYMBOL bool mvkVkFormatIsSupported(VkFormat vkFormat) {
-	return _platformPixelFormats.vkFormatIsSupported(vkFormat);
+	return _platformPixelFormats.isSupported(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL bool mvkMTLPixelFormatIsSupported(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.mtlPixelFormatIsSupported(mtlFormat);
+	return _platformPixelFormats.isSupported(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MVKFormatType mvkFormatTypeFromVkFormat(VkFormat vkFormat) {
-	return _platformPixelFormats.getFormatTypeFromVkFormat(vkFormat);
+	return _platformPixelFormats.getFormatType(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL MVKFormatType mvkFormatTypeFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getFormatTypeFromMTLPixelFormat(mtlFormat);
+	return _platformPixelFormats.getFormatType(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLPixelFormat mvkMTLPixelFormatFromVkFormat(VkFormat vkFormat) {
-	return _platformPixelFormats.getMTLPixelFormatFromVkFormat(vkFormat);
+	return _platformPixelFormats.getMTLPixelFormat(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkFormat mvkVkFormatFromMTLPixelFormat(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getVkFormatFromMTLPixelFormat(mtlFormat);
+	return _platformPixelFormats.getVkFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkVkFormatBytesPerBlock(VkFormat vkFormat) {
-	return _platformPixelFormats.getVkFormatBytesPerBlock(vkFormat);
+	return _platformPixelFormats.getBytesPerBlock(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkMTLPixelFormatBytesPerBlock(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getMTLPixelFormatBytesPerBlock(mtlFormat);
+	return _platformPixelFormats.getBytesPerBlock(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkExtent2D mvkVkFormatBlockTexelSize(VkFormat vkFormat) {
-	return _platformPixelFormats.getVkFormatBlockTexelSize(vkFormat);
+	return _platformPixelFormats.getBlockTexelSize(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL VkExtent2D mvkMTLPixelFormatBlockTexelSize(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getMTLPixelFormatBlockTexelSize(mtlFormat);
+	return _platformPixelFormats.getBlockTexelSize(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL float mvkVkFormatBytesPerTexel(VkFormat vkFormat) {
-	return _platformPixelFormats.getVkFormatBytesPerTexel(vkFormat);
+	return _platformPixelFormats.getBytesPerTexel(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL float mvkMTLPixelFormatBytesPerTexel(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getMTLPixelFormatBytesPerTexel(mtlFormat);
+	return _platformPixelFormats.getBytesPerTexel(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkVkFormatBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow) {
-	return _platformPixelFormats.getVkFormatBytesPerRow(vkFormat, texelsPerRow);
+	return _platformPixelFormats.getBytesPerRow(vkFormat, texelsPerRow);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkMTLPixelFormatBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow) {
-	return _platformPixelFormats.getMTLPixelFormatBytesPerRow(mtlFormat, texelsPerRow);
+	return _platformPixelFormats.getBytesPerRow(mtlFormat, texelsPerRow);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkVkFormatBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-	return _platformPixelFormats.getVkFormatBytesPerLayer(vkFormat, bytesPerRow, texelRowsPerLayer);
+	return _platformPixelFormats.getBytesPerLayer(vkFormat, bytesPerRow, texelRowsPerLayer);
 }
 
 MVK_PUBLIC_SYMBOL size_t mvkMTLPixelFormatBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-	return _platformPixelFormats.getMTLPixelFormatBytesPerLayer(mtlFormat, bytesPerRow, texelRowsPerLayer);
+	return _platformPixelFormats.getBytesPerLayer(mtlFormat, bytesPerRow, texelRowsPerLayer);
 }
 
 MVK_PUBLIC_SYMBOL VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat) {
@@ -103,40 +103,40 @@ MVK_PUBLIC_SYMBOL VkFormatProperties mvkVkFormatProperties(VkFormat vkFormat) {
 }
 
 MVK_PUBLIC_SYMBOL const char* mvkVkFormatName(VkFormat vkFormat) {
-	return _platformPixelFormats.getVkFormatName(vkFormat);
+	return _platformPixelFormats.getName(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL const char* mvkMTLPixelFormatName(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getMTLPixelFormatName(mtlFormat);
+	return _platformPixelFormats.getName(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLVertexFormat mvkMTLVertexFormatFromVkFormat(VkFormat vkFormat) {
-	return _platformPixelFormats.getMTLVertexFormatFromVkFormat(vkFormat);
+	return _platformPixelFormats.getMTLVertexFormat(vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLClearColor mvkMTLClearColorFromVkClearValue(VkClearValue vkClearValue,
 																 VkFormat vkFormat) {
-	return _platformPixelFormats.getMTLClearColorFromVkClearValue(vkClearValue, vkFormat);
+	return _platformPixelFormats.getMTLClearColor(vkClearValue, vkFormat);
 }
 
 MVK_PUBLIC_SYMBOL double mvkMTLClearDepthFromVkClearValue(VkClearValue vkClearValue) {
-	return _platformPixelFormats.getMTLClearDepthFromVkClearValue(vkClearValue);
+	return _platformPixelFormats.getMTLClearDepthValue(vkClearValue);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkMTLClearStencilFromVkClearValue(VkClearValue vkClearValue) {
-	return _platformPixelFormats.getMTLClearStencilFromVkClearValue(vkClearValue);
+	return _platformPixelFormats.getMTLClearStencilValue(vkClearValue);
 }
 
 MVK_PUBLIC_SYMBOL bool mvkMTLPixelFormatIsDepthFormat(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.mtlPixelFormatIsDepthFormat(mtlFormat);
+	return _platformPixelFormats.isDepthFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL bool mvkMTLPixelFormatIsStencilFormat(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.mtlPixelFormatIsStencilFormat(mtlFormat);
+	return _platformPixelFormats.isStencilFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL bool mvkMTLPixelFormatIsPVRTCFormat(MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.mtlPixelFormatIsPVRTCFormat(mtlFormat);
+	return _platformPixelFormats.isPVRTCFormat(mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL MTLTextureType mvkMTLTextureTypeFromVkImageType(VkImageType vkImageType,
@@ -192,11 +192,11 @@ MVK_PUBLIC_SYMBOL MTLTextureType mvkMTLTextureTypeFromVkImageViewType(VkImageVie
 }
 
 MVK_PUBLIC_SYMBOL MTLTextureUsage mvkMTLTextureUsageFromVkImageUsageFlags(VkImageUsageFlags vkImageUsageFlags, MTLPixelFormat mtlPixFmt) {
-	return _platformPixelFormats.getMTLTextureUsageFromVkImageUsageFlags(vkImageUsageFlags, mtlPixFmt);
+	return _platformPixelFormats.getMTLTextureUsage(vkImageUsageFlags, mtlPixFmt);
 }
 
 MVK_PUBLIC_SYMBOL VkImageUsageFlags mvkVkImageUsageFlagsFromMTLTextureUsage(MTLTextureUsage mtlUsage, MTLPixelFormat mtlFormat) {
-	return _platformPixelFormats.getVkImageUsageFlagsFromMTLTextureUsage(mtlUsage, mtlFormat);
+	return _platformPixelFormats.getVkImageUsageFlags(mtlUsage, mtlFormat);
 }
 
 MVK_PUBLIC_SYMBOL uint32_t mvkSampleCountFromVkSampleCountFlagBits(VkSampleCountFlagBits vkSampleCountFlag) {


### PR DESCRIPTION
Many of the names of the MVKPixelFormats member functions where inherited from
function names in mvk_datatypes.h, which is a C API, therefore must have unique
function names, and uses parameter types as part of the names to distinguish.

Since MVKPixelFormats is a C++ class, we can do away with that and make use
of function overloading to simplify the function names.

I forgot to to this when creating MVKPixelFormats in the first place.