### PR TITLE
Fix occasional crash when swizzling used but shader swizzling not enabled.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -516,7 +516,6 @@ public:
 
     void encodeBindings(MVKShaderStage stage,
                         const char* pStageName,
-                        bool fullImageViewSwizzle,
                         std::function<void(MVKCommandEncoder*, MVKMTLBufferBinding&)> bindBuffer,
                         std::function<void(MVKCommandEncoder*, MVKMTLBufferBinding&, const MVKArrayRef<uint32_t>&)> bindImplicitBuffer,
                         std::function<void(MVKCommandEncoder*, MVKMTLTextureBinding&)> bindTexture,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -532,7 +532,7 @@ public:
     void releaseMTLTexture();
 
 	/** Returns the packed component swizzle of this image view. */
-	uint32_t getPackedSwizzle() { return _useSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
+	uint32_t getPackedSwizzle() { return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
 
     ~MVKImageViewPlane();
 
@@ -541,6 +541,7 @@ protected:
     id<MTLTexture> newMTLTexture();
 	id<MTLTexture> getUnswizzledMTLTexture();
 	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
+	bool enableSwizzling();
     MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
 
     friend MVKImageView;
@@ -550,7 +551,8 @@ protected:
     MTLPixelFormat _mtlPixFmt;
 	uint8_t _planeIndex;
     bool _useMTLTextureView;
-	bool _useSwizzle;
+	bool _useNativeSwizzle;
+	bool _useShaderSwizzle;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -173,9 +173,6 @@ public:
 	/** Returns the current indirect parameter buffer bindings. */
 	const MVKShaderImplicitRezBinding& getIndirectParamsIndex() { return _indirectParamsIndex; }
 
-	/** Returns whether or not full image view swizzling is enabled for this pipeline. */
-	bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
-
 	/** Returns whether all internal Metal pipeline states are valid. */
 	bool hasValidMTLPipelineStates() { return _hasValidMTLPipelineStates; }
 
@@ -205,7 +202,6 @@ protected:
 	MVKShaderImplicitRezBinding _indirectParamsIndex;
 	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
 	uint32_t _descriptorSetCount;
-	bool _fullImageViewSwizzle;
 	bool _hasValidMTLPipelineStates = true;
 
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -206,7 +206,6 @@ MVKPipeline::MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVK
 	MVKVulkanAPIDeviceObject(device),
 	_pipelineCache(pipelineCache),
 	_pushConstantsMTLResourceIndexes(layout->getPushConstantBindings()),
-	_fullImageViewSwizzle(mvkConfig().fullImageViewSwizzle),
 	_descriptorSetCount(layout->getDescriptorSetCount()) {}
 
 
@@ -1560,7 +1559,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
 	shaderConfig.options.mslOptions.enable_frag_depth_builtin = pixFmts->isDepthFormat(mtlDSFormat);
 	shaderConfig.options.mslOptions.enable_frag_stencil_ref_builtin = pixFmts->isStencilFormat(mtlDSFormat);
     shaderConfig.options.shouldFlipVertexY = mvkConfig().shaderConversionFlipVertexY;
-    shaderConfig.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle;
+    shaderConfig.options.mslOptions.swizzle_texture_samples = mvkConfig().fullImageViewSwizzle && !_device->_pMetalFeatures->nativeTextureSwizzle;
     shaderConfig.options.mslOptions.tess_domain_origin_lower_left = pTessDomainOriginState && pTessDomainOriginState->domainOrigin == VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
     shaderConfig.options.mslOptions.multiview = mvkRendPass->isMultiview();
     shaderConfig.options.mslOptions.multiview_layered_rendering = getPhysicalDevice()->canUseInstancingForMultiview();
@@ -1776,7 +1775,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
     shaderConfig.options.mslOptions.msl_version = _device->_pMetalFeatures->mslVersion;
     shaderConfig.options.mslOptions.texel_buffer_texture_width = _device->_pMetalFeatures->maxTextureDimension;
     shaderConfig.options.mslOptions.r32ui_linear_texture_alignment = (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT, this);
-	shaderConfig.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !getDevice()->_pMetalFeatures->nativeTextureSwizzle;
+	shaderConfig.options.mslOptions.swizzle_texture_samples = mvkConfig().fullImageViewSwizzle && !_device->_pMetalFeatures->nativeTextureSwizzle;
 	shaderConfig.options.mslOptions.texture_buffer_native = _device->_pMetalFeatures->textureBuffers;
 	shaderConfig.options.mslOptions.dispatch_base = _allowsDispatchBase;
 	shaderConfig.options.mslOptions.texture_1D_as_2D = mvkConfig().texture1DAs2D;


### PR DESCRIPTION
Recent fixes to add depth/stencil swizzling introduced an occasional situational crash. This repairs that, and consolidates tracking of shader swizzling.

`MVKImageViewPlane` distinguish tracking of native and shader swizzling.
Only provide packed swizzle value if shader swizzling is used.
Consolidate and simplify testing for `MVKConfiguration::fullImageViewSwizzle`.