### PR TITLE
MVKCmdClearAttachments: Fix vertex count for clearing multiple layers.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -254,6 +254,7 @@ public:
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
+    uint32_t getVertexCount();
     void populateVertices(simd::float4* vertices, float attWidth, float attHeight);
 	uint32_t populateVertices(simd::float4* vertices, uint32_t startVertex,
 							  VkClearRect& clearRect, float attWidth, float attHeight);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -946,6 +946,16 @@ VkResult MVKCmdClearAttachments<N>::setContent(MVKCommandBuffer* cmdBuff,
 	return VK_SUCCESS;
 }
 
+// Returns the total number of vertices needed to clear all layers of all rectangles.
+template <size_t N>
+uint32_t MVKCmdClearAttachments<N>::getVertexCount() {
+	uint32_t vtxCnt = 0;
+	for (auto& rect : _clearRects) {
+		vtxCnt += 6 * rect.layerCount;
+	}
+	return vtxCnt;
+}
+
 // Populates the vertices for all clear rectangles within an attachment of the specified size.
 template <size_t N>
 void MVKCmdClearAttachments<N>::populateVertices(simd::float4* vertices, float attWidth, float attHeight) {
@@ -1022,7 +1032,7 @@ uint32_t MVKCmdClearAttachments<N>::populateVertices(simd::float4* vertices,
 template <size_t N>
 void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
 
-	uint32_t vtxCnt = (uint32_t)_clearRects.size() * 6;
+	uint32_t vtxCnt = getVertexCount();
 	simd::float4 vertices[vtxCnt];
 	simd::float4 clearColors[kMVKClearAttachmentCount];
 


### PR DESCRIPTION
Prior to this, we were assuming one layer per clear rect. When that
assumption were broken, we wound up smashing the stack. This will be
more important once multiview support lands, since all views must be
cleared by the clear command.