### PR TITLE
MVKPixelFormats: Enable RenderTarget usage for linear textures on Apple GPUs.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -665,7 +665,7 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 		mvkIsAnyFlagEnabled(mtlFmtCaps, (kMVKMTLFmtCapsColorAtt | kMVKMTLFmtCapsDSAtt))) {
 
 #if MVK_MACOS
-        if(!isLinear) {
+        if(!isLinear || (_physicalDevice && _physicalDevice->getMetalFeatures()->renderLinearTextures)) {
             mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
         }
 #else


### PR DESCRIPTION
I forgot to do this when I added the `renderLinearTexture` feature.