### PR TITLE
MVKPhysicalDevice: Reduce maximum point size to 64.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1720,7 +1720,7 @@ void MVKPhysicalDevice::initLimits() {
 	_properties.limits.timestampPeriod = mvkGetTimestampPeriod();
 
     _properties.limits.pointSizeRange[0] = 1;
-    _properties.limits.pointSizeRange[1] = 511;
+    _properties.limits.pointSizeRange[1] = 64;
     _properties.limits.pointSizeGranularity = 1;
     _properties.limits.lineWidthRange[0] = 1;
     _properties.limits.lineWidthRange[1] = 1;


### PR DESCRIPTION
The Metal Feature Set Tables lied. The maximum point size supported by a
device varies; values higher than the true maximum are clamped. For
example, my AMD Radeon Pro 460 clamps point sizes above 64, and my Intel
HD Graphics 530 clamps them above 256. 64 is the minimum maximum
mandated by Vulkan, so that's what we'll report.