### PR TITLE
MVKDevice: Increase minimum OS for shared-storage textures.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1236,7 +1236,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.native3DCompressedTextures = true;
         _metalFeatures.renderWithoutAttachments = true;
-        if ( mvkOSVersionIsAtLeast(mvkMakeOSVersion(10, 15, 5)) ) {
+        if ( mvkOSVersionIsAtLeast(mvkMakeOSVersion(10, 15, 6)) ) {
             _metalFeatures.sharedLinearTextures = true;
         }
 		if (supportsMTLGPUFamily(Mac2)) {


### PR DESCRIPTION
In #1093 it was reported that `MTLStorageModeShared` textures don't
actually work on 10.15.5, but do work on 10.15.7. I've increased the
minimum to 10.15.6 for now. If someone else reports that it doesn't work
on 10.15.6 either, I'll bump it to 10.15.7.