### PR TITLE
MVKComputePipeline: Override max threads per threadgroup.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1635,6 +1635,7 @@ MVKComputePipeline::MVKComputePipeline(MVKDevice* device,
 	if (mtlFunc) {
 		MTLComputePipelineDescriptor* plDesc = [MTLComputePipelineDescriptor new];	// temp retain
 		plDesc.computeFunction = mtlFunc;
+		plDesc.maxTotalThreadsPerThreadgroup = _mtlThreadgroupSize.width * _mtlThreadgroupSize.height * _mtlThreadgroupSize.depth;
 
 		// Metal does not allow the name of the pipeline to be changed after it has been created,
 		// and we need to create the Metal pipeline immediately to provide error feedback to app.


### PR DESCRIPTION
We know the actual threadgroup size, because it is declared in the
shader. Therefore, we know the total count of threads per threadgroup,
which is simply the product of the threadgroup size in all three
dimensions. This is necessary if Metal picks a size lower than the app
is expecting. At least one game (NieR: Automata) needs this to work
correctly.