### PR TITLE
MVKShaderLibraryCache: Fix owner of merged MVKShaderLibraries.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -239,6 +239,7 @@ void MVKShaderLibraryCache::merge(MVKShaderLibraryCache* other) {
 	for (auto& otherPair : other->_shaderLibraries) {
 		if ( !findShaderLibrary(&otherPair.first) ) {
 			_shaderLibraries.emplace_back(otherPair.first, new MVKShaderLibrary(*otherPair.second));
+			_shaderLibraries.back().second->_owner = _owner;
 		}
 	}
 }


### PR DESCRIPTION
When a pipeline cache were merged into another pipeline cache, we would
create new `MVKShaderLibrary` objects for each one contained in the
source. The objects would be exact copies of the originals... including
their owner, which could be destroyed after the pipeline caches were
merged. Fix the owner in the new objects to prevent a dangling
reference.