### PR TITLE
Optionally hide additional static Vulkan linkage symbols.

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -100,6 +100,10 @@ extern "C" {
 /** Directive to identify public symbols. */
 #define MVK_PUBLIC_SYMBOL        	__attribute__((visibility("default")))
 
+
+/** Directive to make a public alias of another symbol. */
+#define MVK_PUBLIC_ALIAS(ALIAS, TARGET)   asm(".globl _" #ALIAS "\n\t_" #ALIAS " = _" #TARGET)
+
 /**
  * Directives to hide public symbols from the Vulkan API, to avoid library linking
  * conflicts when bound to a Vulkan Loader that also exports identical symbols.
@@ -109,12 +113,11 @@ extern "C" {
 #endif
 #if MVK_HIDE_VULKAN_SYMBOLS
 #	define MVK_PUBLIC_VULKAN_SYMBOL
+#	define MVK_PUBLIC_VULKAN_ALIAS(ALIAS, TARGET)
 #else
 #	define MVK_PUBLIC_VULKAN_SYMBOL		MVK_PUBLIC_SYMBOL
+#	define MVK_PUBLIC_VULKAN_ALIAS(ALIAS, TARGET)	MVK_PUBLIC_ALIAS(ALIAS, TARGET)
 #endif
-
-/** Directive to make a public alias of another symbol. */
-#define MVK_PUBLIC_ALIAS(ALIAS, TARGET)   asm(".globl _" #ALIAS "\n\t_" #ALIAS " = _" #TARGET)
 
 
 #ifdef __cplusplus

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -55,7 +55,7 @@ typedef unsigned long MTLLanguageVersion;
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            32
+#define VK_MVK_MOLTENVK_SPEC_VERSION            33
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /** Identifies the level of logging MoltenVK should be limited to outputting. */
@@ -1113,11 +1113,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKConfigurationMVK(
  * In that case, this function will set *pMetalFeaturesSize to the size that MoltenVK expects
  * MVKPhysicalDeviceMetalFeatures to be.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkPhysicalDevice object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceMetalFeaturesMVK(
 	VkPhysicalDevice                            physicalDevice,
@@ -1146,11 +1143,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceMetalFeaturesMVK(
  * pPerf to NULL. In that case, this function will set *pPerfSize to the size that MoltenVK
  * expects MVKPerformanceStatistics to be.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkDevice object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPerformanceStatisticsMVK(
 	VkDevice                                    device,
@@ -1177,11 +1171,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetVersionStringsMVK(
  * source code or MSL compiled code. Workgroup size is determined automatically
  * if you're using SPIR-V.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkShaderModule object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR void VKAPI_CALL vkSetWorkgroupSizeMVK(
     VkShaderModule                              shaderModule,
@@ -1194,11 +1185,8 @@ VKAPI_ATTR void VKAPI_CALL vkSetWorkgroupSizeMVK(
 /**
  * Returns, in the pMTLDevice pointer, the MTLDevice used by the VkPhysicalDevice.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkPhysicalDevice object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR void VKAPI_CALL vkGetMTLDeviceMVK(
     VkPhysicalDevice                           physicalDevice,
@@ -1214,11 +1202,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetMTLDeviceMVK(
  *
  * Returns VK_SUCCESS.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkImage object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR VkResult VKAPI_CALL vkSetMTLTextureMVK(
     VkImage                                     image,
@@ -1227,11 +1212,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkSetMTLTextureMVK(
 /**
  * Returns, in the pMTLTexture pointer, the MTLTexture currently underlaying the VkImage.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkImage object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR void VKAPI_CALL vkGetMTLTextureMVK(
     VkImage                                     image,
@@ -1240,11 +1222,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetMTLTextureMVK(
 /**
 * Returns, in the pMTLBuffer pointer, the MTLBuffer currently underlaying the VkBuffer.
 *
-* This function is not supported by the Vulkan SDK Loader and Layers framework.
-* The VkBuffer object you provide here must have been retrieved directly from
-* MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
-* objects are often changed by layers, and passing them from one layer to another,
-* or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
 */
 VKAPI_ATTR void VKAPI_CALL vkGetMTLBufferMVK(
     VkBuffer                                    buffer,
@@ -1253,11 +1232,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetMTLBufferMVK(
 /**
 * Returns, in the pMTLCommandQueue pointer, the MTLCommandQueue currently underlaying the VkQueue.
 *
-* This function is not supported by the Vulkan SDK Loader and Layers framework.
-* The VkQueue object you provide here must have been retrieved directly from
-* MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
-* objects are often changed by layers, and passing them from one layer to another,
-* or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
 */
 VKAPI_ATTR void VKAPI_CALL vkGetMTLCommandQueueMVK(
     VkQueue                                     queue,
@@ -1289,11 +1265,8 @@ VKAPI_ATTR void VKAPI_CALL vkGetMTLCommandQueueMVK(
  *   - VK_ERROR_FEATURE_NOT_PRESENT if IOSurfaces are not supported on the platform.
  *   - VK_ERROR_INITIALIZATION_FAILED if ioSurface is specified and is not compatible with this VkImage.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkImage object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR VkResult VKAPI_CALL vkUseIOSurfaceMVK(
     VkImage                                     image,
@@ -1304,11 +1277,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkUseIOSurfaceMVK(
  * as set by the useIOSurfaceMVK() function, or returns null if the VkImage is not using
  * an IOSurface, or if the platform does not support IOSurfaces.
  *
- * This function is not supported by the Vulkan SDK Loader and Layers framework.
- * The VkImage object you provide here must have been retrieved directly from
- * MoltenVK, and not through the Vulkan SDK Loader and Layers framework. Opaque Vulkan
- * objects are often changed by layers, and passing them from one layer to another,
- * or from a layer directly to MoltenVK, will result in undefined behaviour.
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
  */
 VKAPI_ATTR void VKAPI_CALL vkGetIOSurfaceMVK(
     VkImage                                     image,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -386,7 +386,10 @@ void MVKInstance::initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo) {
 	}
 }
 
-#define ADD_ENTRY_POINT(func, api, ext1, ext2, isDev)	_entryPoints[""#func] = { (PFN_vkVoidFunction)&func, api, ext1,  ext2,  isDev }
+#define ADD_ENTRY_POINT_MAP(name, func, api, ext1, ext2, isDev)	\
+	_entryPoints[""#name] = { (PFN_vkVoidFunction)&func, api, ext1,  ext2,  isDev }
+
+#define ADD_ENTRY_POINT(func, api, ext1, ext2, isDev)	ADD_ENTRY_POINT_MAP(func, func, api, ext1, ext2, isDev)
 
 #define ADD_INST_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, false)
 #define ADD_DVC_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, true)
@@ -394,11 +397,21 @@ void MVKInstance::initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo) {
 #define ADD_INST_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, false)
 #define ADD_DVC_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, true)
 
-#define ADD_INST_EXT_ENTRY_POINT(func, EXT)			ADD_ENTRY_POINT(func, 0, VK_ ##EXT ##_EXTENSION_NAME, nullptr, false)
-#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)			ADD_ENTRY_POINT(func, 0, VK_ ##EXT ##_EXTENSION_NAME, nullptr, true)
+// Adds both the 1.1 function and the promoted extension function.
+#define ADD_INST_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
+	ADD_INST_1_1_ENTRY_POINT(func);	\
+	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
 
-#define ADD_INST_EXT2_ENTRY_POINT(func, EXT1, EXT2)	ADD_ENTRY_POINT(func, 0, VK_ ##EXT1 ##_EXTENSION_NAME, VK_ ##EXT2 ##_EXTENSION_NAME, false)
-#define ADD_DVC_EXT2_ENTRY_POINT(func, EXT1, EXT2)	ADD_ENTRY_POINT(func, 0, VK_ ##EXT1 ##_EXTENSION_NAME, VK_ ##EXT2 ##_EXTENSION_NAME, true)
+// Adds both the 1.1 function and the promoted extension function.
+#define ADD_DVC_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
+	ADD_DVC_1_1_ENTRY_POINT(func);	\
+	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+
+#define ADD_INST_EXT_ENTRY_POINT(func, EXT)				ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)				ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+
+#define ADD_INST_EXT2_ENTRY_POINT(func, EXT1, EXT2)		ADD_ENTRY_POINT(func, 0, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, false)
+#define ADD_DVC_EXT2_ENTRY_POINT(func, EXT1, EXT2)		ADD_ENTRY_POINT(func, 0, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, true)
 
 // Initializes the function pointer map.
 void MVKInstance::initProcAddrs() {
@@ -418,17 +431,17 @@ void MVKInstance::initProcAddrs() {
 	ADD_INST_ENTRY_POINT(vkEnumerateDeviceLayerProperties);
 	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties);
 
-	ADD_INST_1_1_ENTRY_POINT(vkEnumeratePhysicalDeviceGroups);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceFeatures2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties2);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceExternalFenceProperties);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceExternalBufferProperties);
-	ADD_INST_1_1_ENTRY_POINT(vkGetPhysicalDeviceExternalSemaphoreProperties);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkEnumeratePhysicalDeviceGroups, KHR_DEVICE_GROUP_CREATION);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFeatures2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalFenceProperties, KHR_EXTERNAL_FENCE_CAPABILITIES);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalBufferProperties, KHR_EXTERNAL_MEMORY_CAPABILITIES);
+	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalSemaphoreProperties, KHR_EXTERNAL_SEMAPHORE_CAPABILITIES);
 
 	// Device functions:
 	ADD_DVC_ENTRY_POINT(vkGetDeviceProcAddr);
@@ -554,34 +567,23 @@ void MVKInstance::initProcAddrs() {
 	ADD_DVC_ENTRY_POINT(vkCmdExecuteCommands);
 
 	ADD_DVC_1_1_ENTRY_POINT(vkGetDeviceQueue2);
-	ADD_DVC_1_1_ENTRY_POINT(vkBindBufferMemory2);
-	ADD_DVC_1_1_ENTRY_POINT(vkBindImageMemory2);
-	ADD_DVC_1_1_ENTRY_POINT(vkGetBufferMemoryRequirements2);
-	ADD_DVC_1_1_ENTRY_POINT(vkGetImageMemoryRequirements2);
-	ADD_DVC_1_1_ENTRY_POINT(vkGetImageSparseMemoryRequirements2);
-	ADD_DVC_1_1_ENTRY_POINT(vkGetDeviceGroupPeerMemoryFeatures);
-	ADD_DVC_1_1_ENTRY_POINT(vkCreateDescriptorUpdateTemplate);
-	ADD_DVC_1_1_ENTRY_POINT(vkDestroyDescriptorUpdateTemplate);
-	ADD_DVC_1_1_ENTRY_POINT(vkUpdateDescriptorSetWithTemplate);
-	ADD_DVC_1_1_ENTRY_POINT(vkGetDescriptorSetLayoutSupport);
-	ADD_DVC_1_1_ENTRY_POINT(vkCreateSamplerYcbcrConversion);
-	ADD_DVC_1_1_ENTRY_POINT(vkDestroySamplerYcbcrConversion);
-	ADD_DVC_1_1_ENTRY_POINT(vkTrimCommandPool);
-	ADD_DVC_1_1_ENTRY_POINT(vkCmdSetDeviceMask);
-	ADD_DVC_1_1_ENTRY_POINT(vkCmdDispatchBase);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindBufferMemory2, KHR_BIND_MEMORY_2);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindImageMemory2, KHR_BIND_MEMORY_2);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetBufferMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageSparseMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDeviceGroupPeerMemoryFeatures, KHR_DEVICE_GROUP);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateDescriptorUpdateTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroyDescriptorUpdateTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkUpdateDescriptorSetWithTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDescriptorSetLayoutSupport, KHR_MAINTENANCE3);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateSamplerYcbcrConversion, KHR_SAMPLER_YCBCR_CONVERSION);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroySamplerYcbcrConversion, KHR_SAMPLER_YCBCR_CONVERSION);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkTrimCommandPool, KHR_MAINTENANCE1);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdSetDeviceMask, KHR_DEVICE_GROUP);
+	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdDispatchBase, KHR_DEVICE_GROUP);
 
 	// Instance extension functions:
-	ADD_INST_EXT_ENTRY_POINT(vkEnumeratePhysicalDeviceGroupsKHR, KHR_DEVICE_GROUP_CREATION);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceExternalFencePropertiesKHR, KHR_EXTERNAL_FENCE_CAPABILITIES);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceExternalBufferPropertiesKHR, KHR_EXTERNAL_MEMORY_CAPABILITIES);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceExternalSemaphorePropertiesKHR, KHR_EXTERNAL_SEMAPHORE_CAPABILITIES);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceFeatures2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties2KHR, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
 	ADD_INST_EXT_ENTRY_POINT(vkDestroySurfaceKHR, KHR_SURFACE);
 	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceSupportKHR, KHR_SURFACE);
 	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR, KHR_SURFACE);
@@ -626,27 +628,12 @@ void MVKInstance::initProcAddrs() {
     ADD_INST_EXT_ENTRY_POINT(vkGetMTLCommandQueueMVK, MVK_MOLTENVK);
 
 	// Device extension functions:
-	ADD_DVC_EXT_ENTRY_POINT(vkBindBufferMemory2KHR, KHR_BIND_MEMORY_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkBindImageMemory2KHR, KHR_BIND_MEMORY_2);
 	ADD_DVC_EXT_ENTRY_POINT(vkCreateRenderPass2KHR, KHR_CREATE_RENDERPASS_2);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdBeginRenderPass2KHR, KHR_CREATE_RENDERPASS_2);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdNextSubpass2KHR, KHR_CREATE_RENDERPASS_2);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdEndRenderPass2KHR, KHR_CREATE_RENDERPASS_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkCreateDescriptorUpdateTemplateKHR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_EXT_ENTRY_POINT(vkDestroyDescriptorUpdateTemplateKHR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_EXT_ENTRY_POINT(vkUpdateDescriptorSetWithTemplateKHR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetDeviceGroupPeerMemoryFeaturesKHR, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDeviceMaskKHR, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdDispatchBaseKHR, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetBufferMemoryRequirements2KHR, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetImageMemoryRequirements2KHR, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetImageSparseMemoryRequirements2KHR, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkTrimCommandPoolKHR, KHR_MAINTENANCE1);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetDescriptorSetLayoutSupportKHR, KHR_MAINTENANCE3);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdPushDescriptorSetKHR, KHR_PUSH_DESCRIPTOR);
 	ADD_DVC_EXT2_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplateKHR, KHR_PUSH_DESCRIPTOR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_EXT_ENTRY_POINT(vkCreateSamplerYcbcrConversionKHR, KHR_SAMPLER_YCBCR_CONVERSION);
-	ADD_DVC_EXT_ENTRY_POINT(vkDestroySamplerYcbcrConversionKHR, KHR_SAMPLER_YCBCR_CONVERSION);
 	ADD_DVC_EXT_ENTRY_POINT(vkCreateSwapchainKHR, KHR_SWAPCHAIN);
 	ADD_DVC_EXT_ENTRY_POINT(vkDestroySwapchainKHR, KHR_SWAPCHAIN);
 	ADD_DVC_EXT_ENTRY_POINT(vkGetSwapchainImagesKHR, KHR_SWAPCHAIN);

--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -69,7 +69,7 @@ MVK_PUBLIC_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
 	return rslt;
 }
 
-MVK_PUBLIC_SYMBOL VkResult vkGetPhysicalDeviceMetalFeaturesMVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetPhysicalDeviceMetalFeaturesMVK(
 	VkPhysicalDevice                            physicalDevice,
 	MVKPhysicalDeviceMetalFeatures*             pMetalFeatures,
 	size_t*                                     pMetalFeaturesSize) {
@@ -78,7 +78,7 @@ MVK_PUBLIC_SYMBOL VkResult vkGetPhysicalDeviceMetalFeaturesMVK(
 	return mvkCopy(pMetalFeatures, mvkPD->getMetalFeatures(), pMetalFeaturesSize);
 }
 
-MVK_PUBLIC_SYMBOL VkResult vkGetPerformanceStatisticsMVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetPerformanceStatisticsMVK(
 	VkDevice                                    device,
 	MVKPerformanceStatistics*            		pPerf,
 	size_t*                                     pPerfSize) {
@@ -105,7 +105,7 @@ MVK_PUBLIC_SYMBOL void vkGetVersionStringsMVK(
 	pVulkanVersionStringBuffer[len] = 0;    // terminator
 }
 
-MVK_PUBLIC_SYMBOL void vkGetMTLDeviceMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkGetMTLDeviceMVK(
     VkPhysicalDevice                           physicalDevice,
     id<MTLDevice>*                             pMTLDevice) {
 
@@ -113,7 +113,7 @@ MVK_PUBLIC_SYMBOL void vkGetMTLDeviceMVK(
     *pMTLDevice = mvkPD->getMTLDevice();
 }
 
-MVK_PUBLIC_SYMBOL VkResult vkSetMTLTextureMVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetMTLTextureMVK(
     VkImage                                     image,
     id<MTLTexture>                              mtlTexture) {
 
@@ -121,7 +121,7 @@ MVK_PUBLIC_SYMBOL VkResult vkSetMTLTextureMVK(
     return mvkImg->setMTLTexture(0, mtlTexture);
 }
 
-MVK_PUBLIC_SYMBOL void vkGetMTLTextureMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkGetMTLTextureMVK(
     VkImage                                     image,
     id<MTLTexture>*                             pMTLTexture) {
 
@@ -129,7 +129,7 @@ MVK_PUBLIC_SYMBOL void vkGetMTLTextureMVK(
     *pMTLTexture = mvkImg->getMTLTexture(0);
 }
 
-MVK_PUBLIC_SYMBOL void vkGetMTLBufferMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkGetMTLBufferMVK(
     VkBuffer                                    buffer,
     id<MTLBuffer>*                              pMTLBuffer) {
 
@@ -137,7 +137,7 @@ MVK_PUBLIC_SYMBOL void vkGetMTLBufferMVK(
     *pMTLBuffer = mvkBuffer->getMTLBuffer();
 }
 
-MVK_PUBLIC_SYMBOL void vkGetMTLCommandQueueMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkGetMTLCommandQueueMVK(
     VkQueue                                     queue,
     id<MTLCommandQueue>*                        pMTLCommandQueue) {
 
@@ -145,7 +145,7 @@ MVK_PUBLIC_SYMBOL void vkGetMTLCommandQueueMVK(
     *pMTLCommandQueue = mvkQueue->getMTLCommandQueue();
 }
 
-MVK_PUBLIC_SYMBOL VkResult vkUseIOSurfaceMVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkUseIOSurfaceMVK(
     VkImage                                     image,
     IOSurfaceRef                                ioSurface) {
 
@@ -153,7 +153,7 @@ MVK_PUBLIC_SYMBOL VkResult vkUseIOSurfaceMVK(
     return mvkImg->useIOSurface(ioSurface);
 }
 
-MVK_PUBLIC_SYMBOL void vkGetIOSurfaceMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkGetIOSurfaceMVK(
     VkImage                                     image,
     IOSurfaceRef*                               pIOSurface) {
 
@@ -161,7 +161,7 @@ MVK_PUBLIC_SYMBOL void vkGetIOSurfaceMVK(
     *pIOSurface = mvkImg->getIOSurface();
 }
 
-MVK_PUBLIC_SYMBOL void vkSetWorkgroupSizeMVK(
+MVK_PUBLIC_VULKAN_SYMBOL void vkSetWorkgroupSizeMVK(
     VkShaderModule                              shaderModule,
     uint32_t                                    x,
     uint32_t                                    y,

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -162,7 +162,7 @@ static inline void MVKTraceVulkanCallEndImpl(const char* funcName, uint64_t star
 	}
 
 // Define an extension call as an alias of a core call
-#define MVK_PUBLIC_CORE_ALIAS(vkf)	MVK_PUBLIC_ALIAS(vkf##KHR, vkf)
+#define MVK_PUBLIC_VULKAN_CORE_ALIAS(vkf)	MVK_PUBLIC_VULKAN_ALIAS(vkf##KHR, vkf)
 
 
 #pragma mark -
@@ -2321,8 +2321,8 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdDispatchBase(
 #pragma mark -
 #pragma mark VK_KHR_bind_memory2 extension
 
-MVK_PUBLIC_CORE_ALIAS(vkBindBufferMemory2);
-MVK_PUBLIC_CORE_ALIAS(vkBindImageMemory2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkBindBufferMemory2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkBindImageMemory2);
 
 
 #pragma mark -
@@ -2377,73 +2377,73 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdEndRenderPass2KHR(
 #pragma mark -
 #pragma mark VK_KHR_descriptor_update_template extension
 
-MVK_PUBLIC_CORE_ALIAS(vkCreateDescriptorUpdateTemplate);
-MVK_PUBLIC_CORE_ALIAS(vkDestroyDescriptorUpdateTemplate);
-MVK_PUBLIC_CORE_ALIAS(vkUpdateDescriptorSetWithTemplate);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCreateDescriptorUpdateTemplate);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkDestroyDescriptorUpdateTemplate);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkUpdateDescriptorSetWithTemplate);
 
 
 #pragma mark -
 #pragma mark VK_KHR_device_group extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetDeviceGroupPeerMemoryFeatures);
-MVK_PUBLIC_CORE_ALIAS(vkCmdSetDeviceMask);
-MVK_PUBLIC_CORE_ALIAS(vkCmdDispatchBase);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetDeviceGroupPeerMemoryFeatures);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdSetDeviceMask);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdDispatchBase);
 
 
 #pragma mark -
 #pragma mark VK_KHR_device_group_creation extension
 
-MVK_PUBLIC_CORE_ALIAS(vkEnumeratePhysicalDeviceGroups);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkEnumeratePhysicalDeviceGroups);
 
 
 #pragma mark -
 #pragma mark VK_KHR_external_fence_capabilities extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceExternalFenceProperties);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceExternalFenceProperties);
 
 
 #pragma mark -
 #pragma mark VK_KHR_external_memory_capabilities extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceExternalBufferProperties);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceExternalBufferProperties);
 
 
 #pragma mark -
 #pragma mark VK_KHR_external_semaphore_capabilities extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceExternalSemaphoreProperties);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceExternalSemaphoreProperties);
 
 
 #pragma mark -
 #pragma mark VK_KHR_get_memory_requirements2 extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetBufferMemoryRequirements2);
-MVK_PUBLIC_CORE_ALIAS(vkGetImageMemoryRequirements2);
-MVK_PUBLIC_CORE_ALIAS(vkGetImageSparseMemoryRequirements2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetBufferMemoryRequirements2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetImageMemoryRequirements2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetImageSparseMemoryRequirements2);
 
 
 #pragma mark -
 #pragma mark VK_KHR_get_physical_device_properties2 extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceFeatures2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceProperties2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceFormatProperties2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceImageFormatProperties2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceQueueFamilyProperties2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceMemoryProperties2);
-MVK_PUBLIC_CORE_ALIAS(vkGetPhysicalDeviceSparseImageFormatProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceFeatures2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceFormatProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceImageFormatProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceQueueFamilyProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceMemoryProperties2);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetPhysicalDeviceSparseImageFormatProperties2);
 
 
 #pragma mark -
 #pragma mark VK_KHR_maintenance1 extension
 
-MVK_PUBLIC_CORE_ALIAS(vkTrimCommandPool);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkTrimCommandPool);
 
 
 #pragma mark -
 #pragma mark VK_KHR_maintenance3 extension
 
-MVK_PUBLIC_CORE_ALIAS(vkGetDescriptorSetLayoutSupport);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetDescriptorSetLayoutSupport);
 
 
 #pragma mark -
@@ -2478,8 +2478,8 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
 #pragma mark -
 #pragma mark VK_KHR_sampler_ycbcr_conversion extension
 
-MVK_PUBLIC_CORE_ALIAS(vkCreateSamplerYcbcrConversion);
-MVK_PUBLIC_CORE_ALIAS(vkDestroySamplerYcbcrConversion);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCreateSamplerYcbcrConversion);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkDestroySamplerYcbcrConversion);
 
 
 #pragma mark -


### PR DESCRIPTION
Move the aliasing of promoted function pointers to the function pointer lookup collection, because non-global function alias symbols in `vulkan.mm` are not available in separately compiled `MVKInstance` object file.

Add public aliased Vulkan extension functions that were promoted to 1.1 to the public symbols that are hidden when `MVK_HIDE_VULKAN_SYMBOLS` is enabled.

Add functions from the private `VK_MVK_moltenvk` extension that depend on Vulkan object handles to the public symbols that are hidden when `MVK_HIDE_VULKAN_SYMBOLS` is enabled, to discourage their use by apps that are using the Vulkan Loader and Layers, because they are not supported by the Vulkan Loader and Layers.

Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version 33.