### PR TITLE
Fix inconsistent handling of linear attachment decisions on Apple Silicon.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -27,9 +27,11 @@ Released TBD
 - Rename `kMVKShaderStageMax` to `kMVKShaderStageCount`.
 - Fix crash when requesting `MTLCommandBuffer` logs in runtime debug mode on older OS versions.
 - Fix synchronization issue with locking `MTLArgumentEncoder` for Metal Argument Buffers.
+- Fix inconsistent handling of linear attachment decisions on Apple Silicon.
 - Protect against crash when retrieving `MTLTexture` when `VkImage` has no `VkDeviceMemory` bound.
 - Adjust some `VkPhysicalDeviceLimits` values for Vulkan and Metal compliance. 
 - Fix internal reference from `SPIRV_CROSS_NAMESPACE_OVERRIDE` to `SPIRV_CROSS_NAMESPACE`.
+
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -611,7 +611,7 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 					return VK_ERROR_FORMAT_NOT_SUPPORTED;
 				}
 #if !MVK_APPLE_SILICON
-				// - On macOS IMR GPU's, Linear textures may not be used as framebuffer attachments.
+				// - On macOS IMR GPUs, Linear textures may not be used as framebuffer attachments.
 				if (hasAttachmentUsage) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
 #endif
 				// Linear textures may only have one mip level, layer & sample.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -610,8 +610,8 @@ VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
 				if (mvkFmt == kMVKFormatDepthStencil || mvkFmt == kMVKFormatCompressed || isBGRG) {
 					return VK_ERROR_FORMAT_NOT_SUPPORTED;
 				}
-#if MVK_MACOS
-				// - On macOS, Linear textures may not be used as framebuffer attachments.
+#if !MVK_APPLE_SILICON
+				// - On macOS IMR GPU's, Linear textures may not be used as framebuffer attachments.
 				if (hasAttachmentUsage) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
 #endif
 				// Linear textures may only have one mip level, layer & sample.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1102,7 +1102,7 @@ bool MVKImage::validateLinear(const VkImageCreateInfo* pCreateInfo, bool isAttac
 		isLin = false;
 	}
 
-#if MVK_MACOS
+#if !MVK_APPLE_SILICON
 	if (isAttachment) {
 		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : This device does not support rendering to linear (VK_IMAGE_TILING_LINEAR) images."));
 		isLin = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -2072,13 +2072,11 @@ void MVKPixelFormats::setFormatProperties(MVKVkFormatDesc& vkDesc) {
 		// Linear tiling can support atomic writing for some formats, even though optimal tiling does not.
 		enableFormatFeatures(Atomic, Tex, mtlPixFmtCaps, vkProps.linearTilingFeatures);
 
-#if MVK_MACOS
-		// On IMR GPUs, linear textures cannot be used as attachments, so disable those features.
-		if (![mtlDev respondsToSelector: @selector(supportsFamily:)] || ![mtlDev supportsFamily: MTLGPUFamilyApple5]) {
-			mvkDisableFlags(vkProps.linearTilingFeatures, (kMVKVkFormatFeatureFlagsTexColorAtt |
-														   kMVKVkFormatFeatureFlagsTexDSAtt |
-														   kMVKVkFormatFeatureFlagsTexBlend));
-		}
+#if !MVK_APPLE_SILICON
+		// On macOS IMR GPUs, linear textures cannot be used as attachments, so disable those features.
+		mvkDisableFlags(vkProps.linearTilingFeatures, (kMVKVkFormatFeatureFlagsTexColorAtt |
+													   kMVKVkFormatFeatureFlagsTexDSAtt |
+													   kMVKVkFormatFeatureFlagsTexBlend));
 #endif
 	}
 


### PR DESCRIPTION
Was causing some CTS attachment clearing tests to fail, or incorrectly report Not Supported, on Apple Silicon.