### PR TITLE
Cleanup handling of sampler border color and mirror edge clamp.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -286,13 +286,10 @@ VkExtent3D mvkMipmapBaseSizeFromLevelSize3D(VkExtent3D levelSize, uint32_t level
 
 #pragma mark Samplers
 
-/**
- * Returns the Metal MTLSamplerAddressMode corresponding to the specified Vulkan VkSamplerAddressMode,
- * or returns MTLSamplerAddressModeMirrorClampToEdge if no corresponding MTLSamplerAddressMode exists.
- */
+/** Returns the Metal MTLSamplerAddressMode corresponding to the specified Vulkan VkSamplerAddressMode. */
 MTLSamplerAddressMode mvkMTLSamplerAddressModeFromVkSamplerAddressMode(VkSamplerAddressMode vkMode);
 
-#if MVK_MACOS_OR_IOS 
+#if MVK_MACOS_OR_IOS
 /**
  * Returns the Metal MTLSamplerBorderColor corresponding to the specified Vulkan VkBorderColor,
  * or returns MTLSamplerBorderColorTransparentBlack if no corresponding MTLSamplerBorderColor exists.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -695,7 +695,6 @@ public:
     /** Returns the number of planes if this is a ycbcr conversion or 0 otherwise. */
     inline uint8_t getPlaneCount() { return (_ycbcrConversion) ? _ycbcrConversion->getPlaneCount() : 0; }
 
-
 	/**
 	 * If this sampler requires hardcoding in MSL, populates the hardcoded sampler in the resource binding.
 	 * Returns whether this sampler requires hardcoding in MSL, and the constant sampler was populated.
@@ -704,6 +703,9 @@ public:
 
 	/** Returns whether this sampler must be implemented as a hardcoded constant sampler in the shader MSL code. */
 	inline 	bool getRequiresConstExprSampler() { return _requiresConstExprSampler; }
+
+	/** Returns the Metal MTLSamplerAddressMode corresponding to the specified Vulkan VkSamplerAddressMode. */
+	MTLSamplerAddressMode getMTLSamplerAddressMode(VkSamplerAddressMode vkMode);
 
 	MVKSampler(MVKDevice* device, const VkSamplerCreateInfo* pCreateInfo);
 

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -282,12 +282,12 @@ MVK_PUBLIC_SYMBOL MTLSamplerAddressMode mvkMTLSamplerAddressModeFromVkSamplerAdd
 	switch (vkMode) {
 		case VK_SAMPLER_ADDRESS_MODE_REPEAT:				return MTLSamplerAddressModeRepeat;
 		case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE:			return MTLSamplerAddressModeClampToEdge;
-		case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER:		return MTLSamplerAddressModeClampToZero;
 		case VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT:		return MTLSamplerAddressModeMirrorRepeat;
-#if MVK_MACOS
+#if MVK_MACOS || (MVK_IOS && MVK_XCODE_12)
 		case VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE:	return MTLSamplerAddressModeMirrorClampToEdge;
+		case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER:		return MTLSamplerAddressModeClampToBorderColor;
 #endif
-		default:								return MTLSamplerAddressModeClampToZero;
+		default:											return MTLSamplerAddressModeClampToZero;
 	}
 }
 


### PR DESCRIPTION
- `mvkMTLSamplerAddressModeFromVkSamplerAddressMode()` support `MTLSamplerAddressModeClampToBorderColor` and `MTLSamplerAddressModeMirrorClampToEdge` if available.
- Add `MVKSampler::getMTLSamplerAddressMode()` to test for device feature availability.
Remove special border color handling in `MVKSampler::newMTLSamplerDescriptor()`.