### PR TITLE
MVKSwapchainImage: Retain image and swapchain until presentation is done.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -402,6 +402,8 @@ public:
 					  MVKSwapchain* swapchain,
 					  uint32_t swapchainIndex);
 
+	~MVKSwapchainImage() override;
+
 protected:
 	friend class MVKPeerSwapchainImage;
 


### PR DESCRIPTION
Fixes use-after-free bugs in `VK_GOOGLE_display_timing` support.