### PR TITLE
MVKPhysicalDevice: Clamp maximum buffer range to 4 GiB - 1.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1825,13 +1825,13 @@ void MVKPhysicalDevice::initLimits() {
 #if MVK_MACOS
 	_properties.limits.maxUniformBufferRange = (64 * KIBI);
 	if (supportsMTLGPUFamily(Apple5)) {
-		_properties.limits.maxUniformBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
+		_properties.limits.maxUniformBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
 	}
 #endif
 #if MVK_IOS_OR_TVOS
-	_properties.limits.maxUniformBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
+	_properties.limits.maxUniformBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
 #endif
-	_properties.limits.maxStorageBufferRange = (uint32_t)_metalFeatures.maxMTLBufferSize;
+	_properties.limits.maxStorageBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
 	_properties.limits.maxPushConstantsSize = (4 * KIBI);
 
     _properties.limits.minMemoryMapAlignment = _metalFeatures.mtlBufferAlignment;


### PR DESCRIPTION
It is possible for the maximum buffer size to be 4 binary gigabytes or
greater. In that case, the upper 32 bits will be lost, and the value of
the `maxUniformBufferRange` and `maxStorageBufferRange` limits would be
too small or even zero. Clamp it to 4 GiB - 1 in that case, since that
is the maximum value of a 32-bit integer.

For #1240.