### PR TITLE
MVKImage: Always use a texel buffer for atomic linear storage images.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -144,8 +144,10 @@ protected:
     MVKImageMemoryBinding(MVKDevice* device, MVKImage* image, uint8_t planeIndex);
 
     MVKImage* _image;
+    id<MTLBuffer> _mtlTexelBuffer = nil;
+    NSUInteger _mtlTexelBufferOffset = 0;
     uint8_t _planeIndex;
-    bool _usesTexelBuffer;
+    bool _ownsTexelBuffer = false;
 };
 
 
@@ -368,6 +370,7 @@ protected:
 	bool _isAliasable;
 	bool _hasExtendedUsage;
 	bool _hasMutableFormat;
+	bool _isLinearForAtomics;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -318,6 +318,9 @@ public:
 	/** Returns the Metal format capabilities supported by the specified Metal format. */
 	MVKMTLFmtCaps getCapabilities(MTLPixelFormat mtlFormat, bool isExtended = false);
 
+	/** Returns the Metal view class of the specified Vulkan format. */
+	MVKMTLViewClass getViewClass(VkFormat vkFormat);
+
 	/** Returns the Metal view class of the specified Metal format. */
 	MVKMTLViewClass getViewClass(MTLPixelFormat mtlFormat);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -352,6 +352,10 @@ MVKMTLFmtCaps MVKPixelFormats::getCapabilities(MTLPixelFormat mtlFormat, bool is
     return caps;
 }
 
+MVKMTLViewClass MVKPixelFormats::getViewClass(VkFormat vkFormat) {
+    return getMTLPixelFormatDesc(getVkFormatDesc(vkFormat).mtlPixelFormat).mtlViewClass;
+}
+
 MVKMTLViewClass MVKPixelFormats::getViewClass(MTLPixelFormat mtlFormat) {
     return getMTLPixelFormatDesc(mtlFormat).mtlViewClass;
 }


### PR DESCRIPTION
If the image has a format that supports atomic access, or can be cast to
a format which supports atomic access, then use a texel buffer,
regardless of the memory type. If we can't use the `MTLBuffer` from the
device memory, then create our own.

For #1027.