### PR TITLE
Travis CI: Update to Xcode 11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 
 # macOS and Xcode Version
 os: osx
-osx_image: xcode11.3
+osx_image: xcode11.5
 
 # Build dependencies
 # Travis has trouble with python3, which SPIRV-Tools requires,


### PR DESCRIPTION
from Xcode 11.3. Also updates macOS version from 10.14.6 to 10.15.4 and JDK from 14.0.0 to 14.0.1