### PR TITLE
 Check for stencil only image view in identity swizzle case 

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -148,7 +148,11 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
                 MVKBuffer* buffer = (MVKBuffer*)bufferInfo.buffer;
                 bb.mtlBuffer = buffer->getMTLBuffer();
                 bb.offset = buffer->getMTLBufferOffset() + bufferInfo.offset;
-				bb.size = (uint32_t)buffer->getByteCount();
+                if (bufferInfo.range == VK_WHOLE_SIZE)
+                    bb.size = (uint32_t)(buffer->getByteCount() - bb.offset);
+                else
+                    bb.size = (uint32_t)bufferInfo.range;
+
                 for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
                     if (_applyToStage[i]) {
                         bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
@@ -493,7 +497,10 @@ void MVKBufferDescriptor::bind(MVKCommandEncoder* cmdEncoder,
 			if (_mvkBuffer) {
 				bb.mtlBuffer = _mvkBuffer->getMTLBuffer();
 				bb.offset = _mvkBuffer->getMTLBufferOffset() + _buffOffset + bufferDynamicOffset;
-				bb.size = (uint32_t)_mvkBuffer->getByteCount();
+				if (_buffRange == VK_WHOLE_SIZE)
+					bb.size = (uint32_t)(_mvkBuffer->getByteCount() - bb.offset);
+				else
+					bb.size = _buffRange;
 			}
 			for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
 				if (stages[i]) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1231,6 +1231,16 @@ VkResult MVKImageView::validateSwizzledMTLPixelFormat(const VkImageViewCreateInf
 
 	// If we have an identity swizzle, we're all good.
 	if (SWIZZLE_MATCHES(R, G, B, A)) {
+		// Change to stencil-only format if only stencil aspect is requested
+		if (pCreateInfo->subresourceRange.aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
+			if (mtlPixFmt == MTLPixelFormatDepth32Float_Stencil8)
+				mtlPixFmt = MTLPixelFormatX32_Stencil8;
+#if MVK_MACOS
+			else if (mtlPixFmt == MTLPixelFormatDepth24Unorm_Stencil8)
+				mtlPixFmt = MTLPixelFormatX24_Stencil8;
+#endif
+		}
+
 		return VK_SUCCESS;
 	}
 


### PR DESCRIPTION
The buffer binding size looks unused now (?), but the other commit sets it to the specified value.