### PR TITLE
Fix occasional crash when swizzling used but shader swizzling not enabled.

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -423,7 +423,7 @@ typedef struct {
 	 * a very limited set of VkImageView component swizzles are supported via format substitutions.
 	 *
 	 * If Metal supports native per-texture swizzling, this parameter is ignored.
-
+	 *
 	 * When running on an older version of Metal that does not support native per-texture
 	 * swizzling, if this parameter is enabled, both when a VkImageView is created, and
 	 * when any pipeline that uses that VkImageView is compiled, VkImageView swizzling is

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -532,7 +532,7 @@ public:
     void releaseMTLTexture();
 
 	/** Returns the packed component swizzle of this image view. */
-	uint32_t getPackedSwizzle() { return _useSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
+	uint32_t getPackedSwizzle() { return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
 
     ~MVKImageViewPlane();
 
@@ -541,6 +541,7 @@ protected:
     id<MTLTexture> newMTLTexture();
 	id<MTLTexture> getUnswizzledMTLTexture();
 	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
+	bool enableSwizzling();
     MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
 
     friend MVKImageView;
@@ -550,7 +551,8 @@ protected:
     MTLPixelFormat _mtlPixFmt;
 	uint8_t _planeIndex;
     bool _useMTLTextureView;
-	bool _useSwizzle;
+	bool _useNativeSwizzle;
+	bool _useShaderSwizzle;
 };
 
 


### PR DESCRIPTION
`MVKImageViewPlane` distinguish tracking of native and shader swizzling.
Only provide packed swizzle value if shader swizzling is used.