### PR TITLE
Fixes and consistency improvements to the recent VK_KHR_sampler_ycbcr_conversion extension.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -86,7 +86,6 @@ public:
 
 protected:
 	friend class MVKDeviceMemory;
-	using MVKResource::needsHostReadSync;
 
 	void propagateDebugName() override;
 	bool needsHostReadSync(VkPipelineStageFlags srcStageMask,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2252,7 +2252,7 @@ MVKImage* MVKDevice::createImage(const VkImageCreateInfo* pCreateInfo,
         ? new MVKPeerSwapchainImage(this, pCreateInfo, (MVKSwapchain*)swapchainInfo->swapchain, uint32_t(-1))
         : new MVKImage(this, pCreateInfo);
     for (auto& memoryBinding : mvkImg->_memoryBindings) {
-        addResource(memoryBinding.get());
+        addResource(memoryBinding);
     }
 	return mvkImg;
 }
@@ -2261,7 +2261,7 @@ void MVKDevice::destroyImage(MVKImage* mvkImg,
 							 const VkAllocationCallbacks* pAllocator) {
 	if (mvkImg) {
 		for (auto& memoryBinding : mvkImg->_memoryBindings) {
-            removeResource(memoryBinding.get());
+            removeResource(memoryBinding);
         }
 		mvkImg->destroy();
 	}
@@ -2293,7 +2293,7 @@ MVKPresentableSwapchainImage* MVKDevice::createPresentableSwapchainImage(const V
 																		 const VkAllocationCallbacks* pAllocator) {
     MVKPresentableSwapchainImage* mvkImg = new MVKPresentableSwapchainImage(this, pCreateInfo, swapchain, swapchainIndex);
     for (auto& memoryBinding : mvkImg->_memoryBindings) {
-        addResource(memoryBinding.get());
+        addResource(memoryBinding);
     }
     return mvkImg;
 }
@@ -2302,7 +2302,7 @@ void MVKDevice::destroyPresentableSwapchainImage(MVKPresentableSwapchainImage* m
 												 const VkAllocationCallbacks* pAllocator) {
 	if (mvkImg) {
 		for (auto& memoryBinding : mvkImg->_memoryBindings) {
-            removeResource(memoryBinding.get());
+            removeResource(memoryBinding);
         }
 		mvkImg->destroy();
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -77,7 +77,7 @@ public:
 	/** Unmaps a previously mapped memory range. */
 	void unmap();
 
-	/** 
+	/**
 	 * If this memory is host-visible, the specified memory range is flushed to the device.
 	 * Normally, flushing will only occur if the device memory is non-coherent, but flushing
 	 * to coherent memory can be forced by setting evenIfCoherent to true.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -320,7 +320,7 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 		}
 #endif
         for (auto& memoryBinding : ((MVKImage*)dedicatedImage)->_memoryBindings) {
-            _imageMemoryBindings.push_back(memoryBinding.get());
+            _imageMemoryBindings.push_back(memoryBinding);
         }
 		return;
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -28,6 +28,7 @@
 
 #import <IOSurface/IOSurfaceRef.h>
 
+class MVKImage;
 class MVKImageView;
 class MVKSwapchain;
 class MVKCommandEncoder;
@@ -43,10 +44,14 @@ typedef struct {
     VkImageLayout layoutState;
 } MVKImageSubresource;
 
-class MVKImagePlane {
+class MVKImagePlane : public MVKBaseObject {
 
 public:
-    /** Returns the Metal texture underlying this image plane. */
+
+	/** Returns the Vulkan API opaque object controlling this object. */
+	MVKVulkanAPIObject* getVulkanAPIObject() override;
+
+	/** Returns the Metal texture underlying this image plane. */
     id<MTLTexture> getMTLTexture();
 
     /** Returns a Metal texture that interprets the pixels in the specified format. */
@@ -332,8 +337,8 @@ protected:
 	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
     void releaseIOSurface();
 
-    MVKSmallVector<std::unique_ptr<MVKImageMemoryBinding>, 3> _memoryBindings;
-    MVKSmallVector<std::unique_ptr<MVKImagePlane>, 3> _planes;
+    MVKSmallVector<MVKImageMemoryBinding*, 3> _memoryBindings;
+    MVKSmallVector<MVKImagePlane*, 3> _planes;
     VkExtent3D _extent;
     uint32_t _mipLevels;
     uint32_t _arrayLayers;
@@ -483,7 +488,10 @@ protected:
 #pragma mark -
 #pragma mark MVKImageViewPlane
 
-class MVKImageViewPlane {
+class MVKImageViewPlane : public MVKBaseObject {
+
+	/** Returns the Vulkan API opaque object controlling this object. */
+	MVKVulkanAPIObject* getVulkanAPIObject() override;
 
 public:
     /** Returns the Metal texture underlying this image view. */
@@ -581,13 +589,15 @@ public:
 				 const VkImageViewCreateInfo* pCreateInfo,
 				 const MVKConfiguration* pAltMVKConfig = nullptr);
 
+	~MVKImageView();
+
 protected:
     friend MVKImageViewPlane;
     
 	void propagateDebugName() override;
 
     MVKImage* _image;
-    MVKSmallVector<std::unique_ptr<MVKImageViewPlane>, 3> _planes;
+    MVKSmallVector<MVKImageViewPlane*, 3> _planes;
     VkImageSubresourceRange _subresourceRange;
     VkImageUsageFlags _usage;
 	std::mutex _lock;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -488,7 +488,7 @@ protected:
 #pragma mark -
 #pragma mark MVKImageViewPlane
 
-class MVKImageViewPlane : public MVKBaseObject {
+class MVKImageViewPlane : public MVKBaseDeviceObject {
 
 	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -119,7 +119,7 @@ protected:
     void propagateDebugName() override;
     bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
                            VkPipelineStageFlags dstStageMask,
-                           VkMemoryBarrier* pMemoryBarrier) override;
+                           MVKPipelineBarrier& barrier);
     bool shouldFlushHostMemory();
     VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
     VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
@@ -72,10 +72,6 @@ public:
     MVKResource(MVKDevice* device) : MVKVulkanAPIDeviceObject(device) {}
 
 protected:
-	virtual bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
-								   VkPipelineStageFlags dstStageMask,
-								   VkMemoryBarrier* pMemoryBarrier);
-
 	MVKDeviceMemory* _deviceMemory = nullptr;
 	VkDeviceSize _deviceMemoryOffset = 0;
     VkDeviceSize _byteCount = 0;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.mm
@@ -34,18 +34,3 @@ VkResult MVKResource::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize mem
 	return VK_SUCCESS;
 }
 
-// Returns whether the specified global memory barrier requires a sync between this
-// texture and host memory for the purpose of the host reading texture memory.
-bool MVKResource::needsHostReadSync(VkPipelineStageFlags srcStageMask,
-									VkPipelineStageFlags dstStageMask,
-									VkMemoryBarrier* pMemoryBarrier) {
-#if MVK_IOS
-	return false;
-#endif
-#if MVK_MACOS
-	return (mvkIsAnyFlagEnabled(dstStageMask, (VK_PIPELINE_STAGE_HOST_BIT)) &&
-			mvkIsAnyFlagEnabled(pMemoryBarrier->dstAccessMask, (VK_ACCESS_HOST_READ_BIT)) &&
-			isMemoryHostAccessible() && !isMemoryHostCoherent());
-#endif
-}
-


### PR DESCRIPTION
This includes some fixes and consistency improvements to the recent `VK_KHR_sampler_ycbcr_conversion` extension code.

- Fix `MVKImageViewPlane` ignoring swizzle. Allow `MVKImageViewPlane MTLPixelFormat` to be modified by swizzle settings by `MVKImageView::validateSwizzledMTLPixelFormat()`.
- Treat `MVKImageMemoryBinding`, `MVKImagePlane`, and `MVKImageViewPlane` as subclasses of `MVKBaseObject` for lifecycles. Remove use of `unique_ptr` to manage destruction of instances of these classes, and instead, call `destroy()` on them during destruction of `MVKImage` and `MVKImageView`.
- Make `MVKImageViewPlane` a subclass of `MVKBaseDeviceObject` to streamline device access.
- `MVKImageMemoryBinding::needsHostReadSync()` use `MVKPipelineBarrier`, and remove obsolete `MVKResource::needsHostReadSync()`, which was no longer being used.

@Lichtso The only real functionality change here is the first one (swizzle behaviour). It was breaking on apps that use standard swizzles. I assume that was just an oversight and not a deliberate change. But let me know if otherwise. 