### PR TITLE
Fix advertising single-texel alignment capability for texel buffers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1889,11 +1889,11 @@ void MVKPhysicalDevice::initLimits() {
             }
             if (mvkAreAllFlagsEnabled(props.bufferFeatures, VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
                 maxStorage = max(maxStorage, uint32_t(alignment));
-                if (alignment % texelSize != 0) { singleTexelStorage = false; }
+                if (alignment > texelSize) { singleTexelStorage = false; }
             }
             if (mvkAreAllFlagsEnabled(props.bufferFeatures, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
                 maxUniform = max(maxUniform, uint32_t(alignment));
-                if (alignment % texelSize != 0) { singleTexelUniform = false; }
+                if (alignment > texelSize) { singleTexelUniform = false; }
             }
             return true;
         });


### PR DESCRIPTION
The test for single-texel capability used a mod calculation to compare the linear
alignment requirement reported by Metal to the texel size. Instead, it should use an
inequality comparison, to check if the alignment requirement is LTE the texel size.

Fixes #1318.