### PR TITLE
Fixes #1390 - when MVKRenderSubpass::populateClearAttachments determi…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -201,6 +201,9 @@ public:
     /** Returns whether this attachment should be cleared in the subpass. */
     bool shouldUseClearAttachment(MVKRenderSubpass* subpass);
 
+    /** Returns stencil attachment load op */
+	VkAttachmentLoadOp getAttachmentStencilLoadOp() const;
+
 	/** Constructs an instance for the specified parent renderpass. */
 	MVKRenderPassAttachment(MVKRenderPass* renderPass,
 							const VkAttachmentDescription* pCreateInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -201,7 +201,7 @@ public:
     /** Returns whether this attachment should be cleared in the subpass. */
     bool shouldUseClearAttachment(MVKRenderSubpass* subpass);
 
-    /** Returns stencil attachment load op */
+    /** If this is a depth attachment, the stencil load op may be different than the depth load op. */
 	VkAttachmentLoadOp getAttachmentStencilLoadOp() const;
 
 	/** Constructs an instance for the specified parent renderpass. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -425,7 +425,10 @@ void MVKRenderSubpass::populateClearAttachments(MVKClearAttachments& clearAtts,
 		MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
 		MTLPixelFormat mtlDSFmt = _renderPass->getPixelFormats()->getMTLPixelFormat(getDepthStencilFormat());
 		if (pixFmts->isDepthFormat(mtlDSFmt)) { cAtt.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT; }
-		if (pixFmts->isStencilFormat(mtlDSFmt)) { cAtt.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT; }
+		if (pixFmts->isStencilFormat(mtlDSFmt) &&
+			_renderPass->_attachments[attIdx].getAttachmentStencilLoadOp() == VK_ATTACHMENT_LOAD_OP_CLEAR) {
+			cAtt.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+		}
 		if (cAtt.aspectMask) { clearAtts.push_back(cAtt); }
 	}
 }
@@ -718,6 +721,10 @@ bool MVKRenderPassAttachment::shouldUseClearAttachment(MVKRenderSubpass* subpass
 	}
 
 	return (_info.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR);
+}
+
+VkAttachmentLoadOp MVKRenderPassAttachment::getAttachmentStencilLoadOp() const {
+	return _info.stencilLoadOp;
 }
 
 void MVKRenderPassAttachment::validateFormat() {


### PR DESCRIPTION
…nes whether to clear stencil, it was using the loadOp for the depth.  It needs to look at the loadOp for the stencil which is set independently.