### PR TITLE
Ensure dynamic pipeline state always respects pipeline dynamic flags.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,8 @@ Released TBD
 - Improved checks for timestamp GPU counter support on older devices.
 - Fix incorrect validation error on multilayer `VkImage` marked for rendering, when multilayered-rendering 
   is not supported on platform, but app doesn't actually attempt to render to multiple layers.
+- Fix dynamic pipeline state such as `vkCmdSetDepthBias()` sometimes ignoring pipeline dyamic 
+  state flags when called before `vkCmdBindPipeline()`.
 - Update to latest SPIRV-Cross version:
 	- MSL: Add support for `OpSpecConstantOp` ops `OpQuantizeToF16` and `OpSRem`.
 	- MSL: Return fragment function value even when last SPIR-V Op is discard (`OpKill`).


### PR DESCRIPTION
Dynamic pipeline state set before the pipeline is set was reading dynamic flags from previous pipeline. This is fixed here by accepting the dynamic state, but deferring the decision to use either dynamic or static state until the pipeline is encoded.

Fixes issue #1441.