### PR TITLE
Images in coherent memory

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -93,6 +93,8 @@ void MVKCmdCopyImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
     VkBufferImageCopy vkDstCopies[copyCnt];
     size_t tmpBuffSize = 0;
 
+    _srcImage->flushToDevice(0, VK_WHOLE_SIZE);
+
     for (uint32_t copyIdx = 0; copyIdx < copyCnt; copyIdx++) {
         auto& vkIC = _vkImageCopies[copyIdx];
         

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -148,6 +148,7 @@ public:
 protected:
 	friend class MVKBuffer;
     friend class MVKImageMemoryBinding;
+    friend class MVKImagePlane;
 
 	void propagateDebugName() override;
 	VkDeviceSize adjustMemorySize(VkDeviceSize size, VkDeviceSize offset);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -257,6 +257,9 @@ public:
 								 MVKCommandEncoder* cmdEncoder,
 								 MVKCommandUse cmdUse);
 
+    /** Flush underlying buffer memory into the image if necessary */
+    void flushToDevice(VkDeviceSize offset, VkDeviceSize size);
+
 #pragma mark Metal
 
 	/** Returns the Metal texture underlying this image. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -178,7 +178,7 @@ void MVKImagePlane::updateMTLTextureContent(MVKImageSubresource& subresource,
 
     VkImageSubresource& imgSubRez = subresource.subresource;
     VkSubresourceLayout& imgLayout = subresource.layout;
-
+    size = getMemoryBinding()->getDeviceMemory()->adjustMemorySize(size, offset);
     // Check if subresource overlaps the memory range.
 	if ( !overlaps(imgLayout, offset, size) ) { return; }
 
@@ -511,6 +511,13 @@ uint8_t MVKImage::getPlaneFromVkImageAspectFlags(VkImageAspectFlags aspectMask) 
 void MVKImage::propagateDebugName() {
     for (uint8_t planeIndex = 0; planeIndex < _planes.size(); planeIndex++) {
         _planes[planeIndex]->propagateDebugName();
+    }
+}
+
+void MVKImage::flushToDevice(VkDeviceSize offset, VkDeviceSize size) {
+    for (int bindingIndex = 0; bindingIndex < _memoryBindings.size(); bindingIndex++) {
+        MVKImageMemoryBinding *binding = _memoryBindings[bindingIndex];
+        binding->flushToDevice(offset, size);
     }
 }
 


### PR DESCRIPTION
It looks like pretending to have images in coherent memory strikes again. Here I add flushing to source images of a image to image transfer. That's probably not great, but it fixes some games having invalid data loaded into textures. I'm not sure to what extent this is a dxvk specific problem in my cases.
Maybe we should also flush (and queue a pull from destination images) in other kinds of transfers? Or do something else entirely?