### PR TITLE
Use VK_KHR_image_format_list to disable MTLTextureUsagePixelFormatView where possible.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,17 @@ For best results, use a Markdown reader.*
 
 
 
+MoltenVK 1.1.1
+--------------
+
+Released TBD
+
+- Use `VK_KHR_image_format_list` to disable `MTLTextureUsagePixelFormatView` 
+  if only swizzles or `sRGB` conversion will be used for image views, improving 
+  performance on *iOS* by allowing Metal to use lossless texture compression.
+
+
+
 MoltenVK 1.1.0
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -50,7 +50,7 @@ typedef unsigned long MTLLanguageVersion;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   1
-#define MVK_VERSION_PATCH   0
+#define MVK_VERSION_PATCH   1
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -330,6 +330,7 @@ public:
 	/** Returns the Metal CPU cache mode used by this image. */
 	MTLCPUCacheMode getMTLCPUCacheMode();
 
+
 #pragma mark Construction
 
 	MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo);
@@ -351,9 +352,12 @@ protected:
 	bool validateLinear(const VkImageCreateInfo* pCreateInfo, bool isAttachment);
 	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
     void releaseIOSurface();
+	bool getIsValidViewFormat(VkFormat viewFormat);
+	MTLTextureUsage getMTLTextureUsage(MTLPixelFormat mtlPixFmt);
 
     MVKSmallVector<MVKImageMemoryBinding*, 3> _memoryBindings;
     MVKSmallVector<MVKImagePlane*, 3> _planes;
+	MVKSmallVector<VkFormat, 2> _viewFormats;
     VkExtent3D _extent;
     uint32_t _mipLevels;
     uint32_t _arrayLayers;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1564,11 +1564,6 @@ MVKImageView::MVKImageView(MVKDevice* device,
 		}
 	}
 
-    // Validate whether the image view configuration can be supported
-	if ( !_image->getIsValidViewFormat(pCreateInfo->format) ) {
-		setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateImageView(): The format is not in the list of allowed view formats declared in the VkImageFormatListCreateInfo provided in vkCreateImage()."));
-	}
-
 	VkImageType imgType = _image->getImageType();
 	VkImageViewType viewType = pCreateInfo->viewType;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -109,18 +109,10 @@ void MVKImagePlane::releaseMTLTexture() {
 // Returns a Metal texture descriptor constructed from the properties of this image.
 // It is the caller's responsibility to release the returned descriptor object.
 MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
-    MTLPixelFormat mtlPixFmt = _mtlPixFmt;
-    MTLTextureUsage minUsage = MTLTextureUsageUnknown;
-#if MVK_MACOS
-    if (_image->_is3DCompressed) {
-        // Metal before 3.0 doesn't support 3D compressed textures, so we'll decompress
-        // the texture ourselves. This, then, is the *uncompressed* format.
-        mtlPixFmt = MTLPixelFormatBGRA8Unorm;
-        minUsage = MTLTextureUsageShaderWrite;
-    }
-#endif
 
-    MVKImageMemoryBinding* memoryBinding = getMemoryBinding();
+	// Metal before 3.0 doesn't support 3D compressed textures, so we'll decompress
+	// the texture ourselves. This, then, is the *uncompressed* format.
+	MTLPixelFormat mtlPixFmt = (MVK_MACOS && _image->_is3DCompressed) ? MTLPixelFormatBGRA8Unorm : _mtlPixFmt;
 
     VkExtent3D extent = _image->getExtent3D(_planeIndex, 0);
     MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor new];    // retained
@@ -132,12 +124,7 @@ MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
     mtlTexDesc.mipmapLevelCount = _image->_mipLevels;
     mtlTexDesc.sampleCount = mvkSampleCountFromVkSampleCountFlagBits(_image->_samples);
     mtlTexDesc.arrayLength = _image->_arrayLayers;
-    if (_image->_isAliasable && memoryBinding->_deviceMemory && memoryBinding->_deviceMemory->isDedicatedAllocation()) {
-        // Unfortunately, in this instance, we must presume the texture can be used for anything.
-        mtlTexDesc.usageMVK = MTLTextureUsageUnknown;
-    } else {
-        mtlTexDesc.usageMVK = _image->getPixelFormats()->getMTLTextureUsage(_image->_usage, mtlPixFmt, minUsage, _image->_isLinear, _image->_hasMutableFormat, _image->_hasExtendedUsage);
-    }
+	mtlTexDesc.usageMVK = _image->getMTLTextureUsage(mtlPixFmt);
     mtlTexDesc.storageModeMVK = _image->getMTLStorageMode();
     mtlTexDesc.cpuCacheMode = _image->getMTLCPUCacheMode();
 
@@ -608,6 +595,16 @@ void MVKImage::getTransferDescriptorData(MVKImageDescriptorData& imgData) {
     imgData.usage = _usage;
 }
 
+// Returns whether an MVKImageView can have the specified format.
+// If the list of pre-declared view formats is not empty,
+// and the format is not on that list, the view format is not valid.
+bool MVKImage::getIsValidViewFormat(VkFormat viewFormat) {
+	for (VkFormat viewFmt : _viewFormats) {
+		if (viewFormat == viewFmt) { return true; }
+	}
+	return _viewFormats.empty();
+}
+
 
 #pragma mark Resource memory
 
@@ -815,6 +812,31 @@ MTLCPUCacheMode MVKImage::getMTLCPUCacheMode() {
 	return _memoryBindings[0]->_deviceMemory ? _memoryBindings[0]->_deviceMemory->getMTLCPUCacheMode() : MTLCPUCacheModeDefaultCache;
 }
 
+MTLTextureUsage MVKImage::getMTLTextureUsage(MTLPixelFormat mtlPixFmt) {
+
+	// In the special case of a dedicated aliasable image, we must presume the texture can be used for anything.
+	MVKDeviceMemory* dvcMem = _memoryBindings[0]->_deviceMemory;
+	if (_isAliasable && dvcMem && dvcMem->isDedicatedAllocation()) { return MTLTextureUsageUnknown; }
+
+	MVKPixelFormats* pixFmts = getPixelFormats();
+
+	// The image view will need reinterpretation if this image is mutable, unless view formats are provided
+	// and all of the view formats are either identical to, or an sRGB variation of, the incoming format.
+	bool needsReinterpretation = _hasMutableFormat && _viewFormats.empty();
+	for (VkFormat viewFmt : _viewFormats) {
+		needsReinterpretation = needsReinterpretation || !pixFmts->compatibleAsLinearOrSRGB(mtlPixFmt, viewFmt);
+	}
+
+	MTLTextureUsage mtlUsage = pixFmts->getMTLTextureUsage(_usage, mtlPixFmt, _isLinear, needsReinterpretation, _hasExtendedUsage);
+
+	// Metal before 3.0 doesn't support 3D compressed textures, so we'll
+	// decompress the texture ourselves, and we need to be able to write to it.
+	if (MVK_MACOS && _is3DCompressed) {
+		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
+	}
+
+	return mtlUsage;
+}
 
 #pragma mark Construction
 
@@ -852,7 +874,6 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
     // If this is a storage image of format R32_UINT or R32_SINT, or MUTABLE_FORMAT is set
     // and R32_UINT is in the set of possible view formats, then we must use a texel buffer,
     // or image atomics won't work.
-    // TODO: Also add handling for VK_KHR_image_format_list here.
     _isLinearForAtomics = _isLinear && mvkIsAnyFlagEnabled(_usage, VK_IMAGE_USAGE_STORAGE_BIT) &&
                           ((_vkFormat == VK_FORMAT_R32_UINT || _vkFormat == VK_FORMAT_R32_SINT) ||
                            (_hasMutableFormat && pixFmts->getViewClass(_vkFormat) == MVKMTLViewClass::Color32));
@@ -915,6 +936,13 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
 			case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO: {
 				auto* pExtMemInfo = (const VkExternalMemoryImageCreateInfo*)next;
 				initExternalMemory(pExtMemInfo->handleTypes);
+				break;
+			}
+			case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
+				auto* pFmtListInfo = (const VkImageFormatListCreateInfo*)next;
+				for (uint32_t fmtIdx = 0; fmtIdx < pFmtListInfo->viewFormatCount; fmtIdx++) {
+					_viewFormats.push_back(pFmtListInfo->pViewFormats[fmtIdx]);
+				}
 				break;
 			}
 			default:
@@ -1532,6 +1560,11 @@ MVKImageView::MVKImageView(MVKDevice* device,
 
     // Validate whether the image view configuration can be supported
     if ( _image ) {
+
+		if ( !_image->getIsValidViewFormat(pCreateInfo->format) ) {
+			setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateImageView(): The format is not in the list of allowed view formats declared in the VkImageFormatListCreateInfo provided in vkCreateImage()."));
+		}
+
         VkImageType imgType = _image->getImageType();
         VkImageViewType viewType = pCreateInfo->viewType;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -170,6 +170,7 @@ typedef struct {
 	VkFormat vkFormat;
 	MVKMTLFmtCaps mtlFmtCaps;
 	MVKMTLViewClass mtlViewClass;
+	MTLPixelFormat mtlPixelFormatLinear;
 	const char* name;
 
 	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mtlFmtCaps != kMVKMTLFmtCapsNone); };
@@ -204,6 +205,17 @@ public:
 
 	/** Returns whether the specified Metal MTLPixelFormat is a PVRTC format. */
 	bool isPVRTCFormat(MTLPixelFormat mtlFormat);
+
+	/**
+	 * Returns whether the VkFormat only differs from the MTLPixelFormat in that one may be the sRGB
+	 * version of the other. Either or both the VkFormat and MTLPixelFormat may be a linear or sRGB format.
+	 * Returns true if any of the following are true:
+	 *   - The MTLPixelFormat is the Metal version of the VkFormat.
+	 *   - The MTLPixelFormat is the Metal sRGB version of the linear VkFormat.
+	 *   - The MTLPixelFormat is the Metal linear version of the sRGB VkFormat.
+	 * Returns false if none of those conditions apply.
+	 */
+	bool compatibleAsLinearOrSRGB(MTLPixelFormat mtlFormat, VkFormat vkFormat);
 
 	/** Returns the format type corresponding to the specified Vulkan VkFormat, */
 	MVKFormatType getFormatType(VkFormat vkFormat);
@@ -346,17 +358,16 @@ public:
 	VkImageUsageFlags getVkImageUsageFlags(MTLTextureUsage mtlUsage, MTLPixelFormat mtlFormat);
 
 	/**
-	 * Returns the Metal texture usage from the Vulkan image usage and Metal format, ensuring that at least the
-	 * usages in minUsage are included, even if they wouldn't naturally be included based on the other two parameters.
+	 * Returns the Metal texture usage from the Vulkan image usage and Metal format.
      * isLinear further restricts the allowed usage to those that are valid for linear textures.
+	 * needsReinterpretation indicates an image view with a format that needs reinterpretation will be applied.
      * isExtended expands the allowed usage to those that are valid for all formats which
      * can be used in a view created from the specified format.
 	 */
 	MTLTextureUsage getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
 									   MTLPixelFormat mtlFormat,
-									   MTLTextureUsage minUsage = MTLTextureUsageUnknown,
                                        bool isLinear = false,
-                                       bool isMutableFormat = true,
+                                       bool needsReinterpretation = true,
                                        bool isExtended = false);
 
 	/** Enumerates all formats that support the given features, calling a specified function for each one. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -355,6 +355,19 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 
     if ( getIsSurfaceLost() ) { return; }
 
+	VkImageFormatListCreateInfo fmtListInfo;
+	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
+		switch (next->sType) {
+			case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
+				fmtListInfo = *(VkImageFormatListCreateInfo*)next;
+				fmtListInfo.pNext = VK_NULL_HANDLE;		// Terminate the new chain
+				break;
+			}
+			default:
+				break;
+		}
+	}
+
     VkExtent2D imgExtent = mvkVkExtent2DFromCGSize(_mtlLayerOrigDrawSize);
 
     VkImageCreateInfo imgInfo = {
@@ -373,6 +386,7 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 
 	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)) {
 		mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+		imgInfo.pNext = &fmtListInfo;
 	}
 	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR)) {
 		// We don't really support this, but set the flag anyway.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,18 @@ encumbrances. In submitting code to this repository, you are agreeing that the c
 Property claims.  
 
 
+### *Vulkan* Validation
+
+Despite running on top of *Metal*, **MoltenVK** operates as a *Vulkan* core layer. As such, as per the 
+error handling guidelines of the [*Vulkan* specification](https://www.khronos.org/registry/vulkan/specs/1.1/html/vkspec.html#fundamentals-errors), **MoltenVK** should not perform *Vulkan* validation. When adding functionality 
+to **MoltenVK**, avoid adding unnecessary validation code.
+
+Validation and error generation **_is_** appropriate within **MoltenVK** in cases where **MoltenVK** deviates 
+from behavior defined by the *Vulkan* specification. This most commonly occurs when required behavior cannot 
+be mapped to functionality available within *Metal*. In that situation, it is important to provide feedback to
+the application developer to that effect, by performing the necessary validation, and reporting an error.
+
+
 ### Memory Management
 
 *Metal*, and other *Objective-C* objects in *Apple's SDK* frameworks, use reference counting for memory management. 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,11 @@ from behavior defined by the *Vulkan* specification. This most commonly occurs w
 be mapped to functionality available within *Metal*. In that situation, it is important to provide feedback to
 the application developer to that effect, by performing the necessary validation, and reporting an error.
 
+Currently, there is some excess *Vulkan* validation and error reporting code within **MoltenVK**, added before 
+this guideline was introduced. You are encouraged to remove such code if you encounter it while performing other 
+**MoltenVK** development. Do not remove validation and error reporting code that is covering a deviation in 
+behavior from the *Vulkan* specification.
+
 
 ### Memory Management
 


### PR DESCRIPTION
Don't use `MTLTextureUsagePixelFormatView` if image will only allow views that use same format or its sRGB/linear variation.

- `MVKImage` track `VkImageFormatListCreateInfo::pViewFormats` and validate `MVKImageView` format against them.
- Add `MVKImage::getMTLTextureUsage()` and move tests for dedicated aliasables, compressed formats, and minimum image usage into it.
- Add `MVKMTLFormatDesc::mtlPixelFormatLinear` and `MVKPixelFormats::compatibleAsLinearOrSRGB()` to track linear counterparts to each Metal `sRGB` format.
- Don't use `MTLTextureUsagePixelFormatView` if image will only allow views that use same format or its sRGB/linear variation.
- Propagate `VkImageFormatListCreateInfo` from mutable format swapchain to swapchain images.