### PR TITLE
Create enums for remaining MVKConfiguration enumerated values.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -58,6 +58,25 @@ typedef unsigned long MTLLanguageVersion;
 #define VK_MVK_MOLTENVK_SPEC_VERSION            31
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
+/** Identifies the level of logging MoltenVK should be limited to outputting. */
+typedef enum MVKConfigLogLevelBits {
+	MVK_CONFIG_LOG_LEVEL_NONE     = 0,	/**< No logging. */
+	MVK_CONFIG_LOG_LEVEL_ERROR    = 1,	/**< Log errors only. */
+	MVK_CONFIG_LOG_LEVEL_INFO     = 2,	/**< Log errors and informational messages. */
+	MVK_CONFIG_LOG_LEVEL_MAX_ENUM = 0x7FFFFFFF
+} MVKConfigLogLevelBits;
+typedef VkFlags MVKConfigLogLevel;
+
+/** Identifies the level of Vulkan call trace logging MoltenVK should perform. */
+typedef enum MVKConfigTraceVulkanCallsBits {
+	MVK_CONFIG_TRACE_VULKAN_CALLS_NONE       = 0,	/**< No Vulkan call logging. */
+	MVK_CONFIG_TRACE_VULKAN_CALLS_ENTER      = 1,	/**< Log the name of each Vulkan call when the call is entered. */
+	MVK_CONFIG_TRACE_VULKAN_CALLS_ENTER_EXIT = 2,	/**< Log the name of each Vulkan call when the call is entered and exited. This effectively brackets any other logging activity within the scope of the Vulkan call. */
+	MVK_CONFIG_TRACE_VULKAN_CALLS_DURATION   = 3,	/**< Same as MVK_CONFIG_TRACE_VULKAN_CALLS_ENTER_EXIT, plus logs the time spent inside the Vulkan function. */
+	MVK_CONFIG_TRACE_VULKAN_CALLS_MAX_ENUM   = 0x7FFFFFFF
+} MVKConfigTraceVulkanCallsBits;
+typedef VkFlags MVKConfigTraceVulkanCalls;
+
 /** Identifies the scope for Metal to run an automatic GPU capture for diagnostic debugging purposes. */
 typedef enum MVKConfigAutoGPUCaptureScopeBits {
 	MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_NONE     = 0,	/**< No automatic GPU capture. */
@@ -498,10 +517,7 @@ typedef struct {
 	VkBool32 fastMathEnabled;
 
 	/**
-	 * Controls the level of logging performned by MoltenVK using the following numeric values:
-	 *   0: No logging.
-	 *   1: Log errors only.
-	 *   2: Log errors and informational messages.
+	 * Controls the level of logging performned by MoltenVK.
 	 *
 	 * The value of this parameter may be changed at any time during application runtime,
 	 * and the changed value will immediately effect subsequent MoltenVK behaviour.
@@ -511,18 +527,11 @@ typedef struct {
 	 * runtime environment variable or MoltenVK compile-time build setting.
 	 * If neither is set, errors and informational messages are logged.
 	 */
-	uint32_t logLevel;
+	MVKConfigLogLevel logLevel;
 
 	/**
 	 * Causes MoltenVK to log the name of each Vulkan call made by the application,
 	 * along with the Mach thread ID, global system thread ID, and thread name.
-	 * The logging format options can be controlled as follows:
-	 *   0: No Vulkan call logging.
-	 *   1: Log the name of each Vulkan call when the call is entered.
-	 *   2: Log the name of each Vulkan call when the call is entered and exited. This
-	 *      effectively brackets any other logging activity within the scope of the Vulkan call.
-	 *   3: Same as option 2, plus logs the time spent inside the Vulkan function.
-	 * If none of these is set, no Vulkan call logging will occur.
 	 *
 	 * The value of this parameter may be changed at any time during application runtime,
 	 * and the changed value will immediately effect subsequent MoltenVK behaviour.
@@ -532,7 +541,7 @@ typedef struct {
 	 * runtime environment variable or MoltenVK compile-time build setting.
 	 * If neither is set, no Vulkan call logging will occur.
 	 */
-	uint32_t traceVulkanCalls;
+	MVKConfigTraceVulkanCalls traceVulkanCalls;
 
 	/**
 	 * Force MoltenVK to use a low-power GPU, if one is availble on the device.

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -178,26 +178,14 @@ void mvkSetMVKConfiguration(MVKConfiguration* pMVKConfig);
 #   define MVK_CONFIG_FAST_MATH_ENABLED 1
 #endif
 
-/**
- * Set the logging level:
- *   0 = None
- *   1 = Errors only
- *   2 = All
- */
+/** Set the logging level: */
 #ifndef MVK_CONFIG_LOG_LEVEL
-#   define MVK_CONFIG_LOG_LEVEL    2
+#   define MVK_CONFIG_LOG_LEVEL    MVK_CONFIG_LOG_LEVEL_INFO
 #endif
 
-/**
- * Set the Vulkan call logging level:
- *   0: No Vulkan call logging.
- *   1: Log the name of each Vulkan call when the call is entered.
- *   2: Log the name of each Vulkan call when the call is entered and exited. This effectively
- *      brackets any other logging activity within the scope of the Vulkan call.
- *   3: Same as option 2, plus logs the time spent inside the Vulkan function.
- */
+/** Set the Vulkan call logging level. */
 #ifndef MVK_CONFIG_TRACE_VULKAN_CALLS
-#   define MVK_CONFIG_TRACE_VULKAN_CALLS    0
+#   define MVK_CONFIG_TRACE_VULKAN_CALLS    MVK_CONFIG_TRACE_VULKAN_CALLS_NONE
 #endif
 
 /**

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -48,23 +48,12 @@
 #pragma mark -
 #pragma mark Vulkan call templates
 
-typedef enum {
-	MVKVulkanCallTraceLevelNone = 0,
-	MVKVulkanCallTraceLevelFunctionName = 1,
-	MVKVulkanCallTraceLevelFunctionScope = 2,
-	MVKVulkanCallTraceLevelFunctionTime = 3,
-	MVKVulkanCallTraceLevelFunctionMax
-} MVKVulkanCallTraceLevel;
-
-// Returns Vulkan call trace level from environment variable.
-static inline uint32_t getCallTraceLevel() { return mvkGetMVKConfiguration()->traceVulkanCalls; }
-
 // Optionally log start of function calls to stderr
 static inline uint64_t MVKTraceVulkanCallStartImpl(const char* funcName) {
-	uint32_t traceLvl = getCallTraceLevel();
+	MVKConfigTraceVulkanCalls traceLvl = mvkGetMVKConfiguration()->traceVulkanCalls;
 
-	if (traceLvl == MVKVulkanCallTraceLevelNone ||
-		traceLvl >= MVKVulkanCallTraceLevelFunctionMax) { return 0; }
+	if (traceLvl == MVK_CONFIG_TRACE_VULKAN_CALLS_NONE ||
+		traceLvl > MVK_CONFIG_TRACE_VULKAN_CALLS_DURATION) { return 0; }
 
 	uint64_t gtid, mtid;
 	const uint32_t kThreadNameBuffSize = 256;
@@ -75,19 +64,19 @@ static inline uint64_t MVKTraceVulkanCallStartImpl(const char* funcName) {
 	pthread_getname_np(tid, threadName, kThreadNameBuffSize);
 
 	fprintf(stderr, "[mvk-trace] %s()%s [%llu/%llu/%s]\n",
-			funcName, (traceLvl >= MVKVulkanCallTraceLevelFunctionScope) ? " {" : "",
+			funcName, (traceLvl >= MVK_CONFIG_TRACE_VULKAN_CALLS_ENTER_EXIT) ? " {" : "",
 			mtid, gtid, threadName);
 
-	return (traceLvl >= MVKVulkanCallTraceLevelFunctionTime) ? mvkGetTimestamp() : 0;
+	return (traceLvl == MVK_CONFIG_TRACE_VULKAN_CALLS_DURATION) ? mvkGetTimestamp() : 0;
 }
 
 // Optionally log end of function calls and timings to stderr
 static inline void MVKTraceVulkanCallEndImpl(const char* funcName, uint64_t startTime) {
-	switch(getCallTraceLevel()) {
-		case MVKVulkanCallTraceLevelFunctionTime:
+	switch(mvkGetMVKConfiguration()->traceVulkanCalls) {
+		case MVK_CONFIG_TRACE_VULKAN_CALLS_DURATION:
 			fprintf(stderr, "[mvk-trace] } %s [%.4f ms]\n", funcName, mvkGetElapsedMilliseconds(startTime));
 			break;
-		case MVKVulkanCallTraceLevelFunctionScope:
+		case MVK_CONFIG_TRACE_VULKAN_CALLS_ENTER_EXIT:
 			fprintf(stderr, "[mvk-trace] } %s\n", funcName);
 			break;
 		default:


### PR DESCRIPTION
Introduce `MVKConfigLogLevelBits` enum to specify values of
`MVKConfiguration::logLevel` in a Vulkan-friendly manner,
while automatically documenting the same values for env vars.

Introduce `MVKConfigTraceVulkanCallsBits` enum to specify values of
`MVKConfiguration::traceVulkanCalls` in a Vulkan-friendly manner,
while automatically documenting the same values for env vars.