### PR TITLE
Fix potential drawable present race conditions.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -467,7 +467,7 @@ protected:
 	friend MVKSwapchain;
 
 	id<CAMetalDrawable> getCAMetalDrawable() override;
-	void presentCAMetalDrawable(MVKPresentTimingInfo presentTimingInfo);
+	void presentCAMetalDrawable(id<CAMetalDrawable> mtlDrawable, MVKPresentTimingInfo presentTimingInfo);
 	void releaseMetalDrawable();
 	MVKSwapchainImageAvailability getAvailability();
 	void makeAvailable();


### PR DESCRIPTION
- Retrieve `MTLDrawable` when presentation requested, not in `MTLCommandBuffer` scheduled
handler, in case a different drawable is established by then.
- Call timed present after adding presented handler, to avoid race
condition if presentation happens before handler is added.

Additional fix for issue #929.