### PR TITLE
Retain MVKQueue in MVKQueueSubmission to avoid possible race condition.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -176,6 +176,8 @@ public:
 					   uint32_t waitSemaphoreCount,
 					   const VkSemaphore* pWaitSemaphores);
 
+	~MVKQueueSubmission() override;
+
 protected:
 	friend class MVKQueue;
 


### PR DESCRIPTION
Follow up to PR #1367, based on issues uncovered in #1178 and #1366.