### PR TITLE
Revert to strict publishing of functions only from enabled extensions.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -42,16 +42,11 @@ typedef struct MVKEntryPoint {
 	bool isDevice;
 
 	bool isCore() { return !ext1Name && !ext2Name; }
-
-	// If we're artificially running without all supported extensions, allow the
-	// associated functions to be available anyway, in case the app is surprised
-	// (ie- expects the functions from past experience and has no alternate handling).
 	bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList) {
 		return ((isCore() && MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion) ||
-				(extList.isEnabled(ext1Name) || extList.isEnabled(ext2Name) ||
-				 !mvkIsAnyFlagEnabled(mvkConfig().advertiseExtensions,
-									  MVK_CONFIG_ADVERTISE_EXTENSIONS_ALL)));
+				extList.isEnabled(ext1Name) || extList.isEnabled(ext2Name));
 	}
+
 } MVKEntryPoint;
 
 


### PR DESCRIPTION
Previously we had loosened the behavior so that function proc addresses are returned
for an extension function even if that extension is disabled, if the API was artificially
restricted during testing, to bypass CTS tests that appeared to assume certain
extension functions were available.

This loosening in turn caused the `dEQP-VK.api.version_check.entry_points` test to fail,
so the restriction is reapplied and only functions from enabled extensions are published.