### PR TITLE
MVKImageView: Use a 2D non-arrayed view for 2D non-arrayed attachments.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1522,6 +1522,28 @@ MVKImageView::MVKImageView(MVKDevice* device,
                 setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImageView(): 2D views on 3D images can only be used as color attachments."));
             }
         }
+
+        // If a 2D array view on a 2D image with layerCount 1, and the only usages are
+        // attachment usages, then force the use of a 2D non-arrayed view. This is important for
+        // input attachments, or they won't match the types declared in the fragment shader.
+        // Transfer usages are OK: the transfer commands don't use image views.
+        // Sampled and storage usages are not: if we try to bind a non-arrayed 2D view
+        // to a 2D image variable, we could wind up with the same problem this is intended to fix.
+        if (mvkIsOnlyAnyFlagEnabled(_usage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                             VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+                                             VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))) {
+            if (_mtlTextureType == MTLTextureType2DArray && _image->_mtlTextureType == MTLTextureType2D) {
+                _mtlTextureType = MTLTextureType2D;
+#if MVK_MACOS
+            } else if (_mtlTextureType == MTLTextureType2DMultisampleArray && _image->_mtlTextureType == MTLTextureType2DMultisample) {
+                _mtlTextureType = MTLTextureType2DMultisample;
+#endif
+            }
+        }
+
     }
 
 	// Remember the subresource range, and determine the actual number of mip levels and texture slices


### PR DESCRIPTION
If a shader uses an input attachment and doesn't do layered rendering,
but the image view is of type `MTLTextureType2DArray`, Metal's
validation layer will complain about the texture type mismatching what
the shader expects. This change makes the texture types line up.