### PR TITLE
Reducing redundant state changes

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -373,7 +373,7 @@ protected:
     // Template function that marks both the vector and all binding elements in the vector as dirty.
     template<class T>
     void markDirty(T& bindings, bool& bindingsDirtyFlag) {
-        for (auto& b : bindings) { b.isDirty = true; }
+        for (auto& b : bindings) { b.markDirty(); }
         bindingsDirtyFlag = true;
     }
 
@@ -384,18 +384,18 @@ protected:
 
         if ( !b.mtlResource ) { return; }
 
-        T db = b;   // Copy that can be marked dirty
         MVKCommandEncoderState::markDirty();
         bindingsDirtyFlag = true;
-        db.isDirty = true;
 
         for (auto iter = bindings.begin(), end = bindings.end(); iter != end; ++iter) {
-            if( iter->index == db.index ) {
-                *iter = db;
+            if (iter->index == b.index) {
+                iter->update(b);
                 return;
             }
         }
-        bindings.push_back(db);
+
+        bindings.push_back(b);
+        bindings.back().markDirty();
     }
 
 	// For texture bindings, we also keep track of whether any bindings need a texture swizzle

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -752,6 +752,10 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
                                                            b.mtlBytes,
                                                            b.size,
                                                            b.index);
+                           else if (b.justOffset)
+                               [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl)
+                                            setBufferOffset: b.offset
+                                            atIndex: b.index];
                            else
                                [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl) setBuffer: b.mtlBuffer
                                                                                                              offset: b.offset
@@ -785,9 +789,14 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
                                                               b.size,
                                                               b.index);
                                } else {
-                                   [cmdEncoder->_mtlRenderEncoder setVertexBuffer: b.mtlBuffer
-                                                                           offset: b.offset
-                                                                          atIndex: b.index];
+                                   if (b.justOffset) {
+                                       [cmdEncoder->_mtlRenderEncoder setVertexBufferOffset: b.offset
+                                                                                    atIndex: b.index];
+                                   } else {
+                                       [cmdEncoder->_mtlRenderEncoder setVertexBuffer: b.mtlBuffer
+                                                                               offset: b.offset
+                                                                              atIndex: b.index];
+                                   }
 
                                    // Add any translated vertex bindings for this binding
                                    auto xltdVtxBindings = pipeline->getTranslatedVertexBindings();
@@ -828,6 +837,9 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
                                                            b.mtlBytes,
                                                            b.size,
                                                            b.index);
+                           else if (b.justOffset)
+                               [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl) setBufferOffset: b.offset
+                                                                                                                  atIndex: b.index];
                            else
                                [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl) setBuffer: b.mtlBuffer
                                                                                                              offset: b.offset
@@ -858,6 +870,9 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
                                                           b.mtlBytes,
                                                           b.size,
                                                           b.index);
+                           else if (b.justOffset)
+                               [cmdEncoder->_mtlRenderEncoder setVertexBufferOffset: b.offset
+                                                                            atIndex: b.index];
                            else
                                [cmdEncoder->_mtlRenderEncoder setVertexBuffer: b.mtlBuffer
                                                                        offset: b.offset
@@ -888,6 +903,9 @@ void MVKGraphicsResourcesCommandEncoderState::encodeImpl(uint32_t stage) {
                                                             b.mtlBytes,
                                                             b.size,
                                                             b.index);
+                           else if (b.justOffset)
+                               [cmdEncoder->_mtlRenderEncoder setFragmentBufferOffset: b.offset
+                                                                              atIndex: b.index];
                            else
                                [cmdEncoder->_mtlRenderEncoder setFragmentBuffer: b.mtlBuffer
                                                                          offset: b.offset
@@ -1027,7 +1045,12 @@ void MVKComputeResourcesCommandEncoderState::encodeImpl(uint32_t) {
 										b.mtlBytes,
 										b.size,
 										b.index);
-		} else {
+        } else if (b.justOffset) {
+            [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch)
+                        setBufferOffset: b.offset
+                                atIndex: b.index];
+
+        } else {
 			[cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch) setBuffer: b.mtlBuffer
 																		 offset: b.offset
 																		atIndex: b.index];

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -37,8 +37,8 @@ MVKDevice* MVKCommandEncoderState::getDevice() { return _cmdEncoder->getDevice()
 #pragma mark MVKPipelineCommandEncoderState
 
 void MVKPipelineCommandEncoderState::bindPipeline(MVKPipeline* pipeline) {
+    if (pipeline != _pipeline) markDirty();
     _pipeline = pipeline;
-    markDirty();
 }
 
 MVKPipeline* MVKPipelineCommandEncoderState::getPipeline() { return _pipeline; }
@@ -71,14 +71,17 @@ void MVKViewportCommandEncoderState::setViewports(const MVKArrayRef<VkViewport> 
 		usingViewports.resize(firstViewport + vpCnt);
 	}
 
+    bool dirty;
 	bool mustSetDynamically = _cmdEncoder->supportsDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
 	if (isSettingDynamically || (!mustSetDynamically && vpCnt > 0)) {
+        dirty = memcmp(&usingViewports[firstViewport], &viewports[0], vpCnt * sizeof(VkViewport)) != 0;
 		std::copy(viewports.begin(), viewports.end(), usingViewports.begin() + firstViewport);
 	} else {
+        dirty = !usingViewports.empty();
 		usingViewports.clear();
 	}
 
-	markDirty();
+	if (dirty) markDirty();
 }
 
 void MVKViewportCommandEncoderState::encodeImpl(uint32_t stage) {
@@ -121,14 +124,17 @@ void MVKScissorCommandEncoderState::setScissors(const MVKArrayRef<VkRect2D> scis
 		usingScissors.resize(firstScissor + sCnt);
 	}
 
+    bool dirty;
 	bool mustSetDynamically = _cmdEncoder->supportsDynamicState(VK_DYNAMIC_STATE_SCISSOR);
 	if (isSettingDynamically || (!mustSetDynamically && sCnt > 0)) {
+        dirty = memcmp(&usingScissors[firstScissor], &scissors[0], sCnt * sizeof(VkRect2D)) != 0;
 		std::copy(scissors.begin(), scissors.end(), usingScissors.begin() + firstScissor);
 	} else {
+        dirty = !usingScissors.empty();
 		usingScissors.clear();
 	}
 
-	markDirty();
+	if (dirty) markDirty();
 }
 
 void MVKScissorCommandEncoderState::encodeImpl(uint32_t stage) {
@@ -248,6 +254,7 @@ bool MVKPushConstantsCommandEncoderState::isTessellating() {
 #pragma mark MVKDepthStencilCommandEncoderState
 
 void MVKDepthStencilCommandEncoderState:: setDepthStencilState(const VkPipelineDepthStencilStateCreateInfo& vkDepthStencilInfo) {
+    auto oldData = _depthStencilData;
 
     if (vkDepthStencilInfo.depthTestEnable) {
         _depthStencilData.depthCompareFunction = mvkMTLCompareFunctionFromVkCompareOp(vkDepthStencilInfo.depthCompareOp);
@@ -260,7 +267,7 @@ void MVKDepthStencilCommandEncoderState:: setDepthStencilState(const VkPipelineD
     setStencilState(_depthStencilData.frontFaceStencilData, vkDepthStencilInfo.front, vkDepthStencilInfo.stencilTestEnable);
     setStencilState(_depthStencilData.backFaceStencilData, vkDepthStencilInfo.back, vkDepthStencilInfo.stencilTestEnable);
 
-    markDirty();
+    if (!(oldData == _depthStencilData)) markDirty();
 }
 
 void MVKDepthStencilCommandEncoderState::setStencilState(MVKMTLStencilDescriptorData& stencilInfo,
@@ -289,6 +296,8 @@ void MVKDepthStencilCommandEncoderState::setStencilState(MVKMTLStencilDescriptor
 // it may not be accurate, and if not dynamic, pipeline will override when it is encoded anyway.
 void MVKDepthStencilCommandEncoderState::setStencilCompareMask(VkStencilFaceFlags faceMask,
                                                                uint32_t stencilCompareMask) {
+    auto oldData = _depthStencilData;
+
     if (mvkAreAllFlagsEnabled(faceMask, VK_STENCIL_FACE_FRONT_BIT)) {
         _depthStencilData.frontFaceStencilData.readMask = stencilCompareMask;
     }
@@ -296,13 +305,15 @@ void MVKDepthStencilCommandEncoderState::setStencilCompareMask(VkStencilFaceFlag
         _depthStencilData.backFaceStencilData.readMask = stencilCompareMask;
     }
 
-    markDirty();
+    if (!(oldData == _depthStencilData)) markDirty();
 }
 
 // We don't check for dynamic state here, because if this is called before pipeline is set,
 // it may not be accurate, and if not dynamic, pipeline will override when it is encoded anyway.
 void MVKDepthStencilCommandEncoderState::setStencilWriteMask(VkStencilFaceFlags faceMask,
                                                              uint32_t stencilWriteMask) {
+    auto oldData = _depthStencilData;
+
     if (mvkAreAllFlagsEnabled(faceMask, VK_STENCIL_FACE_FRONT_BIT)) {
         _depthStencilData.frontFaceStencilData.writeMask = stencilWriteMask;
     }
@@ -310,7 +321,7 @@ void MVKDepthStencilCommandEncoderState::setStencilWriteMask(VkStencilFaceFlags 
         _depthStencilData.backFaceStencilData.writeMask = stencilWriteMask;
     }
 
-    markDirty();
+    if (!(oldData == _depthStencilData)) markDirty();
 }
 
 void MVKDepthStencilCommandEncoderState::beginMetalRenderPass() {
@@ -353,22 +364,27 @@ void MVKStencilReferenceValueCommandEncoderState:: setReferenceValues(const VkPi
     // If ref values are to be set dynamically, don't set them here.
     if (_cmdEncoder->supportsDynamicState(VK_DYNAMIC_STATE_STENCIL_REFERENCE)) { return; }
 
+    if (_frontFaceValue != vkDepthStencilInfo.front.reference || _backFaceValue != vkDepthStencilInfo.back.reference)
+        markDirty();
+
     _frontFaceValue = vkDepthStencilInfo.front.reference;
     _backFaceValue = vkDepthStencilInfo.back.reference;
-    markDirty();
 }
 
 // We don't check for dynamic state here, because if this is called before pipeline is set,
 // it may not be accurate, and if not dynamic, pipeline will override when it is encoded anyway.
 void MVKStencilReferenceValueCommandEncoderState::setReferenceValues(VkStencilFaceFlags faceMask,
                                                                      uint32_t stencilReference) {
+    bool dirty = false;
     if (mvkAreAllFlagsEnabled(faceMask, VK_STENCIL_FACE_FRONT_BIT)) {
+        dirty |= (_frontFaceValue != stencilReference);
         _frontFaceValue = stencilReference;
     }
     if (mvkAreAllFlagsEnabled(faceMask, VK_STENCIL_FACE_BACK_BIT)) {
+        dirty |= (_backFaceValue != stencilReference);
         _backFaceValue = stencilReference;
     }
-    markDirty();
+    if (dirty) markDirty();
 }
 
 void MVKStencilReferenceValueCommandEncoderState::encodeImpl(uint32_t stage) {
@@ -383,16 +399,20 @@ void MVKStencilReferenceValueCommandEncoderState::encodeImpl(uint32_t stage) {
 
 void MVKDepthBiasCommandEncoderState::setDepthBias(const VkPipelineRasterizationStateCreateInfo& vkRasterInfo) {
 
+    auto wasEnabled = _isEnabled;
     _isEnabled = vkRasterInfo.depthBiasEnable;
 
     // If ref values are to be set dynamically, don't set them here.
     if (_cmdEncoder->supportsDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS)) { return; }
 
-    _depthBiasConstantFactor = vkRasterInfo.depthBiasConstantFactor;
-    _depthBiasSlopeFactor = vkRasterInfo.depthBiasSlopeFactor;
-    _depthBiasClamp = vkRasterInfo.depthBiasClamp;
+    if (_isEnabled != wasEnabled || _depthBiasConstantFactor != vkRasterInfo.depthBiasConstantFactor
+        || _depthBiasSlopeFactor != vkRasterInfo.depthBiasSlopeFactor || _depthBiasClamp != vkRasterInfo.depthBiasClamp) {
 
-    markDirty();
+        markDirty();
+        _depthBiasConstantFactor = vkRasterInfo.depthBiasConstantFactor;
+        _depthBiasSlopeFactor = vkRasterInfo.depthBiasSlopeFactor;
+        _depthBiasClamp = vkRasterInfo.depthBiasClamp;
+    }
 }
 
 // We don't check for dynamic state here, because if this is called before pipeline is set,
@@ -400,11 +420,15 @@ void MVKDepthBiasCommandEncoderState::setDepthBias(const VkPipelineRasterization
 void MVKDepthBiasCommandEncoderState::setDepthBias(float depthBiasConstantFactor,
                                                    float depthBiasSlopeFactor,
                                                    float depthBiasClamp) {
-    _depthBiasConstantFactor = depthBiasConstantFactor;
-    _depthBiasSlopeFactor = depthBiasSlopeFactor;
-    _depthBiasClamp = depthBiasClamp;
 
-    markDirty();
+    if (_depthBiasConstantFactor != depthBiasConstantFactor || _depthBiasSlopeFactor != depthBiasSlopeFactor
+        || _depthBiasClamp != depthBiasClamp) {
+
+        markDirty();
+        _depthBiasConstantFactor = depthBiasConstantFactor;
+        _depthBiasSlopeFactor = depthBiasSlopeFactor;
+        _depthBiasClamp = depthBiasClamp;
+    }
 }
 
 void MVKDepthBiasCommandEncoderState::encodeImpl(uint32_t stage) {
@@ -428,12 +452,13 @@ void MVKBlendColorCommandEncoderState::setBlendColor(float red, float green,
     // Abort if we are using dynamic, but call is not dynamic.
 	if ( !isDynamic && _cmdEncoder->supportsDynamicState(VK_DYNAMIC_STATE_BLEND_CONSTANTS) ) { return; }
 
-    _red = red;
-    _green = green;
-    _blue = blue;
-    _alpha = alpha;
-
-    markDirty();
+    if (_red != red || _green != green || _blue != blue || _alpha != alpha) {
+        markDirty();
+        _red = red;
+        _green = green;
+        _blue = blue;
+        _alpha = alpha;
+    }
 }
 
 void MVKBlendColorCommandEncoderState::encodeImpl(uint32_t stage) {

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -314,6 +314,8 @@ void MVKDepthStencilCommandEncoderState::setStencilWriteMask(VkStencilFaceFlags 
 }
 
 void MVKDepthStencilCommandEncoderState::beginMetalRenderPass() {
+    MVKCommandEncoderState::beginMetalRenderPass();
+
 	MVKRenderSubpass* mvkSubpass = _cmdEncoder->getSubpass();
 	MVKPixelFormats* pixFmts = _cmdEncoder->getPixelFormats();
 	MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(mvkSubpass->getDepthStencilFormat());

--- a/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
@@ -34,6 +34,16 @@ typedef struct MVKMTLTextureBinding {
     uint32_t swizzle = 0;
 	uint16_t index = 0;
     bool isDirty = true;
+
+    inline void markDirty() { isDirty = true; }
+
+    inline void update(const MVKMTLTextureBinding &other) {
+        if (mtlTexture != other.mtlTexture || swizzle != other.swizzle) {
+            mtlTexture = other.mtlTexture;
+            swizzle = other.swizzle;
+            markDirty();
+        }
+    }
 } MVKMTLTextureBinding;
 
 /** Describes a MTLSamplerState resource binding. */
@@ -41,6 +51,15 @@ typedef struct MVKMTLSamplerStateBinding {
     union { id<MTLSamplerState> mtlSamplerState = nil; id<MTLSamplerState> mtlResource; }; // aliases
     uint16_t index = 0;
     bool isDirty = true;
+
+    inline void markDirty() { isDirty = true; }
+
+    inline void update(const MVKMTLSamplerStateBinding &other) {
+        if (mtlSamplerState != other.mtlSamplerState) {
+            mtlSamplerState = other.mtlSamplerState;
+            markDirty();
+        }
+    }
 } MVKMTLSamplerStateBinding;
 
 /** Describes a MTLBuffer resource binding. */
@@ -49,8 +68,27 @@ typedef struct MVKMTLBufferBinding {
     VkDeviceSize offset = 0;
     uint32_t size = 0;
 	uint16_t index = 0;
+    bool justOffset = false;
     bool isDirty = true;
     bool isInline = false;
+
+    inline void markDirty() { justOffset = false; isDirty = true; }
+
+    inline void update(const MVKMTLBufferBinding &other) {
+        if (mtlBuffer != other.mtlBuffer || size != other.size || isInline != other.isInline) {
+            mtlBuffer = other.mtlBuffer;
+            size = other.size;
+            isInline = other.isInline;
+            offset = other.offset;
+
+            justOffset = false;
+            isDirty = true;
+        } else if (offset != other.offset) {
+            offset = other.offset;
+            justOffset = !isDirty || justOffset;
+            isDirty = true;
+        }
+    }
 } MVKMTLBufferBinding;
 
 /** Describes a MTLBuffer resource binding as used for an index buffer. */


### PR DESCRIPTION
Here's a couple of patches that in my tests can reduce Metal command buffer encoding time pretty significantly in some cases, by avoiding encoding things redundantly.
There's another one (not included) to allocate MVKCommands into a linear buffer, which speeds things up a little and reduces freeing them to a trivial "count = 0;" (which otherwise takes some time of the order of 1ms from what I've seen), but there's the complication of a handful commands which actually do things in their destructor, which I haven't resolved yet.