### PR TITLE
Align flattened shader inputs to previous stage output structs.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,14 +13,22 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
-MoltenVK 1.1.8
+MoltenVK 1.1.9
 --------------
 
 Released TBD
 
 - Update *glslang* version, to use `python3` in *glslang* scripts, to replace missing `python` on *macOS 12.3*.
-- Remove logged warning if MoltenVK does not support `VkApplicationInfo::apiVersion` value.
 - Fix alignment between outputs and inputs between shader stages when using nested structures. 
+
+
+
+MoltenVK 1.1.8
+--------------
+
+Released 2022/02/22
+
+- Remove logged warning if MoltenVK does not support `VkApplicationInfo::apiVersion` value.
 
 
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released TBD
 
 - Update *glslang* version, to use `python3` in *glslang* scripts, to replace missing `python` on *macOS 12.3*.
 - Remove logged warning if MoltenVK does not support `VkApplicationInfo::apiVersion` value.
+- Fix alignment between outputs and inputs between shader stages when using nested structures. 
 
 
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -50,7 +50,7 @@ typedef unsigned long MTLLanguageVersion;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   1
-#define MVK_VERSION_PATCH   8
+#define MVK_VERSION_PATCH   9
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)


### PR DESCRIPTION
When flattening shader inputs for stage_in, which are to be read from a buffer that was populated as nested structs during an earlier stage, the structs will be aligned according to C++ rules, which can affect the alignment of the first member of the flattened input struct.

Add `SPIRVShaderOutput::firstStructMemberAlignment` to track the alignment requirements of the first member of a nested structure, and recursively determine the alignment of the first member of each nested output structure.

Move `sizeOfOutput()` from `MVKPipeline.mm` to `SPIRVReflection.h`, rename to `getShaderOutputSize()`, and add `getShaderOutputAlignment()` to extract member alignment.