### PR TITLE
Fixes for CTS multithread tests.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1603,15 +1603,17 @@ bool MVKGraphicsPipeline::isRasterizationDisabled(const VkGraphicsPipelineCreate
 }
 
 MVKGraphicsPipeline::~MVKGraphicsPipeline() {
-	[_mtlTessVertexStageDesc release];
+	@synchronized (getMTLDevice()) {
+		[_mtlTessVertexStageDesc release];
 
-	[_mtlTessVertexStageState release];
-	[_mtlTessVertexStageIndex16State release];
-	[_mtlTessVertexStageIndex32State release];
-	[_mtlTessControlStageState release];
-	[_mtlPipelineState release];
+		[_mtlTessVertexStageState release];
+		[_mtlTessVertexStageIndex16State release];
+		[_mtlTessVertexStageIndex32State release];
+		[_mtlTessControlStageState release];
+		[_mtlPipelineState release];
 
-	for (id<MTLFunction> func : _mtlTessVertexFunctions) { [func release]; }
+		for (id<MTLFunction> func : _mtlTessVertexFunctions) { [func release]; }
+	}
 }
 
 
@@ -1716,7 +1718,9 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 }
 
 MVKComputePipeline::~MVKComputePipeline() {
-    [_mtlPipelineState release];
+	@synchronized (getMTLDevice()) {
+		[_mtlPipelineState release];
+	}
 }
 
 
@@ -2147,11 +2151,14 @@ id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(
 	unique_lock<mutex> lock(_completionLock);
 
 	compile(lock, ^{
-		[_owner->getMTLDevice() newRenderPipelineStateWithDescriptor: mtlRPLDesc
-												   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
-													   bool isLate = compileComplete(ps, error);
-													   if (isLate) { destroy(); }
-												   }];
+		auto mtlDev = _owner->getMTLDevice();
+		@synchronized (mtlDev) {
+			[mtlDev newRenderPipelineStateWithDescriptor: mtlRPLDesc
+									   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
+				bool isLate = compileComplete(ps, error);
+				if (isLate) { destroy(); }
+			}];
+		}
 	});
 
 	return [_mtlRenderPipelineState retain];
@@ -2178,11 +2185,14 @@ id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineSta
 	unique_lock<mutex> lock(_completionLock);
 
 	compile(lock, ^{
-		[_owner->getMTLDevice() newComputePipelineStateWithFunction: mtlFunction
-												  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
-													  bool isLate = compileComplete(ps, error);
-													  if (isLate) { destroy(); }
-												  }];
+		auto mtlDev = _owner->getMTLDevice();
+		@synchronized (mtlDev) {
+			[mtlDev newComputePipelineStateWithFunction: mtlFunction
+									  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
+				bool isLate = compileComplete(ps, error);
+				if (isLate) { destroy(); }
+			}];
+		}
 	});
 
 	return [_mtlComputePipelineState retain];
@@ -2192,12 +2202,15 @@ id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineSta
 	unique_lock<mutex> lock(_completionLock);
 
 	compile(lock, ^{
-		[_owner->getMTLDevice() newComputePipelineStateWithDescriptor: plDesc
-															  options: MTLPipelineOptionNone
-													completionHandler: ^(id<MTLComputePipelineState> ps, MTLComputePipelineReflection*, NSError* error) {
-														bool isLate = compileComplete(ps, error);
-														if (isLate) { destroy(); }
-													}];
+		auto mtlDev = _owner->getMTLDevice();
+		@synchronized (mtlDev) {
+			[mtlDev newComputePipelineStateWithDescriptor: plDesc
+												  options: MTLPipelineOptionNone
+										completionHandler: ^(id<MTLComputePipelineState> ps, MTLComputePipelineReflection*, NSError* error) {
+				bool isLate = compileComplete(ps, error);
+				if (isLate) { destroy(); }
+			}];
+		}
 	});
 
 	return [_mtlComputePipelineState retain];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2155,9 +2155,9 @@ id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(
 		@synchronized (mtlDev) {
 			[mtlDev newRenderPipelineStateWithDescriptor: mtlRPLDesc
 									   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
-				bool isLate = compileComplete(ps, error);
-				if (isLate) { destroy(); }
-			}];
+										   bool isLate = compileComplete(ps, error);
+										   if (isLate) { destroy(); }
+									   }];
 		}
 	});
 
@@ -2189,9 +2189,9 @@ id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineSta
 		@synchronized (mtlDev) {
 			[mtlDev newComputePipelineStateWithFunction: mtlFunction
 									  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
-				bool isLate = compileComplete(ps, error);
-				if (isLate) { destroy(); }
-			}];
+										  bool isLate = compileComplete(ps, error);
+										  if (isLate) { destroy(); }
+									  }];
 		}
 	});
 
@@ -2207,9 +2207,9 @@ id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineSta
 			[mtlDev newComputePipelineStateWithDescriptor: plDesc
 												  options: MTLPipelineOptionNone
 										completionHandler: ^(id<MTLComputePipelineState> ps, MTLComputePipelineReflection*, NSError* error) {
-				bool isLate = compileComplete(ps, error);
-				if (isLate) { destroy(); }
-			}];
+											bool isLate = compileComplete(ps, error);
+											if (isLate) { destroy(); }
+										}];
 		}
 	});
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -470,14 +470,12 @@ id<MTLFunction> MVKFunctionSpecializer::newMTLFunction(id<MTLLibrary> mtlLibrary
 	unique_lock<mutex> lock(_completionLock);
 
 	compile(lock, ^{
-		@synchronized (_owner->getMTLDevice()) {
-			[mtlLibrary newFunctionWithName: funcName
-							 constantValues: constantValues
-						  completionHandler: ^(id<MTLFunction> mtlFunc, NSError* error) {
-				bool isLate = compileComplete(mtlFunc, error);
-				if (isLate) { destroy(); }
-			}];
-		}
+		[mtlLibrary newFunctionWithName: funcName
+						 constantValues: constantValues
+					  completionHandler: ^(id<MTLFunction> mtlFunc, NSError* error) {
+			bool isLate = compileComplete(mtlFunc, error);
+			if (isLate) { destroy(); }
+		}];
 	});
 
 	return [_mtlFunction retain];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -429,9 +429,9 @@ id<MTLLibrary> MVKShaderLibraryCompiler::newMTLLibrary(NSString* mslSourceCode,
 								 options: _owner->getDevice()->getMTLCompileOptions(shaderConversionResults.entryPoint.supportsFastMath,
 																					shaderConversionResults.isPositionInvariant)
 					   completionHandler: ^(id<MTLLibrary> mtlLib, NSError* error) {
-				bool isLate = compileComplete(mtlLib, error);
-				if (isLate) { destroy(); }
-			}];
+						   bool isLate = compileComplete(mtlLib, error);
+						   if (isLate) { destroy(); }
+					   }];
 		}
 	});
 
@@ -473,9 +473,9 @@ id<MTLFunction> MVKFunctionSpecializer::newMTLFunction(id<MTLLibrary> mtlLibrary
 		[mtlLibrary newFunctionWithName: funcName
 						 constantValues: constantValues
 					  completionHandler: ^(id<MTLFunction> mtlFunc, NSError* error) {
-			bool isLate = compileComplete(mtlFunc, error);
-			if (isLate) { destroy(); }
-		}];
+						  bool isLate = compileComplete(mtlFunc, error);
+						  if (isLate) { destroy(); }
+					  }];
 	});
 
 	return [_mtlFunction retain];


### PR DESCRIPTION
`MTLDevice` retains an internal object web that is used during the creation of
new objects, such as pipeline states, libraries, functions, and samplers.
Simultaneously creating and destroying objects of these types can trigger
race conditions on the internal `MTLDevice` content.

Wrap the following in `@synchronized (mtlDevice) {...}`:
- `MTLRenderPipelineState` creation and destruction
- `MTLComputePipelineState` creation and destruction
- `MTLLibrary` creation
- `MTLFunction` creation
- `MTLSampler` creation and destruction

Fixes #1269.