### PR TITLE
Support fat platform libraries in XCFrameworks and dylibs.

### DIFF
--- a/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/API-Samples/API-Samples.xcodeproj/project.pbxproj
@@ -722,11 +722,6 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -757,11 +752,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = NO;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/Cube/Cube.xcodeproj/project.pbxproj
@@ -459,11 +459,6 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -497,11 +492,6 @@
 				CLANG_ENABLE_OBJC_ARC = NO;
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;

--- a/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/project.pbxproj
+++ b/Demos/LunarG-VulkanSamples/Hologram/Hologram.xcodeproj/project.pbxproj
@@ -457,11 +457,6 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -493,11 +488,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = NO;
 				ENABLE_BITCODE = NO;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = GLM_FORCE_RADIANS;

--- a/ExternalDependencies.xcodeproj/project.pbxproj
+++ b/ExternalDependencies.xcodeproj/project.pbxproj
@@ -5404,11 +5404,6 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -5458,11 +5453,6 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -1629,11 +1629,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1662,6 +1657,9 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				MVK_SKIP_DYLIB = "";
+				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
+				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKSPIRVToMSLConverter.a ${CONFIGURATION_BUILD_DIR}/libMoltenVKGLSLToSPIRVConverter.a";
 				PRODUCT_NAME = MoltenVK;
@@ -1697,11 +1695,6 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1728,6 +1721,9 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				MVK_SKIP_DYLIB = "";
+				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
+				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKSPIRVToMSLConverter.a ${CONFIGURATION_BUILD_DIR}/libMoltenVKGLSLToSPIRVConverter.a";
 				PRODUCT_NAME = MoltenVK;
 				SKIP_INSTALL = YES;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -989,11 +989,6 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1050,11 +1045,6 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=appletvos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=appletvsimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=iphoneos*]" = arm64e;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
-				"EXCLUDED_ARCHS[sdk=macosx*]" = arm64;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/Scripts/copy_lib_to_staging.sh
+++ b/Scripts/copy_lib_to_staging.sh
@@ -1,25 +1,12 @@
 #!/bin/bash
 
-# Query the architectures in the built static library. If it contains only a single architecture,
-# copy the file into a separate file in its own directory within the XCFrameworkStaging directory.
-# If it contains mulitple architectures, extract each architecture into a separate file in its own
-# directory within the XCFrameworkStaging directory.
+# Copy the static library file to its own directory within the XCFrameworkStaging directory.
 #
 # Requires the variable MVK_XCFWK_STAGING_DIR.
 #
 export MVK_PROD_FILENAME="lib${PRODUCT_NAME}.a"
 export MVK_BUILT_PROD_FILE="${BUILT_PRODUCTS_DIR}/${MVK_PROD_FILENAME}"
 
-IFS=' ' read -ra archs <<< $(lipo -archs "${MVK_BUILT_PROD_FILE}")
-if [ ${#archs[@]} -eq '1' ]; then
-	arch="${archs[0]}"
-	staging_dir="${MVK_XCFWK_STAGING_DIR}/${arch}${EFFECTIVE_PLATFORM_NAME}"
-	mkdir -p "${staging_dir}"
-	cp -a "${MVK_BUILT_PROD_FILE}" "${staging_dir}/${MVK_PROD_FILENAME}"
-else
-	for arch in ${archs[@]}; do
-		staging_dir="${MVK_XCFWK_STAGING_DIR}/${arch}${EFFECTIVE_PLATFORM_NAME}"
-		mkdir -p "${staging_dir}"
-		lipo "${MVK_BUILT_PROD_FILE}" -thin ${arch} -output "${staging_dir}/${MVK_PROD_FILENAME}"
-	done
-fi
+staging_dir="${MVK_XCFWK_STAGING_DIR}/Platform${EFFECTIVE_PLATFORM_NAME}"
+mkdir -p "${staging_dir}"
+cp -a "${MVK_BUILT_PROD_FILE}" "${staging_dir}/${MVK_PROD_FILENAME}"

--- a/Scripts/create_dylib.sh
+++ b/Scripts/create_dylib.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-set -e
+# Allow dylib building to be skipped based on bulid setting.
+# For example, skipping the build of a dylib for Simulator builds
+# because Xcode cannot currently handle creating a Simulator dylib
+# containing both x86_64 and arm64 (Apple Silicon) architectures.
+if [ "${MVK_SKIP_DYLIB}" == "YES" ]; then
+	exit 0
+fi
 
 export MVK_BUILT_PROD_DIR="${BUILT_PRODUCTS_DIR}"
 export MVK_DYLIB_NAME="lib${PRODUCT_NAME}.dylib"

--- a/Scripts/package_moltenvk.sh
+++ b/Scripts/package_moltenvk.sh
@@ -8,19 +8,21 @@ function copy_dylib() {
 	src_dir="${BUILD_DIR}/${CONFIGURATION}${1}/dynamic"
 	dst_dir="${MVK_PKG_PROD_PATH}/dylib/${2}"
 
-echo Copying dylib from "${src_dir}" to "${dst_dir}"
-
-	if [[ -e "${src_dir}" ]]; then
+	# If dylib file exists, copy it, any debug symbol file, and the Vulkan layer JSON file
+	src_file="${src_dir}/lib${MVK_PROD_NAME}.dylib"
+	if [[ -e "${src_file}" ]]; then
 		rm -rf "${dst_dir}"
 		mkdir -p "${dst_dir}"
 
-		cp -a "${src_dir}/lib${MVK_PROD_NAME}.dylib" "${dst_dir}"
+		cp -a "${src_file}" "${dst_dir}"
 
-		if [[ -e "${src_dir}/lib${MVK_PROD_NAME}.dylib.dSYM" ]]; then
-		   cp -a "${src_dir}/lib${MVK_PROD_NAME}.dylib.dSYM" "${dst_dir}"
+		src_file+=".dSYM"
+		if [[ -e "${src_file}" ]]; then
+		   cp -a "${src_file}" "${dst_dir}"
 		fi
 
 		cp -a "${MVK_PROD_PROJ_PATH}/icd/${MVK_PROD_NAME}_icd.json" "${dst_dir}"
+
 	fi
 }
 


### PR DESCRIPTION
Remove EXCLUDED_ARCHS from all Xcode projects to allow fat platform libraries to be built.
Script copy_lib_to_staging.sh no longer breaks fat libraries into single-architecture
libraries, and simply copies fat file to XCFramework staging area.
This permits support for arm64 on macOS, and arm64e on iOS and tvOS.
Creating a Simulator dylib containing both x86_64 and arm64 (Apple Silicon)
architectures is not currently supported by Xcode, so Simulator dylibs are skipped.