### PR TITLE
Add support for VK_KHR_separate_depth_stencil_layouts extension.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -270,6 +270,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_device_group`
 - `VK_KHR_device_group_creation`
 - `VK_KHR_driver_properties`
+- `VK_KHR_dynamic_rendering`
 - `VK_KHR_get_memory_requirements2`
 - `VK_KHR_get_physical_device_properties2`
 - `VK_KHR_get_surface_capabilities2`
@@ -284,6 +285,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_relaxed_block_layout`
 - `VK_KHR_sampler_mirror_clamp_to_edge` *(requires a Mac GPU or Apple family 7 GPU)*
 - `VK_KHR_sampler_ycbcr_conversion`
+- `VK_KHR_separate_depth_stencil_layouts`
 - `VK_KHR_shader_draw_parameters`
 - `VK_KHR_shader_float16_int8`
 - `VK_KHR_shader_subgroup_extended_types` *(requires Metal 2.1 on Mac or Metal 2.2 and Apple family 4 on iOS)*
@@ -309,6 +311,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_EXT_robustness2`
 - `VK_EXT_sample_locations`
 - `VK_EXT_scalar_block_layout`
+- `VK_EXT_separate_stencil_usage`
 - `VK_EXT_shader_stencil_export` *(requires Mac GPU family 2 or iOS GPU family 5)*
 - `VK_EXT_shader_viewport_index_layer`
 - `VK_EXT_subgroup_size_control` *(requires Metal 2.1 on Mac or Metal 2.2 and Apple family 4 on iOS)*

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 	  updated to indicate the impact of the `VK_KHR_portability_enumeration` extension during 
 	  runtime loading on *macOS* via the *Vulkan Loader*.
 	- `VK_KHR_dynamic_rendering`
+	- `VK_KHR_separate_depth_stencil_layouts`
 	- `VK_EXT_separate_stencil_usage`
 - Fix error where previously bound push constants can override a descriptor buffer binding 
   used by a subsequent pipeline that does not use push constants.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -429,6 +429,12 @@ typedef struct MVKMTLBlitEncoder {
 	id<MTLCommandBuffer> mtlCmdBuffer = nil;
 } MVKMTLBlitEncoder;
 
+typedef enum {
+	MVKSemaphoreStyleUseMTLEvent,
+	MVKSemaphoreStyleUseMTLFence,
+	MVKSemaphoreStyleUseEmulation
+} MVKSemaphoreStyle;
+
 /** Represents a Vulkan logical GPU device, associated with a physical device. */
 class MVKDevice : public MVKDispatchableVulkanAPIObject {
 
@@ -762,6 +768,9 @@ public:
 
 #pragma mark Properties directly accessible
 
+	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
+	const MVKExtensionList _enabledExtensions;
+
 	/** Device features available and enabled. */
 	const VkPhysicalDeviceFeatures _enabledFeatures;
 	const VkPhysicalDevice16BitStorageFeatures _enabledStorage16Features;
@@ -781,9 +790,7 @@ public:
 	const VkPhysicalDevicePortabilitySubsetFeaturesKHR _enabledPortabilityFeatures;
 	const VkPhysicalDeviceImagelessFramebufferFeaturesKHR _enabledImagelessFramebufferFeatures;
 	const VkPhysicalDeviceDynamicRenderingFeatures _enabledDynamicRenderingFeatures;
-
-	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
-	const MVKExtensionList _enabledExtensions;
+	const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures _enabledSeparateDepthStencilLayoutsFeatures;
 
 	/** Pointer to the Metal-specific features of the underlying physical device. */
 	const MVKPhysicalDeviceMetalFeatures* _pMetalFeatures;
@@ -858,21 +865,15 @@ protected:
 	std::mutex _rezLock;
 	std::mutex _sem4Lock;
     std::mutex _perfLock;
-    id<MTLBuffer> _globalVisibilityResultMTLBuffer;
-	id<MTLSamplerState> _defaultMTLSamplerState;
-	id<MTLBuffer> _dummyBlitMTLBuffer;
-    uint32_t _globalVisibilityQueryCount;
-    std::mutex _vizLock;
-	bool _logActivityPerformanceInline;
-	bool _isPerformanceTracking;
-	bool _isCurrentlyAutoGPUCapturing;
-
-	typedef enum {
-		VkSemaphoreStyleUseMTLEvent,
-		VkSemaphoreStyleUseMTLFence,
-		VkSemaphoreStyleUseEmulation
-	} VkSemaphoreStyle;
-	VkSemaphoreStyle _vkSemaphoreStyle;
+	std::mutex _vizLock;
+    id<MTLBuffer> _globalVisibilityResultMTLBuffer = nil;
+	id<MTLSamplerState> _defaultMTLSamplerState = nil;
+	id<MTLBuffer> _dummyBlitMTLBuffer = nil;
+	MVKSemaphoreStyle _vkSemaphoreStyle = MVKSemaphoreStyleUseEmulation;
+    uint32_t _globalVisibilityQueryCount = 0;
+	bool _logActivityPerformanceInline = false;
+	bool _isPerformanceTracking = false;
+	bool _isCurrentlyAutoGPUCapturing = false;
 
 };
 

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -72,6 +72,7 @@ MVK_EXTENSION(KHR_push_descriptor,                 KHR_PUSH_DESCRIPTOR,         
 MVK_EXTENSION(KHR_relaxed_block_layout,            KHR_RELAXED_BLOCK_LAYOUT,             DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_sampler_mirror_clamp_to_edge,    KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE,     DEVICE,   10.11, 14.0)
 MVK_EXTENSION(KHR_sampler_ycbcr_conversion,        KHR_SAMPLER_YCBCR_CONVERSION,         DEVICE,   10.11,  8.0)
+MVK_EXTENSION(KHR_separate_depth_stencil_layouts,  KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS,   DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_draw_parameters,          KHR_SHADER_DRAW_PARAMETERS,           DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_float16_int8,             KHR_SHADER_FLOAT16_INT8,              DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_subgroup_extended_types,  KHR_SHADER_SUBGROUP_EXTENDED_TYPES,   DEVICE,   10.14, 13.0)


### PR DESCRIPTION
Add `VK_KHR_separate_depth_stencil_layouts` and enable its features.
Metal generally ignores image layouts, so nothing further needed.
Update `Whats_New.md` and `MoltenVK_Runtime_UserGuide.md` documents with recently-added extensions.

Passes almost all supported separate_layouts CTS tests, with the few remaining tests failing due to issues with unrelated capabilities.

Unrelated cleanup:
- `MVKDevice` enable extensions before features.
- `MVKDevice` reorder ivar declarations to reduce memory layout gaps, and define default values.
- Rename `VkSemaphoreStyle` to `MVKSemaphoreStyle` to remove potential conflicts with Vulkan `Vk` name space.