### PR TITLE
Properly ignore non-null pipeline creation pointers that should be ignored.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -398,6 +398,9 @@ protected:
 	bool _needsFragmentBufferSizeBuffer = false;
 	bool _needsFragmentDynamicOffsetBuffer = false;
 	bool _needsFragmentViewRangeBuffer = false;
+	bool _isRasterizing = false;
+	bool _isRasterizingColor = false;
+	bool _isRasterizingDepthStencil = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1452,7 +1452,7 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
 												: mvkMTLPrimitiveTopologyClassFromVkPrimitiveTopology(pCreateInfo->pInputAssemblyState->topology);
 	}
 
-    // Color attachments - must ignore bad pColorBlendState pointer if rasterization is disable or subpass has not color attachments
+    // Color attachments - must ignore bad pColorBlendState pointer if rasterization is disabled or subpass has no color attachments
     uint32_t caCnt = 0;
     if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
         for (uint32_t caIdx = 0; caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -47,13 +47,19 @@ public:
 	MVKVulkanAPIObject* getVulkanAPIObject() override;
 
 	/** Returns the parent render pass of this subpass. */
-	inline MVKRenderPass* getRenderPass() { return _renderPass; }
+	MVKRenderPass* getRenderPass() { return _renderPass; }
 
 	/** Returns the index of this subpass in its parent render pass. */
-	inline uint32_t getSubpassIndex() { return _subpassIndex; }
+	uint32_t getSubpassIndex() { return _subpassIndex; }
+
+	/** Returns whether this subpass has any color attachments. */
+	bool hasColorAttachments();
+
+	/** Returns whether this subpass has a depth/stencil attachment. */
+	bool hasDepthStencilAttachment();
 
 	/** Returns the number of color attachments, which may be zero for depth-only rendering. */
-	inline uint32_t getColorAttachmentCount() { return uint32_t(_colorAttachments.size()); }
+	uint32_t getColorAttachmentCount() { return uint32_t(_colorAttachments.size()); }
 
 	/** Returns the format of the color attachment at the specified index. */
 	VkFormat getColorAttachmentFormat(uint32_t colorAttIdx);
@@ -74,7 +80,7 @@ public:
 	bool isMultiview() const { return _viewMask != 0; }
 
 	/** Returns the total number of views to be rendered. */
-	inline uint32_t getViewCount() const { return __builtin_popcount(_viewMask); }
+	uint32_t getViewCount() const { return __builtin_popcount(_viewMask); }
 
 	/** Returns the number of Metal render passes needed to render all views. */
 	uint32_t getMultiviewMetalPassCount() const;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -56,7 +56,7 @@ public:
 	bool hasColorAttachments();
 
 	/** Returns whether this subpass has a depth/stencil attachment. */
-	bool hasDepthStencilAttachment();
+	bool hasDepthStencilAttachment() { return _depthStencilAttachment.attachment != VK_ATTACHMENT_UNUSED; }
 
 	/** Returns the number of color attachments, which may be zero for depth-only rendering. */
 	uint32_t getColorAttachmentCount() { return uint32_t(_colorAttachments.size()); }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -35,6 +35,17 @@ using namespace std;
 
 MVKVulkanAPIObject* MVKRenderSubpass::getVulkanAPIObject() { return _renderPass->getVulkanAPIObject(); };
 
+bool MVKRenderSubpass::hasColorAttachments() {
+	for (auto& ca : _colorAttachments) {
+		if (ca.attachment != VK_ATTACHMENT_UNUSED) { return true; }
+	}
+	return false;
+}
+
+bool MVKRenderSubpass::hasDepthStencilAttachment() {
+	return _depthStencilAttachment.attachment != VK_ATTACHMENT_UNUSED;
+}
+
 VkFormat MVKRenderSubpass::getColorAttachmentFormat(uint32_t colorAttIdx) {
 	if (colorAttIdx < _colorAttachments.size()) {
 		uint32_t rpAttIdx = _colorAttachments[colorAttIdx].attachment;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -42,10 +42,6 @@ bool MVKRenderSubpass::hasColorAttachments() {
 	return false;
 }
 
-bool MVKRenderSubpass::hasDepthStencilAttachment() {
-	return _depthStencilAttachment.attachment != VK_ATTACHMENT_UNUSED;
-}
-
 VkFormat MVKRenderSubpass::getColorAttachmentFormat(uint32_t colorAttIdx) {
 	if (colorAttIdx < _colorAttachments.size()) {
 		uint32_t rpAttIdx = _colorAttachments[colorAttIdx].attachment;


### PR DESCRIPTION
See for reference spec description of `VkGraphicsPipelineCreateInfo`, and CTS test
`dEQP-VK.api.pipeline.pipeline_invalid_pointers_unused_structs.graphics`

Struct pointers that should be ignored under certain conditions, are 
permitted to contain non-null garbage according to the spec and tests.