### PR TITLE
Add label strings to MTLCommandBuffers, based on use type, for GPU Capture debugging.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -512,6 +512,9 @@ protected:
 #pragma mark -
 #pragma mark Support functions
 
+/** Returns a name, suitable for use as a MTLCommandBuffer label, based on the MVKCommandUse. */
+NSString* mvkMTLCommandBufferLabel(MVKCommandUse cmdUse);
+
 /** Returns a name, suitable for use as a MTLRenderCommandEncoder label, based on the MVKCommandUse. */
 NSString* mvkMTLRenderCommandEncoderLabel(MVKCommandUse cmdUse);
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -792,48 +792,61 @@ MVKCommandEncoder::MVKCommandEncoder(MVKCommandBuffer* cmdBuffer) : MVKBaseDevic
 #pragma mark -
 #pragma mark Support functions
 
+NSString* mvkMTLCommandBufferLabel(MVKCommandUse cmdUse) {
+	switch (cmdUse) {
+		case kMVKCommandUseEndCommandBuffer:                return @"vkEndCommandBuffer (Prefilled) CommandBuffer";
+		case kMVKCommandUseQueueSubmit:                     return @"vkQueueSubmit CommandBuffer";
+		case kMVKCommandUseQueuePresent:                    return @"vkQueuePresentKHR CommandBuffer";
+		case kMVKCommandUseQueueWaitIdle:                   return @"vkQueueWaitIdle CommandBuffer";
+		case kMVKCommandUseDeviceWaitIdle:                  return @"vkDeviceWaitIdle CommandBuffer";
+		case kMVKCommandUseAcquireNextImage:                return @"vkAcquireNextImageKHR CommandBuffer";
+		case kMVKCommandUseInvalidateMappedMemoryRanges:    return @"vkInvalidateMappedMemoryRanges CommandBuffer";
+		default:                                            return @"Unknown Use CommandBuffer";
+	}
+}
+
 NSString* mvkMTLRenderCommandEncoderLabel(MVKCommandUse cmdUse) {
     switch (cmdUse) {
-        case kMVKCommandUseBeginRenderPass:         return @"vkCmdBeginRenderPass RenderEncoder";
-        case kMVKCommandUseNextSubpass:             return @"vkCmdNextSubpass RenderEncoder";
-        case kMVKCommandUseBlitImage:               return @"vkCmdBlitImage RenderEncoder";
-        case kMVKCommandUseResolveImage:            return @"vkCmdResolveImage (resolve stage) RenderEncoder";
-        case kMVKCommandUseResolveExpandImage:      return @"vkCmdResolveImage (expand stage) RenderEncoder";
-        case kMVKCommandUseClearColorImage:         return @"vkCmdClearColorImage RenderEncoder";
-        case kMVKCommandUseClearDepthStencilImage:  return @"vkCmdClearDepthStencilImage RenderEncoder";
-        default:                                    return @"Unknown Use RenderEncoder";
+        case kMVKCommandUseBeginRenderPass:                 return @"vkCmdBeginRenderPass RenderEncoder";
+        case kMVKCommandUseNextSubpass:                     return @"vkCmdNextSubpass RenderEncoder";
+        case kMVKCommandUseBlitImage:                       return @"vkCmdBlitImage RenderEncoder";
+        case kMVKCommandUseResolveImage:                    return @"vkCmdResolveImage (resolve stage) RenderEncoder";
+        case kMVKCommandUseResolveExpandImage:              return @"vkCmdResolveImage (expand stage) RenderEncoder";
+        case kMVKCommandUseClearColorImage:                 return @"vkCmdClearColorImage RenderEncoder";
+        case kMVKCommandUseClearDepthStencilImage:          return @"vkCmdClearDepthStencilImage RenderEncoder";
+        default:                                            return @"Unknown Use RenderEncoder";
     }
 }
 
 NSString* mvkMTLBlitCommandEncoderLabel(MVKCommandUse cmdUse) {
     switch (cmdUse) {
-        case kMVKCommandUsePipelineBarrier:     return @"vkCmdPipelineBarrier BlitEncoder";
-        case kMVKCommandUseCopyImage:           return @"vkCmdCopyImage BlitEncoder";
-        case kMVKCommandUseResolveCopyImage:    return @"vkCmdResolveImage (copy stage) RenderEncoder";
-        case kMVKCommandUseCopyBuffer:          return @"vkCmdCopyBuffer BlitEncoder";
-        case kMVKCommandUseCopyBufferToImage:   return @"vkCmdCopyBufferToImage BlitEncoder";
-        case kMVKCommandUseCopyImageToBuffer:   return @"vkCmdCopyImageToBuffer BlitEncoder";
-        case kMVKCommandUseFillBuffer:          return @"vkCmdFillBuffer BlitEncoder";
-        case kMVKCommandUseUpdateBuffer:        return @"vkCmdUpdateBuffer BlitEncoder";
-        case kMVKCommandUseResetQueryPool:      return @"vkCmdResetQueryPool BlitEncoder";
-        case kMVKCommandUseCopyQueryPoolResults:return @"vkCmdCopyQueryPoolResults BlitEncoder";
-        default:                                return @"Unknown Use BlitEncoder";
+        case kMVKCommandUsePipelineBarrier:                 return @"vkCmdPipelineBarrier BlitEncoder";
+        case kMVKCommandUseCopyImage:                       return @"vkCmdCopyImage BlitEncoder";
+        case kMVKCommandUseResolveCopyImage:                return @"vkCmdResolveImage (copy stage) RenderEncoder";
+        case kMVKCommandUseCopyBuffer:                      return @"vkCmdCopyBuffer BlitEncoder";
+        case kMVKCommandUseCopyBufferToImage:               return @"vkCmdCopyBufferToImage BlitEncoder";
+        case kMVKCommandUseCopyImageToBuffer:               return @"vkCmdCopyImageToBuffer BlitEncoder";
+        case kMVKCommandUseFillBuffer:                      return @"vkCmdFillBuffer BlitEncoder";
+        case kMVKCommandUseUpdateBuffer:                    return @"vkCmdUpdateBuffer BlitEncoder";
+        case kMVKCommandUseResetQueryPool:                  return @"vkCmdResetQueryPool BlitEncoder";
+        case kMVKCommandUseCopyQueryPoolResults:            return @"vkCmdCopyQueryPoolResults BlitEncoder";
+        default:                                            return @"Unknown Use BlitEncoder";
     }
 }
 
 NSString* mvkMTLComputeCommandEncoderLabel(MVKCommandUse cmdUse) {
     switch (cmdUse) {
-        case kMVKCommandUseDispatch:            return @"vkCmdDispatch ComputeEncoder";
-        case kMVKCommandUseCopyBuffer:          return @"vkCmdCopyBuffer ComputeEncoder";
-        case kMVKCommandUseCopyBufferToImage:   return @"vkCmdCopyBufferToImage ComputeEncoder";
-        case kMVKCommandUseCopyImageToBuffer:   return @"vkCmdCopyImageToBuffer ComputeEncoder";
-        case kMVKCommandUseFillBuffer:          return @"vkCmdFillBuffer ComputeEncoder";
-        case kMVKCommandUseClearColorImage:     return @"vkCmdClearColorImage ComputeEncoder";
-        case kMVKCommandUseTessellationVertexTessCtl: return @"vkCmdDraw (vertex and tess control stages) ComputeEncoder";
-        case kMVKCommandUseMultiviewInstanceCountAdjust: return @"vkCmdDraw (multiview instance count adjustment) ComputeEncoder";
-        case kMVKCommandUseCopyQueryPoolResults:return @"vkCmdCopyQueryPoolResults ComputeEncoder";
-        case kMVKCommandUseAccumOcclusionQuery: return @"Post-render-pass occlusion query accumulation ComputeEncoder";
-        default:                                return @"Unknown Use ComputeEncoder";
+        case kMVKCommandUseDispatch:                        return @"vkCmdDispatch ComputeEncoder";
+        case kMVKCommandUseCopyBuffer:                      return @"vkCmdCopyBuffer ComputeEncoder";
+        case kMVKCommandUseCopyBufferToImage:               return @"vkCmdCopyBufferToImage ComputeEncoder";
+        case kMVKCommandUseCopyImageToBuffer:               return @"vkCmdCopyImageToBuffer ComputeEncoder";
+        case kMVKCommandUseFillBuffer:                      return @"vkCmdFillBuffer ComputeEncoder";
+        case kMVKCommandUseClearColorImage:                 return @"vkCmdClearColorImage ComputeEncoder";
+        case kMVKCommandUseTessellationVertexTessCtl:       return @"vkCmdDraw (vertex and tess control stages) ComputeEncoder";
+        case kMVKCommandUseMultiviewInstanceCountAdjust:    return @"vkCmdDraw (multiview instance count adjustment) ComputeEncoder";
+        case kMVKCommandUseCopyQueryPoolResults:            return @"vkCmdCopyQueryPoolResults ComputeEncoder";
+        case kMVKCommandUseAccumOcclusionQuery:             return @"Post-render-pass occlusion query accumulation ComputeEncoder";
+        default:                                            return @"Unknown Use ComputeEncoder";
     }
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPool.mm
@@ -78,7 +78,7 @@ void MVKCommandPool::freeCommandBuffers(uint32_t commandBufferCount,
 }
 
 id<MTLCommandBuffer> MVKCommandPool::newMTLCommandBuffer(uint32_t queueIndex) {
-	return [_device->getQueue(_queueFamilyIndex, queueIndex)->getMTLCommandBuffer(true) retain];
+	return [_device->getQueue(_queueFamilyIndex, queueIndex)->getMTLCommandBuffer(kMVKCommandUseEndCommandBuffer, true) retain];
 }
 
 // Clear the command type pool member variables.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -36,7 +36,7 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdBlitImageMTLRenderPi
 	id<MTLFunction> vtxFunc = newFunctionNamed(isLayeredBlit ? "vtxCmdBlitImageLayered" : "vtxCmdBlitImage");	// temp retain
 	id<MTLFunction> fragFunc = newBlitFragFunction(blitKey);													// temp retain
     MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];									// temp retain
-    plDesc.label = @"CmdBlitImage";
+    plDesc.label = @"vkCmdBlitImage";
 
 	plDesc.vertexFunction = vtxFunc;
 	plDesc.fragmentFunction = fragFunc;
@@ -116,7 +116,7 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	id<MTLFunction> vtxFunc = newClearVertFunction(attKey);						// temp retain
 	id<MTLFunction> fragFunc = newClearFragFunction(attKey);					// temp retain
 	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// temp retain
-    plDesc.label = @"CmdClearAttachments";
+    plDesc.label = @"vkCmdClearAttachments";
 	plDesc.vertexFunction = vtxFunc;
     plDesc.fragmentFunction = fragFunc;
 	plDesc.sampleCount = attKey.mtlSampleCount;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2855,7 +2855,7 @@ VkResult MVKDevice::waitIdle() {
 	VkResult rslt = VK_SUCCESS;
 	for (auto& queues : _queuesByQueueFamilyIndex) {
 		for (MVKQueue* q : queues) {
-			if ((rslt = q->waitIdle()) != VK_SUCCESS) { return rslt; }
+			if ((rslt = q->waitIdle(kMVKCommandUseDeviceWaitIdle)) != VK_SUCCESS) { return rslt; }
 		}
 	}
 	return VK_SUCCESS;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -109,7 +109,7 @@ VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset,
 
 #if MVK_MACOS
 		if (pBlitEnc && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {
-			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = _device->getAnyQueue()->getMTLCommandBuffer(); }
+			if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = _device->getAnyQueue()->getMTLCommandBuffer(kMVKCommandUseInvalidateMappedMemoryRanges); }
 			if ( !pBlitEnc->mtlBlitEncoder) { pBlitEnc->mtlBlitEncoder = [pBlitEnc->mtlCmdBuffer blitCommandEncoder]; }
 			[pBlitEnc->mtlBlitEncoder synchronizeResource: _mtlBuffer];
 		}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1210,7 +1210,7 @@ void MVKPresentableSwapchainImage::acquireAndSignalWhenAvailable(MVKSemaphore* s
 		@autoreleasepool {
 			MVKSemaphore* mvkSem = signaler.semaphore;
 			id<MTLCommandBuffer> mtlCmdBuff = (mvkSem && mvkSem->isUsingCommandEncoding()
-											   ? _device->getAnyQueue()->getMTLCommandBuffer()
+											   ? _device->getAnyQueue()->getMTLCommandBuffer(kMVKCommandUseAcquireNextImage)
 											   : nil);
 			signal(signaler, mtlCmdBuff);
 			[mtlCmdBuff commit];

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -63,32 +63,35 @@ typedef struct {
 
 /** Tracks the Vulkan command currently being used. */
 typedef enum : uint8_t {
-    kMVKCommandUseNone,                     /**< No use defined. */
-    kMVKCommandUseQueueSubmit,              /**< vkQueueSubmit. */
-    kMVKCommandUseQueuePresent,             /**< vkQueuePresentKHR. */
-    kMVKCommandUseQueueWaitIdle,            /**< vkQueueWaitIdle. */
-    kMVKCommandUseDeviceWaitIdle,           /**< vkDeviceWaitIdle. */
-    kMVKCommandUseBeginRenderPass,          /**< vkCmdBeginRenderPass. */
-    kMVKCommandUseNextSubpass,              /**< vkCmdNextSubpass. */
-    kMVKCommandUsePipelineBarrier,          /**< vkCmdPipelineBarrier. */
-    kMVKCommandUseBlitImage,                /**< vkCmdBlitImage. */
-    kMVKCommandUseCopyImage,                /**< vkCmdCopyImage. */
-    kMVKCommandUseResolveImage,             /**< vkCmdResolveImage - resolve stage. */
-    kMVKCommandUseResolveExpandImage,       /**< vkCmdResolveImage - expand stage. */
-    kMVKCommandUseResolveCopyImage,         /**< vkCmdResolveImage - copy stage. */
-    kMVKCommandUseCopyBuffer,               /**< vkCmdCopyBuffer. */
-    kMVKCommandUseCopyBufferToImage,        /**< vkCmdCopyBufferToImage. */
-    kMVKCommandUseCopyImageToBuffer,        /**< vkCmdCopyImageToBuffer. */
-    kMVKCommandUseFillBuffer,               /**< vkCmdFillBuffer. */
-    kMVKCommandUseUpdateBuffer,             /**< vkCmdUpdateBuffer. */
-    kMVKCommandUseClearColorImage,          /**< vkCmdClearColorImage. */
-    kMVKCommandUseClearDepthStencilImage,   /**< vkCmdClearDepthStencilImage. */
-    kMVKCommandUseResetQueryPool,           /**< vkCmdResetQueryPool. */
-    kMVKCommandUseDispatch,                 /**< vkCmdDispatch. */
-    kMVKCommandUseTessellationVertexTessCtl,/**< vkCmdDraw* - vertex and tessellation control stages. */
-	kMVKCommandUseMultiviewInstanceCountAdjust,/**< vkCmdDrawIndirect* - adjust instance count for multiview. */
-    kMVKCommandUseCopyQueryPoolResults,     /**< vkCmdCopyQueryPoolResults. */
-    kMVKCommandUseAccumOcclusionQuery       /**< Any command terminating a Metal render pass with active visibility buffer. */
+    kMVKCommandUseNone,                         /**< No use defined. */
+	kMVKCommandUseEndCommandBuffer,             /**< vkEndCommandBuffer (prefilled VkCommandBuffer). */
+    kMVKCommandUseQueueSubmit,                  /**< vkQueueSubmit. */
+	kMVKCommandUseAcquireNextImage,             /**< vkAcquireNextImageKHR. */
+    kMVKCommandUseQueuePresent,                 /**< vkQueuePresentKHR. */
+    kMVKCommandUseQueueWaitIdle,                /**< vkQueueWaitIdle. */
+    kMVKCommandUseDeviceWaitIdle,               /**< vkDeviceWaitIdle. */
+	kMVKCommandUseInvalidateMappedMemoryRanges, /**< vkInvalidateMappedMemoryRanges. */
+    kMVKCommandUseBeginRenderPass,              /**< vkCmdBeginRenderPass. */
+    kMVKCommandUseNextSubpass,                  /**< vkCmdNextSubpass. */
+    kMVKCommandUsePipelineBarrier,              /**< vkCmdPipelineBarrier. */
+    kMVKCommandUseBlitImage,                    /**< vkCmdBlitImage. */
+    kMVKCommandUseCopyImage,                    /**< vkCmdCopyImage. */
+    kMVKCommandUseResolveImage,                 /**< vkCmdResolveImage - resolve stage. */
+    kMVKCommandUseResolveExpandImage,           /**< vkCmdResolveImage - expand stage. */
+    kMVKCommandUseResolveCopyImage,             /**< vkCmdResolveImage - copy stage. */
+    kMVKCommandUseCopyBuffer,                   /**< vkCmdCopyBuffer. */
+    kMVKCommandUseCopyBufferToImage,            /**< vkCmdCopyBufferToImage. */
+    kMVKCommandUseCopyImageToBuffer,            /**< vkCmdCopyImageToBuffer. */
+    kMVKCommandUseFillBuffer,                   /**< vkCmdFillBuffer. */
+    kMVKCommandUseUpdateBuffer,                 /**< vkCmdUpdateBuffer. */
+    kMVKCommandUseClearColorImage,              /**< vkCmdClearColorImage. */
+    kMVKCommandUseClearDepthStencilImage,       /**< vkCmdClearDepthStencilImage. */
+    kMVKCommandUseResetQueryPool,               /**< vkCmdResetQueryPool. */
+    kMVKCommandUseDispatch,                     /**< vkCmdDispatch. */
+    kMVKCommandUseTessellationVertexTessCtl,    /**< vkCmdDraw* - vertex and tessellation control stages. */
+	kMVKCommandUseMultiviewInstanceCountAdjust, /**< vkCmdDrawIndirect* - adjust instance count for multiview. */
+    kMVKCommandUseCopyQueryPoolResults,         /**< vkCmdCopyQueryPoolResults. */
+    kMVKCommandUseAccumOcclusionQuery           /**< Any command terminating a Metal render pass with active visibility buffer. */
 } MVKCommandUse;
 
 /** Represents a given stage of a graphics pipeline. */

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -367,7 +367,7 @@ MVK_PUBLIC_SYMBOL VkResult vkQueueSubmit(
 
 	MVKTraceVulkanCallStart();
 	MVKQueue* mvkQ = MVKQueue::getMVKQueue(queue);
-	VkResult rslt = mvkQ->submit(submitCount, pSubmits, fence);
+	VkResult rslt = mvkQ->submit(submitCount, pSubmits, fence, kMVKCommandUseQueueSubmit);
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
@@ -377,7 +377,7 @@ MVK_PUBLIC_SYMBOL VkResult vkQueueWaitIdle(
 	
 	MVKTraceVulkanCallStart();
 	MVKQueue* mvkQ = MVKQueue::getMVKQueue(queue);
-	VkResult rslt = mvkQ->waitIdle();
+	VkResult rslt = mvkQ->waitIdle(kMVKCommandUseQueueWaitIdle);
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }


### PR DESCRIPTION
Extend `MVKCommandUse` enum to identify additional command buffer uses.
`MVKQueueCommandBufferSubmission` track use type.
`MVKQueue` pass use type in functions that result in creation of a `MTLCommandBuffer`.
Add `mvkMTLCommandBufferLabel()` to map use types to label strings.