### PR TITLE
Handle vertex attributes with zero stride

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1009,7 +1009,7 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(MTLRenderPipelineDescriptor* 
 				const VkVertexInputBindingDescription* pVKVB = pVI->pVertexBindingDescriptions;
 				for (uint32_t j = 0; j < vbCnt; j++, pVKVB++) {
 					if (pVKVB->binding == pVKVA->binding) {
-						if (vaOffset >= pVKVB->stride) {
+						if (pVKVB->stride && vaOffset >= pVKVB->stride) {
 							// Move vertex attribute offset into the stride. This vertex attribute may be
 							// combined with other vertex attributes into the same translated buffer binding.
 							// But if the reduced offset combined with the vertex attribute size still won't


### PR DESCRIPTION
6df700f Avoids a div by zero crash below on %= stride line.
I don't have a good test case for 011f029, but searching github for `MTLVertexStepFunctionConstant` reveals that UE4 and Dawn do something similar.