### PR TITLE
MVKPixelFormats: Correct format features for GBGR/BGRG formats.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1554,12 +1554,12 @@ typedef enum : VkFormatFeatureFlags {
                                                     VK_FORMAT_FEATURE_BLIT_SRC_BIT |
                                                     VK_FORMAT_FEATURE_BLIT_DST_BIT),
     kMVKVkFormatFeatureFlagsTexChromaSubsampling = (VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR |
+                                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR),
+    kMVKVkFormatFeatureFlagsTexMultiPlanar       = (VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT_KHR |
                                                     VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR |
                                                     VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR),
-    kMVKVkFormatFeatureFlagsTexMultiPlanar       = (VK_FORMAT_FEATURE_DISJOINT_BIT_KHR),
+                                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR |
+                                                    VK_FORMAT_FEATURE_DISJOINT_BIT_KHR),
 	kMVKVkFormatFeatureFlagsBufRead     = (VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT),
 	kMVKVkFormatFeatureFlagsBufWrite    = (VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT),
 	kMVKVkFormatFeatureFlagsBufAtomic   = (VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT),


### PR DESCRIPTION
Some things I missed in my review.

These formats use implicit reconstruction, and we don't support explicit
reconstruction here yet. If there's a demand for it, I or someone else
can implement it, but I don't expect it to be an issue.

Because it uses implicit reconstruction, chroma sampling is determined
by the implementation, i.e. Metal. My testing shows that Metal on AMD
and Intel uses midpoint reconstruction. Based on this, I think NV will
be the same.

Finally, according to the Vulkan spec:

> Implicit reconstruction takes place by the samples being interpolated,
> as required by the filter settings of the sampler, *except that
> `chromaFilter` takes precedence for the chroma samples*. [emphasis
> added]

Since Metal obviously uses the same filters for chroma and luma, we
can't support the separate reconstruction filter feature here.