### PR TITLE
Fix vkSetMoltenVKConfigurationMVK function typedef

### DIFF
--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -993,7 +993,7 @@ typedef struct {
 #pragma mark Function types
 
 typedef VkResult (VKAPI_PTR *PFN_vkGetMoltenVKConfigurationMVK)(VkInstance ignored, MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
-typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkInstance ignored, MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
+typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkInstance ignored, const MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
 typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceMetalFeaturesMVK)(VkPhysicalDevice physicalDevice, MVKPhysicalDeviceMetalFeatures* pMetalFeatures, size_t* pMetalFeaturesSize);
 typedef VkResult (VKAPI_PTR *PFN_vkGetPerformanceStatisticsMVK)(VkDevice device, MVKPerformanceStatistics* pPerf, size_t* pPerfSize);
 typedef void (VKAPI_PTR *PFN_vkGetVersionStringsMVK)(char* pMoltenVersionStringBuffer, uint32_t moltenVersionStringBufferLength, char* pVulkanVersionStringBuffer, uint32_t vulkanVersionStringBufferLength);


### PR DESCRIPTION
The type of the second argument to `vkSetMoltenVKConfigurationMVK` is missing a `const` qualifier in the function typedef.

Compare the following two lines:

https://github.com/KhronosGroup/MoltenVK/blob/1236d2f5350062327a2428f80dee615a2e67304f/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h#L996

https://github.com/KhronosGroup/MoltenVK/blob/1236d2f5350062327a2428f80dee615a2e67304f/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h#L1089-L1092

Fixes issue https://github.com/KhronosGroup/MoltenVK/issues/1577