### PR TITLE
Restore support for BC1_RGB compressed formats.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,8 +24,6 @@ Released TBD
   is not supported on platform, but app doesn't actually attempt to render to multiple layers.
 - Fix dynamic pipeline state such as `vkCmdSetDepthBias()` sometimes ignoring pipeline dyamic 
   state flags when called before `vkCmdBindPipeline()`.
-- Remove advertising support for pixel formats `VK_FORMAT_BC1_RGB_UNORM_BLOCK` and `VK_FORMAT_BC1_RGB_SRGB_BLOCK`, 
-  as these can cause rare compatibility problems with transparency encoding.
 - Update to latest SPIRV-Cross version:
 	- MSL: Add support for `OpSpecConstantOp` ops `OpQuantizeToF16` and `OpSRem`.
 	- MSL: Return fragment function value even when last SPIR-V Op is discard (`OpKill`).

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1489,6 +1489,19 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 	_componentSwizzle = pCreateInfo->components;
 	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
 
+	// Use swizzle adjustment to bridge some differences between Vulkan and Metal pixel formats.
+	// Do this ahead of other tests and adjustments so that swizzling will be enabled by tests below.
+	switch (pCreateInfo->format) {
+		case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+		case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+			// Metal doesn't support BC1_RGB, so force substituted BC1_RGBA alpha to 1.0.
+			_componentSwizzle.a = VK_COMPONENT_SWIZZLE_ONE;
+			break;
+
+		default:
+			break;
+	}
+
 #define SWIZZLE_MATCHES(R, G, B, A)    mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_ ##R, VK_COMPONENT_SWIZZLE_ ##G, VK_COMPONENT_SWIZZLE_ ##B, VK_COMPONENT_SWIZZLE_ ##A} )
 #define VK_COMPONENT_SWIZZLE_ANY       VK_COMPONENT_SWIZZLE_MAX_ENUM
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1489,13 +1489,19 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 	_componentSwizzle = pCreateInfo->components;
 	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
 
+#define adjustComponentSwizzleValue(comp, currVal, newVal)    if (_componentSwizzle.comp == VK_COMPONENT_SWIZZLE_ ##currVal) { _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_ ##newVal; }
+
 	// Use swizzle adjustment to bridge some differences between Vulkan and Metal pixel formats.
 	// Do this ahead of other tests and adjustments so that swizzling will be enabled by tests below.
 	switch (pCreateInfo->format) {
 		case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
 		case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
-			// Metal doesn't support BC1_RGB, so force substituted BC1_RGBA alpha to 1.0.
-			_componentSwizzle.a = VK_COMPONENT_SWIZZLE_ONE;
+			// Metal doesn't support BC1_RGB, so force references to substituted BC1_RGBA alpha to 1.0.
+			adjustComponentSwizzleValue(r, A, ONE);
+			adjustComponentSwizzleValue(g, A, ONE);
+			adjustComponentSwizzleValue(b, A, ONE);
+			adjustComponentSwizzleValue(a, A, ONE);
+			adjustComponentSwizzleValue(a, IDENTITY, ONE);
 			break;
 
 		default:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -935,8 +935,8 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 
 	addVkFormatDesc( X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil );
 
-	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, Invalid, BC1_RGBA, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, Invalid, BC1_RGBA_sRGB, Invalid, Invalid, 4, 4, 8, Compressed );
+	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
 	addVkFormatDesc( BC1_RGBA_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
 	addVkFormatDesc( BC1_RGBA_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
 


### PR DESCRIPTION
For Vulkan `BC1_RGB` formats, swizzle alpha of substituted
Metal `BC1_RGBA` to `1.0`, to return value expected by Vulkan.

Fixes #1461 and reverses and improves PR #1460.