### PR TITLE
Fix crash in vkGetMTLCommandQueueMVK()

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vk_mvk_moltenvk.mm
@@ -141,7 +141,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetMTLCommandQueueMVK(
     VkQueue                                     queue,
     id<MTLCommandQueue>*                        pMTLCommandQueue) {
 
-    MVKQueue* mvkQueue = (MVKQueue*)queue;
+    MVKQueue* mvkQueue = MVKQueue::getMVKQueue(queue);
     *pMTLCommandQueue = mvkQueue->getMTLCommandQueue();
 }
 


### PR DESCRIPTION
Calls to `vkGetMTLCommandQueueMVK()` returned garbage because `MVKQueue*` cannot be cast from `VkQueue`, use `MVKQueue::getMVKQueue()` instead.