### PR TITLE
Several surface format and colorspace fixes.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.1.3
 
 Released TBD
 
+- Add support for `HDR10` colorspace via `VK_COLOR_SPACE_HDR10_HLG_EXT` and `VK_COLOR_SPACE_HDR10_ST2084_EXT`.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.1.3
 Released TBD
 
 - Add support for `HDR10` colorspace via `VK_COLOR_SPACE_HDR10_HLG_EXT` and `VK_COLOR_SPACE_HDR10_ST2084_EXT`.
+- Always explicitly set `CAMetalLayer` colorspace property based on _Vulkan_ parameters, and don't rely on _Metal_ default values.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -871,12 +871,12 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 			colorSpaces.push_back(VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_BT2020_LINEAR_EXT);
 		}
-// Awaiting Xcode 12 with macOS 11.0 and iOS/tvOS 14 SDK to build.
-// Coordinate with MVKSwapchain::initCAMetalLayer().
-//		if (mvkOSVersionIsAtLeast(11.0)) {
-//			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
-//			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
-//		}
+#if MVK_XCODE_12
+		if (mvkOSVersionIsAtLeast(11.0)) {
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
+		}
+#endif
 #endif
 #if MVK_IOS_OR_TVOS
 		// iOS 8 doesn't support anything but sRGB.
@@ -895,12 +895,12 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 			colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_LINEAR_EXT);
 			colorSpaces.push_back(VK_COLOR_SPACE_BT2020_LINEAR_EXT);
 		}
-// Awaiting Xcode 12 with macOS 11.0 and iOS/tvOS 14 SDK to build.
-// Coordinate with MVKSwapchain::initCAMetalLayer().
-//		if (mvkOSVersionIsAtLeast(14.0)) {
-//			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
-//			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
-//		}
+#if MVK_XCODE_12
+		if (mvkOSVersionIsAtLeast(14.0)) {
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_HLG_EXT);
+			colorSpaces.push_back(VK_COLOR_SPACE_HDR10_ST2084_EXT);
+		}
+#endif
 #endif
 	}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -311,18 +311,16 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearITUR_2020;
 			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
 			break;
-// Awaiting Xcode 12 with macOS 11.0 and iOS/tvOS 14 SDK to build with kCGColorSpaceITUR_2100_PQ
-// and kCGColorSpaceITUR_2100_HLG. The previous values kCGColorSpaceITUR_2020_PQ_EOTF and
-// kCGColorSpaceITUR_2020_HLG now incorrectly break App Store submissions.
-// Coordinate with MVKPhysicalDevice::getSurfaceFormats().
-//		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
-//			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_PQ;
-//			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-//			break;
-//		case VK_COLOR_SPACE_HDR10_HLG_EXT:
-//			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_HLG;
-//			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-//			break;
+#if MVK_XCODE_12
+		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_PQ;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+			break;
+		case VK_COLOR_SPACE_HDR10_HLG_EXT:
+			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_HLG;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+			break;
+#endif
 		case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceAdobeRGB1998;
 			break;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -283,6 +283,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 	switch (pCreateInfo->imageColorSpace) {
 		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceSRGB;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
 			break;
 		case VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceDisplayP3;
@@ -306,6 +307,7 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 			break;
 		case VK_COLOR_SPACE_BT709_NONLINEAR_EXT:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_709;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
 			break;
 		case VK_COLOR_SPACE_BT2020_LINEAR_EXT:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearITUR_2020;
@@ -323,10 +325,14 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 #endif
 		case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
 			_mtlLayer.colorspaceNameMVK = kCGColorSpaceAdobeRGB1998;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
 			break;
 		case VK_COLOR_SPACE_PASS_THROUGH_EXT:
+			_mtlLayer.colorspace = nil;
+			_mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
+			break;
 		default:
-			// Nothing - the default is not to do color matching.
+			setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateSwapchainKHR(): Metal does not support VkColorSpaceKHR value %d.", pCreateInfo->imageColorSpace));
 			break;
 	}
 	_mtlLayer.drawableSize = mvkCGSizeFromVkExtent2D(pCreateInfo->imageExtent);


### PR DESCRIPTION
- Fix `MVKPhysicalDevice::getSurfaceFormats()` returning `VK_FORMAT_UNDEFINED`
in available surface formats when a Metal surface format is available that
doesn't map to a defined Vulkan format (eg. `MTLPixelFormatBGRA10_XR`).
- Restore support for `VK_COLOR_SPACE_HDR10_HLG_EXT` and `VK_COLOR_SPACE_HDR10_ST2084_EXT`
under Xcode12 that was removed due to App Store conflicts using older enum values.
- Don't assume the incoming `CAMetalLayer` has default (no-op) values for `colorspace` and
`wantsExtendedDynamicRangeContent` properties, since they could have been set externally.
Ensure the Vulkan app has control over both of these properties.
- `vkCreateSwapchainKHR()` returns `VK_ERROR_FORMAT_NOT_SUPPORTED` for unsupported colorspaces.

Fixes issues #1292 and #1299.