### PR TITLE
Mark computePipelineState as dirty when destroying mtlComputeEncoder

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -449,6 +449,10 @@ void MVKCommandEncoder::endMetalRenderEncoding() {
 void MVKCommandEncoder::endCurrentMetalEncoding() {
 	endMetalRenderEncoding();
 
+	_computePipelineState.markDirty();
+	_computeResourcesState.markDirty();
+	_computePushConstants.markDirty();
+
 	[_mtlComputeEncoder endEncoding];
 	_mtlComputeEncoder = nil;       // not retained
 	_mtlComputeEncoderUse = kMVKCommandUseNone;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -514,6 +514,8 @@ public:
     /** Sets the current buffer size buffer state. */
     void bindBufferSizeBuffer(const MVKShaderImplicitRezBinding& binding, bool needSizeBuffer);
 
+    void markDirty() override;
+
 #pragma mark Construction
 
     /** Constructs this instance for the specified command encoder. */
@@ -522,7 +524,6 @@ public:
 protected:
     void encodeImpl(uint32_t) override;
     void resetImpl() override;
-    void markDirty() override;
 
     MVKVectorInline<MVKMTLBufferBinding, 4> _bufferBindings;
     MVKVectorInline<MVKMTLTextureBinding, 4> _textureBindings;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -75,7 +75,7 @@ public:
 	id<MTLBuffer> getMTLBuffer();
 
 	/** Returns the offset at which the contents of this instance starts within the underlying Metal buffer. */
-	inline NSUInteger getMTLBufferOffset() { return _deviceMemory && _deviceMemory->getMTLHeap() && !_isHostCoherentTexelBuffer ? 0 : _deviceMemoryOffset; }
+	inline NSUInteger getMTLBufferOffset() { return !_deviceMemory || _deviceMemory->getMTLHeap() || _isHostCoherentTexelBuffer ? 0 : _deviceMemoryOffset; }
 
 
 #pragma mark Construction


### PR DESCRIPTION
Consider the following (approximate) sequence of commands:
1. vkCmdBindPipeline (compute)
2. vkCmdDispatch: will call setComputePipelineState:_ and mark state as clean
3. vkCmdBeginRenderPass .. draw .. vkCmdEndRenderPass: will endCurrentMetalEncoding()
4. vkCmdDispatch: will recreate mtlComputeEncoder, but won't setComputePipelineState:_ as state is still marked clean, and will crash as a result

AFAIU this is valid usage and binding made in 1. should hold. The patch makes endCurrentMetalEncoding() also mark compute pipeline state as dirty.