### PR TITLE
MVKCmdCopyImage: Fix a copy-pasto.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -158,7 +158,7 @@ void MVKCmdCopyImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
             VkExtent3D srcExtent = _srcImage->getExtent3D(srcPlaneIndex, srcLevel);
             uint32_t dstLevel = vkIC.dstSubresource.mipLevel;
             uint32_t dstBaseLayer = vkIC.dstSubresource.baseArrayLayer;
-            VkExtent3D dstExtent = _dstImage->getExtent3D(srcPlaneIndex, srcLevel);
+            VkExtent3D dstExtent = _dstImage->getExtent3D(srcPlaneIndex, dstLevel);
             // If the extent completely covers both images, I can copy all layers at once.
             // This will obviously not apply to copies between a 3D and 2D image.
             if (mvkVkExtent3DsAreEqual(srcExtent, vkIC.extent) && mvkVkExtent3DsAreEqual(dstExtent, vkIC.extent)) {


### PR DESCRIPTION
I know I said I wouldn't have any more, but this fixes a problem with
my change #1064 that could trip Metal's validation layer and/or result in
no data being copied.