### PR TITLE
Descriptor pooling enhancements

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,8 @@ Released TBD
 - Avoid use of _Metal_ renderpass load and store actions on memoryless attachments.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
 - `MVKDescriptorPool` pools its descriptor sets.
+- Enable `MVKConfiguration::preallocateDescriptors` and `MVK_CONFIG_PREALLOCATE_DESCRIPTORS` 
+  environment variable by default to preallocate descriptors when a `VkDescriptorPool` is created.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.
 - Add `MVKConfiguration::advertiseExtensions` and `MVK_CONFIG_ADVERTISE_EXTENSIONS` 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
   and don't rely on _Metal_ default values.
 - Avoid use of _Metal_ renderpass load and store actions on memoryless attachments.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
+- `MVKDescriptorPool` pools its descriptor sets.
 - Add `MVKConfiguration::apiVersionToAdvertise` and `MVK_CONFIG_API_VERSION_TO_ADVERTISE` 
   env var to configure **MoltenVK** to advertise a particular _Vulkan_ version.
 - Add `MVKConfiguration::advertiseExtensions` and `MVK_CONFIG_ADVERTISE_EXTENSIONS` 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -660,22 +660,20 @@ typedef struct {
 	VkBool32 texture1DAs2D;
 
 	/**
-	 * Controls whether MoltenVK should preallocate memory in each VkDescriptorPool
-	 * ccording to the values of the VkDescriptorPoolSize parameters. Doing so may improve
-	 * descriptor set allocation performance at a cost of preallocated application memory,
-	 * and possible descreased performance when creating and reseting the VkDescriptorPool.
-	 * If this setting is disabled, the descriptors required for a descriptor set will
-	 * be dynamically allocated in application memory when the descriptor set itself is allocated.
+	 * Controls whether MoltenVK should preallocate memory in each VkDescriptorPool according
+	 * to the values of the VkDescriptorPoolSize parameters. Doing so may improve descriptor set
+	 * allocation performance and memory stability at a cost of preallocated application memory.
+	 * If this setting is disabled, the descriptors required for a descriptor set will be individually
+	 * dynamically allocated in application memory when the descriptor set itself is allocated.
 	 *
-	 * The value of this parameter may be changed at any time during application runtime,
-	 * and the changed value will immediately effect behavior of VkDescriptorPools created
-	 * after the setting is changed.
+	 * The value of this parameter may be changed at any time during application runtime, and the
+	 * changed value will affect the behavior of VkDescriptorPools created after the value is changed.
 	 *
 	 * The initial value or this parameter is set by the
 	 * MVK_CONFIG_PREALLOCATE_DESCRIPTORS
 	 * runtime environment variable or MoltenVK compile-time build setting.
-	 * If neither is set, this setting is disabled by default, and MoltenVK will
-	 * dynamically allocate descriptors when the containing descriptor set is allocated.
+	 * If neither is set, this setting is enabled by default, and MoltenVK will
+	 * allocate a pool of descriptors when a VkDescriptorPool is created.
 	 */
 	VkBool32 preallocateDescriptors;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -127,11 +127,7 @@ public:
 			  VkBufferView* pTexelBufferView,
 			  VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
 
-	MVKDescriptorSet(MVKDescriptorSetLayout* layout,
-					 uint32_t variableDescriptorCount,
-					 MVKDescriptorPool* pool);
-
-	~MVKDescriptorSet() override;
+	MVKDescriptorSet(MVKDescriptorPool* pool);
 
 protected:
 	friend class MVKDescriptorSetLayoutBinding;
@@ -139,6 +135,8 @@ protected:
 
 	void propagateDebugName() override {}
 	MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex = 0);
+	VkResult allocate(MVKDescriptorSetLayout* layout, uint32_t variableDescriptorCount);
+	void free(bool isPoolReset);
 
 	MVKDescriptorSetLayout* _layout;
 	MVKDescriptorPool* _pool;
@@ -205,14 +203,14 @@ protected:
 	friend class MVKDescriptorSet;
 
 	void propagateDebugName() override {}
-	VkResult allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL, uint32_t variableDescriptorCount, VkDescriptorSet* pVKDS);
 	const uint32_t* getVariableDecriptorCounts(const VkDescriptorSetAllocateInfo* pAllocateInfo);
-	void freeDescriptorSet(MVKDescriptorSet* mvkDS);
+	VkResult allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL, uint32_t variableDescriptorCount, VkDescriptorSet* pVKDS);
+	void freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset);
 	VkResult allocateDescriptor(VkDescriptorType descriptorType, MVKDescriptor** pMVKDesc);
 	void freeDescriptor(MVKDescriptor* mvkDesc);
 
-	uint32_t _maxSets;
-	std::unordered_set<MVKDescriptorSet*> _allocatedSets;
+	MVKSmallVector<MVKDescriptorSet> _descriptorSets;
+	MVKBitArray _descriptorSetAvailablility;
 
 	MVKDescriptorTypePreallocation<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
 	MVKDescriptorTypePreallocation<MVKStorageBufferDescriptor> _storageBufferDescriptors;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -146,17 +146,17 @@ protected:
 
 
 #pragma mark -
-#pragma mark MVKDescriptorTypePreallocation
+#pragma mark MVKDescriptorTypePool
 
-/** Support class for MVKDescriptorPool that holds preallocated instances of a single concrete descriptor class. */
+/** Support class for MVKDescriptorPool that holds a pool of instances of a single concrete descriptor class. */
 template<class DescriptorClass>
-class MVKDescriptorTypePreallocation : public MVKBaseObject {
+class MVKDescriptorTypePool : public MVKBaseObject {
 
 public:
 
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
 
-	MVKDescriptorTypePreallocation(size_t poolSize);
+	MVKDescriptorTypePool(size_t poolSize);
 
 protected:
 	friend class MVKDescriptorPool;
@@ -200,7 +200,7 @@ public:
 
 protected:
 	friend class MVKDescriptorSet;
-	template<class> friend class MVKDescriptorTypePreallocation;
+	template<class> friend class MVKDescriptorTypePool;
 
 	void propagateDebugName() override {}
 	const uint32_t* getVariableDecriptorCounts(const VkDescriptorSetAllocateInfo* pAllocateInfo);
@@ -212,18 +212,18 @@ protected:
 	MVKSmallVector<MVKDescriptorSet> _descriptorSets;
 	MVKBitArray _descriptorSetAvailablility;
 
-	MVKDescriptorTypePreallocation<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageBufferDescriptor> _storageBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKUniformBufferDynamicDescriptor> _uniformBufferDynamicDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageBufferDynamicDescriptor> _storageBufferDynamicDescriptors;
-	MVKDescriptorTypePreallocation<MVKInlineUniformBlockDescriptor> _inlineUniformBlockDescriptors;
-	MVKDescriptorTypePreallocation<MVKSampledImageDescriptor> _sampledImageDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageImageDescriptor> _storageImageDescriptors;
-	MVKDescriptorTypePreallocation<MVKInputAttachmentDescriptor> _inputAttachmentDescriptors;
-	MVKDescriptorTypePreallocation<MVKSamplerDescriptor> _samplerDescriptors;
-	MVKDescriptorTypePreallocation<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
-	MVKDescriptorTypePreallocation<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
-	MVKDescriptorTypePreallocation<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
+	MVKDescriptorTypePool<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
+	MVKDescriptorTypePool<MVKStorageBufferDescriptor> _storageBufferDescriptors;
+	MVKDescriptorTypePool<MVKUniformBufferDynamicDescriptor> _uniformBufferDynamicDescriptors;
+	MVKDescriptorTypePool<MVKStorageBufferDynamicDescriptor> _storageBufferDynamicDescriptors;
+	MVKDescriptorTypePool<MVKInlineUniformBlockDescriptor> _inlineUniformBlockDescriptors;
+	MVKDescriptorTypePool<MVKSampledImageDescriptor> _sampledImageDescriptors;
+	MVKDescriptorTypePool<MVKStorageImageDescriptor> _storageImageDescriptors;
+	MVKDescriptorTypePool<MVKInputAttachmentDescriptor> _inputAttachmentDescriptors;
+	MVKDescriptorTypePool<MVKSamplerDescriptor> _samplerDescriptors;
+	MVKDescriptorTypePool<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
+	MVKDescriptorTypePool<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
+	MVKDescriptorTypePool<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
 	bool _hasPooledDescriptors;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -161,9 +161,8 @@ public:
 protected:
 	friend class MVKDescriptorPool;
 
-	inline bool isPreallocated() { return _availability.size() > 0; }
-	VkResult allocateDescriptor(MVKDescriptor** pMVKDesc);
-	void freeDescriptor(MVKDescriptor* mvkDesc);
+	VkResult allocateDescriptor(MVKDescriptor** pMVKDesc, MVKDescriptorPool* pool);
+	void freeDescriptor(MVKDescriptor* mvkDesc, MVKDescriptorPool* pool);
 	void reset();
 
 	MVKSmallVector<DescriptorClass> _descriptors;
@@ -195,12 +194,13 @@ public:
 	/** Destroys all currently allocated descriptor sets. */
 	VkResult reset(VkDescriptorPoolResetFlags flags);
 
-	MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo);
+	MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo, bool poolDescriptors);
 
 	~MVKDescriptorPool() override;
 
 protected:
 	friend class MVKDescriptorSet;
+	template<class> friend class MVKDescriptorTypePreallocation;
 
 	void propagateDebugName() override {}
 	const uint32_t* getVariableDecriptorCounts(const VkDescriptorSetAllocateInfo* pAllocateInfo);
@@ -224,6 +224,7 @@ protected:
 	MVKDescriptorTypePreallocation<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
 	MVKDescriptorTypePreallocation<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
 	MVKDescriptorTypePreallocation<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
+	bool _hasPooledDescriptors;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -319,12 +319,12 @@ MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorPool* pool) : MVKVulkanAPIDevice
 
 
 #pragma mark -
-#pragma mark MVKDescriptorTypePreallocation
+#pragma mark MVKDescriptorTypePool
 
 // If preallocated, find the next availalble descriptor.
 // If not preallocated, create one on the fly.
 template<class DescriptorClass>
-VkResult MVKDescriptorTypePreallocation<DescriptorClass>::allocateDescriptor(MVKDescriptor** pMVKDesc,
+VkResult MVKDescriptorTypePool<DescriptorClass>::allocateDescriptor(MVKDescriptor** pMVKDesc,
 																			 MVKDescriptorPool* pool) {
 	DescriptorClass* mvkDesc;
 	if (pool->_hasPooledDescriptors) {
@@ -344,7 +344,7 @@ VkResult MVKDescriptorTypePreallocation<DescriptorClass>::allocateDescriptor(MVK
 // The descriptor will be reset when it is re-allocated. This streamlines the reset() of this pool.
 // If not preallocated, simply destroy returning descriptor.
 template<typename DescriptorClass>
-void MVKDescriptorTypePreallocation<DescriptorClass>::freeDescriptor(MVKDescriptor* mvkDesc,
+void MVKDescriptorTypePool<DescriptorClass>::freeDescriptor(MVKDescriptor* mvkDesc,
 																	 MVKDescriptorPool* pool) {
 	if (pool->_hasPooledDescriptors) {
 		size_t descIdx = (DescriptorClass*)mvkDesc - _descriptors.data();
@@ -356,12 +356,12 @@ void MVKDescriptorTypePreallocation<DescriptorClass>::freeDescriptor(MVKDescript
 
 // Preallocated descriptors will be reset when they are reused
 template<typename DescriptorClass>
-void MVKDescriptorTypePreallocation<DescriptorClass>::reset() {
+void MVKDescriptorTypePool<DescriptorClass>::reset() {
 	_availability.setAllBits();
 }
 
 template<typename DescriptorClass>
-MVKDescriptorTypePreallocation<DescriptorClass>::MVKDescriptorTypePreallocation(size_t poolSize) :
+MVKDescriptorTypePool<DescriptorClass>::MVKDescriptorTypePool(size_t poolSize) :
 	_descriptors(poolSize),
 	_availability(poolSize, true) {}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -281,13 +281,9 @@ void MVKDescriptorSet::read(const VkCopyDescriptorSet* pDescriptorCopy,
     }
 }
 
-MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorSetLayout* layout,
-								   uint32_t variableDescriptorCount,
-								   MVKDescriptorPool* pool) :
-	MVKVulkanAPIDeviceObject(pool->_device),
-	_layout(layout),
-	_variableDescriptorCount(variableDescriptorCount),
-	_pool(pool) {
+VkResult MVKDescriptorSet::allocate(MVKDescriptorSetLayout* layout, uint32_t variableDescriptorCount) {
+	_layout = layout;
+	_variableDescriptorCount = variableDescriptorCount;
 
 	_descriptors.reserve(layout->getDescriptorCount());
 	uint32_t bindCnt = (uint32_t)layout->_bindings.size();
@@ -297,15 +293,25 @@ MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorSetLayout* layout,
 		for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
 			MVKDescriptor* mvkDesc = nullptr;
 			setConfigurationResult(_pool->allocateDescriptor(mvkDSLBind->getDescriptorType(), &mvkDesc));
-			if ( !wasConfigurationSuccessful() ) { break; }
+			if ( !wasConfigurationSuccessful() ) { return getConfigurationResult(); }
 			_descriptors.push_back(mvkDesc);
 		}
-		if ( !wasConfigurationSuccessful() ) { break; }
 	}
+	return getConfigurationResult();
 }
 
-MVKDescriptorSet::~MVKDescriptorSet() {
+void MVKDescriptorSet::free(bool isPoolReset) {
+	_layout = nullptr;
+	_variableDescriptorCount = 0;
+
 	for (auto mvkDesc : _descriptors) { _pool->freeDescriptor(mvkDesc); }
+	_descriptors.clear();
+
+	clearConfigurationResult();
+}
+
+MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorPool* pool) : MVKVulkanAPIDeviceObject(pool->_device), _pool(pool) {
+	free(true);
 }
 
 
@@ -360,15 +366,6 @@ MVKDescriptorTypePreallocation<DescriptorClass>::MVKDescriptorTypePreallocation(
 
 VkResult MVKDescriptorPool::allocateDescriptorSets(const VkDescriptorSetAllocateInfo* pAllocateInfo,
 												   VkDescriptorSet* pDescriptorSets) {
-	if (_allocatedSets.size() + pAllocateInfo->descriptorSetCount > _maxSets) {
-		if (_device->_enabledExtensions.vk_KHR_maintenance1.enabled ||
-			_device->getInstance()->getAPIVersion() >= VK_API_VERSION_1_1) {
-			return VK_ERROR_OUT_OF_POOL_MEMORY;		// Failure is an acceptable test...don't log as error.
-		} else {
-			return reportError(VK_ERROR_INITIALIZATION_FAILED, "The maximum number of descriptor sets that can be allocated by this descriptor pool is %d.", _maxSets);
-		}
-	}
-
 	VkResult rslt = VK_SUCCESS;
 	const auto* pVarDescCounts = getVariableDecriptorCounts(pAllocateInfo);
 	for (uint32_t dsIdx = 0; dsIdx < pAllocateInfo->descriptorSetCount; dsIdx++) {
@@ -397,21 +394,49 @@ const uint32_t* MVKDescriptorPool::getVariableDecriptorCounts(const VkDescriptor
 	return nullptr;
 }
 
-// Ensure descriptor set was actually allocated, then return to pool
+// Retieves the first available descriptor set from the pool, and configures it.
+// If none are available, returns an error.
+VkResult MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL,
+												  uint32_t variableDescriptorCount,
+												  VkDescriptorSet* pVKDS) {
+
+	size_t dsIdx = _descriptorSetAvailablility.getIndexOfFirstSetBit(true);
+	if (dsIdx >= _descriptorSets.size()) { return VK_ERROR_OUT_OF_POOL_MEMORY; }
+
+	MVKDescriptorSet* mvkDS = &_descriptorSets[dsIdx];
+	mvkDS->allocate(mvkDSL, variableDescriptorCount);
+	if (mvkDS->wasConfigurationSuccessful()) {
+		*pVKDS = (VkDescriptorSet)mvkDS;
+	} else {
+		freeDescriptorSet(mvkDS, false);
+	}
+	return mvkDS->getConfigurationResult();
+}
+
 VkResult MVKDescriptorPool::freeDescriptorSets(uint32_t count, const VkDescriptorSet* pDescriptorSets) {
 	for (uint32_t dsIdx = 0; dsIdx < count; dsIdx++) {
-		MVKDescriptorSet* mvkDS = (MVKDescriptorSet*)pDescriptorSets[dsIdx];
-		if (_allocatedSets.erase(mvkDS)) {
-			freeDescriptorSet(mvkDS);
-		}
+		freeDescriptorSet((MVKDescriptorSet*)pDescriptorSets[dsIdx], false);
 	}
 	return VK_SUCCESS;
 }
 
-// Destroy all allocated descriptor sets and reset descriptor pools
+// Descriptor sets are held in contiguous memory, so the index of the returning descriptor
+// set can be calculated by pointer differences, and it can be marked as available.
+void MVKDescriptorPool::freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset) {
+	if ( !mvkDS ) { return; }	// Vulkan allows NULL refs.
+
+	if (mvkDS->_pool == this) {
+		mvkDS->free(isPoolReset);
+		size_t dsIdx = mvkDS - _descriptorSets.data();
+		_descriptorSetAvailablility.setBit(dsIdx);
+	} else {
+		reportError(VK_ERROR_INITIALIZATION_FAILED, "A descriptor set is being returned to a descriptor pool that did not allocate it.");
+	}
+}
+
+// Free all descriptor sets and reset descriptor pools
 VkResult MVKDescriptorPool::reset(VkDescriptorPoolResetFlags flags) {
-	for (auto& mvkDS : _allocatedSets) { freeDescriptorSet(mvkDS); }
-	_allocatedSets.clear();
+	for (auto& mvkDS : _descriptorSets) { freeDescriptorSet(&mvkDS, true); }
 
 	_uniformBufferDescriptors.reset();
 	_storageBufferDescriptors.reset();
@@ -428,23 +453,6 @@ VkResult MVKDescriptorPool::reset(VkDescriptorPoolResetFlags flags) {
 
 	return VK_SUCCESS;
 }
-
-VkResult MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL,
-												  uint32_t variableDescriptorCount,
-												  VkDescriptorSet* pVKDS) {
-	MVKDescriptorSet* mvkDS = new MVKDescriptorSet(mvkDSL, variableDescriptorCount, this);
-	VkResult rslt = mvkDS->getConfigurationResult();
-
-	if (mvkDS->wasConfigurationSuccessful()) {
-		_allocatedSets.insert(mvkDS);
-		*pVKDS = (VkDescriptorSet)mvkDS;
-	} else {
-		freeDescriptorSet(mvkDS);
-	}
-	return rslt;
-}
-
-void MVKDescriptorPool::freeDescriptorSet(MVKDescriptorSet* mvkDS) { mvkDS->destroy(); }
 
 // Allocate a descriptor of the specified type
 VkResult MVKDescriptorPool::allocateDescriptor(VkDescriptorType descriptorType,
@@ -553,6 +561,8 @@ static size_t getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo, VkDescr
 
 MVKDescriptorPool::MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo) :
 	MVKVulkanAPIDeviceObject(device),
+	_descriptorSets(pCreateInfo->maxSets, MVKDescriptorSet(this)),
+	_descriptorSetAvailablility(pCreateInfo->maxSets, true),
 	_uniformBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)),
 	_storageBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)),
 	_uniformBufferDynamicDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)),
@@ -564,8 +574,7 @@ MVKDescriptorPool::MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCr
 	_samplerDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_SAMPLER)),
 	_combinedImageSamplerDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)),
 	_uniformTexelBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)),
-	_storageTexelBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)),
-	_maxSets(pCreateInfo->maxSets) {}
+	_storageTexelBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {}
 
 MVKDescriptorPool::~MVKDescriptorPool() {
 	reset(0);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3335,7 +3335,7 @@ void MVKDevice::destroyDescriptorSetLayout(MVKDescriptorSetLayout* mvkDSL,
 
 MVKDescriptorPool* MVKDevice::createDescriptorPool(const VkDescriptorPoolCreateInfo* pCreateInfo,
 												   const VkAllocationCallbacks* pAllocator) {
-	return new MVKDescriptorPool(this, pCreateInfo);
+	return new MVKDescriptorPool(this, pCreateInfo, mvkGetMVKConfiguration()->preallocateDescriptors);
 }
 
 void MVKDevice::destroyDescriptorPool(MVKDescriptorPool* mvkDP,

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -248,9 +248,9 @@ void mvkSetMVKConfiguration(MVKConfiguration* pMVKConfig);
 #   define MVK_CONFIG_TEXTURE_1D_AS_2D    1
 #endif
 
-/** Preallocate descriptors when creating VkDescriptorPool. Disabled by default. */
+/** Preallocate descriptors when creating VkDescriptorPool. Enabled by default. */
 #ifndef MVK_CONFIG_PREALLOCATE_DESCRIPTORS
-#   define MVK_CONFIG_PREALLOCATE_DESCRIPTORS    0
+#   define MVK_CONFIG_PREALLOCATE_DESCRIPTORS    1
 #endif
 
 /** Use pooling for command resources in a VkCommandPool. Enabled by default. */


### PR DESCRIPTION
- Preallocate a pool of descriptors by default.
    - Enable `MVKConfiguration::preallocateDescriptors` and
`MVK_CONFIG_PREALLOCATE_DESCRIPTORS` by default.
    - Rename MVKDescriptorTypePreallocation to `MVKDescriptorTypePool`.

- `MVKDescriptorPool` optimize reseting descriptor pool.
    - Don't free individual pooled descriptors during a pool reset.
    - Don't mark availability of individual descriptor sets during a pool reset.
    - Add `MVKDescriptorPool::_hasPooledDescriptors` as SVOT to track if descriptors
are pooled, and is set from outside constructor to ensure all internal
descriptor pools are constructed with the same SVOT.
    - `MVKDescriptorPool::allocateDescriptorSet()` ensure correct result returned.
 
- `MVKDescriptorPool` pools its descriptor sets.
