### PR TITLE
For Vulkan semaphores, prefer using MTLFence over MTLEvent.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -120,12 +120,15 @@ typedef unsigned long MTLLanguageVersion;
  * 4.  Setting the MVK_ALLOW_METAL_FENCES or MVK_ALLOW_METAL_EVENTS runtime environment variable
  *     or MoltenVK compile-time build setting to 1 will cause MoltenVK to use MTLFence or MTLEvent,
  *     respectively, if it is available on the device, for VkSemaphore synchronization behaviour.
- *     If both variables are set, MVK_ALLOW_METAL_EVENTS takes priority over MVK_ALLOW_METAL_FENCES.
- *     If both are disabled, or if MTLFence or MTLEvent is not available on the device, MoltenVK
- *     will use CPU synchronization to control VkSemaphore synchronization behaviour.
- *     By default, both MVK_ALLOW_METAL_FENCES and MVK_ALLOW_METAL_EVENTS are enabled, meaning 
- *     MoltenVK will preferentially use MTLEvents if they are available, followed by MTLFences
- *     if they are available, to control VkSemaphore synchronization behaviour, by default.
+ *     If both variables are set, MVK_ALLOW_METAL_FENCES takes priority over MVK_ALLOW_METAL_EVENTS.
+ *     If both are disabled, or if neither MTLFence nor MTLEvent is available on the device,
+ *     MoltenVK will use CPU synchronization to control VkSemaphore synchronization behaviour.
+ *     In the special case of VK_SEMAPHORE_TYPE_TIMELINE semaphores, MoltenVK will always
+ *     use MTLSharedEvent if it is available on the platform, regardless of the values of
+ *     MVK_ALLOW_METAL_FENCES or MVK_ALLOW_METAL_EVENTS.
+ *     By default, both MVK_ALLOW_METAL_FENCES and MVK_ALLOW_METAL_EVENTS are enabled, meaning,
+ *     to control VkSemaphore synchronization behaviour, by default MoltenVK will preferentially
+ *     use MTLFence if it is available, followed by MTLEvent if it is available.
  *
  * 5.  The MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE runtime environment variable or MoltenVK compile-time
  *     build setting controls whether Metal should run an automatic GPU capture without the user

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3154,10 +3154,10 @@ MVKSemaphore* MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInf
 			return new MVKTimelineSemaphoreEmulated(this, pCreateInfo, pTypeCreateInfo);
 		}
 	} else {
-		if (_useMTLEventForSemaphores) {
-			return new MVKSemaphoreMTLEvent(this, pCreateInfo);
-		} else if (_useMTLFenceForSemaphores) {
+		if (_useMTLFenceForSemaphores) {
 			return new MVKSemaphoreMTLFence(this, pCreateInfo);
+		} else if (_useMTLEventForSemaphores) {
+			return new MVKSemaphoreMTLEvent(this, pCreateInfo);
 		} else {
 			return new MVKSemaphoreEmulated(this, pCreateInfo);
 		}
@@ -3810,7 +3810,7 @@ void MVKDevice::initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDe
 	if (_pMetalFeatures->events) {
 		MVK_SET_FROM_ENV_OR_BUILD_BOOL(_useMTLEventForSemaphores, MVK_ALLOW_METAL_EVENTS);
 	}
-	MVKLogInfo("Using %s for Vulkan semaphores.", _useMTLEventForSemaphores ? "MTLEvent" : (_useMTLFenceForSemaphores ? "MTLFence" : "emulation"));
+	MVKLogInfo("Using %s for Vulkan semaphores.", _useMTLFenceForSemaphores ? "MTLFence" : (_useMTLEventForSemaphores ? "MTLEvent" : "emulation"));
 
 #	ifndef MVK_CONFIG_USE_COMMAND_POOLING
 #   	define MVK_CONFIG_USE_COMMAND_POOLING    1


### PR DESCRIPTION
Plus add documentation for VK_SEMAPHORE_TYPE_TIMELINE.

Fixes issue #1180.