### PR TITLE
Use deferred store actions instead of tracking multi-pass draws.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -616,6 +616,7 @@ typedef struct {
 	VkBool32 indirectTessellationDrawing;		/**< If true, tessellation draw calls support parameters held in a GPU buffer. */
 	VkBool32 nonUniformThreadgroups;			/**< If true, the device supports arbitrary-sized grids in compute workloads. */
 	VkBool32 renderWithoutAttachments;          /**< If true, we don't have to create a dummy attachment for a render pass if there isn't one. */
+	VkBool32 deferredStoreActions;				/**< If true, render pass store actions can be specified after the render encoder is created. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
@@ -81,7 +81,7 @@ protected:
 #pragma mark MVKCmdDraw
 
 /** Vulkan command to draw vertices. */
-class MVKCmdDraw : public MVKCommand, public MVKLoadStoreOverrideMixin {
+class MVKCmdDraw : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
@@ -106,7 +106,7 @@ protected:
 #pragma mark MVKCmdDrawIndexed
 
 /** Vulkan command to draw indexed vertices. */
-class MVKCmdDrawIndexed : public MVKCommand, public MVKLoadStoreOverrideMixin {
+class MVKCmdDrawIndexed : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
@@ -133,7 +133,7 @@ protected:
 #pragma mark MVKCmdDrawIndirect
 
 /** Vulkan command to draw vertices indirectly. */
-class MVKCmdDrawIndirect : public MVKCommand, public MVKLoadStoreOverrideMixin {
+class MVKCmdDrawIndirect : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
@@ -158,7 +158,7 @@ protected:
 #pragma mark MVKCmdDrawIndexedIndirect
 
 /** Vulkan command to draw indexed vertices indirectly. */
-class MVKCmdDrawIndexedIndirect : public MVKCommand, public MVKLoadStoreOverrideMixin {
+class MVKCmdDrawIndexedIndirect : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -36,7 +36,7 @@ class MVKFramebuffer;
  * Template class to balance vector pre-allocations between very common low counts and fewer larger counts.
  */
 template <size_t N>
-class MVKCmdBeginRenderPass : public MVKCommand, public MVKLoadStoreOverrideMixin {
+class MVKCmdBeginRenderPass : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -36,8 +36,6 @@ VkResult MVKCmdBeginRenderPass<N>::setContent(MVKCommandBuffer* cmdBuff,
 	_renderPass = (MVKRenderPass*)pRenderPassBegin->renderPass;
 	_framebuffer = (MVKFramebuffer*)pRenderPassBegin->framebuffer;
 	_renderArea = pRenderPassBegin->renderArea;
-    _loadOverride = false;
-    _storeOverride = false;
 
 	// Add clear values
 	uint32_t cvCnt = pRenderPassBegin->clearValueCount;
@@ -47,15 +45,13 @@ VkResult MVKCmdBeginRenderPass<N>::setContent(MVKCommandBuffer* cmdBuff,
 		_clearValues.push_back(pRenderPassBegin->pClearValues[i]);
 	}
 
-	cmdBuff->recordBeginRenderPass(this);
-
 	return VK_SUCCESS;
 }
 
 template <size_t N>
 void MVKCmdBeginRenderPass<N>::encode(MVKCommandEncoder* cmdEncoder) {
 //	MVKLogDebug("Encoding vkCmdBeginRenderPass(). Elapsed time: %.6f ms.", mvkGetElapsedMilliseconds());
-	cmdEncoder->beginRenderpass(_contents, _renderPass, _framebuffer, _renderArea, _clearValues.contents(), _loadOverride, _storeOverride);
+	cmdEncoder->beginRenderpass(_contents, _renderPass, _framebuffer, _renderArea, _clearValues.contents());
 }
 
 template class MVKCmdBeginRenderPass<1>;
@@ -82,7 +78,6 @@ void MVKCmdNextSubpass::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark MVKCmdEndRenderPass
 
 VkResult MVKCmdEndRenderPass::setContent(MVKCommandBuffer* cmdBuff) {
-	cmdBuff->recordEndRenderPass();
 	return VK_SUCCESS;
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommand.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommand.h
@@ -76,25 +76,3 @@ protected:
 	virtual MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) = 0;
 };
 
-
-#pragma mark -
-#pragma mark MVKLoadStoreOverrideMixin
-
-/**
- * Shared state mixin for draw commands.
- *
- * As a mixin, this class should only be used as a component of multiple inheritance.
- * Any class that inherits from this class should also inherit from MVKBaseObject.
- * This requirement is to avoid the diamond problem of multiple inheritance.
- */
-class MVKLoadStoreOverrideMixin {
-public:
-	void setLoadOverride(bool loadOverride) { _loadOverride = loadOverride; }
-	void setStoreOverride(bool storeOverride) { _storeOverride = storeOverride; }
-
-protected:
-    bool _loadOverride;
-    bool _storeOverride;
-};
-
-

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -40,7 +40,6 @@ class MVKQueryPool;
 class MVKPipeline;
 class MVKGraphicsPipeline;
 class MVKComputePipeline;
-class MVKLoadStoreOverrideMixin;
 
 typedef uint64_t MVKMTLCommandBufferID;
 
@@ -99,26 +98,11 @@ public:
 
 #pragma mark Tessellation constituent command management
 
-    /** Preps metadata for recording render pass */
-	void recordBeginRenderPass(MVKLoadStoreOverrideMixin* mvkBeginRenderPass);
-	
-	/** Finishes metadata for recording render pass */
-	void recordEndRenderPass();
-	
-	/** Update the last recorded pipeline if it will end and start a new Metal render pass (ie, in tessellation) */
+	/** Update the last recorded pipeline with tessellation shaders */
 	void recordBindPipeline(MVKCmdBindPipeline* mvkBindPipeline);
-	
-	/** Update the last recorded drawcall to determine load/store actions */
-	void recordDraw(MVKLoadStoreOverrideMixin* mvkDraw);
-	
-	/** The most recent recorded begin renderpass */
-	MVKLoadStoreOverrideMixin* _lastBeginRenderPass;
-	
-	/** The most recent recorded multi-pass (ie, tessellation) pipeline */
+
+	/** The most recent recorded tessellation pipeline */
 	MVKCmdBindPipeline* _lastTessellationPipeline;
-	
-	/** The most recent recorded multi-pass (ie, tessellation) draw */
-	MVKLoadStoreOverrideMixin* _lastTessellationDraw;
 
 
 #pragma mark Construction
@@ -269,15 +253,16 @@ public:
 						 MVKRenderPass* renderPass,
 						 MVKFramebuffer* framebuffer,
 						 VkRect2D& renderArea,
-						 MVKArrayRef<VkClearValue> clearValues,
-						 bool loadOverride = false,
-						 bool storeOverride = false);
+						 MVKArrayRef<VkClearValue> clearValues);
 
 	/** Begins the next render subpass. */
 	void beginNextSubpass(VkSubpassContents renderpassContents);
 
 	/** Begins a Metal render pass for the current render subpass. */
-	void beginMetalRenderPass(bool loadOverride = false, bool storeOverride = false);
+	void beginMetalRenderPass(bool loadOverride = false);
+
+	/** If a render encoder is active, encodes store actions for all attachments to it. */
+	void encodeStoreActions(bool storeOverride = false);
 
 	/** Returns the render subpass that is currently active. */
 	MVKRenderSubpass* getSubpass();
@@ -443,7 +428,7 @@ public:
 protected:
     void addActivatedQuery(MVKQueryPool* pQueryPool, uint32_t query);
     void finishQueries();
-	void setSubpass(VkSubpassContents subpassContents, uint32_t subpassIndex, bool loadOverride = false, bool storeOverride = false);
+	void setSubpass(VkSubpassContents subpassContents, uint32_t subpassIndex);
 	void clearRenderArea();
     const MVKMTLBufferAllocation* copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length);
     NSString* getMTLRenderCommandEncoderName();

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -75,6 +75,7 @@ VkResult MVKCommandBuffer::reset(VkCommandBufferResetFlags flags) {
 	_isExecutingNonConcurrently.clear();
 	_commandCount = 0;
 	_initialVisibilityResultMTLBuffer = nil;		// not retained
+	_lastTessellationPipeline = nullptr;
 	setConfigurationResult(VK_NOT_READY);
 
 	if (mvkAreAllFlagsEnabled(flags, VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT)) {
@@ -196,38 +197,8 @@ MVKCommandBuffer::~MVKCommandBuffer() {
 #pragma mark -
 #pragma mark Tessellation constituent command management
 
-void MVKCommandBuffer::recordBeginRenderPass(MVKLoadStoreOverrideMixin* mvkBeginRenderPass) {
-	_lastBeginRenderPass = mvkBeginRenderPass;
-	_lastTessellationPipeline = nullptr;
-	_lastTessellationDraw = nullptr;
-}
-
-void MVKCommandBuffer::recordEndRenderPass() {
-	// Unset the store override for the last draw call
-	if (_lastTessellationDraw != nullptr)
-	{
-		_lastTessellationDraw->setStoreOverride(false);
-		_lastBeginRenderPass->setStoreOverride(true);
-	}
-	_lastBeginRenderPass = nullptr;
-	_lastTessellationPipeline = nullptr;
-	_lastTessellationDraw = nullptr;
-}
-
 void MVKCommandBuffer::recordBindPipeline(MVKCmdBindPipeline* mvkBindPipeline) {
-	if (mvkBindPipeline->isTessellationPipeline())
-		_lastTessellationPipeline = mvkBindPipeline;
-	else
-		_lastTessellationPipeline = nullptr;
-}
-
-void MVKCommandBuffer::recordDraw(MVKLoadStoreOverrideMixin* mvkDraw) {
-	if (_lastTessellationPipeline != nullptr) {
-		// If a multi-pass pipeline is bound and we've already drawn something, need to override load actions
-		mvkDraw->setLoadOverride(true);
-		mvkDraw->setStoreOverride(true);
-		_lastTessellationDraw = mvkDraw;
-	}
+	_lastTessellationPipeline = mvkBindPipeline->isTessellationPipeline() ? mvkBindPipeline : nullptr;
 }
 
 
@@ -265,16 +236,14 @@ void MVKCommandEncoder::beginRenderpass(VkSubpassContents subpassContents,
 										MVKRenderPass* renderPass,
 										MVKFramebuffer* framebuffer,
 										VkRect2D& renderArea,
-										MVKArrayRef<VkClearValue> clearValues,
-										bool loadOverride,
-										bool storeOverride) {
+										MVKArrayRef<VkClearValue> clearValues) {
 	_renderPass = renderPass;
 	_framebuffer = framebuffer;
 	_renderArea = renderArea;
 	_isRenderingEntireAttachment = (mvkVkOffset2DsAreEqual(_renderArea.offset, {0,0}) &&
 									mvkVkExtent2DsAreEqual(_renderArea.extent, _framebuffer->getExtent2D()));
 	_clearValues.assign(clearValues.begin(), clearValues.end());
-	setSubpass(subpassContents, 0, loadOverride, storeOverride);
+	setSubpass(subpassContents, 0);
 }
 
 void MVKCommandEncoder::beginNextSubpass(VkSubpassContents contents) {
@@ -282,7 +251,9 @@ void MVKCommandEncoder::beginNextSubpass(VkSubpassContents contents) {
 }
 
 // Sets the current render subpass to the subpass with the specified index.
-void MVKCommandEncoder::setSubpass(VkSubpassContents subpassContents, uint32_t subpassIndex, bool loadOverride, bool storeOverride) {
+void MVKCommandEncoder::setSubpass(VkSubpassContents subpassContents, uint32_t subpassIndex) {
+	encodeStoreActions();
+
 	_subpassContents = subpassContents;
 	_renderSubpassIndex = subpassIndex;
 
@@ -290,16 +261,16 @@ void MVKCommandEncoder::setSubpass(VkSubpassContents subpassContents, uint32_t s
 							   (_device->_pMetalFeatures->multisampleLayeredRendering ||
 							    (getSubpass()->getSampleCount() == VK_SAMPLE_COUNT_1_BIT)));
 
-	beginMetalRenderPass(loadOverride, storeOverride);
+	beginMetalRenderPass();
 }
 
 // Creates _mtlRenderEncoder and marks cached render state as dirty so it will be set into the _mtlRenderEncoder.
-void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride, bool storeOverride) {
+void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride) {
 
     endCurrentMetalEncoding();
 
     MTLRenderPassDescriptor* mtlRPDesc = [MTLRenderPassDescriptor renderPassDescriptor];
-    getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues.contents(), _isRenderingEntireAttachment, loadOverride, storeOverride);
+    getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _framebuffer, _clearValues.contents(), _isRenderingEntireAttachment, loadOverride);
     mtlRPDesc.visibilityResultBuffer = _occlusionQueryState.getVisibilityResultMTLBuffer();
 
     VkExtent2D fbExtent = _framebuffer->getExtent2D();
@@ -327,6 +298,10 @@ void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride, bool storeOverri
     _depthStencilState.beginMetalRenderPass();
     _stencilReferenceValueState.beginMetalRenderPass();
     _occlusionQueryState.beginMetalRenderPass();
+}
+
+void MVKCommandEncoder::encodeStoreActions(bool storeOverride) {
+	getSubpass()->encodeStoreActions(this, _isRenderingEntireAttachment, storeOverride);
 }
 
 MVKRenderSubpass* MVKCommandEncoder::getSubpass() { return _renderPass->getSubpass(_renderSubpassIndex); }
@@ -430,6 +405,7 @@ void MVKCommandEncoder::finalizeDispatchState() {
 }
 
 void MVKCommandEncoder::endRenderpass() {
+	encodeStoreActions();
 	endMetalRenderEncoding();
 
 	_renderPass = nullptr;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -982,10 +982,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.shaderSpecialization = true;
         _metalFeatures.stencilViews = true;
 		_metalFeatures.fences = true;
+		_metalFeatures.deferredStoreActions = true;
     }
 
 	if (supportsMTLFeatureSet(tvOS_GPUFamily1_v3)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
+        _metalFeatures.renderWithoutAttachments = true;
 	}
 
 	if (supportsMTLFeatureSet(tvOS_GPUFamily1_v4)) {
@@ -1033,10 +1035,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.shaderSpecialization = true;
         _metalFeatures.stencilViews = true;
 		_metalFeatures.fences = true;
+		_metalFeatures.deferredStoreActions = true;
     }
 
     if (supportsMTLFeatureSet(iOS_GPUFamily1_v4)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
+        _metalFeatures.renderWithoutAttachments = true;
     }
 
 	if (supportsMTLFeatureSet(iOS_GPUFamily1_v5)) {
@@ -1072,10 +1076,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.indirectTessellationDrawing = true;
 	}
 
-    if ( mvkOSVersionIsAtLeast(11.0) ) {
-        _metalFeatures.renderWithoutAttachments = true;
-    }
-
 	if ( mvkOSVersionIsAtLeast(13.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.placementHeaps = useMTLHeaps;
@@ -1105,6 +1105,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.stencilViews = true;
         _metalFeatures.samplerClampToBorder = true;
         _metalFeatures.combinedStoreResolveAction = true;
+		_metalFeatures.deferredStoreActions = true;
         _metalFeatures.maxMTLBufferSize = (1 * GIBI);
     }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -25,6 +25,7 @@
 
 class MVKRenderPass;
 class MVKFramebuffer;
+class MVKCommandEncoder;
 
 
 // Parameters to define the sizing of inline collections
@@ -68,8 +69,7 @@ public:
 										 MVKFramebuffer* framebuffer,
 										 const MVKArrayRef<VkClearValue>& clearValues,
 										 bool isRenderingEntireAttachment,
-                                         bool loadOverride = false,
-                                         bool storeOverride = false);
+                                         bool loadOverride = false);
 
 	/**
 	 * Populates the specified vector with the attachments that need to be cleared
@@ -77,6 +77,9 @@ public:
 	 */
 	void populateClearAttachments(MVKClearAttachments& clearAtts,
 								  const MVKArrayRef<VkClearValue>& clearValues);
+
+	/** If a render encoder is active, sets the store actions for all attachments to it. */
+	void encodeStoreActions(MVKCommandEncoder* cmdEncoder, bool isRenderingEntireAttachment, bool storeOverride = false);
 
 	/** Constructs an instance for the specified parent renderpass. */
 	MVKRenderSubpass(MVKRenderPass* renderPass, const VkSubpassDescription* pCreateInfo);
@@ -125,8 +128,16 @@ public:
                                                    bool isRenderingEntireAttachment,
                                                    bool hasResolveAttachment,
                                                    bool isStencil,
-                                                   bool loadOverride = false,
-                                                   bool storeOverride = false);
+                                                   bool loadOverride = false);
+
+	/** If a render encoder is active, sets the store action for this attachment to it. */
+	void encodeStoreAction(MVKCommandEncoder* cmdEncoder,
+						   MVKRenderSubpass* subpass,
+						   bool isRenderingEntireAttachment,
+						   bool hasResolveAttachment,
+						   uint32_t caIdx,
+					   	   bool isStencil,
+						   bool storeOverride = false);
 
     /** Returns whether this attachment should be cleared in the subpass. */
     bool shouldUseClearAttachment(MVKRenderSubpass* subpass);
@@ -136,6 +147,12 @@ public:
 							const VkAttachmentDescription* pCreateInfo);
 
 protected:
+	MTLStoreAction getMTLStoreAction(MVKRenderSubpass* subpass,
+									 bool isRenderingEntireAttachment,
+									 bool hasResolveAttachment,
+									 bool isStencil,
+									 bool storeOverride);
+
 	VkAttachmentDescription _info;
 	MVKRenderPass* _renderPass;
 	uint32_t _attachmentIndex;


### PR DESCRIPTION
The current code does not handle multiple subpasses, nor does it handle
secondary command buffers. Handling subpasses was easy enough. The
problem came with secondary command buffers. Tracking them became
extremely complicated, particularly since pipelines may be set either
inside or outside a render pass, and further, a pipeline set in one
buffer might be used in another.

I then realized a simpler and more elegant solution: Metal's deferred
store actions feature. This allows you to defer setting the store action
for a render pass until encoding time. This is exactly what we need,
since we won't know what store action we actually want until we start
encoding draws. This solution should now work with multiple subpasses
and secondary command buffers, with much less code.