### PR TITLE
MVKCmdDraw: Don't encode commands that draw zero vertices.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -106,6 +106,11 @@ VkResult MVKCmdDraw::setContent(MVKCommandBuffer* cmdBuff,
 
 void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 
+    if (_vertexCount == 0 || _instanceCount == 0) {
+        // Nothing to do.
+        return;
+    }
+
     auto* pipeline = (MVKGraphicsPipeline*)cmdEncoder->_graphicsPipelineState.getPipeline();
 
 	MVKPiplineStages stages;
@@ -290,6 +295,11 @@ VkResult MVKCmdDrawIndexed::setContent(MVKCommandBuffer* cmdBuff,
 }
 
 void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
+
+    if (_indexCount == 0 || _instanceCount == 0) {
+        // Nothing to do.
+        return;
+    }
 
     auto* pipeline = (MVKGraphicsPipeline*)cmdEncoder->_graphicsPipelineState.getPipeline();
 


### PR DESCRIPTION
Nothing will be drawn in that case. Nothing would've been drawn anyway,
but Metal's validation layer complains if you issue a draw command with
zero vertices or instances.

We unfortunately cannot do anything about indirect draws, since we won't
know how many vertices to draw until execute time.