### PR TITLE
Disable blending for VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 on macOS Apple Silicon.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,8 @@ Released TBD
 
 - Fix incorrect translation of clear color values on Apple Silicon.
 - Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
+- Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for 
+  `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` on macOS Apple Silicon.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1546,7 +1546,10 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 	addGPUOSMTLPixFmtCaps( Apple5, 10.16, RGBA8Unorm_sRGB, All );
 	addGPUOSMTLPixFmtCaps( Apple5, 10.16, BGRA8Unorm_sRGB, All );
 
+	// Blending is actually supported for this format, but format channels cannot be individually write-enabled during blending.
+	// Disabling blending is the least-intrusive way to handle this in a Vulkan-friendly way.
 	addGPUOSMTLPixFmtCaps( Apple5, 10.16, RGB9E5Float, All );
+	disableMTLPixFmtCaps ( RGB9E5Float, Blend);
 
 	addGPUOSMTLPixFmtCaps( Apple5, 10.16, PVRTC_RGBA_2BPP, RF );
 	addGPUOSMTLPixFmtCaps( Apple5, 10.16, PVRTC_RGBA_2BPP_sRGB, RF );


### PR DESCRIPTION
Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` on macOS Apple Silicon.

On Apple Silicon (iOS/tvOs/macOS M1), format `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`
is fully supported as a color attachment except that format components cannot
be individually write-enabled. All components must either be write-enabled or
write-disabled together. This is causing several hundred Vulkan CTS blending
tests to fail on M1. The least intrusive behavioural change to allow the CTS
tests to report Not Supported instead, is to disable blending for this format.

Fixes https://github.com/KhronosGroup/Vulkan-Portability/issues/28.