### PR TITLE
Add workaround for zombie memory bug in Intel Iris Plus Graphics driver when repeatedly retrieving GPU counter sets.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -30,6 +30,7 @@ Released TBD
   used by a subsequent pipeline that does not use push constants.
 - Fix error on some Apple GPU's where a `vkCmdTimestampQuery()` after a renderpass was 
   writing timestamp before renderpass activity was complete.
+- Work around zombie memory bug in Intel Iris Plus Graphics driver when repeatedly retrieving GPU counter sets.
 - Update to latest SPIRV-Cross:
 	- MSL: Emit interface block members of array length 1 as arrays instead of scalars.
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2812,6 +2812,14 @@ void MVKPhysicalDevice::initCounterSets() {
 	@autoreleasepool {
 		if (_metalFeatures.counterSamplingPoints) {
 			NSArray<id<MTLCounterSet>>* counterSets = _mtlDevice.counterSets;
+
+			// Workaround for a bug in Intel Iris Plus Graphics driver where the counterSets
+			// array is not properly retained internally, and becomes a zombie when counterSets
+			// is called more than once, which occurs when an app creates more than one VkInstance.
+			// This workaround will cause a very small memory leak on systems that do not have this
+			// bug, so we apply the workaround only when absolutely needed for specific devices.
+			if (_properties.vendorID == kIntelVendorId && _properties.deviceID == 0x8a53) { [counterSets retain]; }
+
 			for (id<MTLCounterSet> cs in counterSets){
 				NSString* csName = cs.name;
 				if ( [csName caseInsensitiveCompare: MTLCommonCounterSetTimestamp] == NSOrderedSame) {


### PR DESCRIPTION
Fixes issue #1580.