### PR TITLE
Support alpha-to-coverage without a color attachment.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
 - Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for 
   `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` on macOS Apple Silicon.
+- Support alpha-to-coverage without a color attachment.
 
 
 


### PR DESCRIPTION
If alpha-to-coverage is enabled, we must enable the fragment shader first color output,
even without a color attachment present or in use, so that coverage can be calculated.

@cdavis5e FWIW...in working through this in CTS `dEQP-VK.pipeline.multisample.alpha_to_coverage_no_color_attachment.samples_2.alpha_opaque`, I noticed that enabling all attachments in `mslOptions.enable_frag_output_mask` did not trigger any Metal validation errors, even with no color attachments and `MTLRenderPipelineDescriptor::alphaToCoverageEnabled` disabled. I'm not sure if Apple no longer performs the validation that catalyzed the requirement for `mslOptions.enable_frag_output_mask`, or whether I just didn't encounter the appropriate use case for that validation. Just in case, I've left it intact except for the new `alphaToCoverageEnable` check.