### PR TITLE
MVKPhysicalDevice: Get the vendor ID before setting the subgroup size.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1243,6 +1243,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #if MVK_MACOS
     if (mvkOSVersionIsAtLeast(10.14)) {
         static const uint32_t kAMDVendorId = 0x1002;
+        initGPUInfoProperties();    // Need to know the vendor ID for this.
         _metalFeatures.subgroupSize = (_properties.vendorID == kAMDVendorId) ? 64 : 32;
     }
 #endif


### PR DESCRIPTION
At this point in device initialization, the device properties have not
yet been initialized. Unfortunately, this includes the vendor ID, on
which the maximum SIMD-group size depends. Initialize that property so
we can use it to set the subgroup size correctly.