### PR TITLE
In a renderpass, don't load or store memoryless attachments.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,7 +19,9 @@ MoltenVK 1.1.3
 Released TBD
 
 - Add support for `HDR10` colorspace via `VK_COLOR_SPACE_HDR10_HLG_EXT` and `VK_COLOR_SPACE_HDR10_ST2084_EXT`.
-- Always explicitly set `CAMetalLayer` colorspace property based on _Vulkan_ parameters, and don't rely on _Metal_ default values.
+- Always explicitly set `CAMetalLayer` colorspace property based on _Vulkan_ parameters, 
+  and don't rely on _Metal_ default values.
+- Avoid use of _Metal_ renderpass load and store actions on memoryless attachments.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -734,10 +734,9 @@ MVK_PUBLIC_SYMBOL MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFl
 
 MVK_PUBLIC_SYMBOL MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags) {
 
-	// If not visible to the host: Private
+	// If not visible to the host, use Private, or Memoryless if available and lazily allocated.
 	if ( !mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ) {
 #if MVK_APPLE_SILICON
-		// iOS: If lazily allocated, Memoryless
 		if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
 			return MTLStorageModeMemoryless;
 		}


### PR DESCRIPTION
For memoryless attachments, setting renderpass load and store
actions to "load" and "store" triggers Metal validation errors.
Refactor determination of renderpass `MTLLoadAction` and `MTLStoreAction`.
For memoryless attachments, replace load with don't care,
and store with resolve or don't care.

Fixes #1308.

@cdavis5e Can you sanity-check my refactored`MTLLoadAction` and `MTLStoreAction` logic, please?