### PR TITLE
MVKPhysicalDevice: Disable SIMD-group permutation for Mac family 1.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1396,7 +1396,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.multisampleArrayTextures = true;
 		_metalFeatures.events = true;
         _metalFeatures.textureBuffers = true;
-		_metalFeatures.simdPermute = true;
     }
 
 	if (supportsMTLFeatureSet(macOS_GPUFamily2_v1)) {
@@ -1404,6 +1403,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.stencilFeedback = true;
 		_metalFeatures.depthResolve = true;
 		_metalFeatures.stencilResolve = true;
+		_metalFeatures.simdPermute = true;
 		_metalFeatures.quadPermute = true;
 		_metalFeatures.simdReduction = true;
 	}


### PR DESCRIPTION
Our testing shows that none of the SIMD-group functions work on family
1, including `simd_is_first()`, which is needed for even `BASIC`
support.