### PR TITLE
Set Metal buffer alignment to 256 on non-Apple Silicon iOS/tvOS simulators.

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -77,19 +77,19 @@ extern "C" {
 #	define MVK_OS_SIMULATOR			TARGET_OS_SIMULATOR
 #endif
 
-/** Building for macOS with support for Apple Silicon. */
-#ifndef MVK_MACOS_APPLE_SILICON
-#	define MVK_MACOS_APPLE_SILICON	(__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600)
+/** Building for Apple Silicon on iOS, tvOS, or macOS platform. */
+#ifndef MVK_APPLE_SILICON
+#	define MVK_APPLE_SILICON    	TARGET_CPU_ARM64
 #endif
 
-/** Building for Apple Silicon. */
-#ifndef MVK_APPLE_SILICON
-#	define MVK_APPLE_SILICON    	(MVK_IOS || MVK_TVOS || MVK_MACOS_APPLE_SILICON)
+/** Building for macOS with support for Apple Silicon. */
+#ifndef MVK_MACOS_APPLE_SILICON
+#	define MVK_MACOS_APPLE_SILICON	(MVK_MACOS && MVK_APPLE_SILICON)
 #endif
 
 /** Building with Xcode 12. */
 #ifndef MVK_XCODE_12
-#	define MVK_XCODE_12 			(MVK_MACOS_APPLE_SILICON || \
+#	define MVK_XCODE_12 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600) || \
 									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000))	// Also covers tvOS
 #endif
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1546,13 +1546,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 	}
 
-	// iOS and tvOS adjustments necessary when running in the simulator on non-Apple GPUs.
-	// Apple1 used as baseline for detecting Apple Silicon on macOS because Apple7 not supported for tvOS.
-	// Must run after setting native iOS and tvOS values above.
-#if MVK_OS_SIMULATOR
-	if ( !supportsMTLGPUFamily(Apple1) ) {
-		_metalFeatures.mtlBufferAlignment = 256;
-	}
+// iOS and tvOS adjustments necessary when running in the simulator on non-Apple GPUs.
+#if MVK_OS_SIMULATOR && !MVK_APPLE_SILICON
+	_metalFeatures.mtlBufferAlignment = 256;
 #endif
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1428,7 +1428,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		if (supportsMTLGPUFamily(Apple5)) {
 			// This is an Apple GPU--treat it accordingly.
 			_metalFeatures.mtlCopyBufferAlignment = 1;
-			_metalFeatures.mtlBufferAlignment = 16;
+			_metalFeatures.mtlBufferAlignment = 16;     // Min float4 alignment for typical vertex buffers. MTLBuffer may go down to 4 bytes for other data.
 			_metalFeatures.maxQueryBufferSize = (64 * KIBI);
 			_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 			_metalFeatures.postDepthCoverage = true;
@@ -1545,6 +1545,15 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			break;
 #endif
 	}
+
+	// iOS and tvOS adjustments necessary when running in the simulator on non-Apple GPUs.
+	// Apple1 used as baseline for detecting Apple Silicon on macOS because Apple7 not supported for tvOS.
+	// Must run after setting native iOS and tvOS values above.
+#if MVK_OS_SIMULATOR
+	if ( !supportsMTLGPUFamily(Apple1) ) {
+		_metalFeatures.mtlBufferAlignment = 256;
+	}
+#endif
 }
 
 // Initializes the physical device features of this instance.


### PR DESCRIPTION
Derive `MVK_APPLE_SILICON` from target CPU.
Derive `MVK_MACOS_APPLE_SILICON` from target CPU and macOS platform.
Derive `MVK_XCODE_12` from macOS and iOS SDK versions.
Test for simulator on non-Apple GPU using `MVK_OS_SIMULATOR` && !MVK_APPLE_SILICON`.

Fixes issue #1250.