### PR TITLE
CI: Update builds to Xcode 13.1, add legacy 12.5.1 build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,18 +15,18 @@ jobs:
       matrix:
         xcode: [ "13.1" ]
         platform: [ "macos", "maccat", "ios", "tvos" ]
-        os: [ "macos-latest" ]
+        os: [ "macos-11" ]
         upload_artifacts: [ true ]
         # additional specific configurations
         include:
           # "Legacy" Xcode 11.7 & 12.5.1 macOS builds
           - xcode: "11.7"
             platform: "macos"
-            os: "macos-latest" 
+            os: "macos-10.15" 
             upload_artifacts: false
           - xcode: "12.5.1"
             platform: "macos"
-            os: "macos-latest" 
+            os: "macos-11" 
             upload_artifacts: false
       fail-fast: false
 


### PR DESCRIPTION
Updates the regular macOS, maccat, iOS and tvOS builds to use Xcode 13.1 instead of 12.4. Also adds a legacy build using Xcode 12.5.1.