### PR TITLE
MVKPipeline: shorten vertex attribute format's length when stride < size

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -342,6 +342,9 @@ public:
 	/** Returns the name of the specified Metal pixel format. */
 	const char* getName(MTLPixelFormat mtlFormat);
 
+	/** Returns the name of the specified Metal vertex format. */
+	const char* getName(MTLVertexFormat mtlFormat);
+
 	/**
 	 * Returns the MTLClearColor value corresponding to the color value in the VkClearValue,
 	 * extracting the color value that is VkFormat for the VkFormat.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -375,6 +375,10 @@ const char* MVKPixelFormats::getName(MTLPixelFormat mtlFormat) {
     return getMTLPixelFormatDesc(mtlFormat).name;
 }
 
+const char* MVKPixelFormats::getName(MTLVertexFormat mtlFormat) {
+    return getMTLVertexFormatDesc(mtlFormat).name;
+}
+
 void MVKPixelFormats::enumerateSupportedFormats(VkFormatProperties properties, bool any, std::function<bool(VkFormat)> func) {
 	static const auto areFeaturesSupported = [any](uint32_t a, uint32_t b) {
 		if (b == 0) return true;


### PR DESCRIPTION
Metal currently does not support overlapping attribute loads and asserts on
them. Prevent it by shortening format's vector length to fit within the stride,
but print a cautionary message.

An example of affected program is Kingdom Come: Deliverance, which sets attribute
format to RGBA32 in IA and binding stride to 12, while the shader input is just
a float3.