### PR TITLE
Handle device loss.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -71,6 +71,8 @@ VkResult MVKQueryPool::getResults(uint32_t firstQuery,
 								  void* pData,
 								  VkDeviceSize stride,
 								  VkQueryResultFlags flags) {
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+
 	unique_lock<mutex> lock(_availabilityLock);
 
 	uint32_t endQuery = firstQuery + queryCount;
@@ -99,6 +101,8 @@ bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQu
 
 // Returns whether all the queries between the start (inclusive) and end (exclusive) queries are available.
 bool MVKQueryPool::areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuery) {
+    // If we lost the device, stop waiting immediately.
+    if (_device->getConfigurationResult() != VK_SUCCESS) { return true; }
     for (uint32_t query = firstQuery; query < endQuery; query++) {
         if ( _availability[query] < Available ) { return false; }
     }
@@ -106,6 +110,8 @@ bool MVKQueryPool::areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuer
 }
 
 VkResult MVKQueryPool::getResult(uint32_t query, void* pQryData, VkQueryResultFlags flags) {
+
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
 
 	bool isAvailable = _availability[query] == Available;
 	bool shouldOutput = (isAvailable || mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_PARTIAL_BIT));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -76,6 +76,8 @@ static inline void execute(MVKQueueSubmission* qSubmit) { @autoreleasepool { qSu
 // Relying on the dispatch queue to find time to drain the autoreleasepool can
 // result in significant memory creep under heavy workloads.
 VkResult MVKQueue::submit(MVKQueueSubmission* qSubmit) {
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+
 	if ( !qSubmit ) { return VK_SUCCESS; }     // Ignore nils
 
 	VkResult rslt = qSubmit->getConfigurationResult();     // Extract result before submission to avoid race condition with early destruction
@@ -129,6 +131,8 @@ VkResult MVKQueue::submit(const VkPresentInfoKHR* pPresentInfo) {
 
 // Create an empty submit struct and fence, submit to queue and wait on fence.
 VkResult MVKQueue::waitIdle() {
+
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
 
 	VkFenceCreateInfo vkFenceInfo = {
 		.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
@@ -292,8 +296,27 @@ void MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool signalCo
 		}];
 	}
 
-	// Use temp var because callback may destroy this instance before this function ends.
+	// Use temp vars because callback may destroy this instance before this function ends.
+	MVKDevice* device = _queue->getDevice();
 	id<MTLCommandBuffer> mtlCmdBuff = _activeMTLCommandBuffer;
+	// If command buffer execution fails, log it, and mark the device lost.
+	[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCmdBuff) {
+		if (mtlCmdBuff.status == MTLCommandBufferStatusError) {
+			device->reportError(device->markLost(), "Command buffer %p \"%s\" execution failed (code %li): %s", mtlCmdBuff, mtlCmdBuff.label ? mtlCmdBuff.label.UTF8String : "", mtlCmdBuff.error.code, mtlCmdBuff.error.localizedDescription.UTF8String);
+			// Some errors indicate we lost the physical device as well.
+			switch (mtlCmdBuff.error.code) {
+				case MTLCommandBufferErrorBlacklisted:
+				// XXX This may also be used for command buffers executed in the background without the right entitlement.
+				case MTLCommandBufferErrorNotPermitted:
+#if MVK_MACOS
+				case MTLCommandBufferErrorDeviceRemoved:
+#endif
+					device->getPhysicalDevice()->setConfigurationResult(VK_ERROR_DEVICE_LOST);
+					break;
+			}
+		}
+	}];
+
 	_activeMTLCommandBuffer = nil;
 	[mtlCmdBuff commit];
 	[mtlCmdBuff release];		// retained

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -82,6 +82,7 @@ public:
 
 	/** Returns the status of the surface. Surface loss takes precedence over out-of-date errors. */
 	inline VkResult getSurfaceStatus() {
+		if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
 		if (getIsSurfaceLost()) { return VK_ERROR_SURFACE_LOST_KHR; }
 		if (getHasSurfaceSizeChanged()) { return VK_ERROR_OUT_OF_DATE_KHR; }
 		return VK_SUCCESS;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -82,6 +82,7 @@ VkResult MVKSwapchain::acquireNextImageKHR(uint64_t timeout,
 										   uint32_t deviceMask,
 										   uint32_t* pImageIndex) {
 
+	if ( _device->getConfigurationResult() != VK_SUCCESS ) { return _device->getConfigurationResult(); }
 	if ( getIsSurfaceLost() ) { return VK_ERROR_SURFACE_LOST_KHR; }
 
 	// Find the image that has the shortest wait by finding the smallest availability measure.
@@ -353,6 +354,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 // The CAMetalLayer should already be initialized when this is called.
 void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt) {
 
+    if ( _device->getConfigurationResult() != VK_SUCCESS ) { return; }
     if ( getIsSurfaceLost() ) { return; }
 
 	VkImageFormatListCreateInfo fmtListInfo;
@@ -401,6 +403,8 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 }
 
 VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRefreshCycleDuration) {
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+
 	NSInteger framesPerSecond = 60;
 #if MVK_IOS_OR_TVOS
 	UIScreen* screen = [UIScreen mainScreen];
@@ -417,6 +421,8 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 }
 
 VkResult MVKSwapchain::getPastPresentationTiming(uint32_t *pCount, VkPastPresentationTimingGOOGLE *pPresentationTimings) {
+	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+
 	std::lock_guard<std::mutex> lock(_presentHistoryLock);
 	if (pCount && pPresentationTimings == nullptr) {
 		*pCount = _presentHistoryCount;

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -653,8 +653,11 @@ MVK_PUBLIC_SYMBOL VkResult vkGetFenceStatus(
     VkFence                                     fence) {
 	
 	MVKTraceVulkanCallStart();
-	MVKFence* mvkFence = (MVKFence*)fence;
-	VkResult rslt = mvkFence->getIsSignaled() ? VK_SUCCESS : VK_NOT_READY;
+	VkResult rslt = MVKDevice::getMVKDevice(device)->getConfigurationResult();
+	if (rslt == VK_SUCCESS) {
+		MVKFence* mvkFence = (MVKFence*)fence;
+		rslt = mvkFence->getIsSignaled() ? VK_SUCCESS : VK_NOT_READY;
+	}
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -732,8 +735,11 @@ MVK_PUBLIC_SYMBOL VkResult vkGetEventStatus(
     VkEvent                                     event) {
 	
 	MVKTraceVulkanCallStart();
-	MVKEvent* mvkEvent = (MVKEvent*)event;
-	VkResult rslt = mvkEvent->isSet() ? VK_EVENT_SET : VK_EVENT_RESET;
+	VkResult rslt = MVKDevice::getMVKDevice(device)->getConfigurationResult();
+	if (rslt == VK_SUCCESS) {
+		MVKEvent* mvkEvent = (MVKEvent*)event;
+		rslt = mvkEvent->isSet() ? VK_EVENT_SET : VK_EVENT_RESET;
+	}
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -2447,10 +2453,13 @@ MVK_PUBLIC_SYMBOL VkResult vkCreateSwapchainKHR(
 
 	MVKTraceVulkanCallStart();
     MVKDevice* mvkDev = MVKDevice::getMVKDevice(device);
-    MVKSwapchain* mvkSwpChn = mvkDev->createSwapchain(pCreateInfo, pAllocator);
-    *pSwapchain = (VkSwapchainKHR)(mvkSwpChn);
-    VkResult rslt = mvkSwpChn->getConfigurationResult();
-    if (rslt < 0) { *pSwapchain = VK_NULL_HANDLE; mvkDev->destroySwapchain(mvkSwpChn, pAllocator); }
+    VkResult rslt = mvkDev->getConfigurationResult();
+    if (rslt == VK_SUCCESS) {
+        MVKSwapchain* mvkSwpChn = mvkDev->createSwapchain(pCreateInfo, pAllocator);
+        *pSwapchain = (VkSwapchainKHR)(mvkSwpChn);
+        rslt = mvkSwpChn->getConfigurationResult();
+        if (rslt < 0) { *pSwapchain = VK_NULL_HANDLE; mvkDev->destroySwapchain(mvkSwpChn, pAllocator); }
+    }
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -2670,10 +2679,13 @@ MVK_PUBLIC_SYMBOL VkResult vkGetSemaphoreCounterValueKHR(
 	uint64_t*									pValue) {
 
 	MVKTraceVulkanCallStart();
-	auto* mvkSem4 = (MVKTimelineSemaphore*)semaphore;
-	*pValue = mvkSem4->getCounterValue();
+	VkResult rslt = MVKDevice::getMVKDevice(device)->getConfigurationResult();
+	if (rslt == VK_SUCCESS) {
+		auto* mvkSem4 = (MVKTimelineSemaphore*)semaphore;
+		*pValue = mvkSem4->getCounterValue();
+	}
 	MVKTraceVulkanCallEnd();
-	return VK_SUCCESS;
+	return rslt;
 }
 
 MVK_PUBLIC_SYMBOL VkResult vkSignalSemaphoreKHR(


### PR DESCRIPTION
If a command buffer fails in Metal, its `status` becomes
`MTLCommandBufferStatusError`, and its `error` property is populated. In
Vulkan, command buffer failure usually triggers device loss. This is
because most drivers can't guarantee that resources weren't affected in
an undefined fashion. We can't make that guarantee, either, so when a
Metal command buffer has an error, mark the device lost. The error is
also logged. All waits are immediately signaled; those that were client
requests instead of internal implementation details immediately return
`VK_ERROR_DEVICE_LOST`.

The app may be able to recreate the logical device and reconstruct its
state. However, some Metal errors are severe enough that all subsequent
command buffers will fail--in those cases, the physical device becomes
lost as well, indicating that the device cannot be recreated.

Only certain commands are allowed to report device loss. These commands
test for device loss before continuing, and will immediately return if
the device is lost.