### PR TITLE
Test for null string on MVKConfiguration copy.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,7 +32,7 @@ Released TBD
 - `Makefile` and `fetchDependencies` support `xcpretty` (if available)
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to `30`.
 - Update copyright notices to year 2021.
-- Update Xcode build settings check to _Xcode 12.3_.
+- Update Xcode build settings check to _Xcode 12.4_.
 
 
 

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -59,7 +59,7 @@ static void mvkInitConfig() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (_mvkConfig.texture1DAs2D,                          MVK_CONFIG_TEXTURE_1D_AS_2D);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (_mvkConfig.preallocateDescriptors,                 MVK_CONFIG_PREALLOCATE_DESCRIPTORS);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (_mvkConfig.useCommandPooling,                      MVK_CONFIG_USE_COMMAND_POOLING);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (_mvkConfig.useMTLHeap,                            MVK_CONFIG_USE_MTLHEAP);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (_mvkConfig.useMTLHeap,                             MVK_CONFIG_USE_MTLHEAP);
 }
 
 // Returns the MoltenVK config, lazily initializing it if necessary.
@@ -77,6 +77,8 @@ const MVKConfiguration* mvkGetMVKConfiguration() {
 // and then repointing the MVKConfiguration member to the contents of the std::string.
 void mvkSetMVKConfiguration(MVKConfiguration* pMVKConfig) {
 	_mvkConfig = *pMVKConfig;
-	_autoGPUCaptureOutputFile = _mvkConfig.autoGPUCaptureOutputFilepath;
+	if (_mvkConfig.autoGPUCaptureOutputFilepath) {
+		_autoGPUCaptureOutputFile = _mvkConfig.autoGPUCaptureOutputFilepath;
+	}
 	_mvkConfig.autoGPUCaptureOutputFilepath = (char*)_autoGPUCaptureOutputFile.c_str();
 }

--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -61,7 +61,7 @@ MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
 	const MVKConfiguration*                     pConfiguration,
 	size_t*                                     pConfigurationSize) {
 
-	MVKConfiguration mvkConfig;
+	MVKConfiguration mvkConfig = {};	// Ensure initialized in case not fully copied
 	VkResult rslt = mvkCopy(&mvkConfig, pConfiguration, pConfigurationSize);
 	mvkSetMVKConfiguration(&mvkConfig);
 	return rslt;


### PR DESCRIPTION
When app sets `MVKConfiguration`, if struct not fully populated by app, or if app sets strings to `null`,
copy can fail. Test for this before copying.

Also unrelated trivial tweak to What's New doc.