### PR TITLE
Allow binding descriptor set using layout different than it was created with.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,7 @@ Released TBD
   performance on *iOS* by allowing Metal to use lossless texture compression.
 - Move *Metal* drawable presentation from `MTLCommandBuffer` to `MTLDrawable`
   to improve performance and reduce blocking.
+- Allow binding descriptor set using layout different than it was created with.
 - Clarify documentation on mapping limitations for host-coherent image memory on *macOS*.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -86,17 +86,12 @@ public:
 	/** Returns the immutable sampler at the index, or nullptr if immutable samplers are not used. */
 	MVKSampler* getImmutableSampler(uint32_t index);
 
-	/**
-	 * Encodes the descriptors in the descriptor set that are specified by this layout,
-	 * starting with the descriptor at the index, on the the command encoder.
-	 * Returns the number of descriptors that were encoded.
-	 */
-	uint32_t bind(MVKCommandEncoder* cmdEncoder,
-				  MVKDescriptorSet* descSet,
-				  uint32_t descStartIndex,
-				  MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-				  MVKArrayRef<uint32_t> dynamicOffsets,
-				  uint32_t baseDynamicOffsetIndex);
+	/** Encodes the descriptors in the descriptor set that are specified by this layout, */
+	void bind(MVKCommandEncoder* cmdEncoder,
+			  MVKDescriptorSet* descSet,
+			  MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+			  MVKArrayRef<uint32_t> dynamicOffsets,
+			  uint32_t baseDynamicOffsetIndex);
 
     /** Encodes this binding layout and the specified descriptor on the specified command encoder immediately. */
     void push(MVKCommandEncoder* cmdEncoder,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -79,23 +79,21 @@ MVKSampler* MVKDescriptorSetLayoutBinding::getImmutableSampler(uint32_t index) {
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-uint32_t MVKDescriptorSetLayoutBinding::bind(MVKCommandEncoder* cmdEncoder,
-											 MVKDescriptorSet* descSet,
-											 uint32_t descStartIndex,
-											 MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-											 MVKArrayRef<uint32_t> dynamicOffsets,
-											 uint32_t baseDynamicOffsetIndex) {
+void MVKDescriptorSetLayoutBinding::bind(MVKCommandEncoder* cmdEncoder,
+										 MVKDescriptorSet* descSet,
+										 MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+										 MVKArrayRef<uint32_t> dynamicOffsets,
+										 uint32_t baseDynamicOffsetIndex) {
 
 	// Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
     MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
 
     uint32_t descCnt = getDescriptorCount();
     for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
-        MVKDescriptor* mvkDesc = descSet->getDescriptor(descStartIndex + descIdx);
-        mvkDesc->bind(cmdEncoder, _info.descriptorType, descIdx, _applyToStage, mtlIdxs, dynamicOffsets,
-					  baseDynamicOffsetIndex + _dynamicOffsetIndex + descIdx);
+		MVKDescriptor* mvkDesc = descSet->getDescriptor(getBinding(), descIdx);
+        mvkDesc->bind(cmdEncoder, _info.descriptorType, descIdx, _applyToStage, mtlIdxs,
+					  dynamicOffsets, baseDynamicOffsetIndex + _dynamicOffsetIndex + descIdx);
     }
-    return descCnt;
 }
 
 template<typename T>

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -137,7 +137,7 @@ protected:
 	friend class MVKDescriptorPool;
 
 	void propagateDebugName() override {}
-	inline MVKDescriptor* getDescriptor(uint32_t index) { return _descriptors[index]; }
+	MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex);
 
 	MVKDescriptorSetLayout* _layout;
 	MVKDescriptorPool* _pool;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -85,7 +85,7 @@ protected:
 
 	void propagateDebugName() override {}
 	inline uint32_t getDescriptorCount() { return _descriptorCount; }
-	inline uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex) { return _bindingToDescriptorIndex[binding] + elementIndex; }
+	inline uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return _bindingToDescriptorIndex[binding] + elementIndex; }
 	inline MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
@@ -138,7 +138,7 @@ protected:
 	friend class MVKDescriptorPool;
 
 	void propagateDebugName() override {}
-	MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex);
+	MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex = 0);
 
 	MVKDescriptorSetLayout* _layout;
 	MVKDescriptorPool* _pool;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -85,11 +85,12 @@ protected:
 
 	void propagateDebugName() override {}
 	inline uint32_t getDescriptorCount() { return _descriptorCount; }
-	uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex);
+	inline uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex) { return _bindingToDescriptorIndex[binding] + elementIndex; }
 	inline MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
 	std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
+	std::unordered_map<uint32_t, uint32_t> _bindingToDescriptorIndex;
 	MVKShaderResourceBinding _mtlResourceCounts;
 	uint32_t _descriptorCount;
 	uint32_t _dynamicDescriptorCount;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -37,19 +37,16 @@ uint32_t MVKDescriptorSetLayout::getDescriptorIndex(uint32_t binding, uint32_t e
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKDescriptorSetLayout::bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
-                                               MVKDescriptorSet* descSet,
-                                               MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-                                               MVKArrayRef<uint32_t> dynamicOffsets,
-                                               uint32_t baseDynamicOffsetIndex) {
-    if (_isPushDescriptorLayout) return;
+											   MVKDescriptorSet* descSet,
+											   MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+											   MVKArrayRef<uint32_t> dynamicOffsets,
+											   uint32_t baseDynamicOffsetIndex) {
+	if (_isPushDescriptorLayout) return;
 
 	clearConfigurationResult();
-    size_t bindCnt = _bindings.size();
-    for (uint32_t descIdx = 0, bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		descIdx += _bindings[bindIdx].bind(cmdEncoder, descSet, descIdx,
-										   dslMTLRezIdxOffsets, dynamicOffsets,
-										   baseDynamicOffsetIndex);
-    }
+	for (auto& dslBind : _bindings) {
+		dslBind.bind(cmdEncoder, descSet, dslMTLRezIdxOffsets, dynamicOffsets, baseDynamicOffsetIndex);
+	}
 }
 
 static const void* getWriteParameters(VkDescriptorType type, const VkDescriptorImageInfo* pImageInfo,
@@ -228,6 +225,10 @@ MVKDescriptorSetLayout::MVKDescriptorSetLayout(MVKDevice* device,
 
 VkDescriptorType MVKDescriptorSet::getDescriptorType(uint32_t binding) {
 	return _layout->getBinding(binding)->getDescriptorType();
+}
+
+MVKDescriptor* MVKDescriptorSet::getDescriptor(uint32_t binding, uint32_t elementIndex) {
+	return _descriptors[_layout->getDescriptorIndex(binding, elementIndex)];
 }
 
 template<typename DescriptorAction>


### PR DESCRIPTION
- Allow binding descriptor set using layout different than it was created with.
- Bind descriptors based on binding number within pipeline layout, not order within layout, and descriptor set looks up descriptor using binding layout it was created with.
- MVKDescriptorSetLayout speed up lookup of descriptor index.
- Streamline binding access in MVKDescriptorSetLayout.  …
- Use temporary MVKSmallVector of bindings to sort dynamic offset indices.
- Use getDescriptor() where in read/write functions.

Fixes issue #1107.