### PR TITLE
Improve accuracy of VkPhysicalDeviceLimits::timestampPeriod.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
 - Fix issue where *MSL 2.3* only available on *Apple Silicon*, even on *macOS*.
 - Fix memory leak of dummy `MTLTexture` in render subpasses that use no attachments.
 - Fix Metal object retain-release errors in assignment operators.
+- Improve accuracy of `VkPhysicalDeviceLimits::timestampPeriod`.
 - Update to latest SPIRV-Cross:
 	- MSL: Add 64 bit support for `OpSwitch`.
 	- MSL: Don't output depth and stencil values with explicit early fragment tests.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -329,6 +329,20 @@ public:
 	/** Returns whether this device is using Metal argument buffers. */
 	bool isUsingMetalArgumentBuffers() const  { return _metalFeatures.argumentBuffers && mvkConfig().useMetalArgumentBuffers; };
 
+	/**
+	 * Returns the start timestamps of a timestamp correlation.
+	 * The returned values should be later passed back to updateTimestampPeriod().
+	 */
+	void startTimestampCorrelation(MTLTimestamp& cpuStart, MTLTimestamp& gpuStart);
+
+	/**
+	 * Updates the current value of VkPhysicalDeviceLimits::timestampPeriod, based on the
+	 * correlation between the CPU time tickes and GPU time ticks, from the specified start
+	 * values, to the current values. The cpuStart and gpuStart values should have been
+	 * retrieved from a prior call to startTimestampCorrelation().
+	 */
+	void updateTimestampPeriod(MTLTimestamp cpuStart, MTLTimestamp gpuStart);
+
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -83,6 +83,9 @@ const static uint32_t kMVKCachedViewportScissorCount = 16;
 const static uint32_t kMVKCachedColorAttachmentCount = 8;
 const static uint32_t kMVKMaxDescriptorSetCount = SPIRV_CROSS_NAMESPACE::kMaxArgumentBuffers;
 
+#if !MVK_XCODE_12
+typedef NSUInteger MTLTimestamp;
+#endif
 
 #pragma mark -
 #pragma mark MVKPhysicalDevice

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -213,7 +213,7 @@ protected:
 	id<MTLCommandBuffer> getActiveMTLCommandBuffer();
 	void setActiveMTLCommandBuffer(id<MTLCommandBuffer> mtlCmdBuff);
 	void commitActiveMTLCommandBuffer(bool signalCompletion = false);
-	void finish();
+	virtual void finish();
 	virtual void submitCommandBuffers() {}
 
 	MVKSmallVector<std::pair<MVKSemaphore*, uint64_t>> _signalSemaphores;
@@ -248,8 +248,11 @@ public:
 
 protected:
 	void submitCommandBuffers() override;
+	void finish() override;
 
 	MVKSmallVector<MVKCommandBuffer*, N> _cmdBuffers;
+	MTLTimestamp _cpuStart = 0;
+	MTLTimestamp _gpuStart = 0;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -511,8 +511,15 @@ MVKQueueCommandBufferSubmission::~MVKQueueCommandBufferSubmission() {
 
 template <size_t N>
 void MVKQueueFullCommandBufferSubmission<N>::submitCommandBuffers() {
+	_queue->getPhysicalDevice()->startTimestampCorrelation(_cpuStart, _gpuStart);
 	MVKCommandEncodingContext encodingContext;
 	for (auto& cb : _cmdBuffers) { cb->submit(this, &encodingContext); }
+}
+
+template <size_t N>
+void MVKQueueFullCommandBufferSubmission<N>::finish() {
+	_queue->getPhysicalDevice()->updateTimestampPeriod(_cpuStart, _gpuStart);
+	MVKQueueCommandBufferSubmission::finish();
 }
 
 


### PR DESCRIPTION
If using GPU counters, on all Apple GPUs lock `timestampPeriod` to 1.0, since Apple GPUs use nanoseconds, and on non-Apple GPUs, dynamically adapt value of `timestampPeriod` by correlating GPU ticks with GPU ticks.

If using CPU sync, set `timestampPeriod` to OS CPU timestamp tick period.

This is a partial fix for issue #1438.