### PR TITLE
MVKDevice: Only force a mux switch when a swapchain is created.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1246,7 +1246,14 @@ void MVKPixelFormats::modifyMTLFormatCapabilities() {
 	if (_physicalDevice) {
 		modifyMTLFormatCapabilities(_physicalDevice->getMTLDevice());
 	} else {
+#if MVK_IOS_OR_TVOS
 		id<MTLDevice> mtlDevice = MTLCreateSystemDefaultDevice();	// temp retained
+#endif
+#if MVK_MACOS
+		NSArray<id<MTLDevice>>* mtlDevices = MTLCopyAllDevices();	// temp retained
+		id<MTLDevice> mtlDevice = [mtlDevices[0] retain];			// temp retained
+		[mtlDevices release];										// temp release
+#endif
 		modifyMTLFormatCapabilities(mtlDevice);
 		[mtlDevice release];										// release temp instance
 	}


### PR DESCRIPTION
We only want the window server to use the high-performance GPU if we
will use it to present to the display. If we won't use it to present, we
can save some battery life by not using the display. I had hoped this
would help window server stability in case something goes horribly
wrong while using the GPU, but my experience has sadly not borne this
out.

My testing shows that the device returned by
`MTLCreateSystemDefaultDevice()` is exactly equal (i.e. has the same
pointer value) to one of the devices returned by `MTLCopyAllDevices()`,
so we should see no problems from doing this at swapchain create time
instead of device create time.