### PR TITLE
Update to latest version of VK_EXT_metal_objects extension

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -303,6 +303,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_EXT_image_robustness`
 - `VK_EXT_inline_uniform_block`
 - `VK_EXT_memory_budget` *(requires Metal 2.0)*
+- `VK_EXT_metal_objects`
 - `VK_EXT_metal_surface`
 - `VK_EXT_post_depth_coverage` *(iOS and macOS, requires family 4 (A11) or better Apple GPU)*
 - `VK_EXT_private_data `

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3881,9 +3881,17 @@ void MVKDevice::getMetalObjects(VkMetalObjectsInfoEXT* pMetalObjectsInfo) {
 			}
 			case VK_STRUCTURE_TYPE_METAL_TEXTURE_INFO_EXT: {
 				VkMetalTextureInfoEXT* pImgInfo = (VkMetalTextureInfoEXT*)next;
+				uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(pImgInfo->aspectMask);
 				auto* mvkImg = (MVKImage*)pImgInfo->image;
-				uint8_t planeIndex = mvkImg->getPlaneFromVkImageAspectFlags(pImgInfo->aspectMask);
-				*(pImgInfo->pMTLTexture) = mvkImg->getMTLTexture(planeIndex);
+				auto* mvkImgView = (MVKImageView*)pImgInfo->imageView;
+				auto* mvkBuffView = (MVKBufferView*)pImgInfo->bufferView;
+				if (mvkImg) {
+					*(pImgInfo->pMTLTexture) = mvkImg->getMTLTexture(planeIndex);
+				} else if (mvkImgView) {
+					*(pImgInfo->pMTLTexture) = mvkImgView->getMTLTexture(planeIndex);
+				} else {
+					*(pImgInfo->pMTLTexture) = mvkBuffView->getMTLTexture();
+				}
 				break;
 			}
 			case VK_STRUCTURE_TYPE_METAL_IOSURFACE_INFO_EXT: {
@@ -3911,9 +3919,11 @@ VkResult MVKDevice::setMetalObjects(const VkMetalObjectsInfoEXT* pMetalObjectsIn
 		switch (next->sType) {
 			case VK_STRUCTURE_TYPE_METAL_TEXTURE_INFO_EXT: {
 				const VkMetalTextureInfoEXT* pImgInfo = (VkMetalTextureInfoEXT*)next;
+				uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(pImgInfo->aspectMask);
 				auto* mvkImg = (MVKImage*)pImgInfo->image;
-				uint8_t planeIndex = mvkImg->getPlaneFromVkImageAspectFlags(pImgInfo->aspectMask);
-				iterRslt = mvkImg->setMTLTexture(planeIndex, *(pImgInfo->pMTLTexture));
+				if (mvkImg) {
+					iterRslt = mvkImg->setMTLTexture(planeIndex, *(pImgInfo->pMTLTexture));
+				}
 				break;
 			}
 			case VK_STRUCTURE_TYPE_METAL_IOSURFACE_INFO_EXT: {

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -3022,7 +3022,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCreateMetalSurfaceEXT(
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkGetMetalObjectsEXT(
 	VkDevice                                    device,
-	VkMetalObjectsInfoEXT*                pMetalObjectsInfo) {
+	VkMetalObjectsInfoEXT*                      pMetalObjectsInfo) {
 
 	MVKTraceVulkanCallStart();
 	MVKDevice* mvkDvc = MVKDevice::getMVKDevice(device);


### PR DESCRIPTION
- Support retrieving `MTLTexture` from `VkImageView` and `VkBufferView`.
- Document support for `VK_EXT_metal_objects` in `MoltenVK_Runtime_UserGuide.md`.