### PR TITLE
Remove project qualifiers from references to SPIRV-Cross and glslang header files.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.1.3
 
 Released TBD
 
+- Remove project qualifiers from references to `SPIRV-Cross` and `glslang` header files.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.
 - Add `MVKConfiguration::advertiseExtensions` and `MVK_CONFIG_ADVERTISE_EXTENSIONS` 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,7 +18,7 @@ MoltenVK 1.1.3
 
 Released TBD
 
-- Remove project qualifiers from references to `SPIRV-Cross` and `glslang` header files.
+- Remove project qualifiers from references to `SPIRV-Cross` header files.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.
 - Add `MVKConfiguration::advertiseExtensions` and `MVK_CONFIG_ADVERTISE_EXTENSIONS` 

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -1580,6 +1580,7 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/include\"",
 					"\"$(SRCROOT)/../MoltenVKShaderConverter\"",
+					"\"$(SRCROOT)/../MoltenVKShaderConverter/SPIRV-Cross\"",
 					"\"$(SRCROOT)/../External/cereal/include\"",
 					"\"${BUILT_PRODUCTS_DIR}\"",
 				);
@@ -1646,6 +1647,7 @@
 				HEADER_SEARCH_PATHS = (
 					"\"$(SRCROOT)/include\"",
 					"\"$(SRCROOT)/../MoltenVKShaderConverter\"",
+					"\"$(SRCROOT)/../MoltenVKShaderConverter/SPIRV-Cross\"",
 					"\"$(SRCROOT)/../External/cereal/include\"",
 					"\"${BUILT_PRODUCTS_DIR}\"",
 				);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -22,7 +22,7 @@
 #include "MVKEnvironment.h"
 #include "MVKOSExtensions.h"
 #include "MVKBaseObject.h"
-#include <SPIRV-Cross/spirv_msl.hpp>
+#include <spirv_msl.hpp>
 #include <unordered_map>
 
 #import <Metal/Metal.h>

--- a/MoltenVKShaderConverter/Common/SPIRVSupport.cpp
+++ b/MoltenVKShaderConverter/Common/SPIRVSupport.cpp
@@ -18,7 +18,7 @@
 
 #include "SPIRVSupport.h"
 #include "MVKStrings.h"
-#include <SPIRV-Cross/spirv.hpp>
+#include <spirv.hpp>
 #include <ostream>
 
 #import <CoreFoundation/CFByteOrder.h>

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -625,7 +625,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)\"",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 				);
@@ -680,7 +680,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)\"",
+					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
 				);

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",
@@ -680,6 +681,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)\"",
 					"\"$(SRCROOT)/SPIRV-Cross\"",
 					"\"$(SRCROOT)/glslang\"",
 					"\"$(SRCROOT)/glslang/External/spirv-tools/include\"",

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
@@ -21,7 +21,7 @@
 #include "SPIRVToMSLConverter.h"
 #include "SPIRVSupport.h"
 #include "MVKStrings.h"
-#include <glslang/SPIRV/GlslangToSpv.h>
+#include <SPIRV/GlslangToSpv.h>
 #include <sstream>
 
 using namespace std;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
@@ -21,7 +21,7 @@
 #include "SPIRVToMSLConverter.h"
 #include "SPIRVSupport.h"
 #include "MVKStrings.h"
-#include <SPIRV/GlslangToSpv.h>
+#include <glslang/SPIRV/GlslangToSpv.h>
 #include <sstream>
 
 using namespace std;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVReflection.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVReflection.h
@@ -19,10 +19,10 @@
 #ifndef __SPIRVReflection_h_
 #define __SPIRVReflection_h_ 1
 
-#include <SPIRV-Cross/spirv.hpp>
-#include <SPIRV-Cross/spirv_common.hpp>
-#include <SPIRV-Cross/spirv_parser.hpp>
-#include <SPIRV-Cross/spirv_reflect.hpp>
+#include <spirv.hpp>
+#include <spirv_common.hpp>
+#include <spirv_parser.hpp>
+#include <spirv_reflect.hpp>
 #include <string>
 #include <vector>
 

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
@@ -19,8 +19,8 @@
 #ifndef __SPIRVToMSLConverter_h_
 #define __SPIRVToMSLConverter_h_ 1
 
-#include <SPIRV-Cross/spirv.hpp>
-#include <SPIRV-Cross/spirv_msl.hpp>
+#include <spirv.hpp>
+#include <spirv_msl.hpp>
 #include <string>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
Remove `SPIRV-Cross/` qualifier from include references to SPIRV-Cross header files.
Remove `glslang/` qualifier from include references to glslang header files.
This change allows easier integration with app build scripts.

Fixes issue #1279.