### PR TITLE
fix incorrect behavior for MVKCmdResolveImage

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -696,7 +696,7 @@ void MVKCmdResolveImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
 			uint32_t layCnt = vkIR.dstSubresource.layerCount;
 			mtlResolveSlices[sliceCnt].dstSubresource.layerCount = 1;
 			mtlResolveSlices[sliceCnt].srcSubresource.layerCount = 1;
-			for (uint32_t layIdx = 0; layIdx < layCnt; layIdx++) {
+			for (uint32_t layIdx = 1; layIdx < layCnt; layIdx++) {
 				MVKMetalResolveSlice& rslvSlice = mtlResolveSlices[sliceCnt++];
 				rslvSlice = mtlResolveSlices[sliceCnt - 2];
 				rslvSlice.dstSubresource.baseArrayLayer++;


### PR DESCRIPTION
fix incorrectly changing first resolve layer's src/dst base layer,
as well and out of bounds access to the mtlResolveSlices array