### PR TITLE
MoltenVK_icd.json support VK_KHR_portability_enumeration extension.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -332,6 +332,15 @@ In order to visibly display your content on *macOS*, *iOS*, or *tvOS*, you must 
 *Vulkan* rendering surface. You can enable the `VK_EXT_metal_surface` extension by defining the `VK_USE_PLATFORM_METAL_EXT` guard macro in your compiler build settings. See the description of 
 the `mvk_vulkan.h` file below for  a convenient way to enable this extension automatically.
 
+Because **MoltenVK** supports the `VK_KHR_portability_subset` extension, when using the 
+*Vulkan Loader* from the *Vulkan SDK* to run **MoltenVK** on *macOS*, the *Vulkan Loader* 
+will only include **MoltenVK** `VkPhysicalDevices` in the list returned by 
+`vkEnumeratePhysicalDevices()` if the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` 
+flag is enabled in `vkCreateInstance()`. See the description of the `VK_KHR_portability_enumeration` 
+extension in the *Vulkan* specification for more information about the use of the 
+`VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag.
+
+
 
 <a name="moltenvk_extension"></a>
 ### MoltenVK `VK_MVK_moltenvk` Extension

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,18 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.1.10
+--------------
+
+Released TBD
+
+- Add support for extensions:
+	- `VK_KHR_portability_enumeration` support added to `MoltenVK_icd.json`, and documentation
+	  updated to indicate the impact of the `VK_KHR_portability_enumeration` extension during 
+	  runtime loading on *macOS* via the *Vulkan Loader*.
+
+
+
 MoltenVK 1.1.9
 --------------
 

--- a/MoltenVK/icd/MoltenVK_icd.json
+++ b/MoltenVK/icd/MoltenVK_icd.json
@@ -2,6 +2,7 @@
     "file_format_version" : "1.0.0",
     "ICD": {
         "library_path": "./libMoltenVK.dylib",
-        "api_version" : "1.1.0"
+        "api_version" : "1.1.0",
+        "is_portability_driver" : true
     }
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developing Vulkan Applications for *macOS, iOS, and tvOS*
 The recommended method for developing a *Vulkan* application for *macOS* is to use the 
 [*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home).
 
-The *Vulkan SDK* includes a  **MoltenVK** runtime library for *macOS*. *Vulkan* is a layered 
+The *Vulkan SDK* includes a **MoltenVK** runtime library for *macOS*. *Vulkan* is a layered 
 architecture that allows applications to add additional functionality without modifying the 
 application itself. The *Validation Layers* included in the *Vulkan SDK* are an essential debugging
 tool for application developers because they identify inappropriate use of the *Vulkan API*. 
@@ -45,6 +45,14 @@ If you are developing a *Vulkan* application for *macOS*, it is highly recommend
 [*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home) and the **MoltenVK** library included in it.
 Refer to the *Vulkan SDK [Getting Started](https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html)* 
 document for more info.
+
+Because **MoltenVK** supports the `VK_KHR_portability_subset` extension, when using the 
+*Vulkan Loader* from the *Vulkan SDK* to run **MoltenVK** on *macOS*, the *Vulkan Loader* 
+will only include **MoltenVK** `VkPhysicalDevices` in the list returned by 
+`vkEnumeratePhysicalDevices()` if the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` 
+flag is enabled in `vkCreateInstance()`. See the description of the `VK_KHR_portability_enumeration` 
+extension in the *Vulkan* specification for more information about the use of the 
+`VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag.
 
 If you are developing a *Vulkan* application for *iOS* or *tvOS*, or are developing a *Vulkan* 
 application for *macOS* and want to use a different version of the **MoltenVK** runtime library 


### PR DESCRIPTION
- Update `README.md` and `MoltenVK_Runtime_UserGuide.md` to document the impact of the `VK_KHR_portability_enumeration` extension during runtime loading on macOS.
- Update MoltenVK version to 1.1.10.