### PR TITLE
Remove limit on VkPhysicalDeviceLimits::maxSamplerAllocationCount when not using Metal argument buffers.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 - Fix alignment between outputs and inputs between shader stages when using nested structures.
 - Fix issue where the depth component of a stencil-only renderpass attachment was incorrectly attempting to be stored.
 - Fix deletion of GPU counter `MTLFence` while it is being used by `MTLCommandBuffer`.
+- Remove limit on `VkPhysicalDeviceLimits::maxSamplerAllocationCount` when not using Metal argument buffers.
 - `MoltenVKShaderConverter` tool defaults to the highest MSL version supported on runtime OS.
 - Update *glslang* version, to use `python3` in *glslang* scripts, to replace missing `python` on *macOS 12.3*.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2698,9 +2698,16 @@ uint64_t MVKPhysicalDevice::getCurrentAllocatedSize() {
 #endif
 }
 
+// When using argument buffers, Metal imposes a hard limit on the number of MTLSamplerState
+// objects that can be created within the app. When not using argument buffers, no such
+// limit is imposed. This has been verified with testing up to 1M MTLSamplerStates.
 uint32_t MVKPhysicalDevice::getMaxSamplerCount() {
-	return ([_mtlDevice respondsToSelector: @selector(maxArgumentBufferSamplerCount)]
-			? (uint32_t)_mtlDevice.maxArgumentBufferSamplerCount : 1024);
+	if (isUsingMetalArgumentBuffers()) {
+		return ([_mtlDevice respondsToSelector: @selector(maxArgumentBufferSamplerCount)]
+				? (uint32_t)_mtlDevice.maxArgumentBufferSamplerCount : 1024);
+	} else {
+		return kMVKUndefinedLargeUInt32;
+	}
 }
 
 void MVKPhysicalDevice::initExternalMemoryProperties() {


### PR DESCRIPTION
When using argument buffers, Metal imposes a hard limit on the number of `MTLSamplerState` objects that can be created within the app. When not using argument buffers, no such limit is imposed. This has been verified with testing up to 1M `MTLSamplerStates`.

Fixes issue #1512.