### PR TITLE
dynamicOffsets are supposed to be ordered by binding index

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -76,6 +76,13 @@ public:
 	/** Returns the descriptor type of this layout. */
 	inline VkDescriptorType getDescriptorType() { return _info.descriptorType; }
 
+	/** If this descriptor is a dynamic buffer type, this returns the index within the dynamicOffsets array where the
+		first descriptor in this binding is located. It will start at 0 for this set, so this number should be incremented
+		by the number of dynamic offsets in previous sets given in vkCmdBindDescriptorSets */
+	inline uint32_t getDynamicOffsetIndex() { return _dynamicOffsetIndex; }
+
+	void setDynamicOffsetIndex(uint32_t i) { _dynamicOffsetIndex = i; }
+
 	/** Returns the immutable sampler at the index, or nullptr if immutable samplers are not used. */
 	MVKSampler* getImmutableSampler(uint32_t index);
 
@@ -89,7 +96,7 @@ public:
 				  uint32_t descStartIndex,
 				  MVKShaderResourceBinding& dslMTLRezIdxOffsets,
 				  MVKArrayRef<uint32_t> dynamicOffsets,
-				  uint32_t* pDynamicOffsetIndex);
+				  uint32_t baseDynamicOffsetIndex);
 
     /** Encodes this binding layout and the specified descriptor on the specified command encoder immediately. */
     void push(MVKCommandEncoder* cmdEncoder,
@@ -126,6 +133,7 @@ protected:
 	MVKSmallVector<MVKSampler*> _immutableSamplers;
 	MVKShaderResourceBinding _mtlResourceIndexOffsets;
 	bool _applyToStage[kMVKShaderStageMax];
+	uint32_t _dynamicOffsetIndex;
 };
 
 
@@ -149,7 +157,7 @@ public:
 					  bool stages[],
 					  MVKShaderResourceBinding& mtlIndexes,
 					  MVKArrayRef<uint32_t> dynamicOffsets,
-					  uint32_t* pDynamicOffsetIndex) = 0;
+					  uint32_t dynamicOffsetIndex) = 0;
 
 	/**
 	 * Updates the internal binding from the specified content. The format of the content depends
@@ -205,7 +213,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -283,7 +291,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -324,7 +332,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -396,7 +404,7 @@ protected:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex);
+			  uint32_t dynamicOffsetIndex);
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -438,7 +446,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -478,7 +486,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,
@@ -516,7 +524,7 @@ public:
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t* pDynamicOffsetIndex) override;
+			  uint32_t dynamicOffsetIndex) override;
 
 	void write(MVKDescriptorSet* mvkDescSet,
 			   VkDescriptorType descriptorType,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -43,12 +43,14 @@ public:
 	/** Returns the debug report object type of this object. */
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT; }
 
+	inline uint32_t getDynamicDescriptorCount() { return _dynamicDescriptorCount; }
+
 	/** Encodes this descriptor set layout and the specified descriptor set on the specified command encoder. */
     void bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
                            MVKDescriptorSet* descSet,
                            MVKShaderResourceBinding& dslMTLRezIdxOffsets,
                            MVKArrayRef<uint32_t> dynamicOffsets,
-                           uint32_t* pDynamicOffsetIndex);
+                           uint32_t baseDynamicOffsetIndex);
 
 
 	/** Encodes this descriptor set layout and the specified descriptor updates on the specified command encoder immediately. */
@@ -90,6 +92,7 @@ protected:
 	std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
 	MVKShaderResourceBinding _mtlResourceCounts;
 	uint32_t _descriptorCount;
+	uint32_t _dynamicDescriptorCount;
 	bool _isPushDescriptorLayout;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -42,7 +42,7 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
                                            uint32_t firstSet,
                                            MVKArrayRef<uint32_t> dynamicOffsets) {
 	clearConfigurationResult();
-	uint32_t pDynamicOffsetIndex = 0;
+	uint32_t baseDynamicOffsetIndex = 0;
 	size_t dsCnt = descriptorSets.size;
 	for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
 		MVKDescriptorSet* descSet = descriptorSets[dsIdx];
@@ -50,7 +50,8 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
 		MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[dslIdx];
 		dsl->bindDescriptorSet(cmdEncoder, descSet,
 							   _dslMTLResourceIndexOffsets[dslIdx],
-							   dynamicOffsets, &pDynamicOffsetIndex);
+							   dynamicOffsets, baseDynamicOffsetIndex);
+		baseDynamicOffsetIndex += dsl->getDynamicDescriptorCount();
 		setConfigurationResult(dsl->getConfigurationResult());
 	}
 }


### PR DESCRIPTION
not by layout element index. Fixes #978

**Note**: I'm not sure if something different needs to be done for push descriptors though. Unfamiliar with those.