### PR TITLE
Refactor preallocated descriptor handling.

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -325,6 +325,9 @@
 		A9C96DD31DDC20C20053187F /* MVKMTLBufferAllocation.mm in Sources */ = {isa = PBXBuildFile; fileRef = A9C96DCF1DDC20C20053187F /* MVKMTLBufferAllocation.mm */; };
 		A9CEAAD5227378D400FAF779 /* mvk_datatypes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9CEAAD1227378D400FAF779 /* mvk_datatypes.hpp */; };
 		A9CEAAD6227378D400FAF779 /* mvk_datatypes.hpp in Headers */ = {isa = PBXBuildFile; fileRef = A9CEAAD1227378D400FAF779 /* mvk_datatypes.hpp */; };
+		A9D7104F25CDE05E00E38106 /* MVKBitArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A9D7104E25CDE05E00E38106 /* MVKBitArray.h */; };
+		A9D7105025CDE05E00E38106 /* MVKBitArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A9D7104E25CDE05E00E38106 /* MVKBitArray.h */; };
+		A9D7105125CDE05E00E38106 /* MVKBitArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A9D7104E25CDE05E00E38106 /* MVKBitArray.h */; };
 		A9E4B7891E1D8AF10046A4CE /* MVKMTLResourceBindings.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E4B7881E1D8AF10046A4CE /* MVKMTLResourceBindings.h */; };
 		A9E4B78A1E1D8AF10046A4CE /* MVKMTLResourceBindings.h in Headers */ = {isa = PBXBuildFile; fileRef = A9E4B7881E1D8AF10046A4CE /* MVKMTLResourceBindings.h */; };
 		A9E53DD72100B197002781DD /* MTLSamplerDescriptor+MoltenVK.m in Sources */ = {isa = PBXBuildFile; fileRef = A9E53DCD2100B197002781DD /* MTLSamplerDescriptor+MoltenVK.m */; };
@@ -523,6 +526,7 @@
 		A9C96DCF1DDC20C20053187F /* MVKMTLBufferAllocation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MVKMTLBufferAllocation.mm; sourceTree = "<group>"; };
 		A9CBEE011B6299D800E45FDC /* libMoltenVK.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libMoltenVK.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9CEAAD1227378D400FAF779 /* mvk_datatypes.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mvk_datatypes.hpp; sourceTree = "<group>"; };
+		A9D7104E25CDE05E00E38106 /* MVKBitArray.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKBitArray.h; sourceTree = "<group>"; };
 		A9DE1083200598C500F18F80 /* icd */ = {isa = PBXFileReference; lastKnownFileType = folder; path = icd; sourceTree = "<group>"; };
 		A9E4B7881E1D8AF10046A4CE /* MVKMTLResourceBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MVKMTLResourceBindings.h; sourceTree = "<group>"; };
 		A9E53DCD2100B197002781DD /* MTLSamplerDescriptor+MoltenVK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MTLSamplerDescriptor+MoltenVK.m"; sourceTree = "<group>"; };
@@ -678,6 +682,7 @@
 			children = (
 				A98149421FB6A3F7005F00B4 /* MVKBaseObject.h */,
 				A98149411FB6A3F7005F00B4 /* MVKBaseObject.mm */,
+				A9D7104E25CDE05E00E38106 /* MVKBitArray.h */,
 				4553AEFA2251617100E8EBCD /* MVKBlockObserver.h */,
 				4553AEF62251617100E8EBCD /* MVKBlockObserver.m */,
 				45557A4D21C9EFF3008868BD /* MVKCodec.cpp */,
@@ -792,6 +797,7 @@
 				2FEA0A4624902F9F00EEF3AD /* MVKSurface.h in Headers */,
 				2FEA0A4724902F9F00EEF3AD /* MTLRenderPipelineDescriptor+MoltenVK.h in Headers */,
 				2FEA0A4824902F9F00EEF3AD /* MVKInstance.h in Headers */,
+				A9D7105025CDE05E00E38106 /* MVKBitArray.h in Headers */,
 				2FEA0A4924902F9F00EEF3AD /* MVKCommandResourceFactory.h in Headers */,
 				2FEA0A4A24902F9F00EEF3AD /* MVKQueryPool.h in Headers */,
 				2FEA0A4B24902F9F00EEF3AD /* MVKCommandEncoderState.h in Headers */,
@@ -868,6 +874,7 @@
 				A95B7D691D3EE486003183D3 /* MVKCommandEncoderState.h in Headers */,
 				A94FB7D81C7DFB4800632CA3 /* MVKCommandPipelineStateFactoryShaderSource.h in Headers */,
 				A94FB7E01C7DFB4800632CA3 /* MVKDescriptorSet.h in Headers */,
+				A9D7104F25CDE05E00E38106 /* MVKBitArray.h in Headers */,
 				A9E53DE12100B197002781DD /* NSString+MoltenVK.h in Headers */,
 				A9E53DDF2100B197002781DD /* CAMetalLayer+MoltenVK.h in Headers */,
 				45557A5421C9EFF3008868BD /* MVKCodec.h in Headers */,
@@ -940,6 +947,7 @@
 				A95B7D6A1D3EE486003183D3 /* MVKCommandEncoderState.h in Headers */,
 				A94FB7D91C7DFB4800632CA3 /* MVKCommandPipelineStateFactoryShaderSource.h in Headers */,
 				A94FB7E11C7DFB4800632CA3 /* MVKDescriptorSet.h in Headers */,
+				A9D7105125CDE05E00E38106 /* MVKBitArray.h in Headers */,
 				A9E53DE22100B197002781DD /* NSString+MoltenVK.h in Headers */,
 				A9E53DE02100B197002781DD /* CAMetalLayer+MoltenVK.h in Headers */,
 				45557A5521C9EFF3008868BD /* MVKCodec.h in Headers */,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -20,6 +20,7 @@
 
 #include "MVKDescriptor.h"
 #include "MVKSmallVector.h"
+#include "MVKBitArray.h"
 #include <unordered_set>
 #include <unordered_map>
 #include <vector>
@@ -155,59 +156,20 @@ class MVKDescriptorTypePreallocation : public MVKBaseObject {
 
 public:
 
-	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
 
-	MVKDescriptorTypePreallocation(const VkDescriptorPoolCreateInfo* pCreateInfo,
-								   VkDescriptorType descriptorType);
-
-protected:
-	friend class MVKPreallocatedDescriptors;
-
-	VkResult allocateDescriptor(MVKDescriptor** pMVKDesc);
-	bool findDescriptor(uint32_t endIndex, MVKDescriptor** pMVKDesc);
-	void freeDescriptor(MVKDescriptor* mvkDesc);
-	void reset();
-
-	MVKSmallVector<DescriptorClass> _descriptors;
-	MVKSmallVector<bool> _availability;
-	uint32_t _nextAvailableIndex;
-	bool _supportAvailability;
-};
-
-
-#pragma mark -
-#pragma mark MVKPreallocatedDescriptors
-
-/** Support class for MVKDescriptorPool that holds preallocated instances of all concrete descriptor classes. */
-class MVKPreallocatedDescriptors : public MVKBaseObject {
-
-public:
-
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
-
-	MVKPreallocatedDescriptors(const VkDescriptorPoolCreateInfo* pCreateInfo);
+	MVKDescriptorTypePreallocation(size_t poolSize);
 
 protected:
 	friend class MVKDescriptorPool;
 
-	VkResult allocateDescriptor(VkDescriptorType descriptorType, MVKDescriptor** pMVKDesc);
+	inline bool isPreallocated() { return _availability.size() > 0; }
+	VkResult allocateDescriptor(MVKDescriptor** pMVKDesc);
 	void freeDescriptor(MVKDescriptor* mvkDesc);
 	void reset();
 
-	MVKDescriptorTypePreallocation<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageBufferDescriptor> _storageBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKUniformBufferDynamicDescriptor> _uniformBufferDynamicDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageBufferDynamicDescriptor> _storageBufferDynamicDescriptors;
-	MVKDescriptorTypePreallocation<MVKInlineUniformBlockDescriptor> _inlineUniformBlockDescriptors;
-	MVKDescriptorTypePreallocation<MVKSampledImageDescriptor> _sampledImageDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageImageDescriptor> _storageImageDescriptors;
-	MVKDescriptorTypePreallocation<MVKInputAttachmentDescriptor> _inputAttachmentDescriptors;
-	MVKDescriptorTypePreallocation<MVKSamplerDescriptor> _samplerDescriptors;
-	MVKDescriptorTypePreallocation<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
-	MVKDescriptorTypePreallocation<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
+	MVKSmallVector<DescriptorClass> _descriptors;
+	MVKBitArray _availability;
 };
 
 
@@ -251,7 +213,19 @@ protected:
 
 	uint32_t _maxSets;
 	std::unordered_set<MVKDescriptorSet*> _allocatedSets;
-	MVKPreallocatedDescriptors* _preallocatedDescriptors;
+
+	MVKDescriptorTypePreallocation<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
+	MVKDescriptorTypePreallocation<MVKStorageBufferDescriptor> _storageBufferDescriptors;
+	MVKDescriptorTypePreallocation<MVKUniformBufferDynamicDescriptor> _uniformBufferDynamicDescriptors;
+	MVKDescriptorTypePreallocation<MVKStorageBufferDynamicDescriptor> _storageBufferDynamicDescriptors;
+	MVKDescriptorTypePreallocation<MVKInlineUniformBlockDescriptor> _inlineUniformBlockDescriptors;
+	MVKDescriptorTypePreallocation<MVKSampledImageDescriptor> _sampledImageDescriptors;
+	MVKDescriptorTypePreallocation<MVKStorageImageDescriptor> _storageImageDescriptors;
+	MVKDescriptorTypePreallocation<MVKInputAttachmentDescriptor> _inputAttachmentDescriptors;
+	MVKDescriptorTypePreallocation<MVKSamplerDescriptor> _samplerDescriptors;
+	MVKDescriptorTypePreallocation<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
+	MVKDescriptorTypePreallocation<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
+	MVKDescriptorTypePreallocation<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
 };
 
 

--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -1,0 +1,181 @@
+/*
+ * MVKBitArray.h
+ *
+ * Copyright (c) 2020-2020 The Brenwill Workshop Ltd. (http://www.brenwill.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "MVKFoundation.h"
+
+
+#pragma mark -
+#pragma mark MVKBitArray
+
+/** Represents an array of bits, optimized for reduced storage and fast scanning for bits that are set. */
+class MVKBitArray {
+
+	static constexpr size_t SectionMaskSize = 6;	// 64 bits
+	static constexpr size_t SectionBitCount = 1U << SectionMaskSize;
+	static constexpr size_t SectionByteCount = SectionBitCount / 8;
+	static constexpr uint64_t SectionMask = SectionBitCount - 1;
+
+public:
+
+	/** Returns the value of the bit. */
+	inline bool getBit(size_t bitIndex) {
+		return mvkIsAnyFlagEnabled(_pSections[getIndexOfSection(bitIndex)], getSectionSetMask(bitIndex));
+	}
+
+	/** Sets the value of the bit to 1. */
+	inline void setBit(size_t bitIndex) {
+		size_t secIdx = getIndexOfSection(bitIndex);
+		mvkEnableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
+
+		if (secIdx < _minUnclearedSectionIndex) { _minUnclearedSectionIndex = secIdx; }
+	}
+
+	/** Sets the value of the bit to 0. */
+	inline void clearBit(size_t bitIndex) {
+		size_t secIdx = getIndexOfSection(bitIndex);
+		mvkDisableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
+
+		if (secIdx == _minUnclearedSectionIndex && !_pSections[secIdx]) { _minUnclearedSectionIndex++; }
+	}
+
+	/** Sets the value of the bit to the value. */
+	inline void setBit(size_t bitIndex, bool val) {
+		if (val) {
+			setBit(bitIndex);
+		} else {
+			clearBit(bitIndex);
+		}
+	}
+
+	/** Sets all bits in the array to 1. */
+	inline void setAllBits() { setAllSections(~0); }
+
+	/** Clears all bits in the array to 0. */
+	inline void clearAllBits() { setAllSections(0); }
+
+	/**
+	 * Returns the index of the first bit that is set, at or after the specified index,
+	 * and optionally clears that bit. If no bits are set, returns the size() of this bit array.
+	 */
+	size_t getIndexOfFirstSetBit(size_t startIndex, bool shouldClear) {
+		size_t startSecIdx = std::max(getIndexOfSection(startIndex), _minUnclearedSectionIndex);
+		size_t bitIdx = startSecIdx << SectionMaskSize;
+		size_t secCnt = getSectionCount();
+		for (size_t secIdx = startSecIdx; secIdx < secCnt; secIdx++) {
+			size_t lclBitIdx = getIndexOfFirstSetBitInSection(_pSections[secIdx], getBitIndexInSection(startIndex));
+			bitIdx += lclBitIdx;
+			if (lclBitIdx < SectionBitCount) {
+				if (startSecIdx == _minUnclearedSectionIndex && !_pSections[startSecIdx]) { _minUnclearedSectionIndex = secIdx; }
+				if (shouldClear) { clearBit(bitIdx); }
+				return bitIdx;
+			}
+		}
+		return std::min(bitIdx, _bitCount);
+	}
+
+	/**
+	 * Returns the index of the first bit that is set, at or after the specified index.
+	 * If no bits are set, returns the size() of this bit array.
+	 */
+	inline size_t getIndexOfFirstSetBit(size_t startIndex) {
+		return getIndexOfFirstSetBit(startIndex, false);
+	}
+
+	/**
+	 * Returns the index of the first bit that is set and optionally clears that bit.
+	 * If no bits are set, returns the size() of this bit array.
+	 */
+	inline size_t getIndexOfFirstSetBit(bool shouldClear) {
+		return getIndexOfFirstSetBit(0, shouldClear);
+	}
+
+	/**
+	 * Returns the index of the first bit that is set.
+	 * If no bits are set, returns the size() of this bit array.
+	 */
+	inline size_t getIndexOfFirstSetBit() {
+		return getIndexOfFirstSetBit(0, false);
+	}
+
+	/** Returns the number of bits in this array. */
+	inline size_t size() { return _bitCount; }
+
+	/** Returns whether this array is empty. */
+	inline bool empty() { return !_bitCount; }
+
+	/** Constructs an instance for the specified number of bits, and sets the initial value of all the bits. */
+	MVKBitArray(size_t size, bool val = false) {
+		_bitCount = size;
+		_pSections = _bitCount ? (uint64_t*)malloc(getSectionCount() * SectionByteCount) : nullptr;
+		if (val) {
+			setAllBits();
+		} else {
+			clearAllBits();
+		}
+	}
+
+	~MVKBitArray() { free(_pSections); }
+
+protected:
+
+	// Returns the number of sections.
+	inline size_t getSectionCount() {
+		return _bitCount ? getIndexOfSection(_bitCount - 1) + 1 : 0;
+	}
+
+	// Returns the index of the section that contains the specified bit.
+	static inline size_t getIndexOfSection(size_t bitIndex) {
+		return bitIndex >> SectionMaskSize;
+	}
+
+	// Converts the bit index to a local bit index within a section, and returns that local bit index.
+	static inline size_t getBitIndexInSection(size_t bitIndex) {
+		return bitIndex & SectionMask;
+	}
+
+	// Returns a section mask containing a single 1 value in the bit in the section that
+	// corresponds to the specified global bit index, and 0 values in all other bits.
+	static inline uint64_t getSectionSetMask(size_t bitIndex) {
+		return (uint64_t)1U << ((SectionBitCount - 1) - getBitIndexInSection(bitIndex));
+	}
+
+	// Returns the local index of the first set bit in the section, starting from the highest order bit.
+	// Clears all bits ahead of the start bit so they will be ignored, then counts the number of zeros
+	// ahead of the set bit. If there are no set bits, returns the number of bits in a section.
+	static size_t getIndexOfFirstSetBitInSection(uint64_t section, size_t lclStartBitIndex) {
+		uint64_t lclStartMask = ~(uint64_t)0;
+		lclStartMask >>= lclStartBitIndex;
+		section &= lclStartMask;
+		return section ? __builtin_clzll(section) : SectionBitCount;
+	}
+
+	// Sets the content of all sections to the value
+	void setAllSections(uint64_t sectionValue) {
+		size_t secCnt = getSectionCount();
+		for (size_t secIdx = 0; secIdx < secCnt; secIdx++) {
+			_pSections[secIdx] = sectionValue;
+		}
+		_minUnclearedSectionIndex = sectionValue ? 0 : secCnt;
+	}
+
+	uint64_t* _pSections;
+	size_t _bitCount;
+	size_t _minUnclearedSectionIndex;	// Tracks where to start looking for bits that are set
+};


### PR DESCRIPTION
Add `MVKBitArray` class.
Consolidate `MVKPreallocatedDescriptors` into `MVKDescriptorPool`
and remove `MVKPreallocatedDescriptors`.

This refactor is part of the larger project for introducing Metal argument buffers. Pushing this out now as part of a cleanup as I rework the actual argument buffer design.