### PR TITLE
MVKDescriptor subclasses: Reduce redundant and unused content.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -222,7 +222,6 @@ protected:
 	MVKSmallVector<VkBufferImageCopy, N> _bufferImageCopyRegions;
     MVKBuffer* _buffer;
     MVKImage* _image;
-    VkImageLayout _imageLayout;
     bool _toImage = false;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -876,7 +876,6 @@ VkResult MVKCmdBufferImageCopy<N>::setContent(MVKCommandBuffer* cmdBuff,
 											  bool toImage) {
     _buffer = (MVKBuffer*)buffer;
     _image = (MVKImage*)image;
-    _imageLayout = imageLayout;
     _toImage = toImage;
 
     // Add buffer regions

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -234,6 +234,7 @@ public:
 protected:
 	MVKBuffer* _mvkBuffer = nullptr;
 	VkDeviceSize _buffOffset = 0;
+	VkDeviceSize _buffRange = 0;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -153,7 +153,8 @@ public:
 
 	/** Encodes this descriptor (based on its layout binding index) on the the command encoder. */
 	virtual void bind(MVKCommandEncoder* cmdEncoder,
-					  uint32_t descriptorIndex,
+					  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+					  uint32_t elementIndex,
 					  bool stages[],
 					  MVKShaderResourceBinding& mtlIndexes,
 					  MVKArrayRef<uint32_t> dynamicOffsets,
@@ -164,7 +165,8 @@ public:
 	 * on the descriptor type, and is extracted from pData at the location given by index * stride.
 	 * MVKInlineUniformBlockDescriptor uses the index as byte offset to write to.
 	 */
-	virtual void write(MVKDescriptorSet* mvkDescSet,
+	virtual void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+					   MVKDescriptorSet* mvkDescSet,
 					   uint32_t index,
 					   size_t stride,
 					   const void* pData) = 0;
@@ -180,15 +182,13 @@ public:
 	 * at which to start writing.
 	 * MVKInlineUniformBlockDescriptor uses the index as byte offset to read from.
 	 */
-	virtual void read(MVKDescriptorSet* mvkDescSet,
+	virtual void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+					  MVKDescriptorSet* mvkDescSet,
 					  uint32_t index,
 					  VkDescriptorImageInfo* pImageInfo,
 					  VkDescriptorBufferInfo* pBufferInfo,
 					  VkBufferView* pTexelBufferView,
 					  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) = 0;
-
-	/** Sets the binding layout. */
-	virtual void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index) {}
 
 	/** Resets any internal content. */
 	virtual void reset() {}
@@ -206,18 +206,21 @@ class MVKBufferDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
@@ -281,33 +284,33 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t dstOffset, // For inline buffers we are using this parameter as dst offset not as src descIdx
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t srcOffset, // For inline buffers we are using this parameter as src offset not as dst descIdx
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
     
-    void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index) override;
-
 	void reset() override;
 
 	~MVKInlineUniformBlockDescriptor() { reset(); }
 
 protected:
 	uint8_t* _buffer = nullptr;
-    uint32_t _length;
 };
 
 
@@ -319,18 +322,21 @@ class MVKImageDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
@@ -388,32 +394,32 @@ class MVKSamplerDescriptorMixin {
 
 protected:
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex);
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData);
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock);
 
-	void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index);
-
 	void reset();
 
 	~MVKSamplerDescriptorMixin() { reset(); }
 
 	MVKSampler* _mvkSampler = nullptr;
-	bool _hasDynamicSampler = true;
 };
 
 
@@ -427,25 +433,26 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_SAMPLER; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
-
-	void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index) override;
 
 	void reset() override;
 
@@ -464,25 +471,26 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
-
-	void setLayout(MVKDescriptorSetLayoutBinding* dslBinding, uint32_t index) override;
 
 	void reset() override;
 
@@ -499,18 +507,21 @@ class MVKTexelBufferDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
-			  uint32_t descriptorIndex,
+			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  uint32_t elementIndex,
 			  bool stages[],
 			  MVKShaderResourceBinding& mtlIndexes,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
 			  uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSet* mvkDescSet,
+	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			   MVKDescriptorSet* mvkDescSet,
 			   uint32_t srcIndex,
 			   size_t stride,
 			   const void* pData) override;
 
-	void read(MVKDescriptorSet* mvkDescSet,
+	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -234,7 +234,6 @@ public:
 protected:
 	MVKBuffer* _mvkBuffer = nullptr;
 	VkDeviceSize _buffOffset = 0;
-	VkDeviceSize _buffRange = 0;
 };
 
 
@@ -349,7 +348,6 @@ public:
 
 protected:
 	MVKImageView* _mvkImageView = nullptr;
-	VkImageLayout _imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -161,6 +161,10 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
                 MVKBuffer* buffer = (MVKBuffer*)bufferInfo.buffer;
                 bb.mtlBuffer = buffer->getMTLBuffer();
                 bb.offset = buffer->getMTLBufferOffset() + bufferInfo.offset;
+                if (bufferInfo.range == VK_WHOLE_SIZE)
+                    bb.size = (uint32_t)(buffer->getByteCount() - bb.offset);
+                else
+                    bb.size = (uint32_t)bufferInfo.range;
 
                 for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
                     if (_applyToStage[i]) {
@@ -207,6 +211,7 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
                         if (mtlTex.parentTexture) { mtlTex = mtlTex.parentTexture; }
                         bb.mtlBuffer = mtlTex.buffer;
                         bb.offset = mtlTex.bufferOffset;
+                        bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
                     }
                     for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
                         if (_applyToStage[i]) {
@@ -239,6 +244,7 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
                     id<MTLTexture> mtlTex = tb.mtlTexture;
                     bb.mtlBuffer = mtlTex.buffer;
                     bb.offset = mtlTex.bufferOffset;
+                    bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
                 }
                 for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
                     if (_applyToStage[i]) {
@@ -521,6 +527,10 @@ void MVKBufferDescriptor::bind(MVKCommandEncoder* cmdEncoder,
 	if (_mvkBuffer) {
 		bb.mtlBuffer = _mvkBuffer->getMTLBuffer();
 		bb.offset = _mvkBuffer->getMTLBufferOffset() + _buffOffset + bufferDynamicOffset;
+		if (_buffRange == VK_WHOLE_SIZE)
+			bb.size = (uint32_t)(_mvkBuffer->getByteCount() - bb.offset);
+		else
+			bb.size = (uint32_t)_buffRange;
 	}
 	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
 		if (stages[i]) {
@@ -544,6 +554,7 @@ void MVKBufferDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 	const auto* pBuffInfo = &get<VkDescriptorBufferInfo>(pData, stride, srcIndex);
 	_mvkBuffer = (MVKBuffer*)pBuffInfo->buffer;
 	_buffOffset = pBuffInfo->offset;
+	_buffRange = pBuffInfo->range;
 
 	if (_mvkBuffer) { _mvkBuffer->retain(); }
 	if (oldBuff) { oldBuff->release(); }
@@ -559,12 +570,14 @@ void MVKBufferDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 	auto& buffInfo = pBufferInfo[dstIndex];
 	buffInfo.buffer = (VkBuffer)_mvkBuffer;
 	buffInfo.offset = _buffOffset;
+	buffInfo.range = _buffRange;
 }
 
 void MVKBufferDescriptor::reset() {
 	if (_mvkBuffer) { _mvkBuffer->release(); }
 	_mvkBuffer = nullptr;
 	_buffOffset = 0;
+	_buffRange = 0;
 	MVKDescriptor::reset();
 }
 
@@ -662,6 +675,7 @@ void MVKImageDescriptor::bind(MVKCommandEncoder* cmdEncoder,
             if (mtlTex.parentTexture) { mtlTex = mtlTex.parentTexture; }
             bb.mtlBuffer = mtlTex.buffer;
             bb.offset = mtlTex.bufferOffset;
+            bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
         }
         for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {
             if (stages[i]) {
@@ -883,6 +897,7 @@ void MVKTexelBufferDescriptor::bind(MVKCommandEncoder* cmdEncoder,
 			id<MTLTexture> mtlTex = tb.mtlTexture;
 			bb.mtlBuffer = mtlTex.buffer;
 			bb.offset = mtlTex.bufferOffset;
+			bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
 		}
 	}
 	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageMax; i++) {


### PR DESCRIPTION
`MVKDescriptor` subclasses: Simplify interface and reduce redundant content.

Remove `MVKDescriptor::setLayout()` and pass `MVKDescriptorSetLayoutBinding`
to `MVKDescriptor::bind(), write(), and read()`.
Remove `MVKSamplerDescriptorMixin::_hasDynamicSampler`.
Remove `MVKInlineUniformBlockDescriptor::_length`.

`MVKDescriptor` subclasses: Reduce unused content.
Don't populate `MVKMTLBufferBinding::size` unless using `mtlBytes` and `isInline`.
Remove `MVKBufferDescriptor::_buffRange`.
Remove `MVKImageDescriptor::_imageLayout`.
Remove `MVKCmdBufferImageCopy::_imageLayout`.

Another prep step compatible with argument buffers.