### PR TITLE
MVKRenderPass: Use a non-trivial granularity for TBDR GPUs.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -649,6 +649,7 @@ typedef struct {
 	VkBool32 simdReduction;						/**< If true, SIMD-group reduction functions (arithmetic) are supported in shaders. */
     uint32_t minSubgroupSize;			        /**< The minimum number of threads in a SIMD-group. */
     VkBool32 textureBarriers;                   /**< If true, texture barriers are supported within Metal render passes. */
+    VkBool32 tileBasedDeferredRendering;        /**< If true, this device uses tile-based deferred rendering. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1202,6 +1202,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     _metalFeatures.sharedLinearTextures = true;
     _metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 	_metalFeatures.renderLinearTextures = true;
+	_metalFeatures.tileBasedDeferredRendering = true;
 
     if (supportsMTLFeatureSet(tvOS_GPUFamily1_v2)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion1_2;
@@ -1268,6 +1269,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.maxTextureDimension = (4 * KIBI);
     _metalFeatures.sharedLinearTextures = true;
 	_metalFeatures.renderLinearTextures = true;
+	_metalFeatures.tileBasedDeferredRendering = true;
 
     if (supportsMTLFeatureSet(iOS_GPUFamily1_v2)) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion1_1;
@@ -1439,6 +1441,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 			_metalFeatures.postDepthCoverage = true;
 			_metalFeatures.renderLinearTextures = true;
+			_metalFeatures.tileBasedDeferredRendering = true;
 			if (supportsMTLGPUFamily(Apple6)) {
 				_metalFeatures.astcHDRTextures = true;
 			}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -767,7 +767,17 @@ MVKRenderPassAttachment::MVKRenderPassAttachment(MVKRenderPass* renderPass,
 #pragma mark -
 #pragma mark MVKRenderPass
 
-VkExtent2D MVKRenderPass::getRenderAreaGranularity() { return { 1, 1 }; }
+VkExtent2D MVKRenderPass::getRenderAreaGranularity() {
+#if MVK_IOS_OR_TVOS || MVK_MACOS_APPLE_SILICON
+    if (_device->_pMetalFeatures->tileBasedDeferredRendering) {
+        // This is the tile area.
+        // FIXME: We really ought to use MTLRenderCommandEncoder.tile{Width,Height}, but that requires
+        // creating a command buffer.
+        return { 32, 32 };
+    }
+#endif
+    return { 1, 1 };
+}
 
 MVKRenderSubpass* MVKRenderPass::getSubpass(uint32_t subpassIndex) { return &_subpasses[subpassIndex]; }
 


### PR DESCRIPTION
This parameter is intended to indicate the optimal granularity for the
render area. For TBDR GPUs, this will be the tile size. IMR GPUs
continue to use 1x1.

Apple GPUs support tile sizes of 16x16, 32x16, and 32x32. But, we can't
read the tile size used for a Metal render pass until a render command
encoder has been created. So for now, hardcode 32x32 for TBDR GPUs.