### PR TITLE
Extend MVKConfiguration::advertiseExtensions to optionally specify a few extensions.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,7 +22,7 @@ Released TBD
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.
 - Add `MVKConfiguration::advertiseExtensions` and `MVK_CONFIG_ADVERTISE_EXTENSIONS` 
-  env var to configure **MoltenVK** to not advertise support for any _Vulkan_  extensions.
+  env var to configure **MoltenVK** to force advertising support for no, or minimal, _Vulkan_  extensions.
 - Remove the `Hologram` and `API-Samples` demo apps, and remove 
   `LunarG/VulkanSamples` as a dependency library.
 - Add `NDEBUG` macro to all Release builds to remove `assert()` calls.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -58,6 +58,18 @@ typedef unsigned long MTLLanguageVersion;
 #define VK_MVK_MOLTENVK_SPEC_VERSION            31
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
+/** Identifies extensions to advertise as part of MoltenVK configuration. */
+typedef enum MVKConfigAdvertiseExtensionBits {
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL                       = 0x00000001,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_VK_MVK_MOLTENVK           = 0x00000002,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_VK_MVK_IOS_SURFACE        = 0x00000004,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_VK_MVK_MACOS_SURFACE      = 0x00000008,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_VK_EXT_METAL_SURFACE      = 0x00000010,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_VK_KHR_PORTABILITY_SUBSET = 0x00000020,
+	MVK_CONFIG_ADVERTISE_EXTENSIONS_MAX_ENUM = 0x7FFFFFFF
+} MVKConfigAdvertiseExtensionBits;
+typedef VkFlags MVKConfigAdvertiseExtensions;
+
 /**
  * MoltenVK configuration settings.
  *
@@ -732,10 +744,12 @@ typedef struct {
 	uint32_t apiVersionToAdvertise;
 
 	/**
-	 * Controls whether MoltenVK should advertise the Vulkan extensions it supports in
+	 * Controls which extensions MoltenVK should advertise it supports in
 	 * vkEnumerateInstanceExtensionProperties() and vkEnumerateDeviceExtensionProperties().
-	 * If this setting is enabled, all supported extensions will be advertised.
-	 * If this setting is disabled, only VK_KHR_portability_subset will be advertised.
+	 * The value of this parameter is a bitwise OR of values from the MVKConfigAdvertiseExtensionBits
+	 * enumeration. Any prerequisite extentions are also advertised.
+	 * If the flag MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL is included, all supported extensions
+	 * will be advertised. A value of zero means no extensions will be advertised.
 	 *
 	 * The value of this parameter must be changed before creating a VkInstance,
 	 * for the change to take effect.
@@ -743,10 +757,10 @@ typedef struct {
 	 * The initial value or this parameter is set by the
 	 * MVK_CONFIG_ADVERTISE_EXTENSIONS
 	 * runtime environment variable or MoltenVK compile-time build setting.
-	 * If neither is set, this setting is enabled by default, and all supported
-	 * extensions will be advertised.
+	 * If neither is set, the value of this setting defaults to
+	 * MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL, and all supported extensions will be advertised.
 	 */
-	VkBool32 advertiseExtensions;
+	MVKConfigAdvertiseExtensions advertiseExtensions;
 
 } MVKConfiguration;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -42,10 +42,15 @@ typedef struct {
 	bool isDevice;
 
 	bool isCore() { return !ext1Name && !ext2Name; }
+
+	// If we're artificially running without all supported extensions, allow the
+	// associated functions to be available anyway, in case the app is surprised
+	// (ie- expects the functions from past experience and has no alternate handling).
 	bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList) {
 		return ((isCore() && MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion) ||
 				(extList.isEnabled(ext1Name) || extList.isEnabled(ext2Name) ||
-				 !mvkGetMVKConfiguration()->advertiseExtensions));
+				 !mvkIsAnyFlagEnabled(mvkGetMVKConfiguration()->advertiseExtensions,
+									  MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL)));
 	}
 } MVKEntryPoint;
 

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -59,7 +59,7 @@ static void mvkInitConfigFromEnvVars() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.useCommandPooling,                      MVK_CONFIG_USE_COMMAND_POOLING);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.useMTLHeap,                             MVK_CONFIG_USE_MTLHEAP);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.apiVersionToAdvertise,                  MVK_CONFIG_API_VERSION_TO_ADVERTISE);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.advertiseExtensions,                    MVK_CONFIG_ADVERTISE_EXTENSIONS);
+	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.advertiseExtensions,                    MVK_CONFIG_ADVERTISE_EXTENSIONS);
 
 	mvkSetMVKConfiguration(&evCfg);
 }

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -283,7 +283,7 @@ void mvkSetMVKConfiguration(MVKConfiguration* pMVKConfig);
 #  	define MVK_CONFIG_API_VERSION_TO_ADVERTISE    MVK_VULKAN_API_VERSION
 #endif
 
-/** Advertise supported extensions. Enabled by default. */
+/** Advertise supported extensions. Defaults to all. */
 #ifndef MVK_CONFIG_ADVERTISE_EXTENSIONS
-#  	define MVK_CONFIG_ADVERTISE_EXTENSIONS    1
+#  	define MVK_CONFIG_ADVERTISE_EXTENSIONS    MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL
 #endif


### PR DESCRIPTION
Introduce `MVKConfigAdvertiseExtensionBits` enum to specify multiple API config values in
a Vulkan-friendly manner, while automatically documenting the same values for env vars.