### PR TITLE
Fix memory overrun when enabling VkPhysicalDevicePortabilitySubsetFeaturesKHR features.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3368,9 +3368,9 @@ void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
 				auto* requestedFeatures = (VkPhysicalDevicePortabilitySubsetFeaturesKHR*)next;
-				enableFeatures(&_enabledPortabilityFeatures.triangleFans,
-							   &requestedFeatures->triangleFans,
-							   &pdPortabilityFeatures.triangleFans, 15);
+				enableFeatures(&_enabledPortabilityFeatures.constantAlphaColorBlendFactors,
+							   &requestedFeatures->constantAlphaColorBlendFactors,
+							   &pdPortabilityFeatures.constantAlphaColorBlendFactors, 15);
 				break;
 			}
 			default:

--- a/MoltenVK/icd/MoltenVK_icd.json
+++ b/MoltenVK/icd/MoltenVK_icd.json
@@ -2,6 +2,6 @@
     "file_format_version" : "1.0.0",
     "ICD": {
         "library_path": "./libMoltenVK.dylib",
-        "api_version" : "1.0.0"
+        "api_version" : "1.1.0"
     }
 }


### PR DESCRIPTION
Plus update MoltenVK_icd.json to tell Vulkan Loader and Layers to use Vulkan 1.1.