### PR TITLE
Fix leak of CoreFoundation objects during calls to vkUseIOSurfaceMVK()

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -801,8 +801,10 @@ VkResult MVKImage::useIOSurface(IOSurfaceRef ioSurface) {
                     });
                 }
                 CFDictionaryAddValue(properties, (id)kIOSurfacePlaneInfo, planeProperties);
+                CFRelease(planeProperties);
             }
             _ioSurface = IOSurfaceCreate(properties);
+            CFRelease(properties);
         }
     }
 


### PR DESCRIPTION
A small leak occurs if no existing IOSurface is provided to vkUseIOSurfaceMVK() because CoreFoundation objects returned from functions with Create in their name must be released with CFRelease()