### PR TITLE
Fix swizzle of depth and stencil values into RGBA (float4) variable in shaders.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.1.5
 Released TBD
 
 - Fix incorrect translation of clear color values on Apple Silicon.
+- Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -539,6 +539,7 @@ public:
 protected:
     void propagateDebugName();
     id<MTLTexture> newMTLTexture();
+	id<MTLTexture> getUnswizzledMTLTexture();
 	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
     MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -536,6 +536,7 @@ public:
 protected:
     void propagateDebugName();
     id<MTLTexture> newMTLTexture();
+	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
     MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
 
     friend MVKImageView;
@@ -545,6 +546,7 @@ protected:
     uint32_t _packedSwizzle;
     id<MTLTexture> _mtlTexture;
     bool _useMTLTextureView;
+	bool _useSwizzle;
 };
 
 
@@ -590,30 +592,6 @@ public:
 	 * with the Metal texture underlying this image.
 	 */
 	void populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPassAttachmentDescriptor* mtlAttDesc);
-
-	/**
-	 * Returns, in mtlPixFmt, a MTLPixelFormat, based on the MTLPixelFormat converted from
-	 * the VkFormat, but possibly modified by the swizzles defined in the VkComponentMapping
-	 * of the VkImageViewCreateInfo.
-	 *
-	 * Metal prior to version 3.0 does not support native per-texture swizzles, so if the swizzle
-	 * is not an identity swizzle, this function attempts to find an alternate MTLPixelFormat that
-	 * coincidentally matches the swizzled format.
-	 *
-	 * If a replacement MTLFormat was found, it is returned and useSwizzle is set to false.
-	 * If a replacement MTLFormat could not be found, the original MTLPixelFormat is returned,
-	 * and the useSwizzle is set to true, indicating that either native or shader swizzling
-	 * should be used for this image view.
-	 *
-	 * This is a static function that can be used to validate image view formats prior to creating one.
-	 */
-	static VkResult validateSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo,
-												   VkImageUsageFlags usage,
-												   MVKVulkanAPIObject* apiObject,
-												   bool hasNativeSwizzleSupport,
-												   bool hasShaderSwizzleSupport,
-												   MTLPixelFormat& mtlPixFmt,
-												   bool& useSwizzle);
 
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -531,6 +531,9 @@ public:
 
     void releaseMTLTexture();
 
+	/** Returns the packed component swizzle of this image view. */
+	uint32_t getPackedSwizzle() { return _useSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
+
     ~MVKImageViewPlane();
 
 protected:
@@ -541,10 +544,10 @@ protected:
 
     friend MVKImageView;
     MVKImageView* _imageView;
-    uint8_t _planeIndex;
+	id<MTLTexture> _mtlTexture;
+	VkComponentMapping _componentSwizzle;
     MTLPixelFormat _mtlPixFmt;
-    uint32_t _packedSwizzle;
-    id<MTLTexture> _mtlTexture;
+	uint8_t _planeIndex;
     bool _useMTLTextureView;
 	bool _useSwizzle;
 };
@@ -570,16 +573,16 @@ public:
 	id<MTLTexture> getMTLTexture(uint8_t planeIndex) { return _planes[planeIndex]->getMTLTexture(); }
 
 	/** Returns the Metal pixel format of this image view. */
-	inline MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex) { return _planes[planeIndex]->_mtlPixFmt; }
+	MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex) { return _planes[planeIndex]->_mtlPixFmt; }
     
     /** Returns the packed component swizzle of this image view. */
-    inline uint32_t getPackedSwizzle() { return _planes[0]->_packedSwizzle; }
+    uint32_t getPackedSwizzle() { return _planes[0]->getPackedSwizzle(); }
     
     /** Returns the number of planes of this image view. */
-    inline uint8_t getPlaneCount() { return _planes.size(); }
+    uint8_t getPlaneCount() { return _planes.size(); }
 
 	/** Returns the Metal texture type of this image view. */
-	inline MTLTextureType getMTLTextureType() { return _mtlTextureType; }
+	MTLTextureType getMTLTextureType() { return _mtlTextureType; }
 
 	/**
 	 * Populates the texture of the specified render pass descriptor


### PR DESCRIPTION
Sampling depth/stencil values into an RGBA value in a shader behaves inconsistency across Metal platforms, resolving to `(v, 0, 0, 1)` (as expected by Vulkan) on some platforms, but to `(v, v, v, v)` on others. This causes several hundred CTS tests to fail.

To get around this, we force an artificial swizzle for D/S textures that are sampled, if it's available on the platform.

- `MVKImageViewPlane` track Vulkan component swizzle instead of just packed swizzle, and modify swizzle when using depth or stencil sampling or reading.
- Refactor `MVKImageView::validateSwizzledMTLPixelFormat()`.
- Move `MVKImageView::validateSwizzledMTLPixelFormat()` to `MVKImageViewPlane::initSwizzledMTLPixelFormat()`, make it non-static, and use instance member content instead of passing all the data as function arguments.
- Use unswizzled `MTLTexture` for attachments.