### PR TITLE
Device loss fixes

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -27,6 +27,9 @@ Released TBD
 - Rename `kMVKShaderStageMax` to `kMVKShaderStageCount`.
 - Fix crash when requesting `MTLCommandBuffer` logs in runtime debug mode on older OS versions.
 - Fix synchronization issue with locking `MTLArgumentEncoder` for Metal Argument Buffers.
+- Fix race condition on submission fence during device loss.
+- On command buffer submission failure, if `MVKConfiguration::resumeLostDevice` enabled,  do not release 
+  waits on `VkDevice`, and do not return `VK_ERROR_DEVICE_LOST`, unless `VkPhysicalDevice` is also lost.
 - Fix inconsistent handling of linear attachment decisions on Apple Silicon.
 - Protect against crash when retrieving `MTLTexture` when `VkImage` has no `VkDeviceMemory` bound.
 - Adjust some `VkPhysicalDeviceLimits` values for Vulkan and Metal compliance. 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -780,7 +780,7 @@ typedef struct {
 	 * Controls whether MoltenVK should treat a lost VkDevice as resumable, unless the
 	 * corresponding VkPhysicalDevice has also been lost. The VK_ERROR_DEVICE_LOST error has
 	 * a broad definitional range, and can mean anything from a GPU hiccup on the current
-	 * command buffer submission, to a phyisically removed GPU. In the case where this error does
+	 * command buffer submission, to a physically removed GPU. In the case where this error does
 	 * not impact the VkPhysicalDevice, Vulkan requires that the app destroy and re-create a new
 	 * VkDevice. However, not all apps (including CTS) respect that requirement, leading to what
 	 * might be a transient command submission failure causing an unexpected catastophic app failure.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -780,24 +780,24 @@ typedef struct {
 	 * Controls whether MoltenVK should treat a lost VkDevice as resumable, unless the
 	 * corresponding VkPhysicalDevice has also been lost. The VK_ERROR_DEVICE_LOST error has
 	 * a broad definitional range, and can mean anything from a GPU hiccup on the current
-	 * command buffer submission, to a phyically removed GPU. In the case where this error does
+	 * command buffer submission, to a phyisically removed GPU. In the case where this error does
 	 * not impact the VkPhysicalDevice, Vulkan requires that the app destroy and re-create a new
 	 * VkDevice. However, not all apps (including CTS) respect that requirement, leading to what
 	 * might be a transient command submission failure causing an unexpected catastophic app failure.
-	 * If this setting is enabled, in the case of a VK_ERROR_DEVICE_LOST error that does not
-	 * impact the VkPhysicalDevice, MoltenVK will remove the error condition on the VkDevice after
-	 * the current queue submission is finished, allowing the VkDevice to continue to be used.
-	 * If this setting is disabled, MoltenVK will maintain the VK_ERROR_DEVICE_LOST error condition
-	 * on the VkDevice, and subsequent use of that VkDevice will be reduced or prohibited.
 	 *
-	 * The value of this parameter should be changed before creating a VkDevice
-	 * that will use it, for the change to take effect.
+	 * If this setting is enabled, in the case of a VK_ERROR_DEVICE_LOST error that does NOT impact
+	 * the VkPhysicalDevice, MoltenVK will log the error, but will not mark the VkDevice as lost,
+	 * allowing the VkDevice to continue to be used. If this setting is disabled, MoltenVK will
+	 * mark the VkDevice as lost, and subsequent use of that VkDevice will be reduced or prohibited.
+	 *
+	 * The value of this parameter may be changed at any time during application runtime,
+	 * and the changed value will affect the error behavior of subsequent command submissions.
 	 *
 	 * The initial value or this parameter is set by the
 	 * MVK_CONFIG_RESUME_LOST_DEVICE
 	 * runtime environment variable or MoltenVK compile-time build setting.
-	 * If neither is set, this setting is disabled by default, and MoltenVK will not
-	 * resume a VkDevice that enters the VK_ERROR_DEVICE_LOST error state.
+	 * If neither is set, this setting is disabled by default, and MoltenVK
+	 * will mark the VkDevice as lost when a command submission failure occurs.
 	 */
 	VkBool32 resumeLostDevice;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -447,8 +447,8 @@ public:
 	/** Block the current thread until all queues in this device are idle. */
 	VkResult waitIdle();
 	
-	/** Mark this device as lost. Releases all waits for this device. */
-	VkResult markLost();
+	/** Mark this device (and optionally the physical device) as lost. Releases all waits for this device. */
+	VkResult markLost(bool alsoMarkPhysicalDevice = false);
 
 	/** Returns whether or not the given descriptor set layout is supported. */
 	void getDescriptorSetLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2861,9 +2861,12 @@ VkResult MVKDevice::waitIdle() {
 	return VK_SUCCESS;
 }
 
-VkResult MVKDevice::markLost() {
+VkResult MVKDevice::markLost(bool alsoMarkPhysicalDevice) {
 	lock_guard<mutex> lock(_sem4Lock);
+
 	setConfigurationResult(VK_ERROR_DEVICE_LOST);
+	if (alsoMarkPhysicalDevice) { _physicalDevice->setConfigurationResult(VK_ERROR_DEVICE_LOST); }
+
 	for (auto* sem4 : _awaitingSemaphores) {
 		sem4->release();
 	}
@@ -2874,7 +2877,8 @@ VkResult MVKDevice::markLost() {
 	}
 	_awaitingSemaphores.clear();
 	_awaitingTimelineSem4s.clear();
-	return VK_ERROR_DEVICE_LOST;
+
+	return getConfigurationResult();
 }
 
 void MVKDevice::getDescriptorSetLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -195,6 +195,8 @@ public:
 
 	MVKQueueCommandBufferSubmission(MVKQueue* queue, const VkSubmitInfo* pSubmit, VkFence fence);
 
+	~MVKQueueCommandBufferSubmission() override;
+
 protected:
 	friend MVKCommandBuffer;
 


### PR DESCRIPTION
- Fix race condition on `MVKQueueCommandBufferSubmission` fence during device loss.
- `MVKQueueCommandBufferSubmission` `retain()` and `release()` fence and signal semaphores
to ensure they live long enough for the submission to finish using them.
- On command buffer submission failure, if `MVKConfiguration::resumeLostDevice` enabled,
do not release waits on `VkDevice`, and do not return `VK_ERROR_DEVICE_LOST`, unless
`VkPhysicalDevice` is also lost.

Fixes #1366. But I decided not to do anything further about moving `markLost()` to `MVKPhysicalDevice`. The Vulkan spec is clear that the app should destroy and re-create a `VkDevice` under these conditions, so the current behavior is correct (even if the spec is heavy-handed). I did change the behavior under `MVKConfiguration::resumeLostDevice`, so that the waiting semaphores are not signalled unless it's a `VkPhysicalDevice` fatal error.