### PR TITLE
CI enhancements.

### DIFF
--- a/.github/workflows/CI-legacy.yml
+++ b/.github/workflows/CI-legacy.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-legacy
 
 # Controls when the action will run. 
 on:
@@ -11,8 +11,8 @@ on:
 env:
   # For supported Xcode versions, see: https://github.com/actions/virtual-environments/tree/main/images/macos
   # Then open macos-X.X-Readme.md#xcode
-  # Also see runs-on link for macos-latest below for which macOS platform will be run
-  XCODE_DEV_PATH: /Applications/Xcode_12.4.app/Contents/Developer
+  # Also see runs-on link below for which macOS platform will be run
+  XCODE_DEV_PATH: /Applications/Xcode_11.7.app/Contents/Developer
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -21,15 +21,15 @@ jobs:
       matrix:
         include:
           - platform: "macos"
-          - platform: "maccat"
-          - platform: "ios"
-          - platform: "tvos"
+#          - platform: "maccat"
+#          - platform: "ios"
+#          - platform: "tvos"
       fail-fast: false
 
     name: 'MoltenVK (${{ matrix.platform }})'
     
     # See: https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -83,12 +83,13 @@ jobs:
             cat "xcodebuild.log"
           fi
 
-      - name: Tar Artifacts
-        # See: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
-        run: tar -cvf "${{ matrix.platform }}.tar" Package/Release/
+# Don't package binaries for legacy
+#      - name: Tar Artifacts
+#        # See: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
+#       run: tar -cvf "${{ matrix.platform }}.tar" Package/Release/
 
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.platform }}
-          path: "${{ matrix.platform }}.tar"
+#      - name: Upload Artifacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ matrix.platform }}
+#          path: "${{ matrix.platform }}.tar"

--- a/MoltenVKPackaging.xcodeproj/project.pbxproj
+++ b/MoltenVKPackaging.xcodeproj/project.pbxproj
@@ -194,6 +194,8 @@
 		A9C70F45221B04C800FBA31A /* create_dylib_ios.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = create_dylib_ios.sh; sourceTree = "<group>"; };
 		A9CBBFF924F8A1EB006D41EF /* package_moltenvk_xcframework.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_moltenvk_xcframework.sh; sourceTree = "<group>"; };
 		A9DA8341218A198C002AA662 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		A9E4290425C9B23800224E8C /* CI.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = CI.yml; path = .github/workflows/CI.yml; sourceTree = "<group>"; };
+		A9E4290825C9B69300224E8C /* CI-legacy.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = "CI-legacy.yml"; path = ".github/workflows/CI-legacy.yml"; sourceTree = "<group>"; };
 		A9FC5F60249D2ED3003CB086 /* package_all.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = package_all.sh; sourceTree = "<group>"; };
 		A9FC5F64249D3778003CB086 /* create_dylib_tvos.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = create_dylib_tvos.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -269,6 +271,8 @@
 			isa = PBXGroup;
 			children = (
 				A9DA8341218A198C002AA662 /* .gitignore */,
+				A9E4290425C9B23800224E8C /* CI.yml */,
+				A9E4290825C9B69300224E8C /* CI-legacy.yml */,
 			);
 			name = Git;
 			sourceTree = "<group>";

--- a/README.md
+++ b/README.md
@@ -46,14 +46,19 @@ If you are developing a *Vulkan* application for *macOS*, it is highly recommend
 Refer to the *Vulkan SDK [Getting Started](https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html)* 
 document for more info.
 
-If you are developing a *Vulkan* application for *iOS* or *tvOS*, or are developing a *Vulkan* 
-application for *macOS* and want to use a different version of the **MoltenVK** runtime library 
-provided in the *macOS Vulkan SDK*, you can use this document to learn how to build a **MoltenVK** 
-runtime library from source code.
+You can also download **MoltenVK** runtime library binaries for *macOS*, *iOS* or *tvOS* from the 
+**MoltenVK** [CI builds](https://github.com/KhronosGroup/MoltenVK/actions?query=workflow%3ACI).
+Select a CI build (typically the latest), and click on the appropriate platform *Artifact* to 
+download a **MoltenVK** binary package for that platform.
 
 To learn how to integrate the **MoltenVK** runtime library into a game or application, 
 see the [`MoltenVK_Runtime_UserGuide.md `](Docs/MoltenVK_Runtime_UserGuide.md) 
 document in the `Docs` directory. 
+
+If you are developing a *Vulkan* application for *iOS* or *tvOS*, or are developing a *Vulkan* 
+application for *macOS* and want to use a different version of the **MoltenVK** runtime library 
+provided in the *macOS Vulkan SDK*, you can use this document to learn how to build a **MoltenVK** 
+runtime library from source code.
 
 
 


### PR DESCRIPTION
Add `CI-legacy.yml` workflow to build on older Xcode versions.
Update `README.md` to document availability of MoltenVK binaries via CI artifacts.
Update `CI.yml` workflow to use Xcode 12.4.