### PR TITLE
Improved checks for timestamp GPU counter support on older devices + Ensure timestamp sync.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.1.6
 Released TBD
 
 - Support maximum point primitive size of 511.
+- Improved checks for timestamp GPU counter support on older devices.
 - Update to latest SPIRV-Cross version:
 	- Add support for `OpSpecConstantOp` ops `OpQuantizeToF16` and `OpSRem`.
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -493,6 +493,8 @@ public:
 
 	MVKCommandEncoder(MVKCommandBuffer* cmdBuffer);
 
+	~MVKCommandEncoder() override;
+
 protected:
     void addActivatedQueries(MVKQueryPool* pQueryPool, uint32_t query, uint32_t queryCount);
     void finishQueries();
@@ -501,6 +503,8 @@ protected:
     NSString* getMTLRenderCommandEncoderName(MVKCommandUse cmdUse);
 	void encodeGPUCounterSample(MVKGPUCounterQueryPool* mvkQryPool, uint32_t sampleIndex, MVKCounterSamplingFlags samplingPoints);
 	void encodeTimestampStageCounterSamples();
+	bool hasTimestampStageCounterQueries() { return !_timestampStageCounterQueries.empty(); }
+	id<MTLFence> getStageCountersMTLFence();
 
 	typedef struct GPUCounterQuery {
 		MVKGPUCounterQueryPool* queryPool = nullptr;
@@ -520,6 +524,7 @@ protected:
 	id<MTLComputeCommandEncoder> _mtlComputeEncoder;
 	MVKCommandUse _mtlComputeEncoderUse;
 	id<MTLBlitCommandEncoder> _mtlBlitEncoder;
+	id<MTLFence> _stageCountersMTLFence;
     MVKCommandUse _mtlBlitEncoderUse;
 	MVKPushConstantsCommandEncoderState _vertexPushConstants;
 	MVKPushConstantsCommandEncoderState _tessCtlPushConstants;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -768,8 +768,8 @@ void MVKCommandEncoder::markTimestamp(MVKTimestampQueryPool* pQueryPool, uint32_
     }
 	addActivatedQueries(pQueryPool, query, queryCount);
 
-	MVKCounterSamplingFlags sampPts = _device->_pMetalFeatures->counterSamplingPoints;
-	if (sampPts) {
+	if (pQueryPool->hasMTLCounterBuffer()) {
+		MVKCounterSamplingFlags sampPts = _device->_pMetalFeatures->counterSamplingPoints;
 		for (uint32_t qOfst = 0; qOfst < queryCount; qOfst++) {
 			if (mvkIsAnyFlagEnabled(sampPts, MVK_COUNTER_SAMPLING_AT_PIPELINE_STAGE)) {
 				_timestampStageCounterQueries.push_back({ pQueryPool, query + qOfst });

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
@@ -182,6 +182,9 @@ class MVKGPUCounterQueryPool : public MVKQueryPool {
 
 public:
 
+	/** Returns whether a MTLCounterBuffer is being used by this query pool. */
+	bool hasMTLCounterBuffer() { return _mtlCounterBuffer != nil; }
+
 	/**
 	 * Returns the MTLCounterBuffer being used by this query pool,
 	 * or returns nil if GPU counters are not supported.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -335,7 +335,7 @@ MVKGPUCounterQueryPool::MVKGPUCounterQueryPool(MVKDevice* device, const VkQueryP
 void MVKGPUCounterQueryPool::initMTLCounterSampleBuffer(const VkQueryPoolCreateInfo* pCreateInfo,
 														id<MTLCounterSet> mtlCounterSet,
 														const char* queryTypeName) {
-	if ( !_device->_pMetalFeatures->counterSamplingPoints ) { return; }
+	if ( !mtlCounterSet ) { return; }
 
 	@autoreleasepool {
 		MTLCounterSampleBufferDescriptor* tsDesc = [[[MTLCounterSampleBufferDescriptor alloc] init] autorelease];


### PR DESCRIPTION
- Check that appropriate GPU counter set is supported on the device before creating GPU counter sample buffer. 
- Don't attempt to timestamp using GPU counters unless a GPU sample counter buffer has been created.
- Add `MTLFence` between Metal encoders and timestamp stage counter BLIT encoder to ensure previous work is finished before being timestamped.

Fixes issue #1433.