### PR TITLE
Reduce common memory requirements of MVKCmdSetViewport and MVKCmdSetScissor.

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		A9B51BD2225E986A00AC74D2 /* MVKOSExtensions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MVKOSExtensions.mm; sourceTree = "<group>"; };
 		A9B51BD6225E986A00AC74D2 /* MVKOSExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKOSExtensions.h; sourceTree = "<group>"; };
 		A9B8EE0A1A98D796009C5A02 /* libMoltenVK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMoltenVK.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9C83DCD24533E22003E5261 /* MVKCommandTypePools.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.h; fileEncoding = 4; path = MVKCommandTypePools.def; sourceTree = "<group>"; };
 		A9C86CB61C55B8350096CAF2 /* MoltenVKShaderConverter.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MoltenVKShaderConverter.xcodeproj; path = ../MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj; sourceTree = "<group>"; };
 		A9C96DCE1DDC20C20053187F /* MVKMTLBufferAllocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKMTLBufferAllocation.h; sourceTree = "<group>"; };
 		A9C96DCF1DDC20C20053187F /* MVKMTLBufferAllocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MVKMTLBufferAllocation.mm; sourceTree = "<group>"; };
@@ -479,6 +480,7 @@
 				A94FB77B1C7DFB4800632CA3 /* MVKCommandPool.mm */,
 				A95870F61C90D29F009EB096 /* MVKCommandResourceFactory.h */,
 				A95870F71C90D29F009EB096 /* MVKCommandResourceFactory.mm */,
+				A9C83DCD24533E22003E5261 /* MVKCommandTypePools.def */,
 				A9C96DCE1DDC20C20053187F /* MVKMTLBufferAllocation.h */,
 				A9C96DCF1DDC20C20053187F /* MVKMTLBufferAllocation.mm */,
 				A9E4B7881E1D8AF10046A4CE /* MVKMTLResourceBindings.h */,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDebug.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDebug.mm
@@ -41,8 +41,6 @@ MVKCmdDebugMarker::~MVKCmdDebugMarker() {
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerBegin
 
-MVKFuncionOverride_getTypePool(DebugMarkerBegin)
-
 // Vulkan debug groups are more general than Metal's.
 // If a renderpass is active, push on the render command encoder, otherwise push on the command buffer.
 void MVKCmdDebugMarkerBegin::encode(MVKCommandEncoder* cmdEncoder) {
@@ -57,8 +55,6 @@ void MVKCmdDebugMarkerBegin::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerEnd
-
-MVKFuncionOverride_getTypePool(DebugMarkerEnd)
 
 VkResult MVKCmdDebugMarkerEnd::setContent(MVKCommandBuffer* cmdBuff) { return VK_SUCCESS; }
 
@@ -76,8 +72,6 @@ void MVKCmdDebugMarkerEnd::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerInsert
-
-MVKFuncionOverride_getTypePool(DebugMarkerInsert)
 
 void MVKCmdDebugMarkerInsert::encode(MVKCommandEncoder* cmdEncoder) {
 	[cmdEncoder->getMTLEncoder() insertDebugSignpost: _markerName];

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.mm
@@ -28,8 +28,6 @@
 #pragma mark -
 #pragma mark MVKCmdDispatch
 
-MVKFuncionOverride_getTypePool(Dispatch)
-
 VkResult MVKCmdDispatch::setContent(MVKCommandBuffer* cmdBuff,
 									uint32_t baseGroupX, uint32_t baseGroupY, uint32_t baseGroupZ,
 									uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ) {
@@ -69,8 +67,6 @@ void MVKCmdDispatch::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDispatchIndirect
-
-MVKFuncionOverride_getTypePool(DispatchIndirect)
 
 VkResult MVKCmdDispatchIndirect::setContent(MVKCommandBuffer* cmdBuff, VkBuffer buffer, VkDeviceSize offset) {
 	MVKBuffer* mvkBuffer = (MVKBuffer*)buffer;

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -28,8 +28,6 @@
 #pragma mark -
 #pragma mark MVKCmdBindVertexBuffers
 
-MVKFuncionOverride_getTypePool(BindVertexBuffers)
-
 VkResult MVKCmdBindVertexBuffers::setContent(MVKCommandBuffer* cmdBuff,
 											 uint32_t startBinding,
 											 uint32_t bindingCount,
@@ -59,8 +57,6 @@ void MVKCmdBindVertexBuffers::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdBindIndexBuffer
 
-MVKFuncionOverride_getTypePool(BindIndexBuffer)
-
 VkResult MVKCmdBindIndexBuffer::setContent(MVKCommandBuffer* cmdBuff,
 										   VkBuffer buffer,
 										   VkDeviceSize offset,
@@ -80,8 +76,6 @@ void MVKCmdBindIndexBuffer::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDraw
-
-MVKFuncionOverride_getTypePool(Draw)
 
 VkResult MVKCmdDraw::setContent(MVKCommandBuffer* cmdBuff,
 								uint32_t vertexCount,
@@ -270,8 +264,6 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDrawIndexed
-
-MVKFuncionOverride_getTypePool(DrawIndexed)
 
 VkResult MVKCmdDrawIndexed::setContent(MVKCommandBuffer* cmdBuff,
 									   uint32_t indexCount,
@@ -507,8 +499,6 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDrawIndirect
-
-MVKFuncionOverride_getTypePool(DrawIndirect)
 
 VkResult MVKCmdDrawIndirect::setContent(MVKCommandBuffer* cmdBuff,
 										VkBuffer buffer,
@@ -753,8 +743,6 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdDrawIndexedIndirect
-
-MVKFuncionOverride_getTypePool(DrawIndexedIndirect)
 
 VkResult MVKCmdDrawIndexedIndirect::setContent(MVKCommandBuffer* cmdBuff,
 											   VkBuffer buffer,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -30,8 +30,6 @@
 #pragma mark -
 #pragma mark MVKCmdPipelineBarrier
 
-MVKFuncionOverride_getTypePool(PipelineBarrier)
-
 VkResult MVKCmdPipelineBarrier::setContent(MVKCommandBuffer* cmdBuff,
 										   VkPipelineStageFlags srcStageMask,
 										   VkPipelineStageFlags dstStageMask,
@@ -130,8 +128,6 @@ void MVKCmdPipelineBarrier::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdBindPipeline
 
-MVKFuncionOverride_getTypePool(BindPipeline)
-
 VkResult MVKCmdBindPipeline::setContent(MVKCommandBuffer* cmdBuff,
 										VkPipelineBindPoint pipelineBindPoint,
 										VkPipeline pipeline) {
@@ -157,8 +153,6 @@ bool MVKCmdBindPipeline::isTessellationPipeline() {
 
 #pragma mark -
 #pragma mark MVKCmdBindDescriptorSets
-
-MVKFuncionOverride_getTypePool(BindDescriptorSets)
 
 VkResult MVKCmdBindDescriptorSets::setContent(MVKCommandBuffer* cmdBuff,
 											  VkPipelineBindPoint pipelineBindPoint,
@@ -197,8 +191,6 @@ void MVKCmdBindDescriptorSets::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdPushConstants
 
-MVKFuncionOverride_getTypePool(PushConstants)
-
 VkResult MVKCmdPushConstants::setContent(MVKCommandBuffer* cmdBuff,
 										 VkPipelineLayout layout,
 										 VkShaderStageFlags stageFlags,
@@ -233,8 +225,6 @@ void MVKCmdPushConstants::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdPushDescriptorSet
-
-MVKFuncionOverride_getTypePool(PushDescriptorSet)
 
 VkResult MVKCmdPushDescriptorSet::setContent(MVKCommandBuffer* cmdBuff,
 											 VkPipelineBindPoint pipelineBindPoint,
@@ -330,8 +320,6 @@ void MVKCmdPushDescriptorSet::clearDescriptorWrites() {
 #pragma mark -
 #pragma mark MVKCmdPushDescriptorSetWithTemplate
 
-MVKFuncionOverride_getTypePool(PushDescriptorSetWithTemplate)
-
 VkResult MVKCmdPushDescriptorSetWithTemplate::setContent(MVKCommandBuffer* cmdBuff,
 														 VkDescriptorUpdateTemplateKHR descUpdateTemplate,
 														 VkPipelineLayout layout,
@@ -394,8 +382,6 @@ MVKCmdPushDescriptorSetWithTemplate::~MVKCmdPushDescriptorSetWithTemplate() {
 #pragma mark -
 #pragma mark MVKCmdSetResetEvent
 
-MVKFuncionOverride_getTypePool(SetResetEvent)
-
 VkResult MVKCmdSetResetEvent::setContent(MVKCommandBuffer* cmdBuff,
 										 VkEvent event,
 										 VkPipelineStageFlags stageMask,
@@ -413,8 +399,6 @@ void MVKCmdSetResetEvent::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdWaitEvents
-
-MVKFuncionOverride_getTypePool(WaitEvents)
 
 VkResult MVKCmdWaitEvents::setContent(MVKCommandBuffer* cmdBuff,
 									  uint32_t eventCount,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
@@ -38,8 +38,6 @@ VkResult MVKCmdQuery::setContent(MVKCommandBuffer* cmdBuff,
 #pragma mark -
 #pragma mark MVKCmdBeginQuery
 
-MVKFuncionOverride_getTypePool(BeginQuery)
-
 VkResult MVKCmdBeginQuery::setContent(MVKCommandBuffer* cmdBuff,
 									  VkQueryPool queryPool,
 									  uint32_t query,
@@ -61,8 +59,6 @@ void MVKCmdBeginQuery::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdEndQuery
 
-MVKFuncionOverride_getTypePool(EndQuery)
-
 void MVKCmdEndQuery::encode(MVKCommandEncoder* cmdEncoder) {
     _queryPool->endQuery(_query, cmdEncoder);
 }
@@ -70,8 +66,6 @@ void MVKCmdEndQuery::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdWriteTimestamp
-
-MVKFuncionOverride_getTypePool(WriteTimestamp)
 
 VkResult MVKCmdWriteTimestamp::setContent(MVKCommandBuffer* cmdBuff,
 										  VkPipelineStageFlagBits pipelineStage,
@@ -93,8 +87,6 @@ void MVKCmdWriteTimestamp::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdResetQueryPool
 
-MVKFuncionOverride_getTypePool(ResetQueryPool)
-
 VkResult MVKCmdResetQueryPool::setContent(MVKCommandBuffer* cmdBuff,
 										  VkQueryPool queryPool,
 										  uint32_t firstQuery,
@@ -114,8 +106,6 @@ void MVKCmdResetQueryPool::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdCopyQueryPoolResults
-
-MVKFuncionOverride_getTypePool(CopyQueryPoolResults)
 
 VkResult MVKCmdCopyQueryPoolResults::setContent(MVKCommandBuffer* cmdBuff,
 												VkQueryPool queryPool,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -107,10 +107,17 @@ protected:
 	MVKVectorInline<MVKCommandBuffer*, 64> _secondaryCommandBuffers;
 };
 
+
 #pragma mark -
 #pragma mark MVKCmdSetViewport
 
-/** Vulkan command to set the viewports. */
+/**
+ * Vulkan command to set the viewports.
+ * This is a template class to support different vector pre-allocations, so we can balance
+ * in-line memory allocation betweeen the very common case of a single viewport, and the
+ * maximal number, by choosing which concrete implementation to use based on viewport count.
+ */
+template <size_t N>
 class MVKCmdSetViewport : public MVKCommand {
 
 public:
@@ -125,14 +132,24 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	uint32_t _firstViewport;
-	MVKVectorInline<VkViewport, kMVKCachedViewportScissorCount> _viewports;
+	MVKVectorInline<VkViewport, N> _viewports;
 };
+
+// Concrete template class implemenations.
+typedef MVKCmdSetViewport<1> MVKCmdSetViewport1;
+typedef MVKCmdSetViewport<kMVKCachedViewportScissorCount> MVKCmdSetViewportMulti;
 
 
 #pragma mark -
 #pragma mark MVKCmdSetScissor
 
-/** Vulkan command to set the scissor rectangles. */
+/**
+ * Vulkan command to set the scissor rectangles.
+ * This is a template class to support different vector pre-allocations, so we can balance
+ * in-line memory allocation betweeen the very common case of a single scissor, and the
+ * maximal number, by choosing which concrete implementation to use based on scissor count.
+ */
+template <size_t N>
 class MVKCmdSetScissor : public MVKCommand {
 
 public:
@@ -147,8 +164,12 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
 	uint32_t _firstScissor;
-	MVKVectorInline<VkRect2D, kMVKCachedViewportScissorCount> _scissors;
+	MVKVectorInline<VkRect2D, N> _scissors;
 };
+
+// Concrete template class implemenations.
+typedef MVKCmdSetScissor<1> MVKCmdSetScissor1;
+typedef MVKCmdSetScissor<kMVKCachedViewportScissorCount> MVKCmdSetScissorMulti;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -109,10 +109,11 @@ void MVKCmdExecuteCommands::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetViewport
 
-VkResult MVKCmdSetViewport::setContent(MVKCommandBuffer* cmdBuff,
-									   uint32_t firstViewport,
-									   uint32_t viewportCount,
-									   const VkViewport* pViewports) {
+template <size_t N>
+VkResult MVKCmdSetViewport<N>::setContent(MVKCommandBuffer* cmdBuff,
+										  uint32_t firstViewport,
+										  uint32_t viewportCount,
+										  const VkViewport* pViewports) {
 	_firstViewport = firstViewport;
 	_viewports.clear();	// Clear for reuse
 	_viewports.reserve(viewportCount);
@@ -123,18 +124,23 @@ VkResult MVKCmdSetViewport::setContent(MVKCommandBuffer* cmdBuff,
 	return VK_SUCCESS;
 }
 
-void MVKCmdSetViewport::encode(MVKCommandEncoder* cmdEncoder) {
-    cmdEncoder->_viewportState.setViewports(_viewports, _firstViewport, true);
+template <size_t N>
+void MVKCmdSetViewport<N>::encode(MVKCommandEncoder* cmdEncoder) {
+	cmdEncoder->_viewportState.setViewports(_viewports, _firstViewport, true);
 }
+
+template class MVKCmdSetViewport<1>;
+template class MVKCmdSetViewport<kMVKCachedViewportScissorCount>;
 
 
 #pragma mark -
 #pragma mark MVKCmdSetScissor
 
-VkResult MVKCmdSetScissor::setContent(MVKCommandBuffer* cmdBuff,
-									  uint32_t firstScissor,
-									  uint32_t scissorCount,
-									  const VkRect2D* pScissors) {
+template <size_t N>
+VkResult MVKCmdSetScissor<N>::setContent(MVKCommandBuffer* cmdBuff,
+										 uint32_t firstScissor,
+										 uint32_t scissorCount,
+										 const VkRect2D* pScissors) {
 	_firstScissor = firstScissor;
 	_scissors.clear();	// Clear for reuse
 	_scissors.reserve(scissorCount);
@@ -145,9 +151,13 @@ VkResult MVKCmdSetScissor::setContent(MVKCommandBuffer* cmdBuff,
 	return VK_SUCCESS;
 }
 
-void MVKCmdSetScissor::encode(MVKCommandEncoder* cmdEncoder) {
+template <size_t N>
+void MVKCmdSetScissor<N>::encode(MVKCommandEncoder* cmdEncoder) {
     cmdEncoder->_scissorState.setScissors(_scissors, _firstScissor, true);
 }
+
+template class MVKCmdSetScissor<1>;
+template class MVKCmdSetScissor<kMVKCachedViewportScissorCount>;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -28,8 +28,6 @@
 #pragma mark -
 #pragma mark MVKCmdBeginRenderPass
 
-MVKFuncionOverride_getTypePool(BeginRenderPass)
-
 VkResult MVKCmdBeginRenderPass::setContent(MVKCommandBuffer* cmdBuff,
 										   const VkRenderPassBeginInfo* pRenderPassBegin,
 										   VkSubpassContents contents) {
@@ -61,8 +59,6 @@ void MVKCmdBeginRenderPass::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdNextSubpass
 
-MVKFuncionOverride_getTypePool(NextSubpass)
-
 VkResult MVKCmdNextSubpass::setContent(MVKCommandBuffer* cmdBuff,
 									   VkSubpassContents contents) {
 	_contents = contents;
@@ -78,8 +74,6 @@ void MVKCmdNextSubpass::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdEndRenderPass
 
-MVKFuncionOverride_getTypePool(EndRenderPass)
-
 VkResult MVKCmdEndRenderPass::setContent(MVKCommandBuffer* cmdBuff) {
 	cmdBuff->recordEndRenderPass(this);
 	return VK_SUCCESS;
@@ -93,8 +87,6 @@ void MVKCmdEndRenderPass::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdExecuteCommands
-
-MVKFuncionOverride_getTypePool(ExecuteCommands)
 
 VkResult MVKCmdExecuteCommands::setContent(MVKCommandBuffer* cmdBuff,
 										   uint32_t commandBuffersCount,
@@ -116,8 +108,6 @@ void MVKCmdExecuteCommands::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdSetViewport
-
-MVKFuncionOverride_getTypePool(SetViewport)
 
 VkResult MVKCmdSetViewport::setContent(MVKCommandBuffer* cmdBuff,
 									   uint32_t firstViewport,
@@ -141,8 +131,6 @@ void MVKCmdSetViewport::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetScissor
 
-MVKFuncionOverride_getTypePool(SetScissor)
-
 VkResult MVKCmdSetScissor::setContent(MVKCommandBuffer* cmdBuff,
 									  uint32_t firstScissor,
 									  uint32_t scissorCount,
@@ -165,8 +153,6 @@ void MVKCmdSetScissor::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetLineWidth
 
-MVKFuncionOverride_getTypePool(SetLineWidth)
-
 VkResult MVKCmdSetLineWidth::setContent(MVKCommandBuffer* cmdBuff,
 										float lineWidth) {
     _lineWidth = lineWidth;
@@ -184,8 +170,6 @@ void MVKCmdSetLineWidth::encode(MVKCommandEncoder* cmdEncoder) {}
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthBias
-
-MVKFuncionOverride_getTypePool(SetDepthBias)
 
 VkResult MVKCmdSetDepthBias::setContent(MVKCommandBuffer* cmdBuff,
 										float depthBiasConstantFactor,
@@ -208,8 +192,6 @@ void MVKCmdSetDepthBias::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetBlendConstants
 
-MVKFuncionOverride_getTypePool(SetBlendConstants)
-
 VkResult MVKCmdSetBlendConstants::setContent(MVKCommandBuffer* cmdBuff,
 											 const float blendConst[4]) {
     _red = blendConst[0];
@@ -227,8 +209,6 @@ void MVKCmdSetBlendConstants::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthBounds
-
-MVKFuncionOverride_getTypePool(SetDepthBounds)
 
 VkResult MVKCmdSetDepthBounds::setContent(MVKCommandBuffer* cmdBuff,
 										  float minDepthBounds,
@@ -250,8 +230,6 @@ void MVKCmdSetDepthBounds::encode(MVKCommandEncoder* cmdEncoder) {}
 #pragma mark -
 #pragma mark MVKCmdSetStencilCompareMask
 
-MVKFuncionOverride_getTypePool(SetStencilCompareMask)
-
 VkResult MVKCmdSetStencilCompareMask::setContent(MVKCommandBuffer* cmdBuff,
 												 VkStencilFaceFlags faceMask,
 												 uint32_t stencilCompareMask) {
@@ -269,8 +247,6 @@ void MVKCmdSetStencilCompareMask::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetStencilWriteMask
 
-MVKFuncionOverride_getTypePool(SetStencilWriteMask)
-
 VkResult MVKCmdSetStencilWriteMask::setContent(MVKCommandBuffer* cmdBuff,
 											   VkStencilFaceFlags faceMask,
 											   uint32_t stencilWriteMask) {
@@ -287,8 +263,6 @@ void MVKCmdSetStencilWriteMask::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdSetStencilReference
-
-MVKFuncionOverride_getTypePool(SetStencilReference)
 
 VkResult MVKCmdSetStencilReference::setContent(MVKCommandBuffer* cmdBuff,
 											   VkStencilFaceFlags faceMask,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -47,8 +47,6 @@ static inline MTLSize mvkClampMTLSize(MTLSize size, MTLOrigin origin, MTLSize ma
 #pragma mark -
 #pragma mark MVKCmdCopyImage
 
-MVKFuncionOverride_getTypePool(CopyImage)
-
 VkResult MVKCmdCopyImage::setContent(MVKCommandBuffer* cmdBuff,
 									 VkImage srcImage,
 									 VkImageLayout srcImageLayout,
@@ -237,8 +235,6 @@ void MVKCmdCopyImage::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdBlitImage
-
-MVKFuncionOverride_getTypePool(BlitImage)
 
 VkResult MVKCmdBlitImage::setContent(MVKCommandBuffer* cmdBuff,
 									 VkImage srcImage,
@@ -449,8 +445,6 @@ MVKCmdBlitImage::~MVKCmdBlitImage() {
 #pragma mark -
 #pragma mark MVKCmdResolveImage
 
-MVKFuncionOverride_getTypePool(ResolveImage)
-
 VkResult MVKCmdResolveImage::setContent(MVKCommandBuffer* cmdBuff,
 										VkImage srcImage,
 										VkImageLayout srcImageLayout,
@@ -643,8 +637,6 @@ MVKCmdResolveImage::~MVKCmdResolveImage() {
 #pragma mark -
 #pragma mark MVKCmdCopyBuffer
 
-MVKFuncionOverride_getTypePool(CopyBuffer)
-
 // Matches shader struct.
 typedef struct {
 	uint32_t srcOffset;
@@ -714,8 +706,6 @@ void MVKCmdCopyBuffer::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdBufferImageCopy
-
-MVKFuncionOverride_getTypePool(BufferImageCopy)
 
 // Matches shader struct.
 typedef struct {
@@ -937,8 +927,6 @@ bool MVKCmdBufferImageCopy::isArrayTexture() {
 #pragma mark -
 #pragma mark MVKCmdClearAttachments
 
-MVKFuncionOverride_getTypePool(ClearAttachments)
-
 VkResult MVKCmdClearAttachments::setContent(MVKCommandBuffer* cmdBuff,
 											uint32_t attachmentCount,
 											const VkClearAttachment* pAttachments,
@@ -1107,8 +1095,6 @@ void MVKCmdClearAttachments::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdClearImage
 
-MVKFuncionOverride_getTypePool(ClearImage)
-
 VkResult MVKCmdClearImage::setContent(MVKCommandBuffer* cmdBuff,
 									  VkImage image,
 									  VkImageLayout imageLayout,
@@ -1224,8 +1210,6 @@ void MVKCmdClearImage::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdFillBuffer
 
-MVKFuncionOverride_getTypePool(FillBuffer)
-
 VkResult MVKCmdFillBuffer::setContent(MVKCommandBuffer* cmdBuff,
 									  VkBuffer dstBuffer,
 									  VkDeviceSize dstOffset,
@@ -1291,8 +1275,6 @@ void MVKCmdFillBuffer::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdUpdateBuffer
-
-MVKFuncionOverride_getTypePool(UpdateBuffer)
 
 VkResult MVKCmdUpdateBuffer::setContent(MVKCommandBuffer* cmdBuff,
 										VkBuffer dstBuffer,

--- a/MoltenVK/MoltenVK/Commands/MVKCommand.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommand.h
@@ -70,13 +70,10 @@ public:
 protected:
 	friend MVKCommandBuffer;
 
+	// Returns the command type pool used by this command, from the command pool.
+	// This function is overridden in each concrete subclass declaration, but the implementation of
+	// this function in each subclass is automatically generated in the MVKCommandPool implementation.
 	virtual MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) = 0;
-
-	// Macro to implement a subclass override of the getTypePool(MVKCommandPool* cmdPool) function.
-#	define MVKFuncionOverride_getTypePool(cmdType)					  							\
-	MVKCommandTypePool<MVKCommand>* MVKCmd ##cmdType ::getTypePool(MVKCommandPool* cmdPool) {	\
-		return (MVKCommandTypePool<MVKCommand>*)&cmdPool->_cmd  ##cmdType ##Pool;				\
-	}
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.h
@@ -59,99 +59,10 @@ public:
 	/** Returns the debug report object type of this object. */
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT; }
 
-#pragma mark Command type pools
-
-	MVKCommandTypePool<MVKCmdPipelineBarrier> _cmdPipelineBarrierPool;
-
-	MVKCommandTypePool<MVKCmdBindPipeline> _cmdBindPipelinePool;
-
-	MVKCommandTypePool<MVKCmdBeginRenderPass> _cmdBeginRenderPassPool;
-
-	MVKCommandTypePool<MVKCmdNextSubpass> _cmdNextSubpassPool;
-
-	MVKCommandTypePool<MVKCmdEndRenderPass> _cmdEndRenderPassPool;
-
-	MVKCommandTypePool<MVKCmdExecuteCommands> _cmdExecuteCommandsPool;
-
-	MVKCommandTypePool<MVKCmdBindDescriptorSets> _cmdBindDescriptorSetsPool;
-
-	MVKCommandTypePool<MVKCmdSetViewport> _cmdSetViewportPool;
-
-	MVKCommandTypePool<MVKCmdSetScissor> _cmdSetScissorPool;
-
-    MVKCommandTypePool<MVKCmdSetLineWidth> _cmdSetLineWidthPool;
-
-    MVKCommandTypePool<MVKCmdSetDepthBias> _cmdSetDepthBiasPool;
-
-    MVKCommandTypePool<MVKCmdSetBlendConstants> _cmdSetBlendConstantsPool;
-
-    MVKCommandTypePool<MVKCmdSetDepthBounds> _cmdSetDepthBoundsPool;
-
-    MVKCommandTypePool<MVKCmdSetStencilCompareMask> _cmdSetStencilCompareMaskPool;
-
-    MVKCommandTypePool<MVKCmdSetStencilWriteMask> _cmdSetStencilWriteMaskPool;
-
-    MVKCommandTypePool<MVKCmdSetStencilReference> _cmdSetStencilReferencePool;
-
-	MVKCommandTypePool<MVKCmdBindVertexBuffers> _cmdBindVertexBuffersPool;
-
-	MVKCommandTypePool<MVKCmdBindIndexBuffer> _cmdBindIndexBufferPool;
-
-	MVKCommandTypePool<MVKCmdDraw> _cmdDrawPool;
-
-	MVKCommandTypePool<MVKCmdDrawIndexed> _cmdDrawIndexedPool;
-
-	MVKCommandTypePool<MVKCmdDrawIndirect> _cmdDrawIndirectPool;
-
-	MVKCommandTypePool<MVKCmdDrawIndexedIndirect> _cmdDrawIndexedIndirectPool;
-
-	MVKCommandTypePool<MVKCmdCopyImage> _cmdCopyImagePool;
-
-	MVKCommandTypePool<MVKCmdBlitImage> _cmdBlitImagePool;
-
-    MVKCommandTypePool<MVKCmdResolveImage> _cmdResolveImagePool;
-
-    MVKCommandTypePool<MVKCmdFillBuffer> _cmdFillBufferPool;
-
-    MVKCommandTypePool<MVKCmdUpdateBuffer> _cmdUpdateBufferPool;
-
-	MVKCommandTypePool<MVKCmdCopyBuffer> _cmdCopyBufferPool;
-
-    MVKCommandTypePool<MVKCmdBufferImageCopy> _cmdBufferImageCopyPool;
-
-	MVKCommandTypePool<MVKCmdClearAttachments> _cmdClearAttachmentsPool;
-
-	MVKCommandTypePool<MVKCmdClearImage> _cmdClearImagePool;
-
-    MVKCommandTypePool<MVKCmdBeginQuery> _cmdBeginQueryPool;
-
-    MVKCommandTypePool<MVKCmdEndQuery> _cmdEndQueryPool;
-
-	MVKCommandTypePool<MVKCmdWriteTimestamp> _cmdWriteTimestampPool;
-
-    MVKCommandTypePool<MVKCmdResetQueryPool> _cmdResetQueryPoolPool;
-
-    MVKCommandTypePool<MVKCmdCopyQueryPoolResults> _cmdCopyQueryPoolResultsPool;
-
-	MVKCommandTypePool<MVKCmdPushConstants> _cmdPushConstantsPool;
-
-    MVKCommandTypePool<MVKCmdDispatch> _cmdDispatchPool;
-
-    MVKCommandTypePool<MVKCmdDispatchIndirect> _cmdDispatchIndirectPool;
-
-    MVKCommandTypePool<MVKCmdPushDescriptorSet> _cmdPushDescriptorSetPool;
-
-    MVKCommandTypePool<MVKCmdPushDescriptorSetWithTemplate> _cmdPushDescriptorSetWithTemplatePool;
-
-	MVKCommandTypePool<MVKCmdDebugMarkerBegin> _cmdDebugMarkerBeginPool;
-
-	MVKCommandTypePool<MVKCmdDebugMarkerEnd> _cmdDebugMarkerEndPool;
-
-	MVKCommandTypePool<MVKCmdDebugMarkerInsert> _cmdDebugMarkerInsertPool;
-
-	MVKCommandTypePool<MVKCmdSetResetEvent> _cmdSetResetEventPool;
-
-	MVKCommandTypePool<MVKCmdWaitEvents> _cmdWaitEventsPool;
+	// Command type pool member variables.
+	// Each has a form similar to (here for a draw command):  MVKCommandTypePool<MVKCmdDraw> _cmdDrawPool;
+#	define MVK_CMD_TYPE_POOL(cmdType)  MVKCommandTypePool<MVKCmd ##cmdType> _cmd ##cmdType ##Pool;
+#	include "MVKCommandTypePools.def"
 
 
 #pragma mark Command resources

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -109,3 +109,14 @@ MVKCommandPool::~MVKCommandPool() {
 	}
 }
 
+#pragma mark -
+#pragma mark MVKCommand subclass getTypePool() functions
+
+// Implementations of the MVKCommand subclass getTypePool() functions.
+#define MVK_CMD_TYPE_POOL(cmdType)					  							\
+MVKCommandTypePool<MVKCommand>* MVKCmd ##cmdType ::getTypePool(MVKCommandPool* cmdPool) {	\
+	return (MVKCommandTypePool<MVKCommand>*)&cmdPool->_cmd  ##cmdType ##Pool;				\
+}
+#include "MVKCommandTypePools.def"
+
+

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -79,55 +79,10 @@ id<MTLCommandBuffer> MVKCommandPool::newMTLCommandBuffer(uint32_t queueIndex) {
 	return [[_device->getQueue(_queueFamilyIndex, queueIndex)->getMTLCommandQueue() commandBuffer] retain];
 }
 
+// Clear the command type pool member variables.
 void MVKCommandPool::trim() {
-	_commandBufferPool.clear();
-	_commandEncodingPool.clear();
-	_cmdPipelineBarrierPool.clear();
-	_cmdBindPipelinePool.clear();
-	_cmdBeginRenderPassPool.clear();
-	_cmdNextSubpassPool.clear();
-	_cmdExecuteCommandsPool.clear();
-	_cmdEndRenderPassPool.clear();
-	_cmdBindDescriptorSetsPool.clear();
-	_cmdSetViewportPool.clear();
-	_cmdSetScissorPool.clear();
-	_cmdSetLineWidthPool.clear();
-	_cmdSetDepthBiasPool.clear();
-	_cmdSetBlendConstantsPool.clear();
-	_cmdSetDepthBoundsPool.clear();
-	_cmdSetStencilCompareMaskPool.clear();
-	_cmdSetStencilWriteMaskPool.clear();
-	_cmdSetStencilReferencePool.clear();
-	_cmdBindVertexBuffersPool.clear();
-	_cmdBindIndexBufferPool.clear();
-	_cmdDrawPool.clear();
-	_cmdDrawIndexedPool.clear();
-	_cmdDrawIndirectPool.clear();
-	_cmdDrawIndexedIndirectPool.clear();
-	_cmdCopyImagePool.clear();
-	_cmdBlitImagePool.clear();
-	_cmdResolveImagePool.clear();
-	_cmdFillBufferPool.clear();
-	_cmdUpdateBufferPool.clear();
-	_cmdCopyBufferPool.clear();
-	_cmdBufferImageCopyPool.clear();
-	_cmdClearAttachmentsPool.clear();
-	_cmdClearImagePool.clear();
-	_cmdBeginQueryPool.clear();
-	_cmdEndQueryPool.clear();
-	_cmdWriteTimestampPool.clear();
-	_cmdResetQueryPoolPool.clear();
-	_cmdCopyQueryPoolResultsPool.clear();
-	_cmdPushConstantsPool.clear();
-	_cmdDispatchPool.clear();
-	_cmdDispatchIndirectPool.clear();
-	_cmdPushDescriptorSetPool.clear();
-	_cmdPushDescriptorSetWithTemplatePool.clear();
-	_cmdDebugMarkerBeginPool.clear();
-	_cmdDebugMarkerEndPool.clear();
-	_cmdDebugMarkerInsertPool.clear();
-	_cmdSetResetEventPool.clear();
-	_cmdWaitEventsPool.clear();
+#	define MVK_CMD_TYPE_POOL(cmdType)  _cmd ##cmdType ##Pool.clear();
+#	include "MVKCommandTypePools.def"
 }
 
 
@@ -140,53 +95,12 @@ MVKCommandPool::MVKCommandPool(MVKDevice* device,
 	_queueFamilyIndex(pCreateInfo->queueFamilyIndex),
 	_commandBufferPool(device, usePooling),
 	_commandEncodingPool(this),
-	_cmdPipelineBarrierPool(usePooling),
-	_cmdBindPipelinePool(usePooling),
-	_cmdBeginRenderPassPool(usePooling),
-	_cmdNextSubpassPool(usePooling),
-	_cmdExecuteCommandsPool(usePooling),
-	_cmdEndRenderPassPool(usePooling),
-	_cmdBindDescriptorSetsPool(usePooling),
-	_cmdSetViewportPool(usePooling),
-	_cmdSetScissorPool(usePooling),
-	_cmdSetLineWidthPool(usePooling),
-	_cmdSetDepthBiasPool(usePooling),
-	_cmdSetBlendConstantsPool(usePooling),
-	_cmdSetDepthBoundsPool(usePooling),
-	_cmdSetStencilCompareMaskPool(usePooling),
-	_cmdSetStencilWriteMaskPool(usePooling),
-	_cmdSetStencilReferencePool(usePooling),
-	_cmdBindVertexBuffersPool(usePooling),
-	_cmdBindIndexBufferPool(usePooling),
-	_cmdDrawPool(usePooling),
-	_cmdDrawIndexedPool(usePooling),
-	_cmdDrawIndirectPool(usePooling),
-	_cmdDrawIndexedIndirectPool(usePooling),
-	_cmdCopyImagePool(usePooling),
-	_cmdBlitImagePool(usePooling),
-	_cmdResolveImagePool(usePooling),
-	_cmdFillBufferPool(usePooling),
-	_cmdUpdateBufferPool(usePooling),
-	_cmdCopyBufferPool(usePooling),
-	_cmdBufferImageCopyPool(usePooling),
-	_cmdClearAttachmentsPool(usePooling),
-	_cmdClearImagePool(usePooling),
-	_cmdBeginQueryPool(usePooling),
-	_cmdEndQueryPool(usePooling),
-	_cmdWriteTimestampPool(usePooling),
-	_cmdResetQueryPoolPool(usePooling),
-	_cmdCopyQueryPoolResultsPool(usePooling),
-	_cmdPushConstantsPool(usePooling),
-	_cmdDispatchPool(usePooling),
-	_cmdDispatchIndirectPool(usePooling),
-	_cmdPushDescriptorSetPool(usePooling),
-	_cmdPushDescriptorSetWithTemplatePool(usePooling),
-	_cmdDebugMarkerBeginPool(usePooling),
-	_cmdDebugMarkerEndPool(usePooling),
-	_cmdDebugMarkerInsertPool(usePooling),
-	_cmdSetResetEventPool(usePooling),
-	_cmdWaitEventsPool(usePooling)
-// when extending be sure to add to trim() as well
+
+// Initialize the command type pool member variables.
+#	define MVK_CMD_TYPE_POOL_LAST(cmdType)  _cmd ##cmdType ##Pool(usePooling)
+#	define MVK_CMD_TYPE_POOL(cmdType)  MVK_CMD_TYPE_POOL_LAST(cmdType),
+#	include "MVKCommandTypePools.def"
+
 {}
 
 MVKCommandPool::~MVKCommandPool() {

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -113,7 +113,8 @@ MVKCommandPool::~MVKCommandPool() {
 #pragma mark MVKCommand subclass getTypePool() functions
 
 // Implementations of the MVKCommand subclass getTypePool() functions.
-#define MVK_CMD_TYPE_POOL(cmdType)					  							\
+#define MVK_TMPLT_DECL  template<>
+#define MVK_CMD_TYPE_POOL(cmdType)					  										\
 MVKCommandTypePool<MVKCommand>* MVKCmd ##cmdType ::getTypePool(MVKCommandPool* cmdPool) {	\
 	return (MVKCommandTypePool<MVKCommand>*)&cmdPool->_cmd  ##cmdType ##Pool;				\
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandTypePools.def
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandTypePools.def
@@ -1,0 +1,83 @@
+/*
+ * MVKCommandTypePools.def
+ *
+ * Copyright (c) 2015-2020 The Brenwill Workshop Ltd. (http://www.brenwill.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// To use this file, define a macro MVK_CMD_TYPE_POOL(cmdType), then #include this file.
+// If the last entry needs to be different (for example to avoid a dangling ',' at the
+// end of an initializer list, also define a macro MVK_CMD_TYPE_POOL_LAST(cmdType).
+
+// To add a new command type, simply add an MVK_CMD_TYPE_POOL() line below.
+// The last line in the list must be MVK_CMD_TYPE_POOL_LAST().
+
+#ifndef MVK_CMD_TYPE_POOL
+#error MVK_CMD_TYPE_POOL must be defined before including this file
+#endif
+
+#ifndef MVK_CMD_TYPE_POOL_LAST
+#define MVK_CMD_TYPE_POOL_LAST(cmdType) MVK_CMD_TYPE_POOL(cmdType)
+#endif
+
+MVK_CMD_TYPE_POOL(PipelineBarrier)
+MVK_CMD_TYPE_POOL(BindPipeline)
+MVK_CMD_TYPE_POOL(BeginRenderPass)
+MVK_CMD_TYPE_POOL(NextSubpass)
+MVK_CMD_TYPE_POOL(EndRenderPass)
+MVK_CMD_TYPE_POOL(ExecuteCommands)
+MVK_CMD_TYPE_POOL(BindDescriptorSets)
+MVK_CMD_TYPE_POOL(SetViewport)
+MVK_CMD_TYPE_POOL(SetScissor)
+MVK_CMD_TYPE_POOL(SetLineWidth)
+MVK_CMD_TYPE_POOL(SetDepthBias)
+MVK_CMD_TYPE_POOL(SetBlendConstants)
+MVK_CMD_TYPE_POOL(SetDepthBounds)
+MVK_CMD_TYPE_POOL(SetStencilCompareMask)
+MVK_CMD_TYPE_POOL(SetStencilWriteMask)
+MVK_CMD_TYPE_POOL(SetStencilReference)
+MVK_CMD_TYPE_POOL(BindVertexBuffers)
+MVK_CMD_TYPE_POOL(BindIndexBuffer)
+MVK_CMD_TYPE_POOL(Draw)
+MVK_CMD_TYPE_POOL(DrawIndexed)
+MVK_CMD_TYPE_POOL(DrawIndirect)
+MVK_CMD_TYPE_POOL(DrawIndexedIndirect)
+MVK_CMD_TYPE_POOL(CopyImage)
+MVK_CMD_TYPE_POOL(BlitImage)
+MVK_CMD_TYPE_POOL(ResolveImage)
+MVK_CMD_TYPE_POOL(FillBuffer)
+MVK_CMD_TYPE_POOL(UpdateBuffer)
+MVK_CMD_TYPE_POOL(CopyBuffer)
+MVK_CMD_TYPE_POOL(BufferImageCopy)
+MVK_CMD_TYPE_POOL(ClearAttachments)
+MVK_CMD_TYPE_POOL(ClearImage)
+MVK_CMD_TYPE_POOL(BeginQuery)
+MVK_CMD_TYPE_POOL(EndQuery)
+MVK_CMD_TYPE_POOL(WriteTimestamp)
+MVK_CMD_TYPE_POOL(ResetQueryPool)
+MVK_CMD_TYPE_POOL(CopyQueryPoolResults)
+MVK_CMD_TYPE_POOL(PushConstants)
+MVK_CMD_TYPE_POOL(Dispatch)
+MVK_CMD_TYPE_POOL(DispatchIndirect)
+MVK_CMD_TYPE_POOL(PushDescriptorSet)
+MVK_CMD_TYPE_POOL(PushDescriptorSetWithTemplate)
+MVK_CMD_TYPE_POOL(DebugMarkerBegin)
+MVK_CMD_TYPE_POOL(DebugMarkerEnd)
+MVK_CMD_TYPE_POOL(DebugMarkerInsert)
+MVK_CMD_TYPE_POOL(SetResetEvent)
+MVK_CMD_TYPE_POOL_LAST(WaitEvents)
+
+#undef MVK_CMD_TYPE_POOL
+#undef MVK_CMD_TYPE_POOL_LAST

--- a/MoltenVK/MoltenVK/Commands/MVKCommandTypePools.def
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandTypePools.def
@@ -21,15 +21,24 @@
 // If the last entry needs to be different (for example to avoid a dangling ',' at the
 // end of an initializer list, also define a macro MVK_CMD_TYPE_POOL_LAST(cmdType).
 
+// MVK_TMPLT_DECL is used to support adding a "template<>" prefix when this file is used
+// to define function implementations for a concrete implementation of a class template
+
 // To add a new command type, simply add an MVK_CMD_TYPE_POOL() line below.
 // The last line in the list must be MVK_CMD_TYPE_POOL_LAST().
+// If the command is a concrete implementation of a template class, include the
+// MVK_TMPLT_DECL prefix.
+
+#ifndef MVK_TMPLT_DECL
+#	define MVK_TMPLT_DECL
+#endif
 
 #ifndef MVK_CMD_TYPE_POOL
-#error MVK_CMD_TYPE_POOL must be defined before including this file
+#	error MVK_CMD_TYPE_POOL must be defined before including this file
 #endif
 
 #ifndef MVK_CMD_TYPE_POOL_LAST
-#define MVK_CMD_TYPE_POOL_LAST(cmdType) MVK_CMD_TYPE_POOL(cmdType)
+#	define MVK_CMD_TYPE_POOL_LAST(cmdType) MVK_CMD_TYPE_POOL(cmdType)
 #endif
 
 MVK_CMD_TYPE_POOL(PipelineBarrier)
@@ -39,8 +48,10 @@ MVK_CMD_TYPE_POOL(NextSubpass)
 MVK_CMD_TYPE_POOL(EndRenderPass)
 MVK_CMD_TYPE_POOL(ExecuteCommands)
 MVK_CMD_TYPE_POOL(BindDescriptorSets)
-MVK_CMD_TYPE_POOL(SetViewport)
-MVK_CMD_TYPE_POOL(SetScissor)
+MVK_TMPLT_DECL MVK_CMD_TYPE_POOL(SetViewport1)
+MVK_TMPLT_DECL MVK_CMD_TYPE_POOL(SetViewportMulti)
+MVK_TMPLT_DECL MVK_CMD_TYPE_POOL(SetScissor1)
+MVK_TMPLT_DECL MVK_CMD_TYPE_POOL(SetScissorMulti)
 MVK_CMD_TYPE_POOL(SetLineWidth)
 MVK_CMD_TYPE_POOL(SetDepthBias)
 MVK_CMD_TYPE_POOL(SetBlendConstants)
@@ -81,3 +92,4 @@ MVK_CMD_TYPE_POOL_LAST(WaitEvents)
 
 #undef MVK_CMD_TYPE_POOL
 #undef MVK_CMD_TYPE_POOL_LAST
+#undef MVK_TMPLT_DECL

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1352,7 +1352,11 @@ MVK_PUBLIC_SYMBOL void vkCmdSetViewport(
 	const VkViewport*                           pViewports) {
 
 	MVKTraceVulkanCallStart();
-	MVKAddCmd(SetViewport, commandBuffer, firstViewport, viewportCount, pViewports);
+	if (viewportCount <= 1) {
+		MVKAddCmd(SetViewport1, commandBuffer, firstViewport, viewportCount, pViewports);
+	} else {
+		MVKAddCmd(SetViewportMulti, commandBuffer, firstViewport, viewportCount, pViewports);
+	}
 	MVKTraceVulkanCallEnd();
 }
 
@@ -1363,7 +1367,11 @@ MVK_PUBLIC_SYMBOL void vkCmdSetScissor(
 	const VkRect2D*                             pScissors) {
 
 	MVKTraceVulkanCallStart();
-	MVKAddCmd(SetScissor, commandBuffer, firstScissor, scissorCount, pScissors);
+	if (scissorCount <= 1) {
+		MVKAddCmd(SetScissor1, commandBuffer, firstScissor, scissorCount, pScissors);
+	} else {
+		MVKAddCmd(SetScissorMulti, commandBuffer, firstScissor, scissorCount, pScissors);
+	}
 	MVKTraceVulkanCallEnd();
 }
 


### PR DESCRIPTION
To allow these classes to contain reasonably-sized pre-allocated vectors,
make `MVKCmdSetViewport` & `MVKCmdSetScissor` template classes based on quantities.
Create two concrete implementations of each for 1 and 16 viewports or scissors.
`vkCmdSetViewport()` and `vkCmdSetScissor()` choose which concrete template class
implementation to use based on the number of viewports or scissors, respectively.

