### PR TITLE
Disable culling for the duration of vkCmdClearAttachments

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1300,6 +1300,10 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(isClearingDepth, isClearingStencil)];
     [mtlRendEnc setStencilReferenceValue: _mtlStencilValue];
     [mtlRendEnc setCullMode:MTLCullModeNone];
+    [mtlRendEnc setTriangleFillMode:MTLTriangleFillModeFill];
+    [mtlRendEnc setDepthBias:0 slopeScale:0 clamp:0];
+    cmdEncoder->_viewportState.reset();
+    cmdEncoder->_scissorState.reset();
 
     cmdEncoder->setVertexBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);
     cmdEncoder->setFragmentBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);
@@ -1311,6 +1315,9 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->_graphicsPipelineState.markDirty();
 	cmdEncoder->_depthStencilState.markDirty();
 	cmdEncoder->_stencilReferenceValueState.markDirty();
+    cmdEncoder->_depthBiasState.markDirty();
+    cmdEncoder->_viewportState.markDirty();
+    cmdEncoder->_scissorState.markDirty();
 	cmdEncoder->_graphicsResourcesState.beginMetalRenderPass();
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1299,11 +1299,11 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     [mtlRendEnc setRenderPipelineState: cmdEncPool->getCmdClearMTLRenderPipelineState(_rpsKey)];
     [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(isClearingDepth, isClearingStencil)];
     [mtlRendEnc setStencilReferenceValue: _mtlStencilValue];
-    [mtlRendEnc setCullMode:MTLCullModeNone];
-    [mtlRendEnc setTriangleFillMode:MTLTriangleFillModeFill];
-    [mtlRendEnc setDepthBias:0 slopeScale:0 clamp:0];
-    cmdEncoder->_viewportState.reset();
-    cmdEncoder->_scissorState.reset();
+    [mtlRendEnc setCullMode: MTLCullModeNone];
+    [mtlRendEnc setTriangleFillMode: MTLTriangleFillModeFill];
+    [mtlRendEnc setDepthBias: 0 slopeScale: 0 clamp: 0];
+    [mtlRendEnc setViewport: {0, 0, (double) fbExtent.width, (double) fbExtent.height, 0.0, 1.0}];
+    [mtlRendEnc setScissorRect: {0, 0, fbExtent.width, fbExtent.height}];
 
     cmdEncoder->setVertexBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);
     cmdEncoder->setFragmentBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1299,6 +1299,7 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     [mtlRendEnc setRenderPipelineState: cmdEncPool->getCmdClearMTLRenderPipelineState(_rpsKey)];
     [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(isClearingDepth, isClearingStencil)];
     [mtlRendEnc setStencilReferenceValue: _mtlStencilValue];
+    [mtlRendEnc setCullMode:MTLCullModeNone];
 
     cmdEncoder->setVertexBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);
     cmdEncoder->setFragmentBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0);


### PR DESCRIPTION
This fixes a bug where the quad drawn by `vkCmdClearAttachments` can be culled if the winding order of the quad happens to match the current pipeline's cull mode. Note that the original cull mode will be restored immediately after the quad is drawn via the existing `cmdEncoder->_graphicsPipelineState.markDirty();` call, so no pushing and popping of state should be necessary.