### PR TITLE
MVKImagePlane: Reset _mtlTexture after releasing.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -100,6 +100,8 @@ id<MTLTexture> MVKImagePlane::getMTLTexture(MTLPixelFormat mtlPixFmt) {
 
 void MVKImagePlane::releaseMTLTexture() {
     [_mtlTexture release];
+    _mtlTexture = nil;
+
     for (auto elem : _mtlTextureViews) {
         [elem.second release];
     }


### PR DESCRIPTION
For an `MVKImage`, when we call `vkUseIOSurfaceMVK()`, the `_mtlTexture` object of each plane will be released but not reset. And later when we destroy the `MVKImage`, the destructor of `MVKImagePlane` calls `releaseMTLTexture()` again, which will cause a crash because of double releasing of an object.

To solve this we need to reset `_mtlTexture` to `nil` after it is successfully released.
