### PR TITLE
Fix memory leak where swapchains and images were not destroyed due to a retention loop.

### DIFF
--- a/Demos/Cube/iOS/DemoViewController.m
+++ b/Demos/Cube/iOS/DemoViewController.m
@@ -62,6 +62,12 @@
 	demo_draw(&demo);
 }
 
+// Allow device rotation to resize the swapchain
+-(void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id)coordinator {
+	[super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+	demo_resize(&demo);
+}
+
 @end
 
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Always explicitly set `CAMetalLayer` colorspace property based on _Vulkan_ parameters, 
   and don't rely on _Metal_ default values.
 - Avoid use of _Metal_ renderpass load and store actions on memoryless attachments.
+- Fix memory leak on swapchain destruction.
 - Remove project qualifiers from references to `SPIRV-Cross` header files.
 - `MVKDescriptorPool` pools its descriptor sets.
 - Enable `MVKConfiguration::preallocateDescriptors` and `MVK_CONFIG_PREALLOCATE_DESCRIPTORS` 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -97,6 +97,8 @@ public:
 	/** VK_GOOGLE_display_timing - returns past presentation times */
 	VkResult getPastPresentationTiming(uint32_t *pCount, VkPastPresentationTimingGOOGLE *pPresentationTimings);
 	
+	void destroy() override;
+
 #pragma mark Construction
 	
 	MVKSwapchain(MVKDevice* device, const VkSwapchainCreateInfoKHR* pCreateInfo);


### PR DESCRIPTION
Add Cube app iOS device rotation support, to test swapchain destruction on iOS.

Fixes issue #1324.