### PR TITLE
MVKRenderPass: Don't use Load/Store actions for memoryless.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -175,6 +175,7 @@ public:
     bool populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc,
                                                    MVKRenderSubpass* subpass,
                                                    bool isRenderingEntireAttachment,
+												   bool isMemorylessAttachment,
                                                    bool hasResolveAttachment,
                                                    bool isStencil,
                                                    bool loadOverride = false);
@@ -183,6 +184,7 @@ public:
 	void encodeStoreAction(MVKCommandEncoder* cmdEncoder,
 						   MVKRenderSubpass* subpass,
 						   bool isRenderingEntireAttachment,
+						   bool isMemorylessAttachment,
 						   bool hasResolveAttachment,
 						   uint32_t caIdx,
 					   	   bool isStencil,
@@ -207,6 +209,7 @@ protected:
 	bool isLastUseOfAttachment(MVKRenderSubpass* subpass);
 	MTLStoreAction getMTLStoreAction(MVKRenderSubpass* subpass,
 									 bool isRenderingEntireAttachment,
+									 bool isMemorylessAttachment,
 									 bool hasResolveAttachment,
 									 bool isStencil,
 									 bool storeOverride);


### PR DESCRIPTION
Memoryless textures cannot use `Load`/`Store` actions, because there is
no memory to load from or store to. So don't use these actions, even if
we're not rendering to the whole thing.

Multiple subpasses might be a problem. Tessellation and indirect
multiview *will* be problems, because these require us to interrupt the
render pass in order to do compute--and that causes us to use `Store`
unconditionally.

One option, which I've mentioned before, is using tile shaders for these
cases. But I haven't looked seriously into that yet. The other involves
a subtle distinction between Metal's `MTLStorageModeMemoryless` and
Vulkan's `VK_MEMORY_TYPE_LAZILY_ALLOCATED_BIT`: the former *never*
commits memory; while the latter doesn't commit memory *at first*, but
may do so later. If we find that we're going to need to `Store` to a
`LAZILY_ALLOCATED` image, then what we can do is replace the
`Memoryless` texture with one with a real backing store in `Private`
memory. This change does not do that yet. It'll require some more
thought.

As for multiple subpasses, I eventually want to look into optimizing
render passes by shuffling the subpasses around to minimize the need to
load and store attachments from/to memory, which TBDR GPUs absolutely
hate. That should help with this problem, too.