### PR TITLE
Don't use barriers in render passes on Apple GPUs.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -648,6 +648,7 @@ typedef struct {
 	VkBool32 simdPermute;						/**< If true, SIMD-group permutation functions (vote, ballot, shuffle) are supported in shaders. */
 	VkBool32 simdReduction;						/**< If true, SIMD-group reduction functions (arithmetic) are supported in shaders. */
     uint32_t minSubgroupSize;			        /**< The minimum number of threads in a SIMD-group. */
+    VkBool32 textureBarriers;                   /**< If true, texture barriers are supported within Metal render passes. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -106,7 +106,7 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 														  afterStages: srcStages
 														 beforeStages: dstStages];
 		}
-	} else {
+	} else if (cmdEncoder->getDevice()->_pMetalFeatures->textureBarriers) {
 #if !MVK_MACCAT
 		if (coversTextures()) { [cmdEncoder->_mtlRenderEncoder textureBarrier]; }
 #endif

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1401,7 +1401,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
         _metalFeatures.multisampleArrayTextures = true;
 		_metalFeatures.events = true;
-        _metalFeatures.memoryBarriers = true;
         _metalFeatures.textureBuffers = true;
 		_metalFeatures.quadPermute = true;
 		_metalFeatures.simdPermute = true;
@@ -1440,15 +1439,25 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 			_metalFeatures.postDepthCoverage = true;
 			_metalFeatures.renderLinearTextures = true;
+			if (supportsMTLGPUFamily(Apple6)) {
+				_metalFeatures.astcHDRTextures = true;
+			}
+			if (supportsMTLGPUFamily(Apple7)) {
+				_metalFeatures.maxQueryBufferSize = (256 * KIBI);
+			}
+		} else {
+			// Apple devices don't like barriers in render passes.
+			_metalFeatures.memoryBarriers = true;
+			_metalFeatures.textureBarriers = true;
 		}
-		if (supportsMTLGPUFamily(Apple6)) {
-			_metalFeatures.astcHDRTextures = true;
-		}
-		if (supportsMTLGPUFamily(Apple7)) {
-			_metalFeatures.maxQueryBufferSize = (256 * KIBI);
-		}
-	}
+	} else
 #endif
+	{
+		if (supportsMTLFeatureSet(macOS_GPUFamily1_v4)) {
+			_metalFeatures.memoryBarriers = true;
+		}
+		_metalFeatures.textureBarriers = true;
+	}
 
 #endif
 


### PR DESCRIPTION
Apple GPUs don't support them, and in fact Metal's validation layer will
complain if you try to use them.