### PR TITLE
Add MVKDeviceTrackingMixin::getPhysicalDevice() to streamline access.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -518,7 +518,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 
     auto* pipeline = (MVKGraphicsPipeline*)cmdEncoder->_graphicsPipelineState.getPipeline();
     bool needsInstanceAdjustment = cmdEncoder->getSubpass()->isMultiview() &&
-                                   cmdEncoder->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview();
+                                   cmdEncoder->getPhysicalDevice()->canUseInstancingForMultiview();
     // The indirect calls for dispatchThreadgroups:... and drawPatches:... have different formats.
     // We have to convert from the drawPrimitives:... format to them.
     // While we're at it, we can create the temporary output buffers once and reuse them
@@ -831,7 +831,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
     MVKIndexMTLBufferBinding& ibb = cmdEncoder->_graphicsResourcesState._mtlIndexBufferBinding;
     auto* pipeline = (MVKGraphicsPipeline*)cmdEncoder->_graphicsPipelineState.getPipeline();
     bool needsInstanceAdjustment = cmdEncoder->getSubpass()->isMultiview() &&
-                                   cmdEncoder->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview();
+                                   cmdEncoder->getPhysicalDevice()->canUseInstancingForMultiview();
     // The indirect calls for dispatchThreadgroups:... and drawPatches:... have different formats.
     // We have to convert from the drawIndexedPrimitives:... format to them.
     // While we're at it, we can create the temporary output buffers once and reuse them

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -51,10 +51,10 @@ VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequireme
 		pMemoryRequirements->size = getByteCount();
 		pMemoryRequirements->alignment = _byteAlignment;
 	}
-	pMemoryRequirements->memoryTypeBits = _device->getPhysicalDevice()->getAllMemoryTypes();
+	pMemoryRequirements->memoryTypeBits = getPhysicalDevice()->getAllMemoryTypes();
 #if MVK_APPLE_SILICON
 	// Memoryless storage is not allowed for buffers
-	mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+	mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
 #endif
 	return VK_SUCCESS;
 }
@@ -236,7 +236,7 @@ MVKBuffer::MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo) :
 void MVKBuffer::initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes) {
 	if (mvkIsOnlyAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
 		_externalMemoryHandleTypes = handleTypes;
-		auto& xmProps = _device->getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
+		auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
 		_requiresDedicatedMemoryAllocation = _requiresDedicatedMemoryAllocation || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
 	} else {
 		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateBuffer(): Only external memory handle type VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR is supported."));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -817,6 +817,9 @@ public:
 	/** Returns the device for which this object was created. */
 	inline MVKDevice* getDevice() { return _device; }
 
+	/** Returns the physical device underlying this logical device. */
+	inline MVKPhysicalDevice* getPhysicalDevice() { return _device->getPhysicalDevice(); }
+
 	/** Returns the underlying Metal device. */
 	inline id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -352,11 +352,11 @@ void MVKDeviceMemory::initExternalMemory(VkExternalMemoryHandleTypeFlags handleT
 
 	bool requiresDedicated = false;
 	if (mvkIsAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
-		auto& xmProps = _device->getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
+		auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
 		requiresDedicated = requiresDedicated || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
 	}
 	if (mvkIsAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
-		auto& xmProps = _device->getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
+		auto& xmProps = getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
 		requiresDedicated = requiresDedicated || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
 	}
 	if (requiresDedicated && !_isDedicated) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -639,18 +639,18 @@ void MVKImage::applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
 
 VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements, uint8_t planeIndex) {
     pMemoryRequirements->memoryTypeBits = (_isDepthStencilAttachment)
-                                          ? _device->getPhysicalDevice()->getPrivateMemoryTypes()
-                                          : _device->getPhysicalDevice()->getAllMemoryTypes();
+                                          ? getPhysicalDevice()->getPrivateMemoryTypes()
+                                          : getPhysicalDevice()->getAllMemoryTypes();
 #if MVK_MACOS
     // Metal on macOS does not provide native support for host-coherent memory, but Vulkan requires it for Linear images
     if ( !_isLinear ) {
-        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getHostCoherentMemoryTypes());
+        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getHostCoherentMemoryTypes());
     }
 #endif
 #if MVK_APPLE_SILICON
     // Only transient attachments may use memoryless storage
     if (!mvkAreAllFlagsEnabled(_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ) {
-        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, _device->getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
     }
 #endif
     return _memoryBindings[planeIndex]->getMemoryRequirements(pMemoryRequirements);
@@ -1113,7 +1113,7 @@ bool MVKImage::validateLinear(const VkImageCreateInfo* pCreateInfo, bool isAttac
 
 void MVKImage::initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes) {
 	if (mvkIsOnlyAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
-        auto& xmProps = _device->getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
+        auto& xmProps = getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
         for(auto& memoryBinding : _memoryBindings) {
             memoryBinding->_externalMemoryHandleTypes = handleTypes;
             memoryBinding->_requiresDedicatedMemoryAllocation = memoryBinding->_requiresDedicatedMemoryAllocation || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
@@ -1940,7 +1940,7 @@ MTLSamplerDescriptor* MVKSampler::newMTLSamplerDescriptor(const VkSamplerCreateI
 
 #if MVK_MACOS_OR_IOS
 	mtlSampDesc.borderColorMVK = mvkMTLSamplerBorderColorFromVkBorderColor(pCreateInfo->borderColor);
-	if (_device->getPhysicalDevice()->getMetalFeatures()->samplerClampToBorder) {
+	if (getPhysicalDevice()->getMetalFeatures()->samplerClampToBorder) {
 		if (pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) {
 			mtlSampDesc.sAddressMode = MTLSamplerAddressModeClampToBorderColor;
 		}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1485,7 +1485,7 @@ void MVKGraphicsPipeline::initMVKShaderConverterContext(SPIRVToMSLConversionConf
     shaderContext.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle;
     shaderContext.options.mslOptions.tess_domain_origin_lower_left = pTessDomainOriginState && pTessDomainOriginState->domainOrigin == VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
     shaderContext.options.mslOptions.multiview = mvkRendPass->isMultiview();
-    shaderContext.options.mslOptions.multiview_layered_rendering = getDevice()->getPhysicalDevice()->canUseInstancingForMultiview();
+    shaderContext.options.mslOptions.multiview_layered_rendering = getPhysicalDevice()->canUseInstancingForMultiview();
     shaderContext.options.mslOptions.view_index_from_device_index = mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT);
 #if MVK_MACOS
     shaderContext.options.mslOptions.emulate_subgroups = !_device->_pMetalFeatures->simdPermute;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -97,7 +97,7 @@ static uint32_t getNextViewMaskGroup(uint32_t viewMask, uint32_t* startView, uin
 uint32_t MVKRenderSubpass::getViewMaskGroupForMetalPass(uint32_t passIdx) {
 	if (!_viewMask) { return 0; }
 	assert(passIdx < getMultiviewMetalPassCount());
-	if (!_renderPass->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview()) {
+	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
 		return 1 << getFirstViewIndexInMetalPass(passIdx);
 	}
 	uint32_t mask = _viewMask, groupMask = 0;
@@ -109,7 +109,7 @@ uint32_t MVKRenderSubpass::getViewMaskGroupForMetalPass(uint32_t passIdx) {
 
 uint32_t MVKRenderSubpass::getMultiviewMetalPassCount() const {
 	if (!_viewMask) { return 0; }
-	if (!_renderPass->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview()) {
+	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
 		// If we can't use instanced drawing for this, we'll have to unroll the render pass.
 		return __builtin_popcount(_viewMask);
 	}
@@ -129,7 +129,7 @@ uint32_t MVKRenderSubpass::getFirstViewIndexInMetalPass(uint32_t passIdx) const 
 	assert(passIdx < getMultiviewMetalPassCount());
 	uint32_t mask = _viewMask;
 	uint32_t startView = 0, viewCount = 0;
-	if (!_renderPass->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview()) {
+	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
 		for (uint32_t i = 0; mask != 0; ++i) {
 			mask = getNextViewMaskGroup(mask, &startView, &viewCount);
 			while (passIdx-- > 0 && viewCount-- > 0) {
@@ -147,7 +147,7 @@ uint32_t MVKRenderSubpass::getFirstViewIndexInMetalPass(uint32_t passIdx) const 
 uint32_t MVKRenderSubpass::getViewCountInMetalPass(uint32_t passIdx) const {
 	if (!_viewMask) { return 0; }
 	assert(passIdx < getMultiviewMetalPassCount());
-	if (!_renderPass->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview()) {
+	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
 		return 1;
 	}
 	uint32_t mask = _viewMask;
@@ -160,7 +160,7 @@ uint32_t MVKRenderSubpass::getViewCountInMetalPass(uint32_t passIdx) const {
 
 uint32_t MVKRenderSubpass::getViewCountUpToMetalPass(uint32_t passIdx) const {
 	if (!_viewMask) { return 0; }
-	if (!_renderPass->getDevice()->getPhysicalDevice()->canUseInstancingForMultiview()) {
+	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
 		return passIdx+1;
 	}
 	uint32_t mask = _viewMask;


### PR DESCRIPTION
Trivial cleanup.