### PR TITLE
MVKSync: Miscellaneous fixes.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -438,7 +438,11 @@ typedef struct  {
 } MVKPresentTimingInfo;
 
 /** Tracks a semaphore and fence for later signaling. */
-typedef std::pair<MVKSemaphore*, MVKFence*> MVKSwapchainSignaler;
+struct MVKSwapchainSignaler {
+	MVKFence* fence;
+	MVKSemaphore* semaphore;
+	uint64_t semaphoreSignalToken;
+};
 
 
 /** Represents a Vulkan swapchain image that can be submitted to the presentation engine. */
@@ -470,15 +474,16 @@ protected:
 	void presentCAMetalDrawable(id<CAMetalDrawable> mtlDrawable, MVKPresentTimingInfo presentTimingInfo);
 	void releaseMetalDrawable();
 	MVKSwapchainImageAvailability getAvailability();
-	void makeAvailable();
+	void makeAvailable(const MVKSwapchainSignaler& signaler);
 	void acquireAndSignalWhenAvailable(MVKSemaphore* semaphore, MVKFence* fence);
-	void signal(MVKSwapchainSignaler& signaler, id<MTLCommandBuffer> mtlCmdBuff);
-	void signalPresentationSemaphore(id<MTLCommandBuffer> mtlCmdBuff);
-	static void markAsTracked(MVKSwapchainSignaler& signaler);
-	static void unmarkAsTracked(MVKSwapchainSignaler& signaler);
+	void signal(const MVKSwapchainSignaler& signaler, id<MTLCommandBuffer> mtlCmdBuff);
+	void signalPresentationSemaphore(const MVKSwapchainSignaler& signaler, id<MTLCommandBuffer> mtlCmdBuff);
+	static void markAsTracked(const MVKSwapchainSignaler& signaler);
+	static void unmarkAsTracked(const MVKSwapchainSignaler& signaler);
 	void renderWatermark(id<MTLCommandBuffer> mtlCmdBuff);
 
 	id<CAMetalDrawable> _mtlDrawable;
+	id<MTLCommandBuffer> _presentingMTLCmdBuff;
 	MVKSwapchainImageAvailability _availability;
 	MVKSmallVector<MVKSwapchainSignaler, 1> _availabilitySignalers;
 	MVKSwapchainSignaler _preSignaler;


### PR DESCRIPTION
Fix reversed condition in `MVKTimelineSemaphoreEmulated`, which probably
caused some test failures.

Don't increment the `MTLEvent` binary semaphore's counter unless a
command buffer is actually present to schedule a wait on.

Defer signal operations when a swapchain image is not yet available.
That way, the correct value will be signaled when the image is ready,
instead of causing GPU lockups and timeouts.

When a drawable is presented, immediately mark it available, instead of
waiting until the command buffer finishes. Otherwise, the wrong
semaphore could be signaled when an image is used twice in a row.

This should fix the problems using `MTLEvent` binary semaphores with
presentation, which was preventing us from enabling them by default when
available.

Special thanks to @apayen, whose
[idea](https://github.com/KhronosGroup/MoltenVK/issues/803) and
[change](https://github.com/apayen/MoltenVK/commit/a4ac715975ea3aa4cb95e91973b8f9010516304f)
were the basis for this.