### PR TITLE
Adds VkPhysicalDeviceSubgroupProperties.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -611,7 +611,7 @@ typedef struct {
 	VkBool32 placementHeaps;					/**< If true, MTLHeap objects support placement of resources. */
 	VkDeviceSize pushConstantSizeAlignment;		/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
 	uint32_t maxTextureLayers;					/**< The maximum number of layers in an array texture. */
-    uint32_t subgroupSize;			            /**< The number of threads in a wavefront. */
+    uint32_t subgroupSize;			            /**< The number of threads in a SIMD-group. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -611,6 +611,7 @@ typedef struct {
 	VkBool32 placementHeaps;					/**< If true, MTLHeap objects support placement of resources. */
 	VkDeviceSize pushConstantSizeAlignment;		/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
 	uint32_t maxTextureLayers;					/**< The maximum number of layers in an array texture. */
+    uint32_t subgroupSize;			            /**< The number of threads in a wavefront. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -241,7 +241,6 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
                     subgroupProps->supportedStages =
                         VK_SHADER_STAGE_COMPUTE_BIT |
                         VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
-                        VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
                         VK_SHADER_STAGE_FRAGMENT_BIT;
                     subgroupProps->supportedOperations =
                         VK_SUBGROUP_FEATURE_BASIC_BIT |
@@ -1117,8 +1116,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
         }
     }
 
-    static const uint32_t kAMDVendorId = 0x1002;
-    _metalFeatures.subgroupSize = (_properties.vendorID == kAMDVendorId) ? 64 : 32;
+#if MVK_MACOS
+    if (mvkOSVersionIsAtLeast(10.14)) {
+        static const uint32_t kAMDVendorId = 0x1002;
+        _metalFeatures.subgroupSize = (_properties.vendorID == kAMDVendorId) ? 64 : 32;
+    }
+#endif
 
 #define setMSLVersion(maj, min)	\
 	_metalFeatures.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj, min);


### PR DESCRIPTION
As discussed in #918.
This comes with a fixed subgroupSize per physical device until VK_EXT_subgroup_size_control is implemented.