### PR TITLE
MVKImagePlane::getMTLTexture() protect against crash when image has no device memory bound.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,7 @@ Released TBD
 - Improve cache hits when matching `SPIRVToMSLConversionConfiguration` structs to each other 
   to find a cached shader, by only considering resources from the current shader stage.
 - Rename `kMVKShaderStageMax` to `kMVKShaderStageCount`.
+- Protect against crash when retrieving `MTLTexture` when `VkImage` has no `VkDeviceMemory` bound.
 - Fix internal reference from `SPIRV_CROSS_NAMESPACE_OVERRIDE` to `SPIRV_CROSS_NAMESPACE`.
 
 


### PR DESCRIPTION
Fixes #1329.