### PR TITLE
MVKQueue: Only create one GPUCaptureScope per queue.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -149,7 +149,6 @@ protected:
 	std::string _name;
 	MVKMTLCommandBufferID _nextMTLCmdBuffID;
 	MVKGPUCaptureScope* _submissionCaptureScope;
-	MVKGPUCaptureScope* _presentationCaptureScope;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -192,20 +192,18 @@ void MVKQueue::initMTLCommandQueue() {
 void MVKQueue::initGPUCaptureScopes() {
 	const MVKConfiguration* pMVKConfig = getInstance()->getMoltenVKConfiguration();
 
-	_submissionCaptureScope = new MVKGPUCaptureScope(this, "CommandBuffer-Submission");
+	_submissionCaptureScope = new MVKGPUCaptureScope(this);
 
-	_presentationCaptureScope = new MVKGPUCaptureScope(this, "Surface-Presentation");
 	if (_queueFamily->getIndex() == pMVKConfig->defaultGPUCaptureScopeQueueFamilyIndex &&
 		_index == pMVKConfig->defaultGPUCaptureScopeQueueIndex) {
-		_presentationCaptureScope->makeDefault();
+		_submissionCaptureScope->makeDefault();
 	}
-	_presentationCaptureScope->beginScope();	// Allow Xcode to capture the first frame if desired.
+	_submissionCaptureScope->beginScope();	// Allow Xcode to capture the first frame if desired.
 }
 
 MVKQueue::~MVKQueue() {
 	destroyExecQueue();
 	_submissionCaptureScope->destroy();
-	_presentationCaptureScope->destroy();
 }
 
 // Destroys the execution dispatch queue.
@@ -359,7 +357,7 @@ void MVKQueuePresentSurfaceSubmission::execute() {
 	[mtlCmdBuff commit];
 
 	// Let Xcode know the current frame is done, then start a new frame
-	auto cs = _queue->_presentationCaptureScope;
+	auto cs = _queue->_submissionCaptureScope;
 	cs->endScope();
 	cs->beginScope();
 

--- a/MoltenVK/MoltenVK/OS/MVKGPUCapture.h
+++ b/MoltenVK/MoltenVK/OS/MVKGPUCapture.h
@@ -49,12 +49,11 @@ public:
 	void makeDefault();
 
 	/**
-	 * Constructs an instance for the specified queue and purpose.
+	 * Constructs an instance for the specified queue.
 	 *
-	 * The purpose is combined with the name of the queue to create a unique identification name
-	 * for this instance, which will be displayed in Xcode when selecting a capture scope to use.
+	 * If the queue has a debug name, it will be displayed in Xcode when selecting a capture scope to use.
 	 */
-	MVKGPUCaptureScope(MVKQueue* mvkQueue, const char* purpose);
+	MVKGPUCaptureScope(MVKQueue* mvkQueue);
 
 	~MVKGPUCaptureScope() override;
 

--- a/MoltenVK/MoltenVK/OS/MVKGPUCapture.mm
+++ b/MoltenVK/MoltenVK/OS/MVKGPUCapture.mm
@@ -56,13 +56,11 @@ void MVKGPUCaptureScope::makeDefault() {
 	}
 }
 
-MVKGPUCaptureScope::MVKGPUCaptureScope(MVKQueue* mvkQueue, const char* purpose) : _queue(mvkQueue) {
+MVKGPUCaptureScope::MVKGPUCaptureScope(MVKQueue* mvkQueue) : _queue(mvkQueue) {
 	_mtlQueue = [_queue->getMTLCommandQueue() retain];	// retained
 	if (mvkOSVersionIsAtLeast(kMinOSVersionMTLCaptureScope)) {
-		NSString* nsQLbl = [[NSString alloc] initWithUTF8String: (_queue->getName() + "-" + purpose).c_str()];		// temp retained
 		_mtlCaptureScope = [[MTLCaptureManager sharedCaptureManager] newCaptureScopeWithCommandQueue: _mtlQueue];	// retained
-		_mtlCaptureScope.label = nsQLbl;
-		[nsQLbl release];																							// release temp
+		_mtlCaptureScope.label = @(_queue->getName().c_str());
 	}
 }
 


### PR DESCRIPTION
The `MTLCaptureManager`--at least, the one in the capture layer--uniques
capture scopes created for queues. The two scopes we created--for
command buffer submission and surface presentation, respectively--wound
up referring to the same scope. So don't even bother creating a second
one. Use one scope for everything on the queue.

Since there's no need for the 'purpose' parameter anymore, remove it.

Honestly, I think this is a shame. It's useful to be able to create
distinct scopes for command buffer submission and swapchain
presentation. I've filed FB8791712 to get Apple to let us create
multiple scopes for a single queue. Unfortunately, until that's
resolved, because the objects are uniqued, this will interfere with a
forthcoming workaround for a retain bug in Metal relating to capture
scopes.