### PR TITLE
Advertise support for shaderInt64 feature.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.1.2
 
 Released TBD
 
+- Advertise support for `shaderInt64` feature.
 - Support fast math on MSL compiler via `MVKConfiguration::fastMathEnabled` configuration 
   setting and `MVK_CONFIG_FAST_MATH_ENABLED` environment variable (both disabled by default).
 - Support _GitHub Actions_ for CI builds on pull requests.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -322,6 +322,10 @@ public:
 		}
 	}
 
+	/** Returns whether the MSL version is supported on this device. */
+	inline bool mslVersionIsAtLeast(MTLLanguageVersion minVer) { return _metalFeatures.mslVersionEnum >= minVer; }
+
+
 #pragma mark Construction
 
 	/** Constructs an instance wrapping the specified Vulkan instance and Metal device. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1575,7 +1575,6 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderStorageBufferArrayDynamicIndexing = true;
     _features.shaderClipDistance = true;
     _features.shaderInt16 = true;
-	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_2);
     _features.multiDrawIndirect = true;
     _features.inheritedQueries = true;
 
@@ -1588,6 +1587,7 @@ void MVKPhysicalDevice::initFeatures() {
 #if MVK_TVOS
     _features.textureCompressionETC2 = true;
     _features.textureCompressionASTC_LDR = true;
+	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_3) && supportsMTLGPUFamily(Apple3);
 
 	if (supportsMTLFeatureSet(tvOS_GPUFamily1_v3)) {
 		_features.dualSrcBlend = true;
@@ -1604,6 +1604,7 @@ void MVKPhysicalDevice::initFeatures() {
 
 #if MVK_IOS
     _features.textureCompressionETC2 = true;
+	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_3) && supportsMTLGPUFamily(Apple3);
 
     if (supportsMTLFeatureSet(iOS_GPUFamily2_v1)) {
         _features.textureCompressionASTC_LDR = true;
@@ -1646,6 +1647,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.depthClamp = true;
     _features.vertexPipelineStoresAndAtomics = true;
     _features.fragmentStoresAndAtomics = true;
+	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_3);
 
     _features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1575,6 +1575,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderStorageBufferArrayDynamicIndexing = true;
     _features.shaderClipDistance = true;
     _features.shaderInt16 = true;
+	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_2);
     _features.multiDrawIndirect = true;
     _features.inheritedQueries = true;
 
@@ -1719,7 +1720,7 @@ void MVKPhysicalDevice::initFeatures() {
 //    VkBool32    shaderClipDistance;                           // done
 //    VkBool32    shaderCullDistance;
 //    VkBool32    shaderFloat64;
-//    VkBool32    shaderInt64;
+//    VkBool32    shaderInt64;                                  // done
 //    VkBool32    shaderInt16;                                  // done
 //    VkBool32    shaderResourceResidency;
 //    VkBool32    shaderResourceMinLod;                         // done

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -72,9 +72,9 @@ bool mvk::compile(const string& mslSourceCode,
 
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
 	if (mslVer(2, 3, 0)) {
-		mslVerEnum = MTLLanguageVersion2_1;
+		mslVerEnum = MTLLanguageVersion2_3;
 	} else if (mslVer(2, 2, 0)) {
-		mslVerEnum = MTLLanguageVersion2_1;
+		mslVerEnum = MTLLanguageVersion2_2;
 	} else if (mslVer(2, 1, 0)) {
 		mslVerEnum = MTLLanguageVersion2_1;
 	} else if (mslVer(2, 0, 0)) {

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -71,7 +71,11 @@ bool mvk::compile(const string& mslSourceCode,
 #define mslVer(MJ, MN, PT)	mslVersionMajor == MJ && mslVersionMinor == MN && mslVersionPoint == PT
 
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
-	if (mslVer(2, 1, 0)) {
+	if (mslVer(2, 3, 0)) {
+		mslVerEnum = MTLLanguageVersion2_1;
+	} else if (mslVer(2, 2, 0)) {
+		mslVerEnum = MTLLanguageVersion2_1;
+	} else if (mslVer(2, 1, 0)) {
 		mslVerEnum = MTLLanguageVersion2_1;
 	} else if (mslVer(2, 0, 0)) {
 		mslVerEnum = MTLLanguageVersion2_0;


### PR DESCRIPTION
Add `MVKDevice::mslVersionIsAtLeast()` to support tests for MSL version.
Also bump MSL support level of standalone `MoltenVKShaderConverter` tool.

Fixes #1203.