### PR TITLE
Several underlying non-functional changes towards Metal argument buffer support.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -108,25 +108,29 @@ public:
               const void* pData,
               MVKShaderResourceBinding& dslMTLRezIdxOffsets);
 
-	/** Populates the specified shader converter context, at the specified descriptor set binding. */
-	void populateShaderConverterContext(mvk::SPIRVToMSLConversionConfiguration& context,
-                                        MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-                                        uint32_t dslIndex);
+	/** Returns the index of the descriptor within the descriptor set of the element at the index within this descriptor layout. */
+	inline uint32_t getDescriptorIndex(uint32_t elementIndex = 0) { return _descriptorIndex + elementIndex; }
 
 	MVKDescriptorSetLayoutBinding(MVKDevice* device,
 								  MVKDescriptorSetLayout* layout,
 								  const VkDescriptorSetLayoutBinding* pBinding,
-								  VkDescriptorBindingFlagsEXT bindingFlags);
+								  VkDescriptorBindingFlagsEXT bindingFlags,
+								  uint32_t descriptorIndex);
 
 	MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding);
 
 	~MVKDescriptorSetLayoutBinding() override;
 
 protected:
+	friend class MVKDescriptorSetLayout;
     friend class MVKInlineUniformBlockDescriptor;
+	
 	void initMetalResourceIndexOffsets(MVKShaderStageResourceBinding* pBindingIndexes,
 									   MVKShaderStageResourceBinding* pDescSetCounts,
 									   const VkDescriptorSetLayoutBinding* pBinding);
+	void populateShaderConverterContext(mvk::SPIRVToMSLConversionConfiguration& context,
+										MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+										uint32_t dslIndex);
 	bool validate(MVKSampler* mvkSampler);
 
 	MVKDescriptorSetLayout* _layout;
@@ -134,6 +138,7 @@ protected:
 	VkDescriptorBindingFlagsEXT _flags;
 	MVKSmallVector<MVKSampler*> _immutableSamplers;
 	MVKShaderResourceBinding _mtlResourceIndexOffsets;
+	uint32_t _descriptorIndex;
 	bool _applyToStage[kMVKShaderStageMax];
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -376,11 +376,13 @@ void MVKDescriptorSetLayoutBinding::populateShaderConverterContext(mvk::SPIRVToM
 MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(MVKDevice* device,
 															 MVKDescriptorSetLayout* layout,
 															 const VkDescriptorSetLayoutBinding* pBinding,
-															 VkDescriptorBindingFlagsEXT bindingFlags) :
+															 VkDescriptorBindingFlagsEXT bindingFlags,
+															 uint32_t descriptorIndex) :
 	MVKBaseDeviceObject(device),
 	_layout(layout),
 	_info(*pBinding),
-	_flags(bindingFlags) {
+	_flags(bindingFlags),
+	_descriptorIndex(descriptorIndex) {
 
 	_info.pImmutableSamplers = nullptr;     // Remove dangling pointer
 
@@ -412,6 +414,7 @@ MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(const MVKDescriptor
 	_layout(binding._layout),
 	_info(binding._info),
 	_flags(binding._flags),
+	_descriptorIndex(binding._descriptorIndex),
 	_immutableSamplers(binding._immutableSamplers),
 	_mtlResourceIndexOffsets(binding._mtlResourceIndexOffsets) {
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -83,13 +83,12 @@ protected:
 
 	void propagateDebugName() override {}
 	inline uint32_t getDescriptorCount() { return _descriptorCount; }
-	inline uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return _bindingToDescriptorIndex[binding] + elementIndex; }
+	inline uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return getBinding(binding)->getDescriptorIndex(elementIndex); }
 	inline MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
 	const VkDescriptorBindingFlags* getBindingFlags(const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
 	std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
-	std::unordered_map<uint32_t, uint32_t> _bindingToDescriptorIndex;
 	MVKShaderResourceBinding _mtlResourceCounts;
 	uint32_t _descriptorCount;
 	bool _isPushDescriptorLayout;
@@ -138,8 +137,8 @@ protected:
 	VkResult allocate(MVKDescriptorSetLayout* layout, uint32_t variableDescriptorCount);
 	void free(bool isPoolReset);
 
-	MVKDescriptorSetLayout* _layout;
 	MVKDescriptorPool* _pool;
+	MVKDescriptorSetLayout* _layout;
 	MVKSmallVector<MVKDescriptor*> _descriptors;
 	uint32_t _variableDescriptorCount;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -369,7 +369,7 @@ protected:
 	MVKArrayRef<MVKQueueFamily*> getQueueFamilies();
 	void initPipelineCacheUUID();
 	uint32_t getHighestMTLFeatureSet();
-	uint64_t getMoltenVKGitRevision();
+	uint32_t getMoltenVKGitRevision();
 	void populate(VkPhysicalDeviceIDProperties* pDevIdProps);
 	void logGPUInfo();
 

--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -39,30 +39,20 @@ public:
 		return mvkIsAnyFlagEnabled(_pSections[getIndexOfSection(bitIndex)], getSectionSetMask(bitIndex));
 	}
 
-	/** Sets the value of the bit to 1. */
-	inline void setBit(size_t bitIndex) {
+	/** Sets the value of the bit to the val (or to 1 by default). */
+	inline void setBit(size_t bitIndex, bool val = true) {
 		size_t secIdx = getIndexOfSection(bitIndex);
-		mvkEnableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
-
-		if (secIdx < _minUnclearedSectionIndex) { _minUnclearedSectionIndex = secIdx; }
+		if (val) {
+			mvkEnableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
+			if (secIdx < _minUnclearedSectionIndex) { _minUnclearedSectionIndex = secIdx; }
+		} else {
+			mvkDisableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
+			if (secIdx == _minUnclearedSectionIndex && !_pSections[secIdx]) { _minUnclearedSectionIndex++; }
+		}
 	}
 
 	/** Sets the value of the bit to 0. */
-	inline void clearBit(size_t bitIndex) {
-		size_t secIdx = getIndexOfSection(bitIndex);
-		mvkDisableFlags(_pSections[secIdx], getSectionSetMask(bitIndex));
-
-		if (secIdx == _minUnclearedSectionIndex && !_pSections[secIdx]) { _minUnclearedSectionIndex++; }
-	}
-
-	/** Sets the value of the bit to the value. */
-	inline void setBit(size_t bitIndex, bool val) {
-		if (val) {
-			setBit(bitIndex);
-		} else {
-			clearBit(bitIndex);
-		}
-	}
+	inline void clearBit(size_t bitIndex) { setBit(bitIndex, false); }
 
 	/** Sets all bits in the array to 1. */
 	inline void setAllBits() { setAllSections(~0); }
@@ -120,8 +110,10 @@ public:
 	/** Returns whether this array is empty. */
 	inline bool empty() { return !_bitCount; }
 
-	/** Constructs an instance for the specified number of bits, and sets the initial value of all the bits. */
-	MVKBitArray(size_t size, bool val = false) {
+	/** Resize this array to the specified number of bits, and sets the initial value of all the bits. */
+	inline void resize(size_t size = 0, bool val = false) {
+		free(_pSections);
+
 		_bitCount = size;
 		_pSections = _bitCount ? (uint64_t*)malloc(getSectionCount() * SectionByteCount) : nullptr;
 		if (val) {
@@ -129,6 +121,12 @@ public:
 		} else {
 			clearAllBits();
 		}
+	}
+
+	/** Constructs an instance for the specified number of bits, and sets the initial value of all the bits. */
+	MVKBitArray(size_t size = 0, bool val = false) {
+		_pSections = nullptr;
+		resize(size, val);
 	}
 
 	~MVKBitArray() { free(_pSections); }


### PR DESCRIPTION
Move tracking descriptor index to `MVKDescriptorSetLayoutBinding` from `MVKDescriptorSetLayout`.
Refactor `MVKDescriptorSet::write()` to be more DRY.
Grow and shrink `MVKDescriptorSet` memory consumption during allocate and free.
`MVKPhysicalDevice` refactor layout of `pipelineCacheUUID` to remove redundancy in MoltenVK
revision and allow tracking of enabled features that affect pipeline cache content.
`MVKBitArray` support resizing and simplify setBit() functionality.