### PR TITLE
Allow linear images on Apple GPUs in Blit and Clear commands.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -628,6 +628,7 @@ typedef struct {
 	uint32_t maxPerStageDynamicMTLBufferCount;	/**< The maximum number of inline buffers that can be set on a command buffer. */
 	uint32_t maxPerStageStorageTextureCount;    /**< The total number of per-stage Metal textures with read-write access available for writing to from a shader. */
 	VkBool32 astcHDRTextures;					/**< If true, ASTC HDR pixel formats are supported. */
+	VkBool32 renderLinearTextures;				/**< If true, linear textures are renderable. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1143,6 +1143,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     _metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
     _metalFeatures.sharedLinearTextures = true;
     _metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
+	_metalFeatures.renderLinearTextures = true;
 
     if (supportsMTLFeatureSet(tvOS_GPUFamily1_v2)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion1_2;
@@ -1204,6 +1205,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     _metalFeatures.texelBuffers = true;
 	_metalFeatures.maxTextureDimension = (4 * KIBI);
     _metalFeatures.sharedLinearTextures = true;
+	_metalFeatures.renderLinearTextures = true;
 
     if (supportsMTLFeatureSet(iOS_GPUFamily1_v2)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion1_1;
@@ -1361,6 +1363,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			_metalFeatures.maxQueryBufferSize = (64 * KIBI);
 			_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 			_metalFeatures.postDepthCoverage = true;
+			_metalFeatures.renderLinearTextures = true;
 		}
 		if (supportsMTLGPUFamily(Apple6)) {
 			_metalFeatures.astcHDRTextures = true;


### PR DESCRIPTION
They can now be used as blit destinations and be cleared with a render
pass.

This also fixes a bug where we were incorrectly validating that the
format supported shader writes if the image were linear, even on
iOS/tvOS.