### PR TITLE
MVKCmdBlitImage: Support depth/stencil blits with inversion and scaling.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -38,15 +38,17 @@ class MVKQueryPool;
  */
 typedef struct MVKRPSKeyBlitImg {
 	uint16_t srcMTLPixelFormat = 0;			/**< as MTLPixelFormat */
-	uint16_t srcMTLTextureType = 0;			/**< as MTLTextureType */
 	uint16_t dstMTLPixelFormat = 0;			/**< as MTLPixelFormat */
+	uint8_t srcMTLTextureType = 0;			/**< as MTLTextureType */
+	uint8_t srcAspect = 0;					/**< as VkImageAspectFlags */
 	uint8_t srcFilter = 0;					/**< as MTLSamplerMinMagFilter */
 	uint8_t dstSampleCount = 0;
 
 	bool operator==(const MVKRPSKeyBlitImg& rhs) const {
 		if (srcMTLPixelFormat != rhs.srcMTLPixelFormat) { return false; }
-		if (srcMTLTextureType != rhs.srcMTLTextureType) { return false; }
 		if (dstMTLPixelFormat != rhs.dstMTLPixelFormat) { return false; }
+		if (srcMTLTextureType != rhs.srcMTLTextureType) { return false; }
+		if (srcAspect != rhs.srcAspect) { return false; }
 		if (srcFilter != rhs.srcFilter) { return false; }
 		if (dstSampleCount != rhs.dstSampleCount) { return false; }
 		return true;
@@ -72,10 +74,13 @@ typedef struct MVKRPSKeyBlitImg {
 		std::size_t hash = srcMTLPixelFormat;
 
 		hash <<= 16;
+		hash |= dstMTLPixelFormat;
+
+		hash <<= 8;
 		hash |= srcMTLTextureType;
 
-		hash <<= 16;
-		hash |= dstMTLPixelFormat;
+		hash <<= 8;
+		hash |= srcAspect;
 
 		hash <<= 8;
 		hash |= srcFilter;


### PR DESCRIPTION
Prior to this, we weren't even setting the `BLIT_DST` bit for
depth/stencil formats. Conforming apps would thus never pass DS images
at all to `vkCmdBlitImage()`. It is now possible to do that, and even
get scaling and inversion to boot.

Stencil blits require the use of stencil feedback. If this feature isn't
available, both stencil and packed depth/stencil formats have their
`BLIT_SRC` and `BLIT_DST` features turned off, to prevent apps from
attempting to blit the stencil aspect.

There's only a couple of failing tests, involving a 1D stencil blit
(really a 2D stencil with height 1). For some reason, the fragments
produced during a scaled blit get spread out over the rendering surface.
I think this is a bug in Metal; we can't do anything about it.