### PR TITLE
Fix issue where swapchain images were acquired out of order under heavy load.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.1.5
 Released TBD
 
 - Vulkan timestamp query pools use Metal GPU counters when available.
+- Fix issue where swapchain images were acquired out of order under heavy load.
 - Fix incorrect translation of clear color values on Apple Silicon.
 - Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
 - Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for 


### PR DESCRIPTION
Move update of `MVKSwapchainImageAvailability::acquisitionID` to the acquisition
time instead of the become available again time, so other images will be preferred
if either all images are available or no images are available.

Fixes part of issue #1407.