### PR TITLE
Reorganize coherent texture flushing on memory map and unmap.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -88,8 +88,6 @@ void MVKCmdCopyImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
     VkBufferImageCopy vkDstCopies[copyCnt];
     size_t tmpBuffSize = 0;
 
-    _srcImage->flushToDevice(0, VK_WHOLE_SIZE);
-
     for (uint32_t copyIdx = 0; copyIdx < copyCnt; copyIdx++) {
         auto& vkIC = _vkImageCopies[copyIdx];
         

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3616,7 +3616,7 @@ VkResult MVKDevice::invalidateMappedMemoryRanges(uint32_t memRangeCount, const V
 		for (uint32_t i = 0; i < memRangeCount; i++) {
 			const VkMappedMemoryRange* pMem = &pMemRanges[i];
 			MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
-			VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size, false, &mvkBlitEnc);
+			VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size, &mvkBlitEnc);
 			if (rslt == VK_SUCCESS) { rslt = r; }
 		}
 		if (mvkBlitEnc.mtlBlitEncoder) { [mvkBlitEnc.mtlBlitEncoder endEncoding]; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -93,17 +93,11 @@ public:
 	/** Returns whether this device memory is currently mapped to host memory. */
 	bool isMapped() { return _mappedRange.size > 0; }
 
-	/**
-	 * If this memory is host-visible, the specified memory range is flushed to the device.
-	 * Normally, flushing will only occur if the device memory is non-coherent, but flushing
-	 * to coherent memory can be forced by setting evenIfCoherent to true.
-	 */
-	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size, bool evenIfCoherent = false);
+	/** If this memory is host-visible, the specified memory range is flushed to the device. */
+	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
 
 	/**
 	 * If this memory is host-visible, pulls the specified memory range from the device.
-	 * Normally, pulling will only occur if the device memory is non-coherent, but pulling
-	 * to coherent memory can be forced by setting evenIfCoherent to true.
 	 *
 	 * If pBlitEnc is not null, it points to a holder for a MTLBlitCommandEncoder and its
 	 * associated MTLCommandBuffer. If this instance has a MTLBuffer using managed memory,
@@ -114,7 +108,6 @@ public:
 	 */
 	VkResult pullFromDevice(VkDeviceSize offset,
 							VkDeviceSize size,
-							bool evenIfCoherent = false,
 							MVKMTLBlitEncoder* pBlitEnc = nullptr);
 
 
@@ -172,8 +165,10 @@ protected:
 	id<MTLHeap> _mtlHeap = nil;
 	void* _pMemory = nullptr;
 	void* _pHostMemory = nullptr;
-	bool _isDedicated = false;
+	VkMemoryPropertyFlags _vkMemProps;
 	MTLStorageMode _mtlStorageMode;
 	MTLCPUCacheMode _mtlCPUCacheMode;
+	bool _isDedicated = false;
+
 };
 


### PR DESCRIPTION
`MVKDeviceMemory` track original Vulkan memory coherency request, not just Metal coherency status.

`MVKDeviceMemory map()/unmap()` only triggers host flush if coherent Vulkan memory was requested, not just when Metal memory is coherent, because this can be changed for dedicated image resources.

Redesign `MVKDeviceMemory flushToDevice()/pullFromDevice()` to be consistent operation with each other.

Don't trigger automatic texture flush during `vkCmdCopyImage()`, as it can
cause an unexpected update from mapped memory, resulting in a race condition.