### PR TITLE
Fix Metal validation error of duplicate visibility offsets.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -335,7 +335,7 @@ void MVKCommandEncoder::beginMetalRenderPass(bool loadOverride) {
 
     MTLRenderPassDescriptor* mtlRPDesc = [MTLRenderPassDescriptor renderPassDescriptor];
     getSubpass()->populateMTLRenderPassDescriptor(mtlRPDesc, _multiviewPassIndex, _framebuffer, _clearValues.contents(), _isRenderingEntireAttachment, loadOverride);
-    if (_occlusionQueryState.getNeedsVisibilityResultMTLBuffer()) {
+    if (_cmdBuffer->_needsVisibilityResultMTLBuffer) {
         if (!_visibilityResultMTLBuffer) {
             _visibilityResultMTLBuffer = getTempMTLBuffer(_pDeviceMetalFeatures->maxQueryBufferSize, true);
         }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -585,17 +585,12 @@ public:
     /** Ends an occlusion query. */
     void endOcclusionQuery(MVKOcclusionQueryPool* pQueryPool, uint32_t query);
 
-    /** Returns whether an MTLBuffer is needed to hold occlusion query results. */
-    bool getNeedsVisibilityResultMTLBuffer();
-
-    /** Constructs this instance for the specified command encoder. */
-    MVKOcclusionQueryCommandEncoderState(MVKCommandEncoder* cmdEncoder);
+	MVKOcclusionQueryCommandEncoderState(MVKCommandEncoder* cmdEncoder) : MVKCommandEncoderState(cmdEncoder) {}
 
 protected:
     void encodeImpl(uint32_t) override;
     void resetImpl() override;
 
-    bool _needsVisibilityResultMTLBuffer = false;
     MTLVisibilityResultMode _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
     NSUInteger _mtlVisibilityResultOffset = 0;
 	MVKSmallVector<std::pair<MVKQuerySpec, NSUInteger>> _mtlRenderPassQueries;

--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -61,7 +61,8 @@ MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
 	const MVKConfiguration*                     pConfiguration,
 	size_t*                                     pConfigurationSize) {
 
-	MVKConfiguration mvkConfig = {};	// Ensure initialized in case not fully copied
+	// Start with current config, in case incoming is not fully copied
+	MVKConfiguration mvkConfig = *mvkGetMVKConfiguration();
 	VkResult rslt = mvkCopy(&mvkConfig, pConfiguration, pConfigurationSize);
 	mvkSetMVKConfiguration(&mvkConfig);
 	return rslt;


### PR DESCRIPTION
Don't reset `MVKOcclusionQueryCommandEncoderState::_mtlVisibilityResultOffset`
when ending occlusion query, as subsequent queries need different offsets.

Also, remove `MVKOcclusionQueryCommandEncoderState::_needsVisibilityResultMTLBuffer`,
as it is always set once from `MVKCommandBuffer::_needsVisibilityResultMTLBuffer`.

The current logic around deciding whether a visibility buffer is needed is relatively crude. Currently, it is applied to all render passes in a Vulkan command buffer based on at least one occlusion query being present. A Metal renderpass needs a visibility buffer if a query is started either before it or inside it. For a command buffer with multiple Metal render passes, not all of them may need it. 

Fixing that logic was out of scope for this PR, but I'll add another Issue to track and address that logic.

Unrelated fix, when app setting MVKConfiguration it with a partial copy, start with existing.


Fixes #1247.