### PR TITLE
Remove MVKCommandEncoderState::reset().

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -83,23 +83,11 @@ public:
         encodeImpl(stage);
     }
 
-    /**
-     * Marks this instance as dirty and calls resetImpl() function to reset this instance
-     * back to initial state. Subclasses must override the resetImpl() function.
-     */
-    void reset() {
-        _isDirty = true;
-        _isModified = false;
-
-        resetImpl();
-    }
-
 	/** Constructs this instance for the specified command encoder. */
     MVKCommandEncoderState(MVKCommandEncoder* cmdEncoder) : _cmdEncoder(cmdEncoder) {}
 
 protected:
     virtual void encodeImpl(uint32_t stage) = 0;
-    virtual void resetImpl() = 0;
 
     MVKCommandEncoder* _cmdEncoder;
 	bool _isDirty = false;
@@ -127,7 +115,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     MVKPipeline* _pipeline = nullptr;
 };
@@ -156,7 +143,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     MVKSmallVector<VkViewport, kMVKCachedViewportScissorCount> _viewports, _dynamicViewports;
 };
@@ -185,7 +171,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     MVKSmallVector<VkRect2D, kMVKCachedViewportScissorCount> _scissors, _dynamicScissors;
 };
@@ -212,7 +197,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 	bool isTessellating();
 
     MVKSmallVector<char, 128> _pushConstants;
@@ -252,7 +236,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
     void setStencilState(MVKMTLStencilDescriptorData& stencilInfo,
                          const VkStencilOpState& vkStencil,
                          bool enabled);
@@ -283,7 +266,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     uint32_t _frontFaceValue = 0;
     uint32_t _backFaceValue = 0;
@@ -312,7 +294,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     float _depthBiasConstantFactor = 0;
     float _depthBiasClamp = 0;
@@ -340,7 +321,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
 
     float _red = 0;
     float _green = 0;
@@ -440,23 +420,6 @@ protected:
 		bool areSamplerStateBindingsDirty = false;
 
 		bool needsSwizzle = false;
-
-		void reset() {
-			bufferBindings.clear();
-			textureBindings.clear();
-			samplerStateBindings.clear();
-			swizzleConstants.clear();
-			bufferSizes.clear();
-
-			areBufferBindingsDirty = false;
-			areTextureBindingsDirty = false;
-			areSamplerStateBindingsDirty = false;
-			swizzleBufferBinding.isDirty = false;
-			bufferSizeBufferBinding.isDirty = false;
-			viewRangeBufferBinding.isDirty = false;
-
-			needsSwizzle = false;
-		}
 	};
 
 };
@@ -524,7 +487,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t stage) override;
-    void resetImpl() override;
     void markDirty() override;
 
     ResourceBindings<8> _shaderStageResourceBindings[4];
@@ -563,7 +525,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t) override;
-    void resetImpl() override;
 
 	ResourceBindings<4> _resourceBindings;
 };
@@ -589,7 +550,6 @@ public:
 
 protected:
     void encodeImpl(uint32_t) override;
-    void resetImpl() override;
 
     MTLVisibilityResultMode _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
     NSUInteger _mtlVisibilityResultOffset = 0;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -49,10 +49,6 @@ void MVKPipelineCommandEncoderState::encodeImpl(uint32_t stage) {
 	}
 }
 
-void MVKPipelineCommandEncoderState::resetImpl() {
-    _pipeline = nullptr;
-}
-
 
 #pragma mark -
 #pragma mark MVKViewportCommandEncoderState
@@ -103,11 +99,6 @@ void MVKViewportCommandEncoderState::encodeImpl(uint32_t stage) {
     }
 }
 
-void MVKViewportCommandEncoderState::resetImpl() {
-    _viewports.clear();
-	_dynamicViewports.clear();
-}
-
 
 #pragma mark -
 #pragma mark MVKScissorCommandEncoderState
@@ -156,11 +147,6 @@ void MVKScissorCommandEncoderState::encodeImpl(uint32_t stage) {
 	} else {
 		[_cmdEncoder->_mtlRenderEncoder setScissorRect: mvkMTLScissorRectFromVkRect2D(_cmdEncoder->clipToRenderArea(usingScissors[0]))];
 	}
-}
-
-void MVKScissorCommandEncoderState::resetImpl() {
-    _scissors.clear();
-	_dynamicScissors.clear();
 }
 
 
@@ -253,10 +239,6 @@ void MVKPushConstantsCommandEncoderState::encodeImpl(uint32_t stage) {
 bool MVKPushConstantsCommandEncoderState::isTessellating() {
 	MVKGraphicsPipeline* gp = (MVKGraphicsPipeline*)_cmdEncoder->_graphicsPipelineState.getPipeline();
 	return gp ? gp->isTessellationPipeline() : false;
-}
-
-void MVKPushConstantsCommandEncoderState::resetImpl() {
-    _pushConstants.clear();
 }
 
 
@@ -363,12 +345,6 @@ void MVKDepthStencilCommandEncoderState::encodeImpl(uint32_t stage) {
 	}
 }
 
-void MVKDepthStencilCommandEncoderState::resetImpl() {
-    _depthStencilData = kMVKMTLDepthStencilDescriptorDataDefault;
-	_hasDepthAttachment = false;
-	_hasStencilAttachment = false;
-}
-
 
 #pragma mark -
 #pragma mark MVKStencilReferenceValueCommandEncoderState
@@ -404,11 +380,6 @@ void MVKStencilReferenceValueCommandEncoderState::encodeImpl(uint32_t stage) {
     if (stage != kMVKGraphicsStageRasterization) { return; }
     [_cmdEncoder->_mtlRenderEncoder setStencilFrontReferenceValue: _frontFaceValue
                                                backReferenceValue: _backFaceValue];
-}
-
-void MVKStencilReferenceValueCommandEncoderState::resetImpl() {
-    _frontFaceValue = 0;
-    _backFaceValue = 0;
 }
 
 
@@ -453,13 +424,6 @@ void MVKDepthBiasCommandEncoderState::encodeImpl(uint32_t stage) {
     }
 }
 
-void MVKDepthBiasCommandEncoderState::resetImpl() {
-    _depthBiasConstantFactor = 0;
-    _depthBiasClamp = 0;
-    _depthBiasSlopeFactor = 0;
-    _isEnabled = false;
-}
-
 
 #pragma mark -
 #pragma mark MVKBlendColorCommandEncoderState
@@ -482,13 +446,6 @@ void MVKBlendColorCommandEncoderState::setBlendColor(float red, float green,
 void MVKBlendColorCommandEncoderState::encodeImpl(uint32_t stage) {
     if (stage != kMVKGraphicsStageRasterization) { return; }
     [_cmdEncoder->_mtlRenderEncoder setBlendColorRed: _red green: _green blue: _blue alpha: _alpha];
-}
-
-void MVKBlendColorCommandEncoderState::resetImpl() {
-    _red = 0;
-    _green = 0;
-    _blue = 0;
-    _alpha = 0;
 }
 
 
@@ -808,12 +765,6 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
     }
 }
 
-void MVKGraphicsResourcesCommandEncoderState::resetImpl() {
-	for (uint32_t i = kMVKShaderStageVertex; i <= kMVKShaderStageFragment; i++) {
-		_shaderStageResourceBindings[i].reset();
-	}
-}
-
 
 #pragma mark -
 #pragma mark MVKComputeResourcesCommandEncoderState
@@ -908,10 +859,6 @@ void MVKComputeResourcesCommandEncoderState::encodeImpl(uint32_t) {
                                              });
 }
 
-void MVKComputeResourcesCommandEncoderState::resetImpl() {
-	_resourceBindings.reset();
-}
-
 
 #pragma mark -
 #pragma mark MVKOcclusionQueryCommandEncoderState
@@ -965,10 +912,4 @@ void MVKOcclusionQueryCommandEncoderState::encodeImpl(uint32_t stage) {
 
 	[_cmdEncoder->_mtlRenderEncoder setVisibilityResultMode: _mtlVisibilityResultMode
 													 offset: _mtlVisibilityResultOffset];
-}
-
-void MVKOcclusionQueryCommandEncoderState::resetImpl() {
-    _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
-    _mtlVisibilityResultOffset = 0;
-    _mtlRenderPassQueries.clear();
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -338,7 +338,6 @@ protected:
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
 	bool _dynamicStateEnabled[kMVKVkDynamicStateCount];
-	bool _hasDepthStencilInfo;
 	bool _needsVertexSwizzleBuffer = false;
 	bool _needsVertexBufferSizeBuffer = false;
 	bool _needsVertexViewRangeBuffer = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -241,14 +241,9 @@ void MVKGraphicsPipeline::encode(MVKCommandEncoder* cmdEncoder, uint32_t stage) 
 				[mtlCmdEnc setRenderPipelineState: _mtlPipelineState];
 			}
 
-            // Depth stencil state
-            if (_hasDepthStencilInfo) {
-                cmdEncoder->_depthStencilState.setDepthStencilState(_depthStencilInfo);
-                cmdEncoder->_stencilReferenceValueState.setReferenceValues(_depthStencilInfo);
-            } else {
-                cmdEncoder->_depthStencilState.reset();
-                cmdEncoder->_stencilReferenceValueState.reset();
-            }
+            // Depth stencil state - Cleared _depthStencilInfo values will disable depth testing
+			cmdEncoder->_depthStencilState.setDepthStencilState(_depthStencilInfo);
+			cmdEncoder->_stencilReferenceValueState.setReferenceValues(_depthStencilInfo);
 
             // Rasterization
             cmdEncoder->_blendColorState.setBlendColor(_blendConstants[0], _blendConstants[1],
@@ -418,8 +413,9 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 	// Render pipeline state
 	initMTLRenderPipelineState(pCreateInfo, reflectData);
 
-	// Depth stencil content
-	_hasDepthStencilInfo = mvkSetOrClear(&_depthStencilInfo, pCreateInfo->pDepthStencilState);
+	// Depth stencil content - clearing will disable depth and stencil testing
+	mvkSetOrClear(&_depthStencilInfo, pCreateInfo->pDepthStencilState);
+//	_hasDepthStencilInfo = mvkSetOrClear(&_depthStencilInfo, pCreateInfo->pDepthStencilState);
 
 	// Viewports and scissors
 	auto pVPState = pCreateInfo->pViewportState;


### PR DESCRIPTION
`MVKCommandEncoderState` has numerous subclasses, and the polymorphic
`MVKCommandEncoderState::resetImpl()` requires significant maintenance
across these subclasses. It's only use was in disabling depth-stencil state.

Remove `MVKCommandEncoderState::reset()` and all implementations of `resetImpl()`
across all `MVKCommandEncoderState` subclasses.
Remove `MVKPipeline::__hasDepthStencilInfo` and disable depth-stencil state
automatically via cleared Vulkan struct in `MVKPipeline`.

Fixes #1264.