### PR TITLE
WIP: Implement vkGetRefreshCycleDurationGOOGLE() for macOS.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -29,8 +29,15 @@
 #import "CAMetalLayer+MoltenVK.h"
 #import "MVKBlockObserver.h"
 
-#if MVK_IOS_OR_TVOS
+#if MVK_IOS_OR_TVOS || MVK_MACCAT
 #	include <UIKit/UIScreen.h>
+#endif
+
+#if MVK_MACOS && !MVK_MACCAT
+#	include <AppKit/NSApplication.h>
+#	include <AppKit/NSScreen.h>
+#	include <AppKit/NSWindow.h>
+#	include <AppKit/NSView.h>
 #endif
 
 #include <libkern/OSByteOrder.h>
@@ -408,15 +415,33 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRefreshCycleDuration) {
 	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
 
+#if MVK_IOS_OR_TVOS || MVK_MACCAT
 	NSInteger framesPerSecond = 60;
-#if MVK_IOS_OR_TVOS
 	UIScreen* screen = [UIScreen mainScreen];
 	if ([screen respondsToSelector: @selector(maximumFramesPerSecond)]) {
 		framesPerSecond = screen.maximumFramesPerSecond;
 	}
 #endif
-#if MVK_MACOS
-	// TODO: hook this up for macOS, probably need to use CGDisplayModeGetRefeshRate
+
+#if MVK_MACOS && !MVK_MACCAT
+	// Find the screen for the window whose content view is backed by the swapchains CAMetalLayer.
+	// Default to the mainScreen if no such window can be found.
+	NSScreen *screen = [NSScreen mainScreen];
+	for (NSWindow* window in [[NSApplication sharedApplication] windows]) {
+		NSView *view = [window contentView];
+		if (view && ([view layer] == _mtlLayer)) {
+			screen = [window screen];
+		}
+	}
+
+	CGDirectDisplayID displayId = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
+	CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
+	double framesPerSecond = CGDisplayModeGetRefreshRate(mode);
+	CGDisplayModeRelease(mode);
+
+	// Builtin panels, e.g., on MacBook, report a zero refresh rate.
+	if (framesPerSecond == 0)
+		framesPerSecond = 60.0;
 #endif
 
 	pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;


### PR DESCRIPTION
So far it always returned a 60 Hz refresh on macOS. Now we query the
actual refresh interval for the NSScreen on which our swapChain is likely
displaying.

Tested on a MacBookPro dual-display setup with builtin 60 Hz Retina panel
and external 100 Hz monitor, showing proper reporting depending on which
monitor the window was displaying on. Tested on macOS 10.15.7 only.