### PR TITLE
MVKCommandBuffer: Don't set renderTargetArrayLength on devices that don't support it.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1035,7 +1035,7 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
 
     // Populate the render pipeline state attachment key with info from the subpass and framebuffer.
 	_rpsKey.mtlSampleCount = mvkSampleCountFromVkSampleCountFlagBits(subpass->getSampleCount());
-	if (cmdEncoder->_isUsingLayeredRendering) { _rpsKey.enableLayeredRendering(); }
+	if (cmdEncoder->_canUseLayeredRendering && cmdEncoder->_framebuffer->getLayerCount() > 1) { _rpsKey.enableLayeredRendering(); }
 
     uint32_t caCnt = subpass->getColorAttachmentCount();
     for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -432,8 +432,8 @@ public:
     /** The size of the threadgroup for the compute shader. */
     MTLSize _mtlThreadgroupSize;
 
-	/** Indicates whether the current render subpass is rendering to an array (layered) framebuffer. */
-	bool _isUsingLayeredRendering;
+	/** Indicates whether the current render subpass is able to render to an array (layered) framebuffer. */
+	bool _canUseLayeredRendering;
 
 
 #pragma mark Construction


### PR DESCRIPTION
It's a hard validation error to do so. We originally had a check for
this, but it was erroneously completely removed in #988, instead of
being limited to `renderTargetArrayLength`.

Fixes #991.