### PR TITLE
Remove logged warning if MoltenVK does not support VkApplicationInfo::apiVersion value.

### DIFF
--- a/Common/MVKOSExtensions.h
+++ b/Common/MVKOSExtensions.h
@@ -95,7 +95,7 @@ void mvkDispatchToMainAndWait(dispatch_block_t block);
  * Returns the value of the environment variable at the given name,
  * or an empty string if no environment variable with that name exists.
  *
- * If pWasFound is not null, it's value is set to true if the environment
+ * If pWasFound is not null, its value is set to true if the environment
  * variable exists, or false if not.
  */
 std::string mvkGetEnvVar(std::string varName, bool* pWasFound = nullptr);
@@ -104,7 +104,7 @@ std::string mvkGetEnvVar(std::string varName, bool* pWasFound = nullptr);
  * Returns the value of the environment variable at the given name,
  * or zero if no environment variable with that name exists.
  *
- * If pWasFound is not null, it's value is set to true if the environment
+ * If pWasFound is not null, its value is set to true if the environment
  * variable exists, or false if not.
  */
 int64_t mvkGetEnvVarInt64(std::string varName, bool* pWasFound = nullptr);
@@ -113,7 +113,7 @@ int64_t mvkGetEnvVarInt64(std::string varName, bool* pWasFound = nullptr);
  * Returns the value of the environment variable at the given name,
  * or false if no environment variable with that name exists.
  *
- * If pWasFound is not null, it's value is set to true if the environment
+ * If pWasFound is not null, its value is set to true if the environment
  * variable exists, or false if not.
  */
 bool mvkGetEnvVarBool(std::string varName, bool* pWasFound = nullptr);

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,15 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.1.8
+--------------
+
+Released TBD
+
+- Remove logged warning if MoltenVK does not support `VkApplicationInfo::apiVersion` value.
+
+
+
 MoltenVK 1.1.7
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -50,7 +50,7 @@ typedef unsigned long MTLLanguageVersion;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   1
-#define MVK_VERSION_PATCH   7
+#define MVK_VERSION_PATCH   8
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3503,7 +3503,7 @@ void MVKDevice::freeMemory(MVKDeviceMemory* mvkDevMem,
 	if (mvkDevMem) { mvkDevMem->destroy(); }
 }
 
-// Look for an available pre-reserved private data slot and return it's address if found.
+// Look for an available pre-reserved private data slot and return its address if found.
 // Otherwise create a new instance and return it.
 VkResult MVKDevice::createPrivateDataSlot(const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
 										  const VkAllocationCallbacks* pAllocator,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -325,8 +325,6 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
         _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
     }
     else if (MVK_VULKAN_API_VERSION_CONFORM(_appInfo.apiVersion) > MVK_VULKAN_API_VERSION_CONFORM(MVK_VULKAN_API_VERSION)) {
-        MVKLogWarning("Unrecognized CreateInstance->pCreateInfo->pApplicationInfo->apiVersion number (0x%08x). Assuming MoltenVK %d.%d version.",
-                      _appInfo.apiVersion, MVK_VERSION_MAJOR, MVK_VERSION_MINOR);
         _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
     }
     


### PR DESCRIPTION
Update MoltenVK version to 1.1.8.
Minor spelling fixes in comments.