### PR TITLE
vkSetMTLTextureMVK() Fix crash if incoming MTLTexture does not have an IOSurface.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -56,6 +56,7 @@ Released 2020/09/28
   frameworks into a single `MoltenVKShaderConverter` framework.
 - Fix Metal validation error when occlusion query and renderpass are in separate 
   Vulkan command buffers.
+- `vkSetMTLTextureMVK()` Fix crash if incoming `MTLTexture` does not have an associated `IOSurface`. 
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -698,7 +698,7 @@ VkResult MVKImage::setMTLTexture(uint8_t planeIndex, id<MTLTexture> mtlTexture) 
 
 	if (_device->_pMetalFeatures->ioSurfaces) {
 		_ioSurface = mtlTexture.iosurface;
-		CFRetain(_ioSurface);
+		if (_ioSurface) { CFRetain(_ioSurface); }
 	}
 
 	return VK_SUCCESS;


### PR DESCRIPTION
Fixes issue #994.