### PR TITLE
Fixes 4 bugs in VK_EXT_inline_uniform_block

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -71,7 +71,7 @@ public:
 	inline uint32_t getBinding() { return _info.binding; }
 
 	/** Returns the number of descriptors in this layout. */
-	inline uint32_t getDescriptorCount() { return _info.descriptorCount; }
+    inline uint32_t getDescriptorCount() { return (_info.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) ? 1 : _info.descriptorCount; }
 
 	/** Returns the descriptor type of this layout. */
 	inline VkDescriptorType getDescriptorType() { return _info.descriptorType; }
@@ -284,17 +284,19 @@ public:
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
-			   uint32_t srcIndex,
+			   uint32_t dstIndex,
 			   size_t stride,
 			   const void* pData) override;
 
 	void read(MVKDescriptorSet* mvkDescSet,
 			  VkDescriptorType descriptorType,
-			  uint32_t dstIndex,
+			  uint32_t srcIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    
+    void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index) override;
 
 	void reset() override;
 
@@ -302,7 +304,6 @@ public:
 
 protected:
 	id<MTLBuffer> _mtlBuffer = nil;
-	uint32_t _dataSize = 0;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -212,6 +212,7 @@ void MVKDescriptorSet::write(const DescriptorAction* pDescriptorAction,
 	uint32_t descCnt = pDescriptorAction->descriptorCount;
     if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
         uint32_t dstStartIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding, 0);
+        // For inline buffers we are using the index argument as dst offset not as src descIdx
         _descriptors[dstStartIdx]->write(this, descType, pDescriptorAction->dstArrayElement, stride, pData);
     } else {
         uint32_t dstStartIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding,
@@ -241,6 +242,7 @@ void MVKDescriptorSet::read(const VkCopyDescriptorSet* pDescriptorCopy,
     if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
         pInlineUniformBlock->dataSize = pDescriptorCopy->descriptorCount;
         uint32_t srcStartIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding, 0);
+        // For inline buffers we are using the index argument as src offset not as dst descIdx
         _descriptors[srcStartIdx]->read(this, descType, pDescriptorCopy->srcArrayElement, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
     } else {
         uint32_t srcStartIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -209,12 +209,17 @@ void MVKDescriptorSet::write(const DescriptorAction* pDescriptorAction,
 							 const void* pData) {
 
 	VkDescriptorType descType = getDescriptorType(pDescriptorAction->dstBinding);
-	uint32_t dstStartIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding,
-													   pDescriptorAction->dstArrayElement);
 	uint32_t descCnt = pDescriptorAction->descriptorCount;
-	for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
-		_descriptors[dstStartIdx + descIdx]->write(this, descType, descIdx, stride, pData);
-	}
+    if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        uint32_t dstStartIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding, 0);
+        _descriptors[dstStartIdx]->write(this, descType, pDescriptorAction->dstArrayElement, stride, pData);
+    } else {
+        uint32_t dstStartIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding,
+        pDescriptorAction->dstArrayElement);
+        for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
+            _descriptors[dstStartIdx + descIdx]->write(this, descType, descIdx, stride, pData);
+        }
+    }
 }
 
 // Create concrete implementations of the three variations of the write() function.
@@ -232,13 +237,18 @@ void MVKDescriptorSet::read(const VkCopyDescriptorSet* pDescriptorCopy,
 							VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
 
 	VkDescriptorType descType = getDescriptorType(pDescriptorCopy->srcBinding);
-	uint32_t srcStartIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding,
-													   pDescriptorCopy->srcArrayElement);
 	uint32_t descCnt = pDescriptorCopy->descriptorCount;
-	for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
-		_descriptors[srcStartIdx + descIdx]->read(this, descType, descIdx, pImageInfo, pBufferInfo,
-												  pTexelBufferView, pInlineUniformBlock);
-	}
+    if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        pInlineUniformBlock->dataSize = pDescriptorCopy->descriptorCount;
+        uint32_t srcStartIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding, 0);
+        _descriptors[srcStartIdx]->read(this, descType, pDescriptorCopy->srcArrayElement, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
+    } else {
+        uint32_t srcStartIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding,
+                                                           pDescriptorCopy->srcArrayElement);
+        for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
+            _descriptors[srcStartIdx + descIdx]->read(this, descType, descIdx, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
+        }
+    }
 }
 
 // If the descriptor pool fails to allocate a descriptor, record a configuration error
@@ -249,15 +259,23 @@ MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorSetLayout* layout, MVKDescriptor
 	uint32_t bindCnt = (uint32_t)layout->_bindings.size();
 	for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
 		MVKDescriptorSetLayoutBinding* mvkDSLBind = &layout->_bindings[bindIdx];
-		uint32_t descCnt = mvkDSLBind->getDescriptorCount();
-		for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
-			MVKDescriptor* mvkDesc = nullptr;
-			setConfigurationResult(_pool->allocateDescriptor(mvkDSLBind->getDescriptorType(), &mvkDesc));
-			if ( !wasConfigurationSuccessful() ) { break; }
+        MVKDescriptor* mvkDesc = nullptr;
+        if (mvkDSLBind->getDescriptorType() == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+            setConfigurationResult(_pool->allocateDescriptor(mvkDSLBind->getDescriptorType(), &mvkDesc));
+            if ( !wasConfigurationSuccessful() ) { break; }
 
-			mvkDesc->setLayout(mvkDSLBind, descIdx);
-			_descriptors.push_back(mvkDesc);
-		}
+            mvkDesc->setLayout(mvkDSLBind, 0);
+            _descriptors.push_back(mvkDesc);
+        } else {
+            uint32_t descCnt = mvkDSLBind->getDescriptorCount();
+            for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
+                setConfigurationResult(_pool->allocateDescriptor(mvkDSLBind->getDescriptorType(), &mvkDesc));
+                if ( !wasConfigurationSuccessful() ) { break; }
+
+                mvkDesc->setLayout(mvkDSLBind, descIdx);
+                _descriptors.push_back(mvkDesc);
+            }
+        }
 		if ( !wasConfigurationSuccessful() ) { break; }
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -209,6 +209,15 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 				portabilityProps->minVertexInputBindingStrideAlignment = 4;
 				break;
 			}
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT: {
+				auto* inlineUniformBlockProps = (VkPhysicalDeviceInlineUniformBlockPropertiesEXT*)next;
+				inlineUniformBlockProps->maxInlineUniformBlockSize = _metalFeatures.dynamicMTLBufferSize;
+                inlineUniformBlockProps->maxPerStageDescriptorInlineUniformBlocks = _properties.limits.maxPerStageDescriptorUniformBuffers;
+                inlineUniformBlockProps->maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = _properties.limits.maxPerStageDescriptorUniformBuffers;
+                inlineUniformBlockProps->maxDescriptorSetInlineUniformBlocks = _properties.limits.maxDescriptorSetUniformBuffers;
+                inlineUniformBlockProps->maxDescriptorSetUpdateAfterBindInlineUniformBlocks = _properties.limits.maxDescriptorSetUniformBuffers;
+				break;
+			}
 			default:
 				break;
 		}


### PR DESCRIPTION
* descriptorCount measures bytes
* array indices are offsets into the buffer (allow partial read & write)
* missing isInline flag in bind
* missing struct VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT