### PR TITLE
MVKCmdClearAttachments: Don't attempt to clear unused attachments.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -120,7 +120,11 @@ typedef struct MVKRPSKeyClearAtt {
 
     void enableAttachment(uint32_t attIdx) { mvkEnableFlags(flags, bitFlag << attIdx); }
 
+    void disableAttachment(uint32_t attIdx) { mvkDisableFlags(flags, bitFlag << attIdx); }
+
     bool isAttachmentEnabled(uint32_t attIdx) { return mvkIsAnyFlagEnabled(flags, bitFlag << attIdx); }
+
+	bool isAnyAttachmentEnabled() { return mvkIsAnyFlagEnabled(flags, (bitFlag << kMVKClearAttachmentCount) - 1); }
 
 	void enableLayeredRendering() { mvkEnableFlags(flags, bitFlag << kMVKClearAttachmentLayeredRenderingBitIndex); }
 


### PR DESCRIPTION
The attachment index in the `VkClearAttachment` struct is an index into
the current subpass attachment array, not the render pass attachment
array; so it's not enough to check `VkClearAttachment` for
`VK_ATTACHMENT_UNUSED`. We also need to check the current subpass.

If no attachments can be cleared, don't encode a command to the Metal
command buffer.

Perhaps I should bring back `recordBeginRenderPass()` and
`recordEndRenderPass()` (which will be removed in #998) and
keep track of the current subpass; then we can avoid recording
the command entirely if the intersection of the sets
"attachments to clear" and "used attachments" is null.