### PR TITLE
Fix issue where mapped host-coherent device memory not updated from image contents on macOS.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,8 +20,9 @@ Released TBD
 
 - Add support for extensions:
 	- VK_KHR_sampler_ycbcr_conversion
-- Remove use of `@available()` directive as it was causing issues in some build environments
-- Refactor **MoltenVK** *Xcode* build architectures
+- Fix issue where mapped host-coherent device memory not updated from image contents on *macOS*.
+- Remove use of `@available()` directive as it was causing issues in some build environments.
+- Refactor **MoltenVK** *Xcode* build architectures.
 - Demo `API-Samples generateSPIRVShaders` no longer builds `MoltenVKShaderController` tool.
 
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,8 @@ MoltenVK 1.0.44
 
 Released TBD
 
+- Add support for extensions:
+	- VK_KHR_sampler_ycbcr_conversion
 - Remove use of `@available()` directive as it was causing issues in some build environments
 - Refactor **MoltenVK** *Xcode* build architectures
 - Demo `API-Samples generateSPIRVShaders` no longer builds `MoltenVKShaderController` tool.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -46,7 +46,7 @@ public:
 	VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
 
 	/** Binds this resource to the specified offset within the specified memory allocation. */
-	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset);
+	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
 
 	/** Binds this resource to the specified offset within the specified memory allocation. */
 	VkResult bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -33,6 +33,12 @@ static const VkExternalMemoryHandleTypeFlagBits VK_EXTERNAL_MEMORY_HANDLE_TYPE_M
 
 #pragma mark MVKDeviceMemory
 
+typedef struct {
+	VkDeviceSize offset = 0;
+	VkDeviceSize size = 0;
+} MVKMappedMemoryRange;
+
+
 /** Represents a Vulkan device-space memory allocation. */
 class MVKDeviceMemory : public MVKVulkanAPIDeviceObject {
 
@@ -76,6 +82,16 @@ public:
 
 	/** Unmaps a previously mapped memory range. */
 	void unmap();
+
+	/**
+	 * If this device memory is currently mapped to host memory, returns the range within
+	 * this device memory that is currently mapped to host memory, or returns {0,0} if
+	 * this device memory is not currently mapped to host memory.
+	 */
+	inline const MVKMappedMemoryRange& getMappedRange() { return _mappedRange; }
+
+	/** Returns whether this device memory is currently mapped to host memory. */
+	bool isMapped() { return _mappedRange.size > 0; }
 
 	/**
 	 * If this memory is host-visible, the specified memory range is flushed to the device.
@@ -150,13 +166,11 @@ protected:
 	MVKSmallVector<MVKImageMemoryBinding*, 4> _imageMemoryBindings;
 	std::mutex _rezLock;
     VkDeviceSize _allocationSize = 0;
-	VkDeviceSize _mapOffset = 0;
-	VkDeviceSize _mapSize = 0;
+	MVKMappedMemoryRange _mappedRange;
 	id<MTLBuffer> _mtlBuffer = nil;
 	id<MTLHeap> _mtlHeap = nil;
 	void* _pMemory = nullptr;
 	void* _pHostMemory = nullptr;
-	bool _isMapped = false;
 	bool _isDedicated = false;
 	MTLStorageMode _mtlStorageMode;
 	MTLCPUCacheMode _mtlCPUCacheMode;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -70,6 +70,7 @@ protected:
     MVKImageSubresource* getSubresource(uint32_t mipLevel, uint32_t arrayLayer);
     void updateMTLTextureContent(MVKImageSubresource& subresource, VkDeviceSize offset, VkDeviceSize size);
     void getMTLTextureContent(MVKImageSubresource& subresource, VkDeviceSize offset, VkDeviceSize size);
+	bool overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset, VkDeviceSize size);
     void propagateDebugName();
     MVKImageMemoryBinding* getMemoryBinding() const;
 	void applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
@@ -77,6 +78,9 @@ protected:
 								 MVKPipelineBarrier& barrier,
 								 MVKCommandEncoder* cmdEncoder,
 								 MVKCommandUse cmdUse);
+	void pullFromDeviceOnCompletion(MVKCommandEncoder* cmdEncoder,
+									MVKImageSubresource& subresource,
+									const MVKMappedMemoryRange& mappedRange);
 
     MVKImagePlane(MVKImage* image, uint8_t planeIndex);
 
@@ -119,7 +123,7 @@ public:
                             MVKPipelineBarrier& barrier,
                             MVKCommandEncoder* cmdEncoder,
                             MVKCommandUse cmdUse) override;
-    
+
     ~MVKImageMemoryBinding();
 
 protected:
@@ -314,12 +318,6 @@ public:
 
 	/** Returns the Metal CPU cache mode used by this image. */
 	MTLCPUCacheMode getMTLCPUCacheMode();
-
-	/** 
-	 * Returns whether the memory is automatically coherent between device and host. 
-	 * On macOS, this always returns false because textures cannot use Shared storage mode.
-	 */
-	bool isMemoryHostCoherent();
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -62,6 +62,9 @@ public:
     ~MVKImagePlane();
 
 protected:
+	friend class MVKImageMemoryBinding;
+	friend MVKImage;
+
     MTLTextureDescriptor* newMTLTextureDescriptor();
     void initSubresources(const VkImageCreateInfo* pCreateInfo);
     MVKImageSubresource* getSubresource(uint32_t mipLevel, uint32_t arrayLayer);
@@ -69,11 +72,14 @@ protected:
     void getMTLTextureContent(MVKImageSubresource& subresource, VkDeviceSize offset, VkDeviceSize size);
     void propagateDebugName();
     MVKImageMemoryBinding* getMemoryBinding() const;
+	void applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
+								 VkPipelineStageFlags dstStageMask,
+								 MVKPipelineBarrier& barrier,
+								 MVKCommandEncoder* cmdEncoder,
+								 MVKCommandUse cmdUse);
 
     MVKImagePlane(MVKImage* image, uint8_t planeIndex);
 
-    friend class MVKImageMemoryBinding;
-    friend MVKImage;
     MVKImage* _image;
     uint8_t _planeIndex;
     VkExtent2D _blockTexelSize;
@@ -105,7 +111,7 @@ public:
     VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
 
     /** Binds this resource to the specified offset within the specified memory allocation. */
-    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset);
+    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
 
     /** Applies the specified global memory barrier. */
     void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
@@ -40,7 +40,7 @@ public:
     inline VkDeviceSize getDeviceMemoryOffset() { return _deviceMemoryOffset; }
 
 	/** Binds this resource to the specified offset within the specified memory allocation. */
-	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset);
+	virtual VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset);
 
 	/** Returns the device memory underlying this resource. */
 	inline MVKDeviceMemory* getDeviceMemory() { return _deviceMemory; }

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -523,7 +523,7 @@ void mvkDisableFlags(Tv& value, const Tm bitMask) { value = (Tv)(value & ~(Tv)bi
 
 /** Returns whether the specified value has ANY of the flags specified in bitMask enabled (set to 1). */
 template<typename Tv, typename Tm>
-bool mvkIsAnyFlagEnabled(Tv value, const Tm bitMask) { return !!(value & bitMask); }
+bool mvkIsAnyFlagEnabled(Tv value, const Tm bitMask) { return ((value & bitMask) != 0); }
 
 /** Returns whether the specified value has ALL of the flags specified in bitMask enabled (set to 1). */
 template<typename Tv, typename Tm>


### PR DESCRIPTION
Currently, when a mapping is initiated for host-coherent device memory, existing
image contents are copied from the `MTLTexture` to host memory. However, if
host-coherent device memory is already mapped in a long-standing memory mapping,
changes to `MTLTexture` content are not reflected to the host memory.

- This change adds that capability to open memory mappings. When the image pipeline
barrier is applied to an image that is attached to a host-coherent device memory
that currently has an open memory mapping, the `MTLTexture` contents are copied to
the open host memory binding.

- Add `MVKMappedMemoryRange` to retrieve the currently mapped range in an MVKDeviceMemory.

- `MVKImage` cleanup use of `isHostCoherent()`. Let it be same as `MVKDeviceMemory`
and don't test for it from macOS because it is unnecessary.

- Move applyImageMemoryBarrier() logic to `MVKImagePlane`.
- Mark `MVKResource::bindDeviceMemory()` as virtual.
- Remove use of !! from `mvkIsAnyFlagEnabled()`.
- Update What's New document for `VK_KHR_sampler_ycbcr_conversion`.

Fixes issue #908.