### PR TITLE
vkGetPhysicalDeviceFormatProperties() remove log message for unsupported format when retrieving properties.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -263,12 +263,7 @@ size_t MVKPixelFormats::getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesP
 }
 
 VkFormatProperties& MVKPixelFormats::getVkFormatProperties(VkFormat vkFormat) {
-	auto& vkDesc = getVkFormatDesc(vkFormat);
-	if ( !vkDesc.isSupported() ) {
-		MVKBaseObject::reportError(_physicalDevice, VK_ERROR_FORMAT_NOT_SUPPORTED,
-								   "VkFormat %s is not supported on this device.", vkDesc.name);
-	}
-	return vkDesc.properties;
+	return getVkFormatDesc(vkFormat).properties;
 }
 
 MVKMTLFmtCaps MVKPixelFormats::getCapabilities(VkFormat vkFormat) {


### PR DESCRIPTION
Fixes secondary issue in #888.