### PR TITLE
Permit extension functions when all extensions have been disabled via configuration.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -43,8 +43,9 @@ typedef struct {
 
 	bool isCore() { return !ext1Name && !ext2Name; }
 	bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList) {
-		return (isCore() && MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion) ||
-			   extList.isEnabled(ext1Name) || extList.isEnabled(ext2Name);
+		return ((isCore() && MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion) ||
+				(extList.isEnabled(ext1Name) || extList.isEnabled(ext2Name) ||
+				 !mvkGetMVKConfiguration()->advertiseExtensions));
 	}
 } MVKEntryPoint;
 


### PR DESCRIPTION
When `mvkGetMVKConfiguration()->advertiseExtensions` is disabled, and MoltenVK
artificially advertises that all extensions are not supported, allow the functions
of those extensions to be called anyway.

Some CTS tests are structured to assume one or more basic extensions are supported,
and currently do not bother checking for those extensions and provide alternate code paths
based on the extension not being supported. Permitting the calls to be made anyway
allows those tests to proceed and avoid crashing.

I have posted a [CTS issue](https://github.com/KhronosGroup/VK-GL-CTS/issues/245) to request the underlying situation be fixed.