### PR TITLE
Fix execution order of `encodeBindings` for `bufferBindings`

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -677,7 +677,6 @@ void MVKGraphicsResourcesCommandEncoderState::encodeBindings(MVKShaderStage stag
 	encodeMetalArgumentBuffer(stage);
 
     auto& shaderStage = _shaderStageResourceBindings[stage];
-    encodeBinding<MVKMTLBufferBinding>(shaderStage.bufferBindings, shaderStage.areBufferBindingsDirty, bindBuffer);
 
     if (shaderStage.swizzleBufferBinding.isDirty) {
 
@@ -710,6 +709,7 @@ void MVKGraphicsResourcesCommandEncoderState::encodeBindings(MVKShaderStage stag
         bindImplicitBuffer(_cmdEncoder, shaderStage.viewRangeBufferBinding, viewRange.contents());
     }
 
+    encodeBinding<MVKMTLBufferBinding>(shaderStage.bufferBindings, shaderStage.areBufferBindingsDirty, bindBuffer);
     encodeBinding<MVKMTLTextureBinding>(shaderStage.textureBindings, shaderStage.areTextureBindingsDirty, bindTexture);
     encodeBinding<MVKMTLSamplerStateBinding>(shaderStage.samplerStateBindings, shaderStage.areSamplerStateBindingsDirty, bindSampler);
 }


### PR DESCRIPTION
I've ran into an issue where the "buffer size buffer" is empty and the shader ends up indexing into this empty buffer. I believe this is caused by a mistake in order.

`encodeBindings` first calls `encodeBinding` which marks all `shader.bufferBindings` as non-dirty after binding them. 

Here is the implementation of that function:
```c++
// `encodeBinding` body
if (bindingsDirtyFlag) {
	bindingsDirtyFlag = false;
	for (auto& b : bindings) {
		if (b.isDirty) {
			mtlOperation(_cmdEncoder, b);
			b.isDirty = false;
		}
	}
}
```

As you can see it will always set `IsDirty` to false for all bindings as long as the `bindingsDirtyFlag` is true which in this case is `shaderStage.areBufferBindingsDirty` which as far as I can tell should never be false if any of the bindings is dirty.

 However after that is done the following code is ran:
 
```c++
if (shaderStage.bufferSizeBufferBinding.isDirty) {
    for (auto& b : shaderStage.bufferBindings) {
        if (b.isDirty) { updateImplicitBuffer(shaderStage.bufferSizes, b.index, b.size); }
    }

    bindImplicitBuffer(_cmdEncoder, shaderStage.bufferSizeBufferBinding, shaderStage.bufferSizes.contents());
}
```

Which ends up updating the `bufferSizes` list ONLY if they are dirty. If my reasoning is correct it is impossible for it to be dirty at this time, thus never expanding the list of sizes and causing my crash. Essentially the body of that if statement is dead code.

The `textureBindings` code is very similar but unlike `bufferBindings` the order is fine. 
Am I correct here or did I overlook something?