### PR TITLE
MVKImagePlane: When sync'ing, create the texture if it doesn't exist.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -338,7 +338,7 @@ void MVKImagePlane::applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
 			if (pImgRez) { pImgRez->layoutState = barrier.newLayout; }
 			if (needsSync) {
 #if MVK_MACOS
-				[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeTexture: _mtlTexture slice: layer level: mipLvl];
+				[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeTexture: getMTLTexture() slice: layer level: mipLvl];
 #endif
 			}
 			// Check if image content should be pulled into host-mapped device memory after


### PR DESCRIPTION
Before we can upload the texture, we need to make sure there is a
texture to upload to.