### PR TITLE
MVKMTLBufferAllocation: Mark temp buffers as volatile.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -28,6 +28,7 @@
 #include "MVKEnvironment.h"
 #include "mvk_datatypes.hpp"
 #include <algorithm>
+#include <sys/mman.h>
 
 
 #pragma mark -
@@ -1615,7 +1616,10 @@ void MVKCmdUpdateBuffer::encode(MVKCommandEncoder* cmdEncoder) {
 
     // Copy data to the source MTLBuffer
     MVKMTLBufferAllocation* srcMTLBufferAlloc = (MVKMTLBufferAllocation*)cmdEncoder->getCommandEncodingPool()->acquireMTLBufferAllocation(_dataSize);
-    memcpy(srcMTLBufferAlloc->getContents(), _srcDataCache.data(), _dataSize);
+    void* pBuffData = srcMTLBufferAlloc->getContents();
+    mlock(pBuffData, _dataSize);
+    memcpy(pBuffData, _srcDataCache.data(), _dataSize);
+    munlock(pBuffData, _dataSize);
 
     [mtlBlitEnc copyFromBuffer: srcMTLBufferAlloc->_mtlBuffer
                   sourceOffset: srcMTLBufferAlloc->_offset

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -26,6 +26,7 @@
 #include "MTLRenderPassDescriptor+MoltenVK.h"
 #include "MVKCmdDraw.h"
 #include "MVKCmdRenderPass.h"
+#include <sys/mman.h>
 
 using namespace std;
 
@@ -675,7 +676,9 @@ MVKCommandEncodingPool* MVKCommandEncoder::getCommandEncodingPool() {
 const MVKMTLBufferAllocation* MVKCommandEncoder::copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length) {
     const MVKMTLBufferAllocation* mtlBuffAlloc = getTempMTLBuffer(length);
     void* pBuffData = mtlBuffAlloc->getContents();
+    mlock(pBuffData, length);
     memcpy(pBuffData, bytes, length);
+    munlock(pBuffData, length);
 
     return mtlBuffAlloc;
 }

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -82,7 +82,11 @@ const MVKMTLBufferAllocation* MVKMTLBufferAllocator::acquireMTLBufferRegion(NSUI
     // Convert max length to the next power-of-two exponent to use as a lookup
     NSUInteger p2Exp = mvkPowerOfTwoExponent(length);
 	MVKMTLBufferAllocationPool* pRP = _regionPools[p2Exp];
-	return _makeThreadSafe ? pRP->acquireObjectSafely() : pRP->acquireObject();
+	const MVKMTLBufferAllocation* region = _makeThreadSafe ? pRP->acquireObjectSafely() : pRP->acquireObject();
+	if (region) {
+		[region->_mtlBuffer setPurgeableState: MTLPurgeableStateVolatile];
+	}
+	return region;
 }
 
 MVKMTLBufferAllocator::MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxRegionLength, bool makeThreadSafe) : MVKBaseDeviceObject(device) {


### PR DESCRIPTION
They are not expected to be useful beyond the commands that use them,
but they take up memory nonetheless. This is exactly the use case
purgeability was designed for. Tell the system that it's OK to reclaim
their memory if necessary.

Doing this every time the buffer is used will cause the purgeable state
to be reset from `MTLPurgeableStateEmpty`, in case the system really did
reclaim their memory.

In accordance with Apple's advice, lock the pages for the buffer when
loading it, so the memory isn't pulled out from under us.

Fixes #1231.