### PR TITLE
Fix synchronization issue with locking MTLArgumentEncoder.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -26,6 +26,7 @@ Released TBD
   to find a cached shader, by only considering resources from the current shader stage.
 - Rename `kMVKShaderStageMax` to `kMVKShaderStageCount`.
 - Fix crash when requesting `MTLCommandBuffer` logs in runtime debug mode on older OS versions.
+- Fix synchronization issue with locking `MTLArgumentEncoder` for Metal Argument Buffers.
 - Protect against crash when retrieving `MTLTexture` when `VkImage` has no `VkDeviceMemory` bound.
 - Adjust some `VkPhysicalDeviceLimits` values for Vulkan and Metal compliance. 
 - Fix internal reference from `SPIRV_CROSS_NAMESPACE_OVERRIDE` to `SPIRV_CROSS_NAMESPACE`.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -34,8 +34,13 @@ class MVKResourcesCommandEncoderState;
 #pragma mark -
 #pragma mark MVKDescriptorSetLayout
 
-/** Holds and manages the lifecycle of a MTLArgumentEncoder. The encoder can only be set once. */
+/**
+ * Holds and manages the lifecycle of a MTLArgumentEncoder. The encoder can
+ * only be set once, and copying this object results in an uninitialized
+ * empty object, since mutex and MTLArgumentEncoder can/should not be copied.
+ */
 struct MVKMTLArgumentEncoder {
+	std::mutex mtlArgumentEncodingLock;
 	NSUInteger mtlArgumentEncoderSize = 0;
 
 	id<MTLArgumentEncoder> getMTLArgumentEncoder() { return _mtlArgumentEncoder; }
@@ -44,6 +49,10 @@ struct MVKMTLArgumentEncoder {
 		_mtlArgumentEncoder = mtlArgEnc;		// takes ownership
 		mtlArgumentEncoderSize = mtlArgEnc.encodedLength;
 	}
+
+	MVKMTLArgumentEncoder(const MVKMTLArgumentEncoder& other) {}
+	MVKMTLArgumentEncoder& operator=(const MVKMTLArgumentEncoder& other) { return *this; }
+	MVKMTLArgumentEncoder() {}
 	~MVKMTLArgumentEncoder() { [_mtlArgumentEncoder release]; }
 
 private:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -188,9 +188,6 @@ public:
 	/** Returns the number of descriptor sets in this pipeline layout. */
 	uint32_t getDescriptorSetCount() { return _descriptorSetCount; }
 
-	/** A mutex lock to protect access to the Metal argument encoders. */
-	std::mutex _mtlArgumentEncodingLock;
-
 	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
 	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipelineLayout* layout, MVKPipeline* parent);
 


### PR DESCRIPTION
Move mutex lock for using `MTLArgumentEncoder` to `MVKMTLArgumentEncoder` to be tracked along with the `MTLArgumentEncoder` it guards. Previously, the mutex was tracked in `MVKPipeline`, which did not guard any `MTLArgumentEncoder` that came from an `MVKDescriptorSetLayout`.