### PR TITLE
Validation warning fixes

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -615,6 +615,7 @@ typedef struct {
 	VkDeviceSize vertexStrideAlignment;         /**< The alignment used for the stride of vertex attribute bindings. */
 	VkBool32 indirectTessellationDrawing;		/**< If true, tessellation draw calls support parameters held in a GPU buffer. */
 	VkBool32 nonUniformThreadgroups;			/**< If true, the device supports arbitrary-sized grids in compute workloads. */
+	VkBool32 renderWithoutAttachments;          /**< If true, we don't have to create a dummy attachment for a render pass if there isn't one. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -303,13 +303,10 @@ void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride, bool storeOverri
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues.contents(), _isRenderingEntireAttachment, loadOverride, storeOverride);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 
-	// Only set the layered rendering properties if layered rendering is supported and the framebuffer really has multiple layers
-	if (_isUsingLayeredRendering) {
-		VkExtent2D fbExtent = _framebuffer->getExtent2D();
-		mtlRPDesc.renderTargetWidthMVK = min(_renderArea.offset.x + _renderArea.extent.width, fbExtent.width);
-		mtlRPDesc.renderTargetHeightMVK = min(_renderArea.offset.y + _renderArea.extent.height, fbExtent.height);
-		mtlRPDesc.renderTargetArrayLengthMVK = _framebuffer->getLayerCount();
-	}
+    VkExtent2D fbExtent = _framebuffer->getExtent2D();
+    mtlRPDesc.renderTargetWidthMVK = min(_renderArea.offset.x + _renderArea.extent.width, fbExtent.width);
+    mtlRPDesc.renderTargetHeightMVK = min(_renderArea.offset.y + _renderArea.extent.height, fbExtent.height);
+    mtlRPDesc.renderTargetArrayLengthMVK = _framebuffer->getLayerCount();
 
     _mtlRenderEncoder = [_mtlCmdBuffer renderCommandEncoderWithDescriptor: mtlRPDesc];     // not retained
 	setLabelIfNotNil(_mtlRenderEncoder, getMTLRenderCommandEncoderName());

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1072,6 +1072,10 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.indirectTessellationDrawing = true;
 	}
 
+    if ( mvkOSVersionIsAtLeast(11.0) ) {
+        _metalFeatures.renderWithoutAttachments = true;
+    }
+
 	if ( mvkOSVersionIsAtLeast(13.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.placementHeaps = useMTLHeaps;
@@ -1130,6 +1134,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	if ( mvkOSVersionIsAtLeast(10.15) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.native3DCompressedTextures = true;
+        _metalFeatures.renderWithoutAttachments = true;
 		if (supportsMTLGPUFamily(Mac2)) {
 			_metalFeatures.nativeTextureSwizzle = true;
 			_metalFeatures.placementHeaps = useMTLHeaps;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -74,11 +74,12 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
 }
 
 id<MTLTexture> MVKImagePlane::getMTLTexture(MTLPixelFormat mtlPixFmt) {
-    if (mtlPixFmt == _mtlPixFmt) { return _mtlTexture; }
+    if (mtlPixFmt == _mtlPixFmt) { return getMTLTexture(); }
     id<MTLTexture> mtlTex = _mtlTextureViews[mtlPixFmt];
     if ( !mtlTex ) {
         // Lock and check again in case another thread has created the view texture.
-        // baseTex retreived outside of lock to avoid deadlock if it too needs to be lazily created.
+        // Ensure the base texture is present outside of lock to avoid deadlock if it too needs to be lazily created.
+        getMTLTexture();
         lock_guard<mutex> lock(_image->_lock);
         mtlTex = _mtlTextureViews[mtlPixFmt];
         if ( !mtlTex ) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1275,9 +1275,11 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
     if (pixFmts->isDepthFormat(mtlDSFormat)) { plDesc.depthAttachmentPixelFormat = mtlDSFormat; }
     if (pixFmts->isStencilFormat(mtlDSFormat)) { plDesc.stencilAttachmentPixelFormat = mtlDSFormat; }
 
-    // In Vulkan, it's perfectly valid to render with no attachments. Not so in Metal.
-	// If we have no attachments, then we'll have to add a dummy attachment.
-    if (!caCnt && !pixFmts->isDepthFormat(mtlDSFormat) && !pixFmts->isStencilFormat(mtlDSFormat)) {
+    // In Vulkan, it's perfectly valid to render with no attachments. In Metal we need to check for
+    // support for it. If we have no attachments, then we may have to add a dummy attachment.
+    if (!caCnt && !pixFmts->isDepthFormat(mtlDSFormat) && !pixFmts->isStencilFormat(mtlDSFormat) &&
+        !getDevice()->_pMetalFeatures->renderWithoutAttachments) {
+
         MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[0];
         colorDesc.pixelFormat = MTLPixelFormatR8Unorm;
         colorDesc.writeMask = MTLColorWriteMaskNone;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -138,6 +138,14 @@ void MVKRenderSubpass::populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* 
 
 	_mtlDummyTex = nil;
 	if (caUsedCnt == 0 && dsRPAttIdx == VK_ATTACHMENT_UNUSED) {
+        if (_renderPass->getDevice()->_pMetalFeatures->renderWithoutAttachments) {
+            // We support having no attachments.
+#if MVK_MACOS_OR_IOS
+            mtlRPDesc.defaultRasterSampleCount = 1;
+#endif
+            return;
+        }
+
 		// Add a dummy attachment so this passes validation.
 		VkExtent2D fbExtent = framebuffer->getExtent2D();
 		MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: MTLPixelFormatR8Unorm width: fbExtent.width height: fbExtent.height mipmapped: NO];

--- a/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
@@ -57,7 +57,7 @@
 #if MVK_TVOS
 	return 0;
 #endif
-#if MVK_MACOS || MVK_IOS
+#if MVK_MACOS_OR_IOS
 	if ([self respondsToSelector: @selector(renderTargetWidth)])
 		return self.renderTargetWidth;
 	return 0;
@@ -67,7 +67,7 @@
 
 -(void) setRenderTargetWidthMVK: (NSUInteger) width {
 
-#if MVK_MACOS || MVK_IOS
+#if MVK_MACOS_OR_IOS
 	if ([self respondsToSelector: @selector(setRenderTargetWidth:)])
 		self.renderTargetWidth = width;
 #endif
@@ -79,7 +79,7 @@
 #if MVK_TVOS
 	return 0;
 #endif
-#if MVK_MACOS || MVK_IOS
+#if MVK_MACOS_OR_IOS
 	if ([self respondsToSelector: @selector(renderTargetHeight)])
 		return self.renderTargetHeight;
 	return 0;
@@ -89,7 +89,7 @@
 
 -(void) setRenderTargetHeightMVK: (NSUInteger) height {
 
-#if MVK_MACOS || MVK_IOS
+#if MVK_MACOS_OR_IOS
 	if ([self respondsToSelector: @selector(setRenderTargetHeight:)])
 		self.renderTargetHeight = height;
 #endif

--- a/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLRenderPassDescriptor+MoltenVK.m
@@ -54,10 +54,10 @@
 
 -(NSUInteger) renderTargetWidthMVK {
 
-#if MVK_MACOS || MVK_TVOS
+#if MVK_TVOS
 	return 0;
 #endif
-#if MVK_IOS
+#if MVK_MACOS || MVK_IOS
 	if ([self respondsToSelector: @selector(renderTargetWidth)])
 		return self.renderTargetWidth;
 	return 0;
@@ -67,7 +67,7 @@
 
 -(void) setRenderTargetWidthMVK: (NSUInteger) width {
 
-#if MVK_IOS
+#if MVK_MACOS || MVK_IOS
 	if ([self respondsToSelector: @selector(setRenderTargetWidth:)])
 		self.renderTargetWidth = width;
 #endif
@@ -76,10 +76,10 @@
 
 -(NSUInteger) renderTargetHeightMVK {
 
-#if MVK_MACOS || MVK_TVOS
+#if MVK_TVOS
 	return 0;
 #endif
-#if MVK_IOS
+#if MVK_MACOS || MVK_IOS
 	if ([self respondsToSelector: @selector(renderTargetHeight)])
 		return self.renderTargetHeight;
 	return 0;
@@ -89,7 +89,7 @@
 
 -(void) setRenderTargetHeightMVK: (NSUInteger) height {
 
-#if MVK_IOS
+#if MVK_MACOS || MVK_IOS
 	if ([self respondsToSelector: @selector(setRenderTargetHeight:)])
 		self.renderTargetHeight = height;
 #endif


### PR DESCRIPTION
There's one more thing - apparently now it's OK, at least on recent macOS, to not have any attachments. It could be useful to take advantage of that and not allocate a dummy texture - not just to save memory, I've seen one game specify a crazy framebuffer size (16k x 16k x 2k) and then spit out validation warnings when the dummy texture wasn't created. I'm not sure how to detect for that though, and if it deserves a dedicated feature bit.
Maybe `MTLRenderPassDescriptor respondsToSelector: defaultRasterSampleCount` check would do the trick?