### PR TITLE
Fix use of GPU counter sets on older versions of iOS running on the simulator.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1639,10 +1639,10 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	checkSupportsMTLCounterSamplingPoint(Stage, PIPELINE_STAGE);
 #endif
 
-#if !MVK_APPLE_SILICON
+#if MVK_MACOS
 	// On macOS, if we couldn't query supported sample points (on macOS 11),
 	// but the platform can support immediate-mode sample points, indicate that here.
-	if (!_metalFeatures.counterSamplingPoints && mvkOSVersionIsAtLeast(10.15)) {  \
+	if (!_metalFeatures.counterSamplingPoints && mvkOSVersionIsAtLeast(10.15) && !supportsMTLGPUFamily(Apple1)) {  \
 		_metalFeatures.counterSamplingPoints = MVK_COUNTER_SAMPLING_AT_DRAW | MVK_COUNTER_SAMPLING_AT_DISPATCH | MVK_COUNTER_SAMPLING_AT_BLIT;  \
 	}
 #endif


### PR DESCRIPTION
Replace test for `MVK_APPLE_SILICON` with test for `MVK_MACOS` plus `Apple1` GPU.

Fixes issue #1518.