### PR TITLE
Fix crash when requesting MTLCommandBuffer logs in runtime debug mode on older OS versions.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,7 @@ Released TBD
 - Improve cache hits when matching `SPIRVToMSLConversionConfiguration` structs to each other 
   to find a cached shader, by only considering resources from the current shader stage.
 - Rename `kMVKShaderStageMax` to `kMVKShaderStageCount`.
+- Fix crash when requesting `MTLCommandBuffer` logs in runtime debug mode on older OS versions.
 - Fix internal reference from `SPIRV_CROSS_NAMESPACE_OVERRIDE` to `SPIRV_CROSS_NAMESPACE`.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -361,7 +361,7 @@ void MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool signalCo
 #endif
 		}
 #if MVK_XCODE_12
-		if (mvkConfig().debugMode) {
+		if (mvkConfig().debugMode && [mtlCB respondsToSelector: @selector(logs)]) {
 			bool isFirstMsg = true;
 			for (id<MTLFunctionLog> log in mtlCB.logs) {
 				if (isFirstMsg) {


### PR DESCRIPTION
Fixes issue #1336.