### PR TITLE
Add unsupported VkApplicationInfo->apiVersion warning

### DIFF
--- a/Common/MVKLogging.h
+++ b/Common/MVKLogging.h
@@ -35,9 +35,9 @@ extern "C" {
  * This library adds flexible, non-intrusive logging and assertion capabilities
  * that can be efficiently enabled or disabled via compiler switches.
  *
- * There are four levels of logging: Trace, Info, Error and Debug, and each can be enabled
- * independently via the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_INFO, MVK_LOG_LEVEL_ERROR and
- * MVK_LOG_LEVEL_DEBUG switches, respectively.
+ * There are five levels of logging: Trace, Info, Warning, Error and Debug, and each can be enabled
+ * independently via the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_INFO, MVK_LOG_LEVEL_WARNING,
+ * MVK_LOG_LEVEL_ERROR and MVK_LOG_LEVEL_DEBUG switches, respectively.
  *
  * ALL logging can be enabled or disabled via the MVK_LOGGING_ENABLED switch.
  *
@@ -59,12 +59,17 @@ extern "C" {
  *		MVKLogErrorIf(cond, fmt, ...)	- same as MVKLogError if boolean "cond" condition expression evaluates to YES,
  *										  otherwise logs nothing.
  *
+ *      MVKLogWarning(fmt, ...)              - recommended for not immediately harmful errors
+ *                                      - will print if MVK_LOG_LEVEL_WARNING is set on.
+ *      MVKLogWarningIf(cond, fmt, ...)  - same as MVKLogWarning if boolean "cond" condition expression evaluates to YES,
+ *                                        otherwise logs nothing.
+ *
  *		MVKLogInfo(fmt, ...)			- recommended for general, infrequent, information messages
  *										- will print if MVK_LOG_LEVEL_INFO is set on.
  *		MVKLogInfoIf(cond, fmt, ...)	- same as MVKLogInfo if boolean "cond" condition expression evaluates to YES,
  *										  otherwise logs nothing.
  *
- *		MVKLogDebug(fmt, ...)			- recommended for temporary use during debugging
+ *		MVKLogDebug(fmt, ...)		- recommended for temporary use during debugging
  *										- will print if MVK_LOG_LEVEL_DEBUG is set on.
  *		MVKLogDebugIf(cond, fmt, ...)	- same as MVKLogDebug if boolean "cond" condition expression evaluates to YES,
  *										  otherwise logs nothing.
@@ -118,6 +123,9 @@ extern "C" {
 #ifndef MVK_LOG_LEVEL_ERROR
 #	define MVK_LOG_LEVEL_ERROR		MVK_LOGGING_ENABLED
 #endif
+#ifndef MVK_LOG_LEVEL_WARNING
+#   define MVK_LOG_LEVEL_WARNING    MVK_LOGGING_ENABLED
+#endif
 #ifndef MVK_LOG_LEVEL_INFO
 #	define MVK_LOG_LEVEL_INFO		MVK_LOGGING_ENABLED
 #endif
@@ -138,6 +146,15 @@ extern "C" {
 #else
 #	define MVKLogError(...)
 #	define MVKLogErrorIf(cond, fmt, ...)
+#endif
+
+// Warning logging - for not immediately harmful errors
+#if MVK_LOG_LEVEL_WARNING
+#    define MVKLogWarning(fmt, ...)         MVKLogWarningImpl(fmt, ##__VA_ARGS__)
+#    define MVKLogWarningIf(cond, fmt, ...) if(cond) { MVKLogWarningImpl(fmt, ##__VA_ARGS__); }
+#else
+#    define MVKLogWarning(...)
+#    define MVKLogWarningIf(cond, fmt, ...)
 #endif
 
 // Info logging - for general, non-performance affecting information messages
@@ -168,6 +185,7 @@ extern "C" {
 #endif
 
 #define MVKLogErrorImpl(fmt, ...)		reportMessage(ASL_LEVEL_ERR, fmt, ##__VA_ARGS__)
+#define MVKLogWarningImpl(fmt, ...)     reportMessage(ASL_LEVEL_WARNING, fmt, ##__VA_ARGS__)
 #define MVKLogInfoImpl(fmt, ...)		reportMessage(ASL_LEVEL_NOTICE, fmt, ##__VA_ARGS__)
 #define MVKLogTraceImpl(fmt, ...)		reportMessage(ASL_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
 #define MVKLogDebugImpl(fmt, ...)		reportMessage(ASL_LEVEL_DEBUG, fmt, ##__VA_ARGS__)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -334,7 +334,17 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 	initDebugCallbacks(pCreateInfo);	// Do before any creation activities
 
 	mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
-	if (_appInfo.apiVersion == 0) { _appInfo.apiVersion = VK_API_VERSION_1_0; }	// Default
+    
+    if (_appInfo.apiVersion == 0) {
+        _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
+        
+    }
+    else if (VK_API_VERSION_MAJOR(_appInfo.apiVersion) > MVK_VERSION_MAJOR ||
+             VK_API_VERSION_MINOR(_appInfo.apiVersion) > MVK_VERSION_MINOR) {
+        reportMessage(ASL_LEVEL_WARNING, "Unsupported MoltenVK API version. Assuming VK_API_VERSION_1_1.");
+        _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
+    }
+
 
 	initProcAddrs();		// Init function pointers
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -337,11 +337,11 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
     
     if (_appInfo.apiVersion == 0) {
         _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
-        
     }
     else if (VK_API_VERSION_MAJOR(_appInfo.apiVersion) > MVK_VERSION_MAJOR ||
              VK_API_VERSION_MINOR(_appInfo.apiVersion) > MVK_VERSION_MINOR) {
-        reportMessage(ASL_LEVEL_WARNING, "Unsupported MoltenVK API version. Assuming VK_API_VERSION_1_1.");
+        reportMessage(ASL_LEVEL_WARNING,
+            "Unsupported MoltenVK API version. Assuming VK_API_VERSION_1_1.");
         _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
     }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -335,13 +335,15 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 
 	mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
     
-    if (_appInfo.apiVersion > MVK_VULKAN_API_VERSION) {
+    if (_appInfo.apiVersion == 0) {
+        _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
+    }
+    else if (MVK_VULKAN_API_VERSION_CONFORM(_appInfo.apiVersion) > MVK_VULKAN_API_VERSION_CONFORM(MVK_VULKAN_API_VERSION)) {
         MVKLogWarning("Unrecognized CreateInstance->pCreateInfo->pApplicationInfo->apiVersion number (0x%08x). Assuming MoltenVK %d.%d version.",
                       _appInfo.apiVersion, MVK_VERSION_MAJOR, MVK_VERSION_MINOR);
+        _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
     }
     
-    if (_appInfo.apiVersion == 0) { _appInfo.apiVersion = VK_API_VERSION_1_0; }    // Default
-
 	initProcAddrs();		// Init function pointers
 
 	setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -335,16 +335,12 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 
 	mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
     
-    if (_appInfo.apiVersion == 0) {
-        _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
+    if (_appInfo.apiVersion > MVK_VULKAN_API_VERSION) {
+        MVKLogWarning("Unrecognized CreateInstance->pCreateInfo->pApplicationInfo->apiVersion number (0x%08x). Assuming MoltenVK %d.%d version.",
+                      _appInfo.apiVersion, MVK_VERSION_MAJOR, MVK_VERSION_MINOR);
     }
-    else if (VK_API_VERSION_MAJOR(_appInfo.apiVersion) > MVK_VERSION_MAJOR ||
-             VK_API_VERSION_MINOR(_appInfo.apiVersion) > MVK_VERSION_MINOR) {
-        reportMessage(ASL_LEVEL_WARNING,
-            "Unsupported MoltenVK API version. Assuming VK_API_VERSION_1_1.");
-        _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
-    }
-
+    
+    if (_appInfo.apiVersion == 0) { _appInfo.apiVersion = VK_API_VERSION_1_0; }    // Default
 
 	initProcAddrs();		// Init function pointers
 
@@ -365,7 +361,7 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 			_physicalDevices.push_back(new MVKPhysicalDevice(this, mtlDev));
 		}
 	}
-
+    
 	if (_physicalDevices.empty()) {
 		setConfigurationResult(reportError(VK_ERROR_INCOMPATIBLE_DRIVER, "Vulkan is not supported on this device. MoltenVK requires Metal, which is not available on this device."));
 	}


### PR DESCRIPTION
Related to this #1445 issue.

As declared in [spec](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkApplicationInfo.html) "Vulkan 1.1 or later must not return VK_ERROR_INCOMPATIBLE_DRIVER for any value of apiVersion". So I decided to check what a Nvidia driver does in this case, it shows validation warning and sets apiVersion to latest available version. I think it would be great to have similar actions in MoltenVK.