### PR TITLE
Enhancements and fixes to temporary MTLBuffer allocation.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommand.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommand.h
@@ -38,10 +38,10 @@ public:
 	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; }
 
-	/** Returns a new command instance. */
-	T* newObject() override { return new T(); }
-
 	MVKCommandTypePool(bool isPooling = true) : MVKObjectPool<T>(isPooling) {}
+
+protected:
+	T* newObject() override { return new T(); }
 
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -373,7 +373,7 @@ public:
     const MVKMTLBufferAllocation* getTempMTLBuffer(NSUInteger length, bool isPrivate = false, bool isDedicated = false);
 
 	/** Copy the bytes to a temporary MTLBuffer that will be returned to a pool after the command buffer is finished. */
-	const MVKMTLBufferAllocation* copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length, bool isPrivate = false, bool isDedicated = false);
+	const MVKMTLBufferAllocation* copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length, bool isDedicated = false);
 
     /** Returns the command encoding pool. */
     MVKCommandEncodingPool* getCommandEncodingPool();

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -372,6 +372,9 @@ public:
     /** Get a temporary MTLBuffer that will be returned to a pool after the command buffer is finished. */
     const MVKMTLBufferAllocation* getTempMTLBuffer(NSUInteger length, bool isPrivate = false, bool isDedicated = false);
 
+	/** Copy the bytes to a temporary MTLBuffer that will be returned to a pool after the command buffer is finished. */
+	const MVKMTLBufferAllocation* copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length, bool isPrivate = false, bool isDedicated = false);
+
     /** Returns the command encoding pool. */
     MVKCommandEncodingPool* getCommandEncodingPool();
 
@@ -470,7 +473,6 @@ protected:
     void finishQueries();
 	void setSubpass(MVKCommand* passCmd, VkSubpassContents subpassContents, uint32_t subpassIndex);
 	void clearRenderArea();
-    const MVKMTLBufferAllocation* copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length);
     NSString* getMTLRenderCommandEncoderName();
 
 	VkSubpassContents _subpassContents;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -659,8 +659,8 @@ MVKCommandEncodingPool* MVKCommandEncoder::getCommandEncodingPool() {
 }
 
 // Copies the specified bytes into a temporary allocation within a pooled MTLBuffer, and returns the MTLBuffer allocation.
-const MVKMTLBufferAllocation* MVKCommandEncoder::copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length, bool isPrivate, bool isDedicated) {
-	const MVKMTLBufferAllocation* mtlBuffAlloc = getTempMTLBuffer(length, isPrivate, isDedicated);
+const MVKMTLBufferAllocation* MVKCommandEncoder::copyToTempMTLBufferAllocation(const void* bytes, NSUInteger length, bool isDedicated) {
+	const MVKMTLBufferAllocation* mtlBuffAlloc = getTempMTLBuffer(length, false, isDedicated);
     void* pBuffData = mtlBuffAlloc->getContents();
     mlock(pBuffData, length);
     memcpy(pBuffData, bytes, length);

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.h
@@ -75,7 +75,7 @@ protected:
  * To return a MVKMTLBufferAllocation retrieved from this pool, back to this pool, 
  * call the returnToPool() function on the MVKMTLBufferAllocation instance.
  */
-class MVKMTLBufferAllocationPool : public MVKObjectPool<MVKMTLBufferAllocation> {
+class MVKMTLBufferAllocationPool : public MVKObjectPool<MVKMTLBufferAllocation>, public MVKDeviceTrackingMixin {
 
 public:
 
@@ -91,6 +91,7 @@ public:
 protected:
 	friend class MVKMTLBufferAllocation;
 	
+	MVKBaseObject* getBaseObject() override { return this; };
 	MVKMTLBufferAllocation* newObject() override;
 	void returnAllocation(MVKMTLBufferAllocation* ba) { _isThreadSafe ? returnObjectSafely(ba) : returnObject(ba); }
 	uint32_t calcMTLBufferAllocationCount();
@@ -101,7 +102,6 @@ protected:
     NSUInteger _mtlBufferLength;
     MTLStorageMode _mtlStorageMode;
 	MVKSmallVector<id<MTLBuffer>, 64> _mtlBuffers;
-    MVKDevice* _device;
 	bool _isThreadSafe;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -51,8 +51,10 @@ void MVKMTLBufferAllocationPool::addMTLBuffer() {
 
 
 MVKMTLBufferAllocationPool::MVKMTLBufferAllocationPool(MVKDevice* device, NSUInteger allocationLength, bool makeThreadSafe,
-													   bool isDedicated, MTLStorageMode mtlStorageMode) : MVKObjectPool<MVKMTLBufferAllocation>(true) {
-    _device = device;
+													   bool isDedicated, MTLStorageMode mtlStorageMode) :
+	MVKObjectPool<MVKMTLBufferAllocation>(true),
+	MVKDeviceTrackingMixin(device) {
+
     _allocationLength = allocationLength;
 	_isThreadSafe = makeThreadSafe;
     _mtlBufferLength = _allocationLength * (isDedicated ? 1 : calcMTLBufferAllocationCount());

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -892,6 +892,7 @@ public:
 
 protected:
 	MVKBaseObject* getBaseObject() override { return this; };
+
 };
 
 
@@ -929,10 +930,9 @@ protected:
 
 /** Manages a pool of instances of a particular object type that requires an MVKDevice during construction. */
 template <class T>
-class MVKDeviceObjectPool : public MVKObjectPool<T> {
+class MVKDeviceObjectPool : public MVKObjectPool<T>, public MVKDeviceTrackingMixin {
 
 public:
-
 
 	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return _device; };
@@ -941,12 +941,12 @@ public:
 	 * Configures this instance for the device, and either use pooling, or not, depending
 	 * on the value of isPooling, which defaults to true if not indicated explicitly.
 	 */
-	MVKDeviceObjectPool(MVKDevice* device, bool isPooling = true) : MVKObjectPool<T>(isPooling), _device(device) {}
+	MVKDeviceObjectPool(MVKDevice* device, bool isPooling = true) : MVKObjectPool<T>(isPooling), MVKDeviceTrackingMixin(device) {}
 
 protected:
 	T* newObject() override { return new T(_device); }
+	MVKBaseObject* getBaseObject() override { return this; };
 
-	MVKDevice* _device;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -937,9 +937,6 @@ public:
 	/** Returns the Vulkan API opaque object controlling this object. */
 	MVKVulkanAPIObject* getVulkanAPIObject() override { return _device; };
 
-	/** Returns a new instance. */
-	T* newObject() override { return new T(_device); }
-
 	/**
 	 * Configures this instance for the device, and either use pooling, or not, depending
 	 * on the value of isPooling, which defaults to true if not indicated explicitly.
@@ -947,6 +944,8 @@ public:
 	MVKDeviceObjectPool(MVKDevice* device, bool isPooling = true) : MVKObjectPool<T>(isPooling), _device(device) {}
 
 protected:
+	T* newObject() override { return new T(_device); }
+
 	MVKDevice* _device;
 };
 


### PR DESCRIPTION
Check allocations are larger than `MTLBuffer` alignment to avoid Metal errors.
Align returning safely with allocating safely, and change callers to use
`MVKMTLBufferAllocation::returnToPool()` globally, to ensure this match.
Fix use of const on `returnToPool()`;
Move `MVKCommandEncoder::copyToTempMTLBufferAllocation()`
and support setting private and dedicated flags.
Align constructor parameter order on `MVKMTLBufferAllocationPool`
with that of `MVKMTLBufferAllocator`.
Move subclass overrides of `MVKObjectPool::newObject()` to protected access.