### PR TITLE
MVKPipelineLayout: Only set configuration result if validating.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -32,7 +32,7 @@ uint32_t MVKDescriptorSetLayout::bindDescriptorSet(MVKCommandEncoder* cmdEncoder
 												   MVKShaderResourceBinding& dslMTLRezIdxOffsets,
 												   MVKArrayRef<uint32_t> dynamicOffsets,
 												   uint32_t dynamicOffsetIndex) {
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
 	uint32_t dynOffsetsConsumed = 0;
 	if ( !_isPushDescriptorLayout ) {
 		for (auto& dslBind : _bindings) {
@@ -91,7 +91,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
 
     if (!_isPushDescriptorLayout) return;
 
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
     for (const VkWriteDescriptorSet& descWrite : descriptorWrites) {
         uint32_t dstBinding = descWrite.dstBinding;
         uint32_t dstArrayElement = descWrite.dstArrayElement;
@@ -142,7 +142,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
         descUpdateTemplate->getType() != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR)
         return;
 
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
     for (uint32_t i = 0; i < descUpdateTemplate->getNumberOfEntries(); i++) {
         const VkDescriptorUpdateTemplateEntryKHR* pEntry = descUpdateTemplate->getEntry(i);
         uint32_t dstBinding = pEntry->dstBinding;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -41,7 +41,7 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
                                            MVKArrayRef<MVKDescriptorSet*> descriptorSets,
                                            uint32_t firstSet,
                                            MVKArrayRef<uint32_t> dynamicOffsets) {
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
 	uint32_t dynamicOffsetIndex = 0;
 	size_t dsCnt = descriptorSets.size;
 	for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
@@ -51,7 +51,9 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
 		dynamicOffsetIndex += dsl->bindDescriptorSet(cmdEncoder, descSet,
 													 _dslMTLResourceIndexOffsets[dslIdx],
 													 dynamicOffsets, dynamicOffsetIndex);
-		setConfigurationResult(dsl->getConfigurationResult());
+		if (!cmdEncoder && dsl->getConfigurationResult() != VK_SUCCESS) {
+			setConfigurationResult(dsl->getConfigurationResult());
+		}
 	}
 }
 
@@ -59,10 +61,10 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
 void MVKPipelineLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
                                           MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
                                           uint32_t set) {
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
 	MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
 	dsl->pushDescriptorSet(cmdEncoder, descriptorWrites, _dslMTLResourceIndexOffsets[set]);
-	setConfigurationResult(dsl->getConfigurationResult());
+	if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
@@ -70,10 +72,10 @@ void MVKPipelineLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
                                           MVKDescriptorUpdateTemplate* descUpdateTemplate,
                                           uint32_t set,
                                           const void* pData) {
-	clearConfigurationResult();
+	if (!cmdEncoder) { clearConfigurationResult(); }
 	MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
 	dsl->pushDescriptorSet(cmdEncoder, descUpdateTemplate, pData, _dslMTLResourceIndexOffsets[set]);
-	setConfigurationResult(dsl->getConfigurationResult());
+	if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
 }
 
 void MVKPipelineLayout::populateShaderConverterContext(SPIRVToMSLConversionConfiguration& context) {


### PR DESCRIPTION
Fixes a race condition picked up by `tsan`.