### PR TITLE
Remove advertised support for BC1_RGB texel formats.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,8 @@ Released TBD
   is not supported on platform, but app doesn't actually attempt to render to multiple layers.
 - Fix dynamic pipeline state such as `vkCmdSetDepthBias()` sometimes ignoring pipeline dyamic 
   state flags when called before `vkCmdBindPipeline()`.
+- Remove advertising support for pixel formats `VK_FORMAT_BC1_RGB_UNORM_BLOCK` and `VK_FORMAT_BC1_RGB_SRGB_BLOCK`, 
+  as these can cause rare compatibility problems with transparency encoding.
 - Update to latest SPIRV-Cross version:
 	- MSL: Add support for `OpSpecConstantOp` ops `OpQuantizeToF16` and `OpSRem`.
 	- MSL: Return fragment function value even when last SPIR-V Op is discard (`OpKill`).

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -935,8 +935,8 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 
 	addVkFormatDesc( X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil );
 
-	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, Invalid, BC1_RGBA, Invalid, Invalid, 4, 4, 8, Compressed );
+	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, Invalid, BC1_RGBA_sRGB, Invalid, Invalid, 4, 4, 8, Compressed );
 	addVkFormatDesc( BC1_RGBA_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
 	addVkFormatDesc( BC1_RGBA_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
 


### PR DESCRIPTION
Metal does not provide direct support for `BC1_RGB` formats (`VK_FORMAT_BC1_RGB_UNORM_BLOCK` & `VK_FORMAT_BC1_RGB_SRGB_BLOCK`). We have been faking it by mapping these Vulkan formats to Metal formats containing alpha (`MTLPixelFormatBC7_RGBAUnorm` & `MTLPixelFormatBC7_RGBAUnorm_sRGB`, respectively), and advertising support for BC1_RGB formats.

However, this triggers CTS failures, because the `BC1_RGBA` formats can return an alpha value of 0.0 when constructed that way, whereas the `BC1_RGB` formats always expect 1.0 (opaque) to be returned.

This change moves to indirect support for `BC1_RGB` formats. They will still be covered by `MTLPixelFormatBC7_RGBAUnorm` & `MTLPixelFormatBC7_RGBAUnorm_sRGB`, and will effectively work (except transparency), but are no longer advertised through physical device format and image format queries.

I did investigate a few types of heroics we could invoke to work around this, including possibly shader sampling mods, or replacing the compressed content with uncompressed (as is done with certain 3D BCn formats), but decided this was a relatively painless compromise. The RGB formats are still effectively supported if the app does not explicitly look for support.

@cdavis5e Let me know if this works for your BC1 requirements, or whether we will really need to perform those heroics (perhaps by piggy-backing on existing dynamic decompression options).