### PR TITLE
Report accurate value for VkPhysicalDeviceLimits::maxBoundDescriptorSets.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -16,7 +16,7 @@ Copyright (c) 2015-2021 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 MoltenVK 1.1.2
 --------------
 
-Released TBD
+Released 2021/02/22
 
 - Advertise support for `shaderInt64` feature.
 - Support fast math on MSL compiler via `MVKConfiguration::fastMathEnabled` configuration 
@@ -25,6 +25,7 @@ Released TBD
 - `vkGetMoltenVKConfigurationMVK()` and `vkSetMoltenVKConfigurationMVK()` functions
   can now be used with a `VkInstance` from another Vulkan layer, or with a `VK_NULL_HANDLE VkInstance`.
 - `MVKConfiguration` extended to cover all MoltenVK environment variables.
+- Report accurate value of 8 for `VkPhysicalDeviceLimits::maxBoundDescriptorSets`.
 - Add ability to automatically capture first GPU frame by setting `MVKConfiguration::autoGPUCaptureScope`
   (or environment variable `MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE`) to `2`.
 - Remove official support for submitting shaders directly containing MSL source code or compiled MSL code.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -80,6 +80,7 @@ const static uint32_t kMVKMinSwapchainImageCount = 2;
 const static uint32_t kMVKMaxSwapchainImageCount = 3;
 const static uint32_t kMVKCachedViewportScissorCount = 16;
 const static uint32_t kMVKCachedColorAttachmentCount = 8;
+const static uint32_t kMVKMaxDescriptorSetCount = SPIRV_CROSS_NAMESPACE::kMaxArgumentBuffers;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2053,7 +2053,7 @@ void MVKPhysicalDevice::initLimits() {
 
     _properties.limits.maxMemoryAllocationCount = kMVKUndefinedLargeUInt32;
     _properties.limits.maxSamplerAllocationCount = kMVKUndefinedLargeUInt32;
-    _properties.limits.maxBoundDescriptorSets = kMVKUndefinedLargeUInt32;
+    _properties.limits.maxBoundDescriptorSets = kMVKMaxDescriptorSetCount;
 
     _properties.limits.maxComputeWorkGroupCount[0] = kMVKUndefinedLargeUInt32;
     _properties.limits.maxComputeWorkGroupCount[1] = kMVKUndefinedLargeUInt32;


### PR DESCRIPTION
This value is derived from limit expected by SPIRV-Cross.
The previous unbounded value was breaking CTS tests that used this value.