### PR TITLE
Begin renderpass fixes

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,8 @@ MoltenVK 1.1.4
 
 Released TBD
 
+- Add support for extensions:
+	- `VK_KHR_imageless_framebuffer`
 - Make `vkGetPastPresentationTimingGOOGLE()` queuing behavior compliant with Vulkan spec.
 - Expose `vkGetIOSurfaceMVK()` and `vkUseIOSurfaceMVK()` without requiring _Objective-C_.
 - Support _Xcode 12.5_ build settings, build warnings, and SDK change to availability of

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -66,7 +66,9 @@ class MVKCmdBeginRenderPass : public MVKCmdBeginRenderPassBase {
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						const VkRenderPassBeginInfo* pRenderPassBegin,
-						const VkSubpassBeginInfo* pSubpassBeginInfo);
+						const VkSubpassBeginInfo* pSubpassBeginInfo,
+						uint32_t attachmentCount,
+						bool isImageless);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -40,7 +40,7 @@ class MVKCmdBeginRenderPassBase : public MVKCommand {
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						const VkRenderPassBeginInfo* pRenderPassBegin,
-						VkSubpassContents contents);
+						const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 	inline MVKRenderPass* getRenderPass() { return _renderPass; }
 
@@ -64,9 +64,6 @@ template <size_t N_CV, size_t N_A>
 class MVKCmdBeginRenderPass : public MVKCmdBeginRenderPassBase {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						const VkRenderPassBeginInfo* pRenderPassBegin,
-						VkSubpassContents contents);
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						const VkRenderPassBeginInfo* pRenderPassBegin,
 						const VkSubpassBeginInfo* pSubpassBeginInfo);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -67,8 +67,7 @@ public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						const VkRenderPassBeginInfo* pRenderPassBegin,
 						const VkSubpassBeginInfo* pSubpassBeginInfo,
-						uint32_t attachmentCount,
-						bool isImageless);
+						MVKArrayRef<MVKImageView*> attachments);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -58,6 +58,7 @@ VkResult MVKCmdBeginRenderPass<N_CV, N_A>::setContent(MVKCommandBuffer* cmdBuff,
 		_clearValues.push_back(pRenderPassBegin->pClearValues[i]);
 	}
 
+	_attachments.clear();	// Clear for reuse
 	bool imageless = false;
 	for (auto* next = (const VkBaseInStructure*)pRenderPassBegin->pNext; next; next = next->pNext) {
 		switch (next->sType) {

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -31,8 +31,8 @@
 
 VkResult MVKCmdBeginRenderPassBase::setContent(MVKCommandBuffer* cmdBuff,
 											   const VkRenderPassBeginInfo* pRenderPassBegin,
-											   VkSubpassContents contents) {
-	_contents = contents;
+											   const VkSubpassBeginInfo* pSubpassBeginInfo) {
+	_contents = pSubpassBeginInfo->contents;
 	_renderPass = (MVKRenderPass*)pRenderPassBegin->renderPass;
 	_framebuffer = (MVKFramebuffer*)pRenderPassBegin->framebuffer;
 	_renderArea = pRenderPassBegin->renderArea;
@@ -47,8 +47,8 @@ VkResult MVKCmdBeginRenderPassBase::setContent(MVKCommandBuffer* cmdBuff,
 template <size_t N_CV, size_t N_A>
 VkResult MVKCmdBeginRenderPass<N_CV, N_A>::setContent(MVKCommandBuffer* cmdBuff,
 													  const VkRenderPassBeginInfo* pRenderPassBegin,
-													  VkSubpassContents contents) {
-	MVKCmdBeginRenderPassBase::setContent(cmdBuff, pRenderPassBegin, contents);
+													  const VkSubpassBeginInfo* pSubpassBeginInfo) {
+	MVKCmdBeginRenderPassBase::setContent(cmdBuff, pRenderPassBegin, pSubpassBeginInfo);
 
 	// Add clear values
 	uint32_t cvCnt = pRenderPassBegin->clearValueCount;
@@ -74,7 +74,7 @@ VkResult MVKCmdBeginRenderPass<N_CV, N_A>::setContent(MVKCommandBuffer* cmdBuff,
 			break;
 		}
 	}
-	
+
 	if (!imageless) {
 		for(uint32_t i = 0; i < _framebuffer->getAttachmentCount(); i++) {
 			_attachments.push_back((MVKImageView*)_framebuffer->getAttachment(i));
@@ -82,13 +82,6 @@ VkResult MVKCmdBeginRenderPass<N_CV, N_A>::setContent(MVKCommandBuffer* cmdBuff,
 	}
 
 	return VK_SUCCESS;
-}
-
-template <size_t N_CV, size_t N_A>
-VkResult MVKCmdBeginRenderPass<N_CV, N_A>::setContent(MVKCommandBuffer* cmdBuff,
-													  const VkRenderPassBeginInfo* pRenderPassBegin,
-													  const VkSubpassBeginInfo* pSubpassBeginInfo) {
-	return setContent(cmdBuff, pRenderPassBegin, pSubpassBeginInfo->contents);
 }
 
 template <size_t N_CV, size_t N_A>

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
@@ -37,15 +37,13 @@ public:
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT; }
 
 	/** Returns the dimensions of this framebuffer. */
-	inline VkExtent2D getExtent2D() { return _extent; }
+	VkExtent2D getExtent2D() { return _extent; }
 
 	/** Returns the layers covered by this framebuffer. */
-	inline uint32_t getLayerCount() { return _layerCount; }
+	uint32_t getLayerCount() { return _layerCount; }
 
-	/** Returns the attachment at the specified index.  */
-	inline MVKImageView* getAttachment(uint32_t index) { return _attachments[index]; }
-	
-	inline size_t getAttachmentCount() {return _attachments.size(); }
+	/** Returns the attachments.  */
+	MVKArrayRef<MVKImageView*> getAttachments() { return _attachments.contents(); }
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1900,23 +1900,31 @@ static void mvkCmdBeginRenderPass(
 	const VkSubpassBeginInfo*					pSubpassBeginInfo) {
 
 	uint32_t attachmentCount = 0;
+	bool isImageless = false;
 	for (const auto* next = (VkBaseInStructure*)pRenderPassBegin->pNext; next; next = next->pNext) {
 		switch(next->sType) {
 			case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO: {
 				auto* pAttachmentBegin = (VkRenderPassAttachmentBeginInfo*)next;
 				attachmentCount = pAttachmentBegin->attachmentCount;
+				isImageless = true;
 				break;
 			}
 			default:
 				break;
 		}
 	}
+	if ( !isImageless ) {
+		auto* mvkFB = (MVKFramebuffer*)pRenderPassBegin->framebuffer;
+		attachmentCount = mvkFB ? (uint32_t)mvkFB->getAttachmentCount() : 0;
+	}
 	MVKAddCmdFrom5Thresholds(BeginRenderPass,
 							 pRenderPassBegin->clearValueCount, 1, 2,
 							 attachmentCount, 0, 1, 2,
 							 commandBuffer,
 							 pRenderPassBegin,
-							 pSubpassBeginInfo);
+							 pSubpassBeginInfo,
+							 attachmentCount,
+							 isImageless);
 }
 
 MVK_PUBLIC_SYMBOL void vkCmdBeginRenderPass(


### PR DESCRIPTION
PR #1370 introduced a bug by not clearing attachments when `MVKCmdBeginRenderPass` instances were reused from the command pool.

While fixing that, I also cleaned up some redundancies in the `vkCmdBeginRenderPass()` and `vkCmdBeginRenderPass2KHR()` functions and `MVKCmdBeginRenderPass` constructors.

- Clear attachments in `MVKCmdBeginRenderPass` between invocations. Fixes crash due to incorrect number of attachments.
- Consolidate `vkCmdBeginRenderPass()` and `vkCmdBeginRenderPass2KHR()` handling.
- Derive `MVKCmdBeginRenderPass` attachment count and imageless status once.
 
@f32by please review relative to the recent #1370. I can't request you as a reviewer from the list until you accept the collaboration request.