### PR TITLE
Remove use of C++17 deprecated feature: std::iterator.

### DIFF
--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -495,7 +495,7 @@ void mvkRemoveFirstOccurance(C& container, T val) {
 /** Removes all occurances of the specified value from the specified container. */
 template<class C, class T>
 void mvkRemoveAllOccurances(C& container, T val) {
-    container.erase(remove(container.begin(), container.end(), val), container.end());
+    container.erase(std::remove(container.begin(), container.end(), val), container.end());
 }
 
 

--- a/MoltenVK/MoltenVK/Utility/MVKSmallVector.h
+++ b/MoltenVK/MoltenVK/Utility/MVKSmallVector.h
@@ -62,13 +62,18 @@ class MVKSmallVectorImpl
   Allocator  alc;
   
 public:
-  class iterator : public std::iterator<std::random_access_iterator_tag, Type>
+  class iterator
   {
     const MVKSmallVectorImpl *vector;
     size_t               index;
 
   public:
-    typedef typename std::iterator_traits<iterator>::difference_type diff_type;
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = Type;
+    using pointer = value_type*;
+    using reference = value_type&;
+    using difference_type = std::ptrdiff_t;
+    typedef difference_type diff_type;
 
     iterator() : vector{ nullptr }, index{ 0 } { }
     iterator( const size_t _index, const MVKSmallVectorImpl &_vector ) : vector{ &_vector }, index{ _index } { }
@@ -516,13 +521,18 @@ class MVKSmallVectorImpl<Type*, Allocator>
   Allocator  alc;
 
 public:
-  class iterator : public std::iterator<std::random_access_iterator_tag, Type*>
+  class iterator
   {
     MVKSmallVectorImpl *vector;
     size_t         index;
 
   public:
-    typedef typename std::iterator_traits<iterator>::difference_type diff_type;
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = Type*;
+    using pointer = value_type*;
+    using reference = value_type&;
+    using difference_type = std::ptrdiff_t;
+    typedef difference_type diff_type;
 
     iterator() : vector{ nullptr }, index{ 0 } { }
     iterator( const size_t _index, MVKSmallVectorImpl &_vector ) : vector{ &_vector }, index{ _index } { }


### PR DESCRIPTION
`std::iterator` is deprecated in C++17, which triggers multiple compilation warnings.
Update `MVKSmallVector::iterator` to explicitly specify iterator traits, instead of subclassing from `std::iterator`.
Qualify use of `std::remove()` in `mvkRemoveAllOccurances()`, to eliminate resolution ambiguity.