### PR TITLE
Fixes to auto GPU capture

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -698,27 +698,17 @@ public:
 	 * capture scope, and if so, starts capturing from the specified Metal capture object.
 	 * The capture will be made either to Xcode, or to a file if one has been configured.
 	 *
-	 * The autoGPUCaptureScope parameter must be one of:
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME
-	 *
 	 * The mtlCaptureObject must be one of:
 	 *   - MTLDevice for scope MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE
 	 *   - MTLCommandQueue for scope MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME.
 	 */
-	void startAutoGPUCapture(int32_t autoGPUCaptureScope, id mtlCaptureObject);
+	void startAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope, id mtlCaptureObject);
 
 	/**
 	 * Checks if automatic GPU capture is enabled for the specified
 	 * auto capture scope, and if so, stops capturing.
-	 *
-	 * The autoGPUCaptureScope parameter must be one of:
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE
-	 *   - MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME
 	 */
-	void stopAutoGPUCapture(int32_t autoGPUCaptureScope);
+	void stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope);
 
 	/** Returns whether this instance is currently automatically capturing a GPU trace. */
 	inline bool isCurrentlyAutoGPUCapturing() { return _isCurrentlyAutoGPUCapturing; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3680,7 +3680,7 @@ bool MVKDevice::shouldPrefillMTLCommandBuffers() {
 			  _enabledInlineUniformBlockFeatures.descriptorBindingInlineUniformBlockUpdateAfterBind));
 }
 
-void MVKDevice::startAutoGPUCapture(int32_t autoGPUCaptureScope, id mtlCaptureObject) {
+void MVKDevice::startAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope, id mtlCaptureObject) {
 
 	if (_isCurrentlyAutoGPUCapturing || (mvkGetMVKConfiguration()->autoGPUCaptureScope != autoGPUCaptureScope)) { return; }
 
@@ -3729,7 +3729,7 @@ void MVKDevice::startAutoGPUCapture(int32_t autoGPUCaptureScope, id mtlCaptureOb
 	}
 }
 
-void MVKDevice::stopAutoGPUCapture(int32_t autoGPUCaptureScope) {
+void MVKDevice::stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope) {
 	if (_isCurrentlyAutoGPUCapturing && mvkGetMVKConfiguration()->autoGPUCaptureScope == autoGPUCaptureScope) {
 		[[MTLCaptureManager sharedCaptureManager] stopCapture];
 		_isCurrentlyAutoGPUCapturing = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -214,13 +214,15 @@ void MVKQueue::initMTLCommandQueue() {
 void MVKQueue::initGPUCaptureScopes() {
 	_submissionCaptureScope = new MVKGPUCaptureScope(this);
 
-	if (_queueFamily->getIndex() == mvkGetMVKConfiguration()->defaultGPUCaptureScopeQueueFamilyIndex &&
-		_index == mvkGetMVKConfiguration()->defaultGPUCaptureScopeQueueIndex) {
+	const MVKConfiguration* pMVKConfig = mvkGetMVKConfiguration();
+	if (_queueFamily->getIndex() == pMVKConfig->defaultGPUCaptureScopeQueueFamilyIndex &&
+		_index == pMVKConfig->defaultGPUCaptureScopeQueueIndex) {
+
+		getDevice()->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME, _mtlQueue);
 		_submissionCaptureScope->makeDefault();
+
 	}
 	_submissionCaptureScope->beginScope();	// Allow Xcode to capture the first frame if desired.
-
-	getDevice()->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME, _mtlQueue);
 }
 
 MVKQueue::~MVKQueue() {

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -222,9 +222,6 @@ void mvkSetMVKConfiguration(MVKConfiguration* pMVKConfig);
  * developer having to trigger it manually via the Xcode UI. This is useful when trying
  * to capture a one-shot trace, such as when running a Vulkan CTS test case.
  */
-#define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE		0
-#define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE	1
-#define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME		2
 #ifndef MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE
 #   define MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE    	MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE
 #endif


### PR DESCRIPTION
Only start frame-scope automatic GPU capture on queue identified by `MVKConfiguration::defaultGPUCaptureScopeQueueFamilyIndex`
and `defaultGPUCaptureScopeQueueIndex`.

Introduce `MVKConfigAutoGPUCaptureScopeBits` enum to specify values of
`MVKConfiguration::autoGPUCaptureScope` in a Vulkan-friendly manner,
while automatically documenting the same values for env vars.

Update some config documentation.

Fixes #1296.