### PR TITLE
Enable base vertex instance support in shader conversion

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1549,7 +1549,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
 		}
 	}
 
-	shaderConfig.options.mslOptions.ios_support_base_vertex_instance = true;
+	shaderConfig.options.mslOptions.ios_support_base_vertex_instance = getDevice()->_pMetalFeatures->baseVertexInstanceDrawing;
 	shaderConfig.options.mslOptions.texture_1D_as_2D = mvkConfig().texture1DAs2D;
     shaderConfig.options.mslOptions.enable_point_size_builtin = isRenderingPoints(pCreateInfo) || reflectData.pointMode;
 	shaderConfig.options.mslOptions.enable_frag_depth_builtin = pixFmts->isDepthFormat(mtlDSFormat);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1549,6 +1549,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
 		}
 	}
 
+	shaderConfig.options.mslOptions.ios_support_base_vertex_instance = true;
 	shaderConfig.options.mslOptions.texture_1D_as_2D = mvkConfig().texture1DAs2D;
     shaderConfig.options.mslOptions.enable_point_size_builtin = isRenderingPoints(pCreateInfo) || reflectData.pointMode;
 	shaderConfig.options.mslOptions.enable_frag_depth_builtin = pixFmts->isDepthFormat(mtlDSFormat);


### PR DESCRIPTION
Fixes #1525.

This enables support for [base vertex instance attributes for iOS in SPIR-V Cross](https://github.com/KhronosGroup/SPIRV-Cross/blob/2a7f436135bbb74c0b721e1471b07732a523ef72/spirv_msl.hpp#L336). This was included in MVKPipeline::initShaderConversionConfig as suggested by @billhollings :-)

However, I'm curious if a certain platform/metal version actually doesn't support this? Does this not include tvOS (I didn't check yet). Or is this some just weird wording from the SPIRV-Cross devs? Right now it just enables it wholly but I'm testing on a very recent Metal device.