### PR TITLE
MVKImage: Always set the depth plane when rendering to a 3D image.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1537,7 +1537,7 @@ void MVKImageView::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttach
     mtlAttDesc.level = plane->_useMTLTextureView ? 0 : _subresourceRange.baseMipLevel;
     if (mtlAttDesc.texture.textureType == MTLTextureType3D) {
         mtlAttDesc.slice = 0;
-        mtlAttDesc.depthPlane = plane->_useMTLTextureView ? 0 : _subresourceRange.baseArrayLayer;
+        mtlAttDesc.depthPlane = _subresourceRange.baseArrayLayer;
     } else {
         mtlAttDesc.slice = plane->_useMTLTextureView ? 0 : _subresourceRange.baseArrayLayer;
         mtlAttDesc.depthPlane = 0;


### PR DESCRIPTION
Even if we used a texture view. We can't constrain the depth planes in a
3D texture using a texture view, so we need to set the render depth
plane in that case.