### PR TITLE
Clean up MVKLogging

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -680,6 +680,7 @@
 		A98149401FB6A3F7005F00B4 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				A9F0429E1FB4CF82009FCCB8 /* MVKLogging.h */,
 				A98149421FB6A3F7005F00B4 /* MVKBaseObject.h */,
 				A98149411FB6A3F7005F00B4 /* MVKBaseObject.mm */,
 				A9D7104E25CDE05E00E38106 /* MVKBitArray.h */,
@@ -751,7 +752,6 @@
 			isa = PBXGroup;
 			children = (
 				A9F0429D1FB4CF82009FCCB8 /* MVKCommonEnvironment.h */,
-				A9F0429E1FB4CF82009FCCB8 /* MVKLogging.h */,
 				A9B51BD6225E986A00AC74D2 /* MVKOSExtensions.h */,
 				A9B51BD2225E986A00AC74D2 /* MVKOSExtensions.mm */,
 				A981496A1FB6A998005F00B4 /* MVKStrings.h */,

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -62,7 +62,9 @@ typedef unsigned long MTLLanguageVersion;
 typedef enum MVKConfigLogLevel {
 	MVK_CONFIG_LOG_LEVEL_NONE     = 0,	/**< No logging. */
 	MVK_CONFIG_LOG_LEVEL_ERROR    = 1,	/**< Log errors only. */
-	MVK_CONFIG_LOG_LEVEL_INFO     = 2,	/**< Log errors and informational messages. */
+	MVK_CONFIG_LOG_LEVEL_WARNING  = 2,	/**< Log errors and warning messages. */
+	MVK_CONFIG_LOG_LEVEL_INFO     = 3,	/**< Log errors, warnings and informational messages. */
+	MVK_CONFIG_LOG_LEVEL_DEBUG    = 4,	/**< Log errors, warnings, infos and debug messages. */
 	MVK_CONFIG_LOG_LEVEL_MAX_ENUM = 0x7FFFFFFF
 } MVKConfigLogLevel;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -144,7 +144,7 @@ public:
 						   VkDebugUtilsMessageTypeFlagsEXT messageTypes,
 						   const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
 
-	void debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, int aslLvl, const char* pMessage);
+	void debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, MVKConfigLogLevel logLevel, const char* pMessage);
 
 	/** Returns whether debug callbacks are being used. */
 	bool hasDebugCallbacks() { return _hasDebugReportCallbacks || _hasDebugUtilsMessengers; }
@@ -181,8 +181,8 @@ protected:
 	void initProcAddrs();
 	void initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo);
 	NSArray<id<MTLDevice>>* getAvailableMTLDevicesArray();
-	VkDebugReportFlagsEXT getVkDebugReportFlagsFromASLLevel(int aslLvl);
-	VkDebugUtilsMessageSeverityFlagBitsEXT getVkDebugUtilsMessageSeverityFlagBitsFromASLLevel(int aslLvl);
+	VkDebugReportFlagsEXT getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel);
+	VkDebugUtilsMessageSeverityFlagBitsEXT getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(MVKConfigLogLevel logLevel);
 	MVKEntryPoint* getEntryPoint(const char* pName);
     void logVersions();
 	VkResult verifyLayers(uint32_t count, const char* const* names);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -198,17 +198,17 @@ void MVKInstance::debugUtilsMessage(VkDebugUtilsMessageSeverityFlagBitsEXT messa
 	}
 }
 
-void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, int aslLvl, const char* pMessage) {
+void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, MVKConfigLogLevel logLevel, const char* pMessage) {
 
 	if (_hasDebugReportCallbacks) {
-		VkDebugReportFlagsEXT flags = getVkDebugReportFlagsFromASLLevel(aslLvl);
+		VkDebugReportFlagsEXT flags = getVkDebugReportFlagsFromLogLevel(logLevel);
 		uint64_t object = (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr);
 		VkDebugReportObjectTypeEXT objectType = mvkAPIObj ? mvkAPIObj->getVkDebugReportObjectType() : VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
 		debugReportMessage(flags, objectType, object, 0, 0, _debugReportCallbackLayerPrefix, pMessage);
 	}
 
 	if (_hasDebugUtilsMessengers) {
-		VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity = getVkDebugUtilsMessageSeverityFlagBitsFromASLLevel(aslLvl);
+		VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity = getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(logLevel);
 		uint64_t objectHandle = (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr);
 		VkObjectType objectType = mvkAPIObj ? mvkAPIObj->getVkObjectType() : VK_OBJECT_TYPE_UNKNOWN;
 
@@ -237,43 +237,29 @@ void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, int aslLvl, 
 	}
 }
 
-VkDebugReportFlagsEXT MVKInstance::getVkDebugReportFlagsFromASLLevel(int aslLvl) {
-	switch (aslLvl) {
-		case ASL_LEVEL_DEBUG:
+VkDebugReportFlagsEXT MVKInstance::getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel) {
+	switch (logLevel) {
+		case MVK_CONFIG_LOG_LEVEL_DEBUG:
 			return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
-
-		case ASL_LEVEL_INFO:
-		case ASL_LEVEL_NOTICE:
+		case MVK_CONFIG_LOG_LEVEL_INFO:
 			return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-
-		case ASL_LEVEL_WARNING:
+		case MVK_CONFIG_LOG_LEVEL_WARNING:
 			return VK_DEBUG_REPORT_WARNING_BIT_EXT;
-
-		case ASL_LEVEL_ERR:
-		case ASL_LEVEL_CRIT:
-		case ASL_LEVEL_ALERT:
-		case ASL_LEVEL_EMERG:
+		case MVK_CONFIG_LOG_LEVEL_ERROR:
 		default:
 			return VK_DEBUG_REPORT_ERROR_BIT_EXT;
 	}
 }
 
-VkDebugUtilsMessageSeverityFlagBitsEXT MVKInstance::getVkDebugUtilsMessageSeverityFlagBitsFromASLLevel(int aslLvl) {
-	switch (aslLvl) {
-		case ASL_LEVEL_DEBUG:
+VkDebugUtilsMessageSeverityFlagBitsEXT MVKInstance::getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(MVKConfigLogLevel logLevel) {
+	switch (logLevel) {
+		case MVK_CONFIG_LOG_LEVEL_DEBUG:
 			return VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-
-		case ASL_LEVEL_INFO:
-		case ASL_LEVEL_NOTICE:
+		case MVK_CONFIG_LOG_LEVEL_INFO:
 			return VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-
-		case ASL_LEVEL_WARNING:
+		case MVK_CONFIG_LOG_LEVEL_WARNING:
 			return VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-
-		case ASL_LEVEL_ERR:
-		case ASL_LEVEL_CRIT:
-		case ASL_LEVEL_ALERT:
-		case ASL_LEVEL_EMERG:
+		case MVK_CONFIG_LOG_LEVEL_ERROR:
 		default:
 			return VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
 	}

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "mvk_vulkan.h"
+#include "vk_mvk_moltenvk.h"
 #include <string>
 #include <atomic>
 
@@ -47,7 +48,7 @@ public:
 	 * and some subclasses will also forward the message to their VkInstance for
 	 * output to the Vulkan debug report messaging API.
 	 */
-	void reportMessage(int aslLvl, const char* format, ...) __printflike(3, 4);
+	void reportMessage(MVKConfigLogLevel logLevel, const char* format, ...) __printflike(3, 4);
 
 	/**
 	 * Report a Vulkan error message, on behalf of the object, which may be nil.
@@ -55,7 +56,7 @@ public:
 	 * is not nil and has access to the VkInstance, the message will also be forwarded
 	 * to the VkInstance for output to the Vulkan debug report messaging API.
 	 */
-	static void reportMessage(MVKBaseObject* mvkObj, int aslLvl, const char* format, ...) __printflike(3, 4);
+	static void reportMessage(MVKBaseObject* mvkObj, MVKConfigLogLevel logLevel, const char* format, ...) __printflike(3, 4);
 
 	/**
 	 * Report a Vulkan error message, on behalf of the object, which may be nil.
@@ -65,7 +66,7 @@ public:
 	 *
 	 * This is the core reporting implementation. Other similar functions delegate here.
 	 */
-	static void reportMessage(MVKBaseObject* mvkObj, int aslLvl, const char* format, va_list args) __printflike(3, 0);
+	static void reportMessage(MVKBaseObject* mvkObj, MVKConfigLogLevel logLevel, const char* format, va_list args) __printflike(3, 0);
 
 	/**
 	 * Report a Vulkan error message. This includes logging to a standard system logging stream,

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "mvk_vulkan.h"
 #include "vk_mvk_moltenvk.h"
 #include <string>
 #include <atomic>

--- a/MoltenVK/MoltenVK/Utility/MVKLogging.h
+++ b/MoltenVK/MoltenVK/Utility/MVKLogging.h
@@ -34,9 +34,8 @@ extern "C" {
  * This library adds flexible, non-intrusive logging and assertion capabilities
  * that can be efficiently enabled or disabled via compiler switches.
  *
- * There are five levels of logging: Trace, Info, Warning, Error and Debug, and each can be enabled
- * independently via the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_DEBUG, MVK_LOG_LEVEL_INFO,
- * MVK_LOG_LEVEL_WARNING анд MVK_LOG_LEVEL_ERROR switches, respectively.
+ * There are five levels of logging, controlled by the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_DEBUG,
+ * MVK_LOG_LEVEL_INFO, MVK_LOG_LEVEL_WARNING аnd MVK_LOG_LEVEL_ERROR switches.
  *
  * ALL logging can be enabled or disabled via the MVK_LOGGING_ENABLED switch.
  *

--- a/MoltenVK/MoltenVK/Utility/MVKLogging.h
+++ b/MoltenVK/MoltenVK/Utility/MVKLogging.h
@@ -28,7 +28,6 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-#include <asl.h>
 #include <stdbool.h>
 
 /**
@@ -36,8 +35,8 @@ extern "C" {
  * that can be efficiently enabled or disabled via compiler switches.
  *
  * There are five levels of logging: Trace, Info, Warning, Error and Debug, and each can be enabled
- * independently via the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_INFO, MVK_LOG_LEVEL_WARNING,
- * MVK_LOG_LEVEL_ERROR and MVK_LOG_LEVEL_DEBUG switches, respectively.
+ * independently via the MVK_LOG_LEVEL_TRACE, MVK_LOG_LEVEL_DEBUG, MVK_LOG_LEVEL_INFO,
+ * MVK_LOG_LEVEL_WARNING анд MVK_LOG_LEVEL_ERROR switches, respectively.
  *
  * ALL logging can be enabled or disabled via the MVK_LOGGING_ENABLED switch.
  *
@@ -59,10 +58,10 @@ extern "C" {
  *		MVKLogErrorIf(cond, fmt, ...)	- same as MVKLogError if boolean "cond" condition expression evaluates to YES,
  *										  otherwise logs nothing.
  *
- *      MVKLogWarning(fmt, ...)              - recommended for not immediately harmful errors
- *                                      - will print if MVK_LOG_LEVEL_WARNING is set on.
- *      MVKLogWarningIf(cond, fmt, ...)  - same as MVKLogWarning if boolean "cond" condition expression evaluates to YES,
- *                                        otherwise logs nothing.
+ *		MVKLogWarning(fmt, ...)		- recommended for not immediately harmful errors
+ *										- will print if MVK_LOG_LEVEL_WARNING is set on.
+ *		MVKLogWarningIf(cond, fmt, ...) - same as MVKLogWarning if boolean "cond" condition expression evaluates to YES,
+ *										  otherwise logs nothing.
  *
  *		MVKLogInfo(fmt, ...)			- recommended for general, infrequent, information messages
  *										- will print if MVK_LOG_LEVEL_INFO is set on.
@@ -150,8 +149,8 @@ extern "C" {
 
 // Warning logging - for not immediately harmful errors
 #if MVK_LOG_LEVEL_WARNING
-#    define MVKLogWarning(fmt, ...)         MVKLogWarningImpl(fmt, ##__VA_ARGS__)
-#    define MVKLogWarningIf(cond, fmt, ...) if(cond) { MVKLogWarningImpl(fmt, ##__VA_ARGS__); }
+#	define MVKLogWarning(fmt, ...)			MVKLogWarningImpl(fmt, ##__VA_ARGS__)
+#	define MVKLogWarningIf(cond, fmt, ...)	if(cond) { MVKLogWarningImpl(fmt, ##__VA_ARGS__); }
 #else
 #    define MVKLogWarning(...)
 #    define MVKLogWarningIf(cond, fmt, ...)
@@ -166,15 +165,6 @@ extern "C" {
 #	define MVKLogInfoIf(cond, fmt, ...)
 #endif
 
-// Trace logging - for detailed tracing
-#if MVK_LOG_LEVEL_TRACE
-#	define MVKLogTrace(fmt, ...)			MVKLogTraceImpl(fmt, ##__VA_ARGS__)
-#	define MVKLogTraceIf(cond, fmt, ...)	if(cond) { MVKLogTraceImpl(fmt, ##__VA_ARGS__); }
-#else
-#	define MVKLogTrace(...)
-#	define MVKLogTraceIf(cond, fmt, ...)
-#endif
-
 // Debug logging - use only temporarily for highlighting and tracking down problems
 #if MVK_LOG_LEVEL_DEBUG
 #	define MVKLogDebug(fmt, ...)			MVKLogDebugImpl(fmt, ##__VA_ARGS__)
@@ -184,11 +174,20 @@ extern "C" {
 #	define MVKLogDebugIf(cond, fmt, ...)
 #endif
 
-#define MVKLogErrorImpl(fmt, ...)		reportMessage(ASL_LEVEL_ERR, fmt, ##__VA_ARGS__)
-#define MVKLogWarningImpl(fmt, ...)     reportMessage(ASL_LEVEL_WARNING, fmt, ##__VA_ARGS__)
-#define MVKLogInfoImpl(fmt, ...)		reportMessage(ASL_LEVEL_NOTICE, fmt, ##__VA_ARGS__)
-#define MVKLogTraceImpl(fmt, ...)		reportMessage(ASL_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
-#define MVKLogDebugImpl(fmt, ...)		reportMessage(ASL_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
+// Trace logging - for detailed tracing
+#if MVK_LOG_LEVEL_TRACE
+#	define MVKLogTrace(fmt, ...)			MVKLogTraceImpl(fmt, ##__VA_ARGS__)
+#	define MVKLogTraceIf(cond, fmt, ...)	if(cond) { MVKLogTraceImpl(fmt, ##__VA_ARGS__); }
+#else
+#	define MVKLogTrace(...)
+#	define MVKLogTraceIf(cond, fmt, ...)
+#endif
+
+#define MVKLogErrorImpl(fmt, ...)		reportMessage(MVK_CONFIG_LOG_LEVEL_ERROR, fmt, ##__VA_ARGS__)
+#define MVKLogWarningImpl(fmt, ...)		reportMessage(MVK_CONFIG_LOG_LEVEL_WARNING, fmt, ##__VA_ARGS__)
+#define MVKLogInfoImpl(fmt, ...)		reportMessage(MVK_CONFIG_LOG_LEVEL_INFO, fmt, ##__VA_ARGS__)
+#define MVKLogDebugImpl(fmt, ...)		reportMessage(MVK_CONFIG_LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
+#define MVKLogTraceImpl(fmt, ...)		reportMessage(MVK_CONFIG_LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
 
 // Assertions
 #ifdef NS_BLOCK_ASSERTIONS


### PR DESCRIPTION
* Replaced ASL levels with MVKConfigLogLevel.
* Moved ```MVKLogging.h``` to ```Utility/``` directory.
* Added MVKConfigLogLevel Warning and Debug levels.