### PR TITLE
Fix crash using memoryless storage for input attachments on Apple Silicon.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,7 @@ Released TBD
 - Fix crash when requesting `MTLCommandBuffer` logs in runtime debug mode on older OS versions.
 - Fix synchronization issue with locking `MTLArgumentEncoder` for Metal Argument Buffers.
 - Fix race condition on submission fence during device loss.
+- Fix crash using memoryless storage for input attachments on Apple Silicon.
 - On command buffer submission failure, if `MVKConfiguration::resumeLostDevice` enabled,  do not release 
   waits on `VkDevice`, and do not return `VK_ERROR_DEVICE_LOST`, unless `VkPhysicalDevice` is also lost.
 - Fix inconsistent handling of linear attachment decisions on Apple Silicon.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -52,10 +52,8 @@ VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequireme
 		pMemoryRequirements->alignment = _byteAlignment;
 	}
 	pMemoryRequirements->memoryTypeBits = getPhysicalDevice()->getAllMemoryTypes();
-#if MVK_APPLE_SILICON
 	// Memoryless storage is not allowed for buffers
 	mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
-#endif
 	return VK_SUCCESS;
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -648,12 +648,14 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
         mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getHostCoherentMemoryTypes());
     }
 #endif
-#if MVK_APPLE_SILICON
-    // Only transient attachments may use memoryless storage
-    if (!mvkAreAllFlagsEnabled(_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ) {
+    // Only transient attachments may use memoryless storage.
+	// Using memoryless as an input attachment requires shader framebuffer fetch, which MoltenVK does not support yet.
+	// TODO: support framebuffer fetch so VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT uses color(m) in shader instead of setFragmentTexture:, which crashes Metal
+    if (!mvkIsAnyFlagEnabled(_usage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ||
+		 mvkIsAnyFlagEnabled(_usage, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) ) {
         mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
     }
-#endif
+
     return _memoryBindings[planeIndex]->getMemoryRequirements(pMemoryRequirements);
 }
 


### PR DESCRIPTION
Don't allow memoryless storage for `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT`.
Memoryless storage for `VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT` descriptors
requires support for, and use of, shader framebuffer fetch.

Remove compile-time checking for `MVK_APPLE_SILICON` before disabling memoryless storage
for buffers and images, since the requirement exists for all platforms, and memoryless
storage will already otherwise be disabled on other platforms anyway.