### PR TITLE
Several renderpass clearing and input fixes from CTS

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -29,6 +29,7 @@ Released TBD
 - Fix incorrect translation of clear color values on Apple Silicon.
 - Fix swizzle of depth and stencil values into RGBA (`float4`) variable in shaders.
 - Fix pipeline barriers not working inside self-dependent subpasses on Apple GPUs.
+- Fix GPU race condition when clearing a renderpass input attachment on Apple GPUs.
 - Disable `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT` for 
   `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32` on macOS Apple Silicon.
 - Support alpha-to-coverage without a color attachment.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 	- Set default value of the `MVK_ALLOW_METAL_FENCES` environment variable to `0 (false)`,
 - Vulkan timestamp query pools use Metal GPU counters when available.
 - Support resolving attachments with formats that Metal does not natively resolve.
+- Support stencil-only partial attachment clearing.
 - Fix issue where swapchain images were acquired out of order under heavy load.
 - Fix issue with `vkCmdBlitImage()` from compressed textures.
 - Fix incorrect translation of clear color values on Apple Silicon.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -213,7 +213,7 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 				}
                 // Running this stage prematurely ended the render pass, so we have to start it up again.
                 // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                cmdEncoder->beginMetalRenderPass(true);
+                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
                 break;
 			}
             case kMVKGraphicsStageRasterization:
@@ -416,7 +416,7 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 				}
                 // Running this stage prematurely ended the render pass, so we have to start it up again.
                 // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                cmdEncoder->beginMetalRenderPass(true);
+                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
                 break;
 			}
             case kMVKGraphicsStageRasterization:
@@ -686,7 +686,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                                       threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
                 }
                 // Switch back to rendering now, since we don't have compute stages to run anyway.
-                cmdEncoder->beginMetalRenderPass(true);
+                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
             cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
@@ -749,7 +749,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                     mtlIndBuffOfst += sizeof(MTLDispatchThreadgroupsIndirectArguments);
                     // Running this stage prematurely ended the render pass, so we have to start it up again.
                     // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                    cmdEncoder->beginMetalRenderPass(true);
+                    cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {
@@ -1019,7 +1019,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 									  threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
 				}
 				// Switch back to rendering now, since we don't have compute stages to run anyway.
-                cmdEncoder->beginMetalRenderPass(true);
+                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
 	        cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
@@ -1084,7 +1084,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                     mtlTempIndBuffOfst += sizeof(MTLDispatchThreadgroupsIndirectArguments);
                     // Running this stage prematurely ended the render pass, so we have to start it up again.
                     // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                    cmdEncoder->beginMetalRenderPass(true);
+                    cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -130,7 +130,7 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		}
 		if (needsRenderpassRestart) {
 			cmdEncoder->encodeStoreActions(true);
-			cmdEncoder->beginMetalRenderPass(true);
+			cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
 		}
 	}
 #endif

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -296,7 +296,7 @@ public:
 	void beginNextMultiviewPass();
 
 	/** Begins a Metal render pass for the current render subpass. */
-	void beginMetalRenderPass(bool loadOverride = false);
+	void beginMetalRenderPass(MVKCommandUse cmdUse);
 
 	/** If a render encoder is active, encodes store actions for all attachments to it. */
 	void encodeStoreActions(bool storeOverride = false);
@@ -498,7 +498,7 @@ protected:
     void finishQueries();
 	void setSubpass(MVKCommand* passCmd, VkSubpassContents subpassContents, uint32_t subpassIndex);
 	void clearRenderArea();
-    NSString* getMTLRenderCommandEncoderName();
+    NSString* getMTLRenderCommandEncoderName(MVKCommandUse cmdUse);
 	void encodeGPUCounterSample(MVKGPUCounterQueryPool* mvkQryPool, uint32_t sampleIndex, MVKCounterSamplingFlags samplingPoints);
 	void encodeTimestampStageCounterSamples();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -208,10 +208,7 @@ public:
 	void populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects, MVKCommandEncoder* cmdEncoder);
 
     /** Returns whether this attachment should be cleared in the subpass. */
-    bool shouldUseClearAttachment(MVKRenderSubpass* subpass);
-
-    /** If this is a depth attachment, the stencil load op may be different than the depth load op. */
-	VkAttachmentLoadOp getAttachmentStencilLoadOp() const;
+    bool shouldClearAttachment(MVKRenderSubpass* subpass, bool isStencil);
 
 	/** Constructs an instance for the specified parent renderpass. */
 	MVKRenderPassAttachment(MVKRenderPass* renderPass,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -67,6 +67,9 @@ public:
 	/** Returns whether or not the color attachment at the specified index is being used. */
 	bool isColorAttachmentUsed(uint32_t colorAttIdx);
 
+	/** Returns whether or not the color attachment is used as both a color attachment and an input attachment. */
+	bool isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx);
+
 	/** Returns the format of the depth/stencil attachment. */
 	VkFormat getDepthStencilFormat();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -191,7 +191,7 @@ public:
 												   bool hasResolveAttachment,
 												   bool canResolveFormat,
                                                    bool isStencil,
-                                                   bool loadOverride = false);
+                                                   bool loadOverride);
 
 	/** If a render encoder is active, sets the store action for this attachment to it. */
 	void encodeStoreAction(MVKCommandEncoder* cmdEncoder,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -275,10 +275,9 @@ void MVKRenderSubpass::populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* 
 			isMemorylessAttachment = dsImage->getMTLTexture(0).storageMode == MTLStorageModeMemoryless;
 #endif
 			if (dsMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(mtlDepthAttDesc, this,
-                                                                      isRenderingEntireAttachment,
-																	  isMemorylessAttachment,
-                                                                      hasResolveAttachment, false,
-                                                                      loadOverride)) {
+                                                                      isRenderingEntireAttachment, isMemorylessAttachment,
+                                                                      hasResolveAttachment, true,
+																	  false, loadOverride)) {
                 mtlDepthAttDesc.clearDepth = pixFmts->getMTLClearDepthValue(clearValues[dsRPAttIdx]);
 			}
 			if (isMultiview()) {
@@ -303,10 +302,9 @@ void MVKRenderSubpass::populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* 
 			isMemorylessAttachment = dsImage->getMTLTexture(0).storageMode == MTLStorageModeMemoryless;
 #endif
 			if (dsMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(mtlStencilAttDesc, this,
-                                                                      isRenderingEntireAttachment,
-																	  isMemorylessAttachment,
+                                                                      isRenderingEntireAttachment, isMemorylessAttachment,
                                                                       hasResolveAttachment, true,
-                                                                      loadOverride)) {
+																	  true, loadOverride)) {
 				mtlStencilAttDesc.clearStencil = pixFmts->getMTLClearStencilValue(clearValues[dsRPAttIdx]);
 			}
 			if (isMultiview()) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -59,6 +59,19 @@ bool MVKRenderSubpass::isColorAttachmentUsed(uint32_t colorAttIdx) {
 	return _colorAttachments[colorAttIdx].attachment != VK_ATTACHMENT_UNUSED;
 }
 
+
+bool MVKRenderSubpass::isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx) {
+	if (colorAttIdx >= _colorAttachments.size()) { return false; }
+
+	uint32_t rspAttIdx = _colorAttachments[colorAttIdx].attachment;
+	if (rspAttIdx == VK_ATTACHMENT_UNUSED) { return false; }
+
+	for (auto& inAtt : _inputAttachments) {
+		if (inAtt.attachment == rspAttIdx) { return true; }
+	}
+	return false;
+}
+
 VkFormat MVKRenderSubpass::getDepthStencilFormat() {
 	uint32_t rpAttIdx = _depthStencilAttachment.attachment;
 	if (rpAttIdx == VK_ATTACHMENT_UNUSED) { return VK_FORMAT_UNDEFINED; }

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -63,7 +63,7 @@ typedef struct {
 
 /** Tracks the Vulkan command currently being used. */
 typedef enum : uint8_t {
-    kMVKCommandUseNone,                         /**< No use defined. */
+    kMVKCommandUseNone = 0,                     /**< No use defined. */
 	kMVKCommandUseEndCommandBuffer,             /**< vkEndCommandBuffer (prefilled VkCommandBuffer). */
     kMVKCommandUseQueueSubmit,                  /**< vkQueueSubmit. */
 	kMVKCommandUseAcquireNextImage,             /**< vkAcquireNextImageKHR. */
@@ -73,6 +73,8 @@ typedef enum : uint8_t {
 	kMVKCommandUseInvalidateMappedMemoryRanges, /**< vkInvalidateMappedMemoryRanges. */
     kMVKCommandUseBeginRenderPass,              /**< vkCmdBeginRenderPass. */
     kMVKCommandUseNextSubpass,                  /**< vkCmdNextSubpass. */
+	kMVKCommandUseBeginMultiViewPass,           /**< vkCmdBeginRenderPass. */
+	kMVKCommandUseRestartSubpass,               /**< Restart a subpass because of explicit or implicit barrier. */
     kMVKCommandUsePipelineBarrier,              /**< vkCmdPipelineBarrier. */
     kMVKCommandUseBlitImage,                    /**< vkCmdBlitImage. */
     kMVKCommandUseCopyImage,                    /**< vkCmdCopyImage. */

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -73,7 +73,6 @@ typedef enum : uint8_t {
 	kMVKCommandUseInvalidateMappedMemoryRanges, /**< vkInvalidateMappedMemoryRanges. */
     kMVKCommandUseBeginRenderPass,              /**< vkCmdBeginRenderPass. */
     kMVKCommandUseNextSubpass,                  /**< vkCmdNextSubpass. */
-	kMVKCommandUseBeginMultiViewPass,           /**< vkCmdBeginRenderPass. */
 	kMVKCommandUseRestartSubpass,               /**< Restart a subpass because of explicit or implicit barrier. */
     kMVKCommandUsePipelineBarrier,              /**< vkCmdPipelineBarrier. */
     kMVKCommandUseBlitImage,                    /**< vkCmdBlitImage. */


### PR DESCRIPTION
Apologies for the random grouping here. I probably should have done these as three separate PRs. Look at the individual commits for clarity.

1. Support stencil-only partial attachment clearing:

- Rename `MVKRenderPassAttachment::shouldUseClearAttachment()` to `shouldClearAttachment()`, pass whether testing for stencil clearing, and check stencil clearing distinct from depth clearing.
- Refactor `MVKRenderSubpass::populateClearAttachments()` to work with this.
- Remove `MVKRenderPassAttachment::getAttachmentStencilLoadOp()` as obsolete.

2. Fix GPU race condition when clearing a renderpass input attachment on Apple GPUs:

- Apple GPUs do not support rendering/writing to an attachment and then reading from that attachment within a single Metal renderpass. On Apple Silicon, restart the Metal renderpass if an input attachment is cleared inside renderpass.

3. Fix depth/stencil clearing broken during recent fix:
- A recent change for resolving color formats mistakenly broke clearing depth and stencil formats.