### PR TITLE
Fixes to optimize resource objects retained by descriptors beyond their lifetimes.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,7 @@ Released TBD
 - Fix deletion of GPU counter `MTLFence` while it is being used by `MTLCommandBuffer`.
 - Remove limit on `VkPhysicalDeviceLimits::maxSamplerAllocationCount` when not using Metal argument buffers.
 - Avoid adjusting SRGB clear color values by half-ULP on GPUs that round float clear colors down.
+- Fixes to optimize resource objects retained by descriptors beyond their lifetimes.
 - `MoltenVKShaderConverter` tool defaults to the highest MSL version supported on runtime OS.
 - Update *glslang* version, to use `python3` in *glslang* scripts, to replace missing `python` on *macOS 12.3*.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -87,6 +87,8 @@ public:
 
 	~MVKBuffer() override;
 
+	void destroy() override;
+
 protected:
 	friend class MVKDeviceMemory;
 
@@ -99,6 +101,7 @@ protected:
 	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
 	VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);
 	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
+	void detachMemory();
 
 	VkBufferUsageFlags _usage;
 	bool _isHostCoherentTexelBuffer = false;
@@ -133,8 +136,11 @@ public:
 
     ~MVKBufferView() override;
 
+	void destroy() override;
+
 protected:
 	void propagateDebugName() override;
+	void detachMemory();
 
     MVKBuffer* _buffer;
     NSUInteger _offset;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1847,7 +1847,21 @@ MVKImageView::MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCrea
     }
 }
 
+// Memory detached in destructor too, as a fail-safe.
 MVKImageView::~MVKImageView() {
+	detachMemory();
+}
+
+// Overridden to detach from the resource memory when the app destroys this object.
+// This object can be retained in a descriptor after the app destroys it, even
+// though the descriptor can't use it. But doing so retains usuable resource memory.
+void MVKImageView::destroy() {
+	detachMemory();
+	MVKVulkanAPIDeviceObject::destroy();
+}
+
+// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
+void MVKImageView::detachMemory() {
 	mvkDestroyContainerContents(_planes);
 }
 
@@ -2101,8 +2115,23 @@ void MVKSampler::initConstExprSampler(const VkSamplerCreateInfo* pCreateInfo) {
     }
 }
 
+// Memory detached in destructor too, as a fail-safe.
 MVKSampler::~MVKSampler() {
+	detachMemory();
+}
+
+// Overridden to detach from the resource memory when the app destroys this object.
+// This object can be retained in a descriptor after the app destroys it, even
+// though the descriptor can't use it. But doing so retains usuable resource memory.
+void MVKSampler::destroy() {
+	detachMemory();
+	MVKVulkanAPIDeviceObject::destroy();
+}
+
+// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
+void MVKSampler::detachMemory() {
 	@synchronized (getMTLDevice()) {
 		[_mtlSamplerState release];
+		_mtlSamplerState = nil;
 	}
 }

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -135,6 +135,9 @@ public:
 	 * Once all references have been released, this object is free to be deleted.
 	 * If the destroy() function has already been called on this instance by the time
 	 * this function is called, this instance will be deleted.
+	 *
+	 * Note that the destroy() function is called on the BaseClass.
+	 * Releasing will not call any overridden destroy() function in a descendant class.
 	 */
 	void release() { if (--_refCount == 0) { BaseClass::destroy(); } }
 


### PR DESCRIPTION
For a resource object that can be retained by descriptors beyond its lifetime, release memory resources when the object is destroyed by the app. This includes objects of type `MVKBuffer`, `MVKBufferView`, `MVKImageView`, and `MVKSampler`.

When the app destroys an `MVKBuffer`, also detach from the `MVKDeviceMemory`, to fix a potential race condition when the app updates the descriptor on one thread while also freeing the MVKDeviceMemory on another thread.

`MVKImageView` guard against detached planes while in descriptor.

Add comment to clarify how `destroy()` is called from `release()`.

Fixes issue #1315. Long time coming. Sorry for the delay.

@cdavis5e This PR should still be compatible with your original PR #329, and this PR does not affect any CTS tests that I've been running. But let me know if the original PR #329 fixed any conditions that this now breaks...primarily around internal memory resources now being detached from `MVKBuffer`, `MVKBufferView`, `MVKImageView`, and `MVKSampler` while they still may be retained in a pipeline descriptor set.