### PR TITLE
Let SPIRV-Cross assign MSL resource indices.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -44,6 +44,7 @@ VkResult MVKCmdBindVertexBuffers<N>::setContent(MVKCommandBuffer* cmdBuff,
         b.index = mvkDvc->getMetalBufferIndexForVertexAttributeBinding(startBinding + bindIdx);
         b.mtlBuffer = mvkBuffer->getMTLBuffer();
         b.offset = mvkBuffer->getMTLBufferOffset() + pOffsets[bindIdx];
+        b.isFixed = true;
         _bindings.push_back(b);
     }
 

--- a/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
@@ -34,6 +34,7 @@ typedef struct {
     uint32_t swizzle = 0;
 	uint16_t index = 0;
     bool isDirty = true;
+    bool isFixed = false;
 } MVKMTLTextureBinding;
 
 /** Describes a MTLSamplerState resource binding. */
@@ -41,6 +42,7 @@ typedef struct {
     union { id<MTLSamplerState> mtlSamplerState = nil; id<MTLSamplerState> mtlResource; }; // aliases
     uint16_t index = 0;
     bool isDirty = true;
+    bool isFixed = false;
 } MVKMTLSamplerStateBinding;
 
 /** Describes a MTLBuffer resource binding. */
@@ -51,6 +53,7 @@ typedef struct {
 	uint16_t index = 0;
     bool isDirty = true;
     bool isInline = false;
+    bool isFixed = false;
 } MVKMTLBufferBinding;
 
 /** Describes a MTLBuffer resource binding as used for an index buffer. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -171,6 +171,14 @@ public:
 	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
 	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipelineLayout* layout, MVKPipeline* parent);
 
+    
+    /** Resource remapping */
+    MVKSmallVector<uint16_t> _samplerMSLIndices[kMVKShaderStageMax];
+    MVKSmallVector<uint16_t> _textureMSLIndices[kMVKShaderStageMax];
+    MVKSmallVector<uint16_t> _bufferMSLIndices[kMVKShaderStageMax];
+
+    void populateMSLIndices(MVKShaderStage stage, const SPIRVToMSLConversionConfiguration& shaderContext);
+    
 protected:
 	void propagateDebugName() override {}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -165,7 +165,12 @@ MVKPipelineLayout::~MVKPipelineLayout() {
 void MVKPipeline::bindPushConstants(MVKCommandEncoder* cmdEncoder) {
 	if (cmdEncoder) {
 		for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
-			cmdEncoder->getPushConstants(mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(i)))->setMTLBufferIndex(_pushConstantsMTLResourceIndexes.stages[i].bufferIndex);
+            uint16_t index = _pushConstantsMTLResourceIndexes.stages[i].bufferIndex;
+            if (!_bufferMSLIndices[i].empty()) {
+                index = _bufferMSLIndices[i][index];
+            }
+            if (index != (uint16_t)-1)
+                cmdEncoder->getPushConstants(mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(i)))->setMTLBufferIndex(index);
 		}
 	}
 }
@@ -926,6 +931,9 @@ bool MVKGraphicsPipeline::addVertexShaderToPipeline(MTLRenderPipelineDescriptor*
 	if (!verifyImplicitBuffer(_needsVertexViewRangeBuffer, _viewRangeBufferIndex, kMVKShaderStageVertex, "view range", vbCnt)) {
 		return false;
 	}
+    
+    populateMSLIndices(kMVKShaderStageVertex, shaderContext);
+
 	return true;
 }
 
@@ -982,6 +990,9 @@ bool MVKGraphicsPipeline::addVertexShaderToPipeline(MTLComputePipelineDescriptor
 	if (!verifyImplicitBuffer(!shaderContext.shaderInputs.empty(), _indirectParamsIndex, kMVKShaderStageVertex, "index", vbCnt)) {
 		return false;
 	}
+
+    populateMSLIndices(kMVKShaderStageVertex, shaderContext);
+
 	return true;
 }
 
@@ -1038,6 +1049,9 @@ bool MVKGraphicsPipeline::addTessCtlShaderToPipeline(MTLComputePipelineDescripto
 		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Tessellation control shader requires tessellation level output buffer, but there is no free slot to pass it."));
 		return false;
 	}
+
+    populateMSLIndices(kMVKShaderStageTessCtl, shaderContext);
+
 	return true;
 }
 
@@ -1077,6 +1091,9 @@ bool MVKGraphicsPipeline::addTessEvalShaderToPipeline(MTLRenderPipelineDescripto
 	if (!verifyImplicitBuffer(_needsTessEvalBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageTessEval, "buffer size", kMVKTessEvalNumReservedBuffers)) {
 		return false;
 	}
+
+    populateMSLIndices(kMVKShaderStageTessEval, shaderContext);
+
 	return true;
 }
 
@@ -1124,8 +1141,32 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 		if (!verifyImplicitBuffer(_needsFragmentViewRangeBuffer, _viewRangeBufferIndex, kMVKShaderStageFragment, "view range", 0)) {
 			return false;
 		}
+
+        populateMSLIndices(kMVKShaderStageFragment, shaderContext);
 	}
 	return true;
+}
+
+void MVKPipeline::populateMSLIndices(MVKShaderStage stage, const SPIRVToMSLConversionConfiguration& shaderContext) {
+    auto &samplerMSLIndices = _samplerMSLIndices[stage];
+    auto &textureMSLIndices = _textureMSLIndices[stage];
+    auto &bufferMSLIndices = _bufferMSLIndices[stage];
+
+    samplerMSLIndices.resize(shaderContext.resourceBindings.size(), (uint16_t)-1);
+    textureMSLIndices.resize(shaderContext.resourceBindings.size(), (uint16_t)-1);
+    bufferMSLIndices.resize(shaderContext.resourceBindings.size(), (uint16_t)-1);
+
+    for (auto &rb: shaderContext.resourceBindings) {
+        if (rb.mslSamplerIndex != (uint32_t)-1) {
+            samplerMSLIndices[rb.resourceBinding.msl_sampler] = rb.mslSamplerIndex;
+        }
+        if (rb.mslTextureIndex != (uint32_t)-1) {
+            textureMSLIndices[rb.resourceBinding.msl_texture] = rb.mslTextureIndex;
+        }
+        if (rb.mslBufferIndex != (uint32_t)-1) {
+            bufferMSLIndices[rb.resourceBinding.msl_buffer] = rb.mslBufferIndex;
+        }
+    }
 }
 
 template<class T>
@@ -1716,6 +1757,8 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
     _needsBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
     _needsDispatchBaseBuffer = funcRslts.needsDispatchBaseBuffer;
 
+    populateMSLIndices(kMVKShaderStageCompute, shaderContext);
+
 	return func;
 }
 
@@ -2098,7 +2141,10 @@ namespace mvk {
 		archive(rb.resourceBinding,
 				rb.constExprSampler,
 				rb.requiresConstExprSampler,
-				rb.isUsedByShader);
+				rb.isUsedByShader,
+                rb.mslBufferIndex,
+                rb.mslTextureIndex,
+                rb.mslSamplerIndex);
 	}
 
 	template<class Archive>

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
@@ -111,6 +111,10 @@ namespace mvk {
 
 		bool isUsedByShader = false;
 
+        uint32_t mslBufferIndex = (uint32_t)-1;
+        uint32_t mslTextureIndex = (uint32_t)-1;
+        uint32_t mslSamplerIndex = (uint32_t)-1;
+
 		/**
 		 * Returns whether the specified resource binding match this one.
 		 * It does if all corresponding elements except isUsedByShader are equal.


### PR DESCRIPTION
There's an issue with assigning Metal resource indices upfront that this PR attempts to address.
Suppose that a client creates a pipeline with more resources in the layout than is allowed for a shader to use, say, more than 16 samplers. In the current scheme, even if no single stage uses too many samplers by itself, they will get numbered globally for the entire pipeline and crash when an index is > 15.
The proposed solution is to let SPIRV-Cross allocate the resource indices on demand. There's already a mechanism to do that, although I made some changes to make use of it more easily.
Apart from fixing that problem, there are some other upsides to it: we can stop binding unused resources and maybe handle implicit buffers more nicely.
Currently this PR is in a work in progress, not quite working yet state. Although it does seem to work with some games I was testing. @billhollings please let me know if that's a direction you like, or should the problem be addressed in some other way?