### PR TITLE
Fixes to pipeline layout compatibility

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.1.9
 
 Released TBD
 
+- Fixes to pipeline layout compatibility.
 - Reinstate memory barriers on non-Apple GPUs, which were inadvertently disabled in an earlier update.
 - Support base vertex instance support in shader conversion.
 - Fix alignment between outputs and inputs between shader stages when using nested structures.

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -321,7 +321,7 @@ typedef enum {
 	kMVKShaderStageFragment,
 	kMVKShaderStageCompute,
 	kMVKShaderStageCount,
-	kMVKShaderStageMax = kMVKShaderStageCount	// Pubic API legacy value
+	kMVKShaderStageMax = kMVKShaderStageCount	// Public API legacy value
 } MVKShaderStage;
 
 /** Returns the Metal MTLColorWriteMask corresponding to the specified Vulkan VkColorComponentFlags. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -363,15 +363,3 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
 										VkDescriptorUpdateTemplateKHR updateTemplate,
 										const void* pData);
-
-/**
- * If the shader stage binding has a binding defined for the specified stage, populates
- * the context at the descriptor set binding from the shader stage resource binding.
- */
-void mvkPopulateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-									   MVKShaderStageResourceBinding& ssRB,
-									   spv::ExecutionModel stage,
-									   uint32_t descriptorSetIndex,
-									   uint32_t bindingIndex,
-									   uint32_t count,
-									   MVKSampler* immutableSampler);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -100,10 +100,10 @@ public:
 	uint32_t getTessCtlLevelBufferIndex() { return _tessCtlLevelBufferIndex; }
 
 	/** Returns the number of textures in this layout. This is used to calculate the size of the swizzle buffer. */
-	uint32_t getTextureCount() { return _pushConstantsMTLResourceIndexes.getMaxTextureIndex(); }
+	uint32_t getTextureCount() { return _mtlResourceCounts.getMaxTextureIndex(); }
 
 	/** Returns the number of buffers in this layout. This is used to calculate the size of the buffer size buffer. */
-	uint32_t getBufferCount() { return _pushConstantsMTLResourceIndexes.getMaxBufferIndex(); }
+	uint32_t getBufferCount() { return _mtlResourceCounts.getMaxBufferIndex(); }
 
 	/** Returns the number of descriptor sets in this pipeline layout. */
 	uint32_t getDescriptorSetCount() { return (uint32_t)_descriptorSetLayouts.size(); }
@@ -114,9 +114,6 @@ public:
 	/** Returns the descriptor set layout. */
 	MVKDescriptorSetLayout* getDescriptorSetLayout(uint32_t descSetIndex) { return _descriptorSetLayouts[descSetIndex]; }
 
-	/** Returns the push constant binding info. */
-	const MVKShaderResourceBinding& getPushConstantBindings() { return _pushConstantsMTLResourceIndexes; }
-
 	/** Constructs an instance for the specified device. */
 	MVKPipelineLayout(MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo);
 
@@ -126,10 +123,12 @@ protected:
 	friend class MVKPipeline;
 
 	void propagateDebugName() override {}
+	bool stageUsesPushConstants(MVKShaderStage mvkStage);
 
 	MVKSmallVector<MVKDescriptorSetLayout*, 1> _descriptorSetLayouts;
 	MVKSmallVector<MVKShaderResourceBinding, 1> _dslMTLResourceIndexOffsets;
 	MVKSmallVector<VkPushConstantRange> _pushConstants;
+	MVKShaderResourceBinding _mtlResourceCounts;
 	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
 	MVKShaderImplicitRezBinding _swizzleBufferIndex;
 	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
@@ -203,8 +202,9 @@ protected:
 	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
 	MVKShaderImplicitRezBinding _dynamicOffsetBufferIndex;
 	MVKShaderImplicitRezBinding _indirectParamsIndex;
-	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
+	MVKShaderImplicitRezBinding _pushConstantsBufferIndex;
 	uint32_t _descriptorSetCount;
+	bool _stageUsesPushConstants[kMVKShaderStageCount];
 	bool _fullImageViewSwizzle;
 	bool _hasValidMTLPipelineStates = true;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -75,30 +75,6 @@ public:
 	/** Populates the specified shader conversion config. */
 	void populateShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig);
 
-	/** Returns the current swizzle buffer bindings. */
-	const MVKShaderImplicitRezBinding& getSwizzleBufferIndex() { return _swizzleBufferIndex; }
-
-	/** Returns the current buffer size buffer bindings. */
-	const MVKShaderImplicitRezBinding& getBufferSizeBufferIndex() { return _bufferSizeBufferIndex; }
-
-	/** Returns the current dynamic buffer offset buffer bindings. */
-	const MVKShaderImplicitRezBinding& getDynamicOffsetBufferIndex() { return _dynamicOffsetBufferIndex; }
-
-	/** Returns the current view range buffer binding for multiview draws. */
-	const MVKShaderImplicitRezBinding& getViewRangeBufferIndex() { return _viewRangeBufferIndex; }
-
-	/** Returns the current indirect parameter buffer bindings. */
-	const MVKShaderImplicitRezBinding& getIndirectParamsIndex() { return _indirectParamsIndex; }
-
-	/** Returns the current captured output buffer bindings. */
-	const MVKShaderImplicitRezBinding& getOutputBufferIndex() { return _outputBufferIndex; }
-
-	/** Returns the current captured per-patch output buffer binding for the tess. control shader. */
-	uint32_t getTessCtlPatchOutputBufferIndex() { return _tessCtlPatchOutputBufferIndex; }
-
-	/** Returns the current tessellation level buffer binding for the tess. control shader. */
-	uint32_t getTessCtlLevelBufferIndex() { return _tessCtlLevelBufferIndex; }
-
 	/** Returns the number of textures in this layout. This is used to calculate the size of the swizzle buffer. */
 	uint32_t getTextureCount() { return _mtlResourceCounts.getMaxTextureIndex(); }
 
@@ -130,14 +106,6 @@ protected:
 	MVKSmallVector<VkPushConstantRange> _pushConstants;
 	MVKShaderResourceBinding _mtlResourceCounts;
 	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
-	MVKShaderImplicitRezBinding _swizzleBufferIndex;
-	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
-	MVKShaderImplicitRezBinding _dynamicOffsetBufferIndex;
-	MVKShaderImplicitRezBinding _viewRangeBufferIndex;
-	MVKShaderImplicitRezBinding _indirectParamsIndex;
-	MVKShaderImplicitRezBinding _outputBufferIndex;
-	uint32_t _tessCtlPatchOutputBufferIndex = 0;
-	uint32_t _tessCtlLevelBufferIndex = 0;
 };
 
 
@@ -198,6 +166,7 @@ protected:
 															  MVKShaderStage stage);
 
 	MVKPipelineCache* _pipelineCache;
+	MVKShaderImplicitRezBinding _descriptorBufferCounts;
 	MVKShaderImplicitRezBinding _swizzleBufferIndex;
 	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
 	MVKShaderImplicitRezBinding _dynamicOffsetBufferIndex;
@@ -338,8 +307,10 @@ protected:
     void addFragmentOutputToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo);
     bool isRenderingPoints(const VkGraphicsPipelineCreateInfo* pCreateInfo);
     bool isRasterizationDisabled(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-	bool verifyImplicitBuffer(bool needsBuffer, MVKShaderImplicitRezBinding& index, MVKShaderStage stage, const char* name, uint32_t reservedBuffers);
+	bool verifyImplicitBuffer(bool needsBuffer, MVKShaderImplicitRezBinding& index, MVKShaderStage stage, const char* name);
 	uint32_t getTranslatedVertexBinding(uint32_t binding, uint32_t translationOffset, uint32_t maxBinding);
+	uint32_t getImplicitBufferIndex(const VkGraphicsPipelineCreateInfo* pCreateInfo, MVKShaderStage stage, uint32_t bufferIndexOffset);
+	uint32_t getReservedBufferCount(const VkGraphicsPipelineCreateInfo* pCreateInfo, MVKShaderStage stage);
 
 	const VkPipelineShaderStageCreateInfo* _pVertexSS = nullptr;
 	const VkPipelineShaderStageCreateInfo* _pTessCtlSS = nullptr;
@@ -434,6 +405,7 @@ public:
 
 protected:
     MVKMTLFunction getMTLFunction(const VkComputePipelineCreateInfo* pCreateInfo);
+	uint32_t getImplicitBufferIndex(uint32_t bufferIndexOffset);
 
     id<MTLComputePipelineState> _mtlPipelineState;
 	MVKSmallVector<MVKMTLArgumentEncoder> _mtlArgumentEncoders;


### PR DESCRIPTION
For pipeline layout compatibility, consume the Metal resource indexes in this order:
- Consume a fixed number of Metal buffer indexes for Metal argument buffers, but only consume them if Metal argument buffers are not being used.
- Consume push constants  Metal buffer index before descriptor set resources, but only consume it if the stage uses push constants.
- Consume descriptor set bindings.

In `MVKPipelineLayout`, separate tracking resource counts from push constants indexes, and move push constant indexes ahead of descriptor bindings.
In `MVKPipeline`, track which stages use push constants.
Remove unused and obsolete function declaration in `MVKDescriptorSet.h`.

To better support pipeline layout compatibility between pipelines with differing quantities of descriptor sets, move the buffer indexes used by implicit buffers to the top end of the Metal buffer index range, below vertex and tessellation buffers.

`MVKPipeline` calculates implicit buffer indexes based on vertex and tessellation
buffers required by pipeline, instead of based on descriptors in `MVKPipelineLayout`.

`MVKPipeline` track buffer index counts consumed by `MVKPipelineLayout`, to validate
room for implicit buffers.

Fixes issue #1505.

Passes the same CTS tests as before.