### PR TITLE
MVKDeviceMemory: Don't consider Memoryless host-accessible on macOS/tvOS.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -52,7 +52,7 @@ public:
 
 	/** Returns whether the memory is accessible from the host. */
     inline bool isMemoryHostAccessible() {
-#if MVK_IOS
+#if MVK_IOS_OR_TVOS || MVK_MACOS_APPLE_SILICON
         if (_mtlStorageMode == MTLStorageModeMemoryless)
             return false;
 #endif


### PR DESCRIPTION
I missed this when I added support for memoryless on macOS.