### PR TITLE
Re-enable MTLEvent-based binary semaphores.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -29,6 +29,7 @@ Released 2010/12/07
 	- `VK_AMD_shader_image_load_store` (macOS)
 	- `VK_IMG_format_pvrtc` (macOS)
 - Support the *Mac Catalyst* platform for *iOS* apps on *macOS 11.0+*, under both `x86_64` and `arm64` architectures.
+- Re-enable `MTLEvent`-based semaphores.
 - Use `VK_KHR_image_format_list` to disable `MTLTextureUsagePixelFormatView` 
   if only swizzles or `sRGB` conversion will be used for image views, improving 
   performance on *iOS* by allowing Metal to use lossless texture compression.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -120,12 +120,12 @@ typedef unsigned long MTLLanguageVersion;
  * 4.  Setting the MVK_ALLOW_METAL_FENCES or MVK_ALLOW_METAL_EVENTS runtime environment variable
  *     or MoltenVK compile-time build setting to 1 will cause MoltenVK to use MTLFence or MTLEvent,
  *     respectively, if it is available on the device, for VkSemaphore synchronization behaviour.
- *     If both variables are set, MVK_ALLOW_METAL_FENCES takes priority over MVK_ALLOW_METAL_EVENTS.
+ *     If both variables are set, MVK_ALLOW_METAL_EVENTS takes priority over MVK_ALLOW_METAL_FENCES.
  *     If both are disabled, or if MTLFence or MTLEvent is not available on the device, MoltenVK
  *     will use CPU synchronization to control VkSemaphore synchronization behaviour.
- *     By default, MVK_ALLOW_METAL_FENCES is enabled and MVK_ALLOW_METAL_EVENTS is disabled,
- *     meaning MoltenVK will use MTLFences, if they are available, to control VkSemaphore
- *     synchronization behaviour, by default.
+ *     By default, both MVK_ALLOW_METAL_FENCES and MVK_ALLOW_METAL_EVENTS are enabled, meaning 
+ *     MoltenVK will preferentially use MTLEvents if they are available, followed by MTLFences
+ *     if they are available, to control VkSemaphore synchronization behaviour, by default.
  *
  * 5.  The MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE runtime environment variable or MoltenVK compile-time
  *     build setting controls whether Metal should run an automatic GPU capture without the user

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3136,10 +3136,10 @@ MVKSemaphore* MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInf
 			return new MVKTimelineSemaphoreEmulated(this, pCreateInfo, pTypeCreateInfo);
 		}
 	} else {
-		if (_useMTLFenceForSemaphores) {
-			return new MVKSemaphoreMTLFence(this, pCreateInfo);
-		} else if (_useMTLEventForSemaphores) {
+		if (_useMTLEventForSemaphores) {
 			return new MVKSemaphoreMTLEvent(this, pCreateInfo);
+		} else if (_useMTLFenceForSemaphores) {
+			return new MVKSemaphoreMTLFence(this, pCreateInfo);
 		} else {
 			return new MVKSemaphoreEmulated(this, pCreateInfo);
 		}
@@ -3787,7 +3787,7 @@ void MVKDevice::initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDe
 	if (_pMetalFeatures->events) {
 		MVK_SET_FROM_ENV_OR_BUILD_BOOL(_useMTLEventForSemaphores, MVK_ALLOW_METAL_EVENTS);
 	}
-	MVKLogInfo("Using %s for Vulkan semaphores.", _useMTLFenceForSemaphores ? "MTLFence" : (_useMTLEventForSemaphores ? "MTLEvent" : "emulation"));
+	MVKLogInfo("Using %s for Vulkan semaphores.", _useMTLEventForSemaphores ? "MTLEvent" : (_useMTLFenceForSemaphores ? "MTLFence" : "emulation"));
 
 #	ifndef MVK_CONFIG_USE_COMMAND_POOLING
 #   	define MVK_CONFIG_USE_COMMAND_POOLING    1

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -186,13 +186,13 @@
  * Allow the use of MTLFence or MTLEvent for VkSemaphore synchronization behaviour.
  * By default:
  *   - MVK_ALLOW_METAL_FENCES is enabled
- *   - MVK_ALLOW_METAL_EVENTS is disabled
+ *   - MVK_ALLOW_METAL_EVENTS is enabled
  * */
 #ifndef MVK_ALLOW_METAL_FENCES
 #   define MVK_ALLOW_METAL_FENCES    1
 #endif
 #ifndef MVK_ALLOW_METAL_EVENTS
-#   define MVK_ALLOW_METAL_EVENTS    0
+#   define MVK_ALLOW_METAL_EVENTS    1
 #endif
 
 /** Substitute Metal 2D textures for Vulkan 1D images. Enabled by default. */


### PR DESCRIPTION
I haven't seen any problems yet. It passes all the tests--even the
`signal_order` tests. I have tried it with some games, and it seems OK
there, too.