### PR TITLE
Host-coherent texel buffers

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -104,6 +104,7 @@ protected:
 	bool _isHostCoherentTexelBuffer = false;
     id<MTLBuffer> _mtlBufferCache = nil;
 	id<MTLBuffer> _mtlBuffer = nil;
+    std::mutex _lock;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -91,6 +91,7 @@ protected:
 	bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
 						   VkPipelineStageFlags dstStageMask,
 						   MVKPipelineBarrier& barrier);
+    bool overlaps(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize &overlapOffset, VkDeviceSize &overlapSize);
 	bool shouldFlushHostMemory();
 	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
 	VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -72,10 +72,13 @@ public:
 #pragma mark Metal
 
 	/** Returns the Metal buffer underlying this memory allocation. */
-	id<MTLBuffer> getMTLBuffer();
+    id<MTLBuffer> getMTLBuffer();
 
 	/** Returns the offset at which the contents of this instance starts within the underlying Metal buffer. */
-	inline NSUInteger getMTLBufferOffset() { return !_deviceMemory || _deviceMemory->getMTLHeap() || _isHostCoherentTexelBuffer ? 0 : _deviceMemoryOffset; }
+	inline NSUInteger getMTLBufferOffset() { return !_deviceMemory || _deviceMemory->getMTLHeap() ? 0 : _deviceMemoryOffset; }
+
+    /** Returns the Metal buffer used as a cache for host-coherent texel buffers. */
+    id<MTLBuffer> getMTLBufferCache();
 
 
 #pragma mark Construction
@@ -99,6 +102,7 @@ protected:
 
 	VkBufferUsageFlags _usage;
 	bool _isHostCoherentTexelBuffer = false;
+    id<MTLBuffer> _mtlBufferCache = nil;
 	id<MTLBuffer> _mtlBuffer = nil;
 };
 
@@ -132,9 +136,9 @@ protected:
 	void propagateDebugName() override;
 
     MVKBuffer* _buffer;
+    NSUInteger _offset;
 	id<MTLTexture> _mtlTexture;
 	MTLPixelFormat _mtlPixelFormat;
-    NSUInteger _mtlBufferOffset;
 	NSUInteger _mtlBytesPerRow;
     VkExtent2D _textureSize;
 	std::mutex _lock;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -182,6 +182,8 @@ id<MTLBuffer> MVKBuffer::getMTLBuffer() {
 	if (_mtlBuffer) { return _mtlBuffer; }
 	if (_deviceMemory) {
 		if (_deviceMemory->getMTLHeap()) {
+            lock_guard<mutex> lock(_lock);
+            if (_mtlBuffer) { return _mtlBuffer; }
 			_mtlBuffer = [_deviceMemory->getMTLHeap() newBufferWithLength: getByteCount()
 																  options: _deviceMemory->getMTLResourceOptions()
 																   offset: _deviceMemoryOffset];	// retained
@@ -197,6 +199,9 @@ id<MTLBuffer> MVKBuffer::getMTLBuffer() {
 id<MTLBuffer> MVKBuffer::getMTLBufferCache() {
 #if MVK_MACOS
     if (_isHostCoherentTexelBuffer && !_mtlBufferCache) {
+        lock_guard<mutex> lock(_lock);
+        if (_mtlBufferCache) { return _mtlBufferCache; }
+
         _mtlBufferCache = [_device->getMTLDevice() newBufferWithLength: getByteCount()
                                                                options: MTLResourceStorageModeManaged];    // retained
         flushToDevice(_deviceMemoryOffset, _byteCount);


### PR DESCRIPTION
MVKDeviceBuffer cache management code calls the `flushToDevice` and `pullFromDevice` methods on MVKBuffers without regard to their location and overlap with given range. In the first commit I changed those methods to check for overlap and adjust the range, similarly to how it's done in MVKImage.

The other one allows host-coherent texel buffers to be bound as plain buffers using proper host-coherent memory directly, and not the auxiliary buffer. It is only used for buffer views, when a Metal texture needs to be created.

This fixes a problem which arised when using dxvk, which creates buffers with VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT set when the more general D3D11_BIND_SHADER_RESOURCE is used. The root cause of the problem is cache management, or rather the lack of it, for persistently mapped buffers, which I'm not sure how to fix. Even if it was fixed though, this way is still more efficient.

I'm unsure about thread safety here. Should not `MVKBuffer::getMTLBuffer` (and `MVKBuffer::getMTLBufferCache` alike) be protected with a lock?