### PR TITLE
Fix error where previously bound push constants can override a descriptor buffer binding

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,8 @@ Released TBD
 	- `VK_KHR_portability_enumeration` support added to `MoltenVK_icd.json`, and documentation
 	  updated to indicate the impact of the `VK_KHR_portability_enumeration` extension during 
 	  runtime loading on *macOS* via the *Vulkan Loader*.
+- Fix error where previously bound push constants can override a descriptor buffer binding 
+  used by a subsequent pipeline that does not use push constants.
 
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -198,7 +198,7 @@ public:
     void setPushConstants(uint32_t offset, MVKArrayRef<char> pushConstants);
 
     /** Sets the index of the Metal buffer used to hold the push constants. */
-    void setMTLBufferIndex(uint32_t mtlBufferIndex);
+    void setMTLBufferIndex(uint32_t mtlBufferIndex, bool pipelineStageUsesPushConstants);
 
     /** Constructs this instance for the specified command encoder. */
     MVKPushConstantsCommandEncoderState(MVKCommandEncoder* cmdEncoder,
@@ -212,6 +212,7 @@ protected:
     MVKSmallVector<char, 128> _pushConstants;
     VkShaderStageFlagBits _shaderStage;
     uint32_t _mtlBufferIndex = 0;
+	bool _pipelineStageUsesPushConstants = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -175,8 +175,9 @@ MVKPipelineLayout::~MVKPipelineLayout() {
 
 void MVKPipeline::bindPushConstants(MVKCommandEncoder* cmdEncoder) {
 	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		if (cmdEncoder && _stageUsesPushConstants[stage]) {
-			cmdEncoder->getPushConstants(mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(stage)))->setMTLBufferIndex(_pushConstantsBufferIndex.stages[stage]);
+		if (cmdEncoder) {
+			auto* pcState = cmdEncoder->getPushConstants(mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(stage)));
+			pcState->setMTLBufferIndex(_pushConstantsBufferIndex.stages[stage], _stageUsesPushConstants[stage]);
 		}
 	}
 }


### PR DESCRIPTION
Fix error where previously bound push constants can override a descriptor buffer binding used by a subsequent pipeline that does not use push constants.

This error was previously introduced in 2a17f75, where a push constants binding could override the Metal buffer binding 0 of a subsequent pipeline that does not use push constants.

When pipeline binding is encoded, track which stages use push constants and only encode push constants if the pipeline and stage uses them.

(unrelated) Make use of `MVKResourcesCommandEncoderState::getPipeline()` consistent.

Fixes issue #1569.
