### PR TITLE
Move multilayer-rendering validation from MVKImage to MVKImageView.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,8 @@ Released TBD
 
 - Support maximum point primitive size of 511.
 - Improved checks for timestamp GPU counter support on older devices.
+- Fix incorrect validation error on multilayer `VkImage` marked for rendering, when multilayered-rendering 
+  is not supported on platform, but app doesn't actually attempt to render to multiple layers.
 - Update to latest SPIRV-Cross version:
 	- MSL: Add support for `OpSpecConstantOp` ops `OpQuantizeToF16` and `OpSRem`.
 	- MSL: Return fragment function value even when last SPIR-V Op is discard (`OpKill`).


### PR DESCRIPTION
An `MVKImageView` that renders to only one layer of a multilayer `MVKImage` is not performing multilayer-rendering. Only validate multilayer-rendering when it is definitely requested in an `MVKImageView`, instead of presuming when a multilayer `MVKImage` is marked for rendering.

Fixes issue #1440.