### PR TITLE
Hide note about a markdown reader if you already use one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ MoltenVK
 
 Copyright (c) 2015-2020 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
-[comment]: # (This document is written in [Markdown](http://en.wikipedia.org/wiki/Markdown) format.)
-[comment]: # (For best results, use a Markdown reader.)
+[comment]: # "This document is written in Markdown (http://en.wikipedia.org/wiki/Markdown) format."
+[comment]: # "For best results, use a Markdown reader."
 
 [![Build Status](https://travis-ci.org/KhronosGroup/MoltenVK.svg?branch=master)](https://travis-ci.org/KhronosGroup/MoltenVK)
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ MoltenVK
 
 Copyright (c) 2015-2020 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
-*This document is written in [Markdown](http://en.wikipedia.org/wiki/Markdown) format. 
-For best results, use a Markdown reader.*
+[comment]: # (This document is written in [Markdown](http://en.wikipedia.org/wiki/Markdown) format.)
+[comment]: # (For best results, use a Markdown reader.)
 
 [![Build Status](https://travis-ci.org/KhronosGroup/MoltenVK.svg?branch=master)](https://travis-ci.org/KhronosGroup/MoltenVK)
 


### PR DESCRIPTION
I believe this information is unnecessary if you read the document in github for example. Just an idea. Feel free to close the issue if you see any reason to not apply this change.