### PR TITLE
Log enhanced command buffer errors in debug mode.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -78,7 +78,7 @@ void MVKCommandPool::freeCommandBuffers(uint32_t commandBufferCount,
 }
 
 id<MTLCommandBuffer> MVKCommandPool::newMTLCommandBuffer(uint32_t queueIndex) {
-	return [[_device->getQueue(_queueFamilyIndex, queueIndex)->getMTLCommandQueue() commandBuffer] retain];
+	return [_device->getQueue(_queueFamilyIndex, queueIndex)->getMTLCommandBuffer(true) retain];
 }
 
 // Clear the command type pool member variables.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -109,7 +109,7 @@ VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset,
 
 #if MVK_MACOS
 		if (pBlitEnc && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {
-			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = [_device->getAnyQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]; }
+			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = _device->getAnyQueue()->getMTLCommandBuffer(); }
 			if ( !pBlitEnc->mtlBlitEncoder) { pBlitEnc->mtlBlitEncoder = [pBlitEnc->mtlCmdBuffer blitCommandEncoder]; }
 			[pBlitEnc->mtlBlitEncoder synchronizeResource: _mtlBuffer];
 		}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1209,7 +1209,7 @@ void MVKPresentableSwapchainImage::acquireAndSignalWhenAvailable(MVKSemaphore* s
 		@autoreleasepool {
 			MVKSemaphore* mvkSem = signaler.semaphore;
 			id<MTLCommandBuffer> mtlCmdBuff = (mvkSem && mvkSem->isUsingCommandEncoding()
-											   ? [_device->getAnyQueue()->getMTLCommandQueue() commandBufferWithUnretainedReferences]
+											   ? _device->getAnyQueue()->getMTLCommandBuffer()
 											   : nil);
 			signal(signaler, mtlCmdBuff);
 			[mtlCmdBuff commit];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -106,6 +106,9 @@ public:
 	/** Returns the Metal queue underlying this queue. */
 	inline id<MTLCommandQueue> getMTLCommandQueue() { return _mtlQueue; }
 
+	/** Returns a Metal command buffer from the Metal queue. */
+	id<MTLCommandBuffer> getMTLCommandBuffer(bool retainRefs = false);
+
 #pragma mark Construction
 	
 	/** Constructs an instance for the device and queue family. */


### PR DESCRIPTION
If we're on macOS 11 or iOS/tvOS 14, and debug mode (`MVK_DEBUG=1`) were
enabled, then we'll enable enhanced command buffer errors, which give us
more information about which encoder triggered the error. We'll also
print log messages from shader validation.