### PR TITLE
Various fixes

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -312,7 +312,7 @@ public:
      * attempting to copy a depth image with a substituted format to and from a buffer.
      */
     inline bool hasExpectedTexelSize() { return _hasExpectedTexelSize; }
-
+    
 	/** Returns the Metal resource options for this image. */
     MTLStorageMode getMTLStorageMode();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -536,7 +536,7 @@ VkDeviceSize MVKImage::getBytesPerRow(uint8_t planeIndex, uint32_t mipLevel) {
 
 VkDeviceSize MVKImage::getBytesPerLayer(uint8_t planeIndex, uint32_t mipLevel) {
     VkExtent3D extent = getExtent3D(planeIndex, mipLevel);
-    size_t bytesPerRow = mvkAlignByteCount(getPixelFormats()->getBytesPerRow(_vkFormat, extent.width), _rowByteAlignment);
+    size_t bytesPerRow = getBytesPerRow(planeIndex, mipLevel);
     return getPixelFormats()->getBytesPerLayer(_vkFormat, bytesPerRow, extent.height);
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -120,7 +120,7 @@ MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
     mtlTexDesc.mipmapLevelCount = _image->_mipLevels;
     mtlTexDesc.sampleCount = mvkSampleCountFromVkSampleCountFlagBits(_image->_samples);
     mtlTexDesc.arrayLength = _image->_arrayLayers;
-    mtlTexDesc.usageMVK = _image->getPixelFormats()->getMTLTextureUsage(_image->_usage, mtlPixFmt, minUsage);
+    mtlTexDesc.usageMVK = _image->getPixelFormats()->getMTLTextureUsage(_image->_usage, mtlPixFmt, minUsage, _image->_isLinear);
     mtlTexDesc.storageModeMVK = _image->getMTLStorageMode();
     mtlTexDesc.cpuCacheMode = _image->getMTLCPUCacheMode();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -533,7 +533,7 @@ VkDeviceSize MVKImage::getBytesPerRow(uint8_t planeIndex, uint32_t mipLevel) {
 
 VkDeviceSize MVKImage::getBytesPerLayer(uint8_t planeIndex, uint32_t mipLevel) {
     VkExtent3D extent = getExtent3D(planeIndex, mipLevel);
-    size_t bytesPerRow = getPixelFormats()->getBytesPerRow(_vkFormat, extent.width);
+    size_t bytesPerRow = mvkAlignByteCount(getPixelFormats()->getBytesPerRow(_vkFormat, extent.width), _rowByteAlignment);
     return getPixelFormats()->getBytesPerLayer(_vkFormat, bytesPerRow, extent.height);
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -267,8 +267,8 @@ void MVKImagePlane::getMTLTextureContent(MVKImageSubresource& subresource,
 bool MVKImagePlane::overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset, VkDeviceSize size) {
 	VkDeviceSize memStart = offset;
 	VkDeviceSize memEnd = offset + size;
-	VkDeviceSize imgStart = imgLayout.offset;
-	VkDeviceSize imgEnd = imgLayout.offset + imgLayout.size;
+	VkDeviceSize imgStart = getMemoryBinding()->_deviceMemoryOffset + imgLayout.offset;
+	VkDeviceSize imgEnd = imgStart + imgLayout.size;
 	return imgStart < memEnd && imgEnd > memStart;
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -147,12 +147,15 @@ void MVKImagePlane::initSubresources(const VkImageCreateInfo* pCreateInfo) {
         VkDeviceSize rowPitch = _image->getBytesPerRow(_planeIndex, mipLvl);
         VkDeviceSize depthPitch = _image->getBytesPerLayer(_planeIndex, mipLvl);
 
+        VkExtent3D mipExtent = _image->getExtent3D(_planeIndex, mipLvl);
+        
         for (uint32_t layer = 0; layer < _image->_arrayLayers; layer++) {
             subRez.subresource.arrayLayer = layer;
 
             VkSubresourceLayout& layout = subRez.layout;
             layout.offset = offset;
-            layout.size = depthPitch * _image->_extent.depth;
+            layout.size = depthPitch * mipExtent.depth;
+            
             layout.rowPitch = rowPitch;
             layout.depthPitch = depthPitch;
 
@@ -828,7 +831,8 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
             _isAliasable = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_ALIAS_BIT);
         } else {
             for (uint32_t mipLvl = 0; mipLvl < _mipLevels; mipLvl++) {
-                memoryBinding->_byteCount += getBytesPerLayer(planeIndex, mipLvl) * _extent.depth * _arrayLayers;
+                VkExtent3D mipExtent = getExtent3D(planeIndex, mipLvl);
+                memoryBinding->_byteCount += getBytesPerLayer(planeIndex, mipLvl) * mipExtent.depth * _arrayLayers;
             }
             memoryBinding->_byteAlignment = std::max(memoryBinding->_byteAlignment, _rowByteAlignment);
         }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -281,10 +281,12 @@ public:
 	/**
 	 * Returns the Metal texture usage from the Vulkan image usage and Metal format, ensuring that at least the
 	 * usages in minUsage are included, even if they wouldn't naturally be included based on the other two parameters.
+     *  isLinear further restricts the allowed usage to those that are valid for linear textures.
 	 */
 	MTLTextureUsage getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
 									   MTLPixelFormat mtlFormat,
-									   MTLTextureUsage minUsage = MTLTextureUsageUnknown);
+									   MTLTextureUsage minUsage = MTLTextureUsageUnknown,
+                                       bool isLinear = false);
 
 	/** Enumerates all formats that support the given features, calling a specified function for each one. */
 	void enumerateSupportedFormats(VkFormatProperties properties, bool any, std::function<bool(VkFormat)> func);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -453,7 +453,8 @@ VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlags(MTLTextureUsage mtlUsage
 
 MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
 													MTLPixelFormat mtlFormat,
-													MTLTextureUsage minUsage) {
+													MTLTextureUsage minUsage,
+                                                    bool isLinear) {
 	bool isDepthFmt = isDepthFormat(mtlFormat);
 	bool isStencilFmt = isStencilFormat(mtlFormat);
 	bool isCombinedDepthStencilFmt = isDepthFmt && isStencilFmt;
@@ -484,7 +485,13 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 												VK_IMAGE_USAGE_TRANSFER_DST_BIT)) &&	// Scaling a BLIT may use rendering.
 		mvkIsAnyFlagEnabled(mtlFmtCaps, (kMVKMTLFmtCapsColorAtt | kMVKMTLFmtCapsDSAtt))) {
 
-		mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
+#if MVK_MACOS
+        if(!isLinear) {
+            mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
+        }
+#else
+        mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
+#endif
 	}
 
 	// Create view on, but only on color formats, or combined depth-stencil formats if supported by the GPU...


### PR DESCRIPTION
This PR is split into 4 commits, fixing four separate issues:
1. Fixes #962 . Linear textures shouldn't be created with MTLTextureUsageRenderTarget on macOS, otherwise Metal validation complains.
2. `MVKImagePlane::overlaps` did not account for device memory offset. Instead it was just using the subresource layout offset, which is relative to the image memory binding (usually 0).
3. `MVKImage._byteCount` was incorrect in some cases. In my case I had a 16x16 RGBA16F texture that reported row pitch of 256 bytes, yet the size of the entire image was 2048 bytes, which is too small (it should be 16x256=4096). 
This was because `MVKImage::getBytesPerLayer` did not account for the row byte alignment, which was 256 in my case - the actual row size was 128 bytes, rounded to byte alignment it was 256, as reported by `MVKImage::getBytesPerRow`. Yet `MVKImage::getBytesPerLayer` returned 2048. 
4. This is a minor one but hopefully it doesn't hurt. When calculating mip level size we were always multiplying depth pitch by the 0th level mip (`_extents.depth`), rather than the current mip level's. Unsure if this was done for a reason.