### PR TITLE
create_xcframework_func.sh script check for header availability before copying.

### DIFF
--- a/Scripts/create_xcframework_func.sh
+++ b/Scripts/create_xcframework_func.sh
@@ -14,11 +14,15 @@ function create_xcframework() {
 
 	xcfwk_cmd="xcodebuild -quiet -create-xcframework -output \"${xcfwk_path}\""
 
+	# For each platform directory in the staging directory, add the library to the
+	# XCFramework if it exists, and for each library, add headers if they exist.
 	for prod_staging_dir in "${MVK_XCFWK_STAGING_DIR}/${CONFIGURATION}"/*; do
 		prod_lib_path="${prod_staging_dir}/lib${prod_name}.a"
 		if [[ -e "${prod_lib_path}" ]]; then
 			xcfwk_cmd+=" -library \"${prod_lib_path}\""
-#			xcfwk_cmd+=" -headers \"${hdr_path}\""		# Headers currently break build during usage due to Xcode 12 bug: https://developer.apple.com/forums/thread/651043?answerId=628400022#628400022
+			if [[ -e "${hdr_path}" ]]; then
+#				xcfwk_cmd+=" -headers \"${hdr_path}\""		# Headers currently break build due to Xcode 12 ProcessXCFramework bug: https://developer.apple.com/forums/thread/651043?answerId=628400022#628400022
+			fi
 		fi
 	done
 


### PR DESCRIPTION
XCFramework headers are still unusable due to an Xcode bug (documented in
create_xcframework_func.sh), but in testing for this, modifications to
create_xcframework_func.sh were made to test for the header file so that this
will work correctly when the Xcode bug is fixed and headers can be reintroduced.