### PR TITLE
Fix pipeline barriers not working inside self-dependent subpasses on Apple GPUs.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 - Fix issue with `vkCmdBlitImage()` from compressed textures.
 - Fix incorrect translation of clear color values on Apple Silicon.
 - Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
+- Fix pipeline barriers not working inside self-dependent subpasses on Apple GPUs.
 - Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for 
   `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` on macOS Apple Silicon.
 - Support alpha-to-coverage without a color attachment.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1465,10 +1465,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			if (supportsMTLGPUFamily(Apple7)) {
 				_metalFeatures.maxQueryBufferSize = (256 * KIBI);
 			}
-		} else {
-			// Apple devices don't like barriers in render passes.
-			_metalFeatures.memoryBarriers = true;
-			_metalFeatures.textureBarriers = true;
 		}
 	} else
 #endif


### PR DESCRIPTION
On Apple GPUs, `MVKCmdPipelineBarrier` restarts Metal renderpass when encountered inside self-dependent Vulkan subpass where the same attachment acts as both input attachment and render attachment.

Also...`MVKPhysicalDeviceMetalFeatures::memoryBarriers` and `::textureBarriers` are never enabled on Apple Silicon. Remove it as an possibility in `MVKDevice`.