### PR TITLE
Add MVKConfiguration::resumeLostDevice and MVK_CONFIG_RESUME_LOST_DEVICE env var.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -776,6 +776,31 @@ typedef struct {
 	 */
 	MVKConfigAdvertiseExtensions advertiseExtensions;
 
+	/**
+	 * Controls whether MoltenVK should treat a lost VkDevice as resumable, unless the
+	 * corresponding VkPhysicalDevice has also been lost. The VK_ERROR_DEVICE_LOST error has
+	 * a broad definitional range, and can mean anything from a GPU hiccup on the current
+	 * command buffer submission, to a phyically removed GPU. In the case where this error does
+	 * not impact the VkPhysicalDevice, Vulkan requires that the app destroy and re-create a new
+	 * VkDevice. However, not all apps (including CTS) respect that requirement, leading to what
+	 * might be a transient command submission failure causing an unexpected catastophic app failure.
+	 * If this setting is enabled, in the case of a VK_ERROR_DEVICE_LOST error that does not
+	 * impact the VkPhysicalDevice, MoltenVK will remove the error condition on the VkDevice after
+	 * the current queue submission is finished, allowing the VkDevice to continue to be used.
+	 * If this setting is disabled, MoltenVK will maintain the VK_ERROR_DEVICE_LOST error condition
+	 * on the VkDevice, and subsequent use of that VkDevice will be reduced or prohibited.
+	 *
+	 * The value of this parameter should be changed before creating a VkDevice
+	 * that will use it, for the change to take effect.
+	 *
+	 * The initial value or this parameter is set by the
+	 * MVK_CONFIG_RESUME_LOST_DEVICE
+	 * runtime environment variable or MoltenVK compile-time build setting.
+	 * If neither is set, this setting is disabled by default, and MoltenVK will not
+	 * resume a VkDevice that enters the VK_ERROR_DEVICE_LOST error state.
+	 */
+	VkBool32 resumeLostDevice;
+
 } MVKConfiguration;
 
 /**

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -338,6 +338,9 @@ void MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool signalCo
 #endif
 					mvkDev->getPhysicalDevice()->setConfigurationResult(VK_ERROR_DEVICE_LOST);
 					break;
+				default:
+					if (mvkConfig()->resumeLostDevice) { mvkDev->clearConfigurationResult(); }
+					break;
 			}
 #if MVK_XCODE_12
 			if (mvkConfig()->debugMode) {

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -60,6 +60,7 @@ static void mvkInitConfigFromEnvVars() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.useMTLHeap,                             MVK_CONFIG_USE_MTLHEAP);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.apiVersionToAdvertise,                  MVK_CONFIG_API_VERSION_TO_ADVERTISE);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.advertiseExtensions,                    MVK_CONFIG_ADVERTISE_EXTENSIONS);
+	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.resumeLostDevice,                       MVK_CONFIG_RESUME_LOST_DEVICE);
 
 	mvkSetConfig(&evCfg);
 }

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -272,3 +272,8 @@ void mvkSetConfig(MVKConfiguration* pMVKConfig);
 #ifndef MVK_CONFIG_ADVERTISE_EXTENSIONS
 #  	define MVK_CONFIG_ADVERTISE_EXTENSIONS    MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL
 #endif
+
+/** Support Metal argument buffers. Disabled by default. */
+#ifndef MVK_CONFIG_RESUME_LOST_DEVICE
+#   define MVK_CONFIG_RESUME_LOST_DEVICE    0
+#endif

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -273,7 +273,7 @@ void mvkSetConfig(MVKConfiguration* pMVKConfig);
 #  	define MVK_CONFIG_ADVERTISE_EXTENSIONS    MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL
 #endif
 
-/** Support Metal argument buffers. Disabled by default. */
+/** Resume MVKDevice VK_ERROR_DEVICE_LOST errors that do not cause MVKPhysicalDevice errors. Disabled by default. */
 #ifndef MVK_CONFIG_RESUME_LOST_DEVICE
 #   define MVK_CONFIG_RESUME_LOST_DEVICE    0
 #endif


### PR DESCRIPTION
Add `MVKConfiguration::resumeLostDevice` and `MVK_CONFIG_RESUME_LOST_DEVICE` env var,
to allow VkDevice to resume after non-fatal VK_ERROR_DEVICE_LOST error.

When running CTS, when one test triggers a `VK_ERROR_DEVICE_LOST` error condition,
CTS does not create a new `VkDevice` for subsequent tests, which causes all subsequent
tests to fail. This creates an incredible amount of results noise, and makes it
difficult to determine accurate test failure numbers. This is particularly problematic
because `VK_ERROR_DEVICE_LOST` may be triggered sporadically by internal Metal issues,
often making it not traceable to a consistent failure of a particular CTS test.