### PR TITLE
Fix small memory leak when setting swapchain color space.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,7 @@ Released TBD
 - `Makefile` supports building fat *Platform+Simulator* binaries, plus *Debug* builds.
 - `fetchDependencies` script supports platform build selection, plus parallel builds.
 - Fix issue where mapped host-coherent device memory not updated from image contents on *macOS*.
+- Fix small memory leak when setting swapchain color space.
 - Remove use of `@available()` directive as it was causing issues in some build environments.
 - Refactor **MoltenVK** *Xcode* build architectures.
 - Demo `API-Samples generateSPIRVShaders` no longer builds `MoltenVKShaderController` tool.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -282,45 +282,45 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 
 	switch (pCreateInfo->imageColorSpace) {
 		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceSRGB;
 			break;
 		case VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceDisplayP3;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearSRGB);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearSRGB;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedSRGB);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedSRGB;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearDisplayP3);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearDisplayP3;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceDCIP3);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceDCIP3;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_BT709_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_709);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_709;
 			break;
 		case VK_COLOR_SPACE_BT2020_LINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearITUR_2020);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearITUR_2020;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ_EOTF);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2020_PQ_EOTF;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_HDR10_HLG_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_HLG);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2020_HLG;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
 		case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
-			_mtlLayer.colorspace = CGColorSpaceCreateWithName(kCGColorSpaceAdobeRGB1998);
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceAdobeRGB1998;
 			break;
 		case VK_COLOR_SPACE_PASS_THROUGH_EXT:
 		default:

--- a/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.h
+++ b/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.h
@@ -64,4 +64,13 @@
  */
 @property(nonatomic, readwrite) BOOL wantsExtendedDynamicRangeContentMVK;
 
+/**
+ * The name of the CGColorSpaceRef in the colorspace property of this layer.
+ *
+ * Reading this property returns the name of the CGColorSpaceRef in the colorspace property.
+ * Setting this property sets the value in the colorspace property to a CGColorSpaceRef
+ * with that name, creating and releasing the CGColorSpaceRef object itself as needed.
+ */
+@property(nonatomic, readwrite) CFStringRef colorspaceNameMVK;
+
 @end

--- a/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/CAMetalLayer+MoltenVK.m
@@ -76,4 +76,12 @@
 #endif
 }
 
+-(CFStringRef) colorspaceNameMVK { return CGColorSpaceGetName(self.colorspace); }
+
+-(void) setColorspaceNameMVK: (CFStringRef) name {
+	CGColorSpaceRef csRef = CGColorSpaceCreateWithName(name);
+	self.colorspace = csRef;
+	CGColorSpaceRelease(csRef);
+}
+
 @end


### PR DESCRIPTION
- Add CAMetalLayer::colorspaceNameMVK property to handle retain/release automatically.

- Fixes issue #940.