### PR TITLE
Fix deletion of GPU counter MTLFence while it is being used by MTLCommandBuffer.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Support base vertex instance support in shader conversion.
 - Fix alignment between outputs and inputs between shader stages when using nested structures.
 - Fix issue where the depth component of a stencil-only renderpass attachment was incorrectly attempting to be stored.
+- Fix deletion of GPU counter `MTLFence` while it is being used by `MTLCommandBuffer`.
 - `MoltenVKShaderConverter` tool defaults to the highest MSL version supported on runtime OS.
 - Update *glslang* version, to use `python3` in *glslang* scripts, to replace missing `python` on *macOS 12.3*.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -29,7 +29,6 @@
 #include <unordered_map>
 
 class MVKCommandPool;
-class MVKQueue;
 class MVKQueueCommandBufferSubmission;
 class MVKCommandEncoder;
 class MVKCommandEncodingPool;
@@ -491,8 +490,6 @@ public:
 #pragma mark Construction
 
 	MVKCommandEncoder(MVKCommandBuffer* cmdBuffer);
-
-	~MVKCommandEncoder() override;
 
 protected:
     void addActivatedQueries(MVKQueryPool* pQueryPool, uint32_t query, uint32_t queryCount);


### PR DESCRIPTION
Move release of GPU counter MTLFence from `MVKCommandEncoder` destructor to `MTLCommandBuffer` completion handler.

Fixes #1537.