### PR TITLE
fetchDependencies builds serially by default.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -52,6 +52,7 @@ Released 2020/09/28
   within each descriptor set.
 - `vkCmdCopyImage` on macOS flush non-coherent image memory before copy operation.
 - Re-add support for bitcode generation on *iOS* and *tvOS*.
+- `fetchDependencies` builds serially by default for better build script integration. 
 - Combine `MoltenVKSPIRVToMSLConverter` and `MoltenVKGLSLToSPIRVConverter` 
   frameworks into a single `MoltenVKShaderConverter` framework.
 - Fix Metal validation error when occlusion query and renderpass are in separate 

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -37,8 +37,11 @@
 #              Build the external libraries in Debug mode, which may be useful when debugging
 #              and tracing calls into those libraries.
 #
+#      --parallel-build
+#              Build the external libraries in parallel using background processes.
+#
 #      --no-parallel-build
-#              Build the external libraries serially instead of in parallel using background processes.
+#              Build the external libraries serially instead of in parallel. This is the default.
 #
 #      --glslang-root path
 #              "path" specifies a directory path to a KhronosGroup/glslang repository.
@@ -79,7 +82,7 @@ BLD_MACOS=""
 BLD_SPECIFIED=""
 XC_CONFIG="Release"
 XC_BUILD_VERBOSITY="-quiet"
-XC_USE_BCKGND="Y"
+XC_USE_BCKGND=""
 V_HEADERS_ROOT=""
 SPIRV_CROSS_ROOT=""
 GLSLANG_ROOT=""
@@ -128,6 +131,10 @@ while (( "$#" )); do
          ;;
        --debug)
          XC_CONFIG="Debug"
+         shift 1
+         ;;
+       --parallel-build)
+         XC_USE_BCKGND="Y"
          shift 1
          ;;
        --no-parallel-build)


### PR DESCRIPTION
Building in parallel does not significantly improve performance, and makes it
more difficult to integrate calling fetchDependencies from a larger build script,
because of the need to trap and kill child processes on an error.

Fixes #1002.