### PR TITLE
MVKImage: Correct offset for texel buffers and heaps.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -54,13 +54,13 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
         } else if (memoryBinding->_mtlTexelBuffer) {
             _mtlTexture = [memoryBinding->_mtlTexelBuffer
                            newTextureWithDescriptor: mtlTexDesc
-                           offset: memoryBinding->_mtlTexelBufferOffset
+                           offset: memoryBinding->_mtlTexelBufferOffset + _subresources[0].layout.offset
                            bytesPerRow: _subresources[0].layout.rowPitch];
         } else if (memoryBinding->_deviceMemory->getMTLHeap() && !_image->getIsDepthStencil()) {
             // Metal support for depth/stencil from heaps is flaky
             _mtlTexture = [memoryBinding->_deviceMemory->getMTLHeap()
                            newTextureWithDescriptor: mtlTexDesc
-                           offset: memoryBinding->getDeviceMemoryOffset()];
+                           offset: memoryBinding->getDeviceMemoryOffset() + _subresources[0].layout.offset];
             if (_image->_isAliasable) { [_mtlTexture makeAliasable]; }
         } else {
             _mtlTexture = [_image->getMTLDevice() newTextureWithDescriptor: mtlTexDesc];


### PR DESCRIPTION
For planes other than 0, we must add the offset of the first
subresource, so the plane is at the correct place in memory.