### PR TITLE
Use SPIRV_CROSS_NAMESPACE define in MVKDescriptor.mm

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -109,7 +109,7 @@ void mvkPopulateShaderConverterContext(mvk::SPIRVToMSLConversionConfiguration& c
 		mvk::MSLResourceBinding rb;													\
 		auto& rbb = rb.resourceBinding;												\
 		rbb.stage = spvExecModels[stage];											\
-		rbb.basetype = SPIRV_CROSS_NAMESPACE_OVERRIDE::SPIRType::spvRezType;		\
+		rbb.basetype = SPIRV_CROSS_NAMESPACE ::SPIRType::spvRezType;		\
 		rbb.desc_set = descriptorSetIndex;											\
 		rbb.binding = bindingIndex;													\
 		rbb.count = count;															\

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -109,7 +109,7 @@ void mvkPopulateShaderConverterContext(mvk::SPIRVToMSLConversionConfiguration& c
 		mvk::MSLResourceBinding rb;													\
 		auto& rbb = rb.resourceBinding;												\
 		rbb.stage = spvExecModels[stage];											\
-		rbb.basetype = SPIRV_CROSS_NAMESPACE ::SPIRType::spvRezType;		\
+		rbb.basetype = SPIRV_CROSS_NAMESPACE::SPIRType::spvRezType;		\
 		rbb.desc_set = descriptorSetIndex;											\
 		rbb.binding = bindingIndex;													\
 		rbb.count = count;															\


### PR DESCRIPTION
I believe SPIRV_CROSS_NAMESPACE_OVERRIDE should be replaced by SPIRV_CROSS_NAMESPACE defined in SPIRV-Cross spirv_common.hpp. This ensures that SPIRV_CROSS_NAMESPACE_OVERRIDE usage in MVK is optional.