### PR TITLE
Implement vkGetRefreshCycleDurationGOOGLE() for macOS

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -426,10 +426,15 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 #if MVK_MACOS && !MVK_MACCAT
 	// Find the screen for the window whose content view is backed by the swapchains CAMetalLayer.
 	// Default to the mainScreen if no such window can be found.
-	NSScreen *screen = [NSScreen mainScreen];
+	NSScreen* screen = [NSScreen mainScreen];
+	CALayer* layer = _mtlLayer;
+	while (layer.superlayer) {
+		layer = layer.superlayer;
+	}
+
 	for (NSWindow* window in [[NSApplication sharedApplication] windows]) {
 		NSView *view = [window contentView];
-		if (view && ([view layer] == _mtlLayer)) {
+		if (view && ([view layer] == layer)) { // Check against layer and not _mtlLayer.
 			screen = [window screen];
 		}
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -439,19 +439,19 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 		}
 	}
 
-#if MVK_XCODE_13
-    // macOS 12+ only
-    double framesPerSecond = [screen maximumFramesPerSecond];
-#else
 	CGDirectDisplayID displayId = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
 	CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
 	double framesPerSecond = CGDisplayModeGetRefreshRate(mode);
 	CGDisplayModeRelease(mode);
 
+#if MVK_XCODE_13
+	if (framesPerSecond == 0 && [screen respondsToSelector: @selector(maximumFramesPerSecond)])
+     	framesPerSecond = [screen maximumFramesPerSecond];
+#endif
+
 	// Builtin panels, e.g., on MacBook, report a zero refresh rate.
 	if (framesPerSecond == 0)
 		framesPerSecond = 60.0;
-#endif
 #endif
 
 	pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -439,6 +439,10 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 		}
 	}
 
+#if MVK_XCODE_13
+    // macOS 12+ only
+    double framesPerSecond = [screen maximumFramesPerSecond];
+#else
 	CGDirectDisplayID displayId = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
 	CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
 	double framesPerSecond = CGDisplayModeGetRefreshRate(mode);
@@ -447,6 +451,7 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 	// Builtin panels, e.g., on MacBook, report a zero refresh rate.
 	if (framesPerSecond == 0)
 		framesPerSecond = 60.0;
+#endif
 #endif
 
 	pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -29,8 +29,15 @@
 #import "CAMetalLayer+MoltenVK.h"
 #import "MVKBlockObserver.h"
 
-#if MVK_IOS_OR_TVOS
+#if MVK_IOS_OR_TVOS || MVK_MACCAT
 #	include <UIKit/UIScreen.h>
+#endif
+
+#if MVK_MACOS && !MVK_MACCAT
+#	include <AppKit/NSApplication.h>
+#	include <AppKit/NSScreen.h>
+#	include <AppKit/NSWindow.h>
+#	include <AppKit/NSView.h>
 #endif
 
 #include <libkern/OSByteOrder.h>
@@ -408,15 +415,33 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRefreshCycleDuration) {
 	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
 
+#if MVK_IOS_OR_TVOS || MVK_MACCAT
 	NSInteger framesPerSecond = 60;
-#if MVK_IOS_OR_TVOS
 	UIScreen* screen = [UIScreen mainScreen];
 	if ([screen respondsToSelector: @selector(maximumFramesPerSecond)]) {
 		framesPerSecond = screen.maximumFramesPerSecond;
 	}
 #endif
-#if MVK_MACOS
-	// TODO: hook this up for macOS, probably need to use CGDisplayModeGetRefeshRate
+
+#if MVK_MACOS && !MVK_MACCAT
+	// Find the screen for the window whose content view is backed by the swapchains CAMetalLayer.
+	// Default to the mainScreen if no such window can be found.
+	NSScreen *screen = [NSScreen mainScreen];
+	for (NSWindow* window in [[NSApplication sharedApplication] windows]) {
+		NSView *view = [window contentView];
+		if (view && ([view layer] == _mtlLayer)) {
+			screen = [window screen];
+		}
+	}
+
+	CGDirectDisplayID displayId = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
+	CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
+	double framesPerSecond = CGDisplayModeGetRefreshRate(mode);
+	CGDisplayModeRelease(mode);
+
+	// Builtin panels, e.g., on MacBook, report a zero refresh rate.
+	if (framesPerSecond == 0)
+		framesPerSecond = 60.0;
 #endif
 
 	pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;


### PR DESCRIPTION
Continuation of #1358. Thanks to @kleinerm for the initial work.

The aforementioned PR was already over a year old and was not merged because of a flaw where the CALayer of the swap chain was not the top layer of a window, making the code default to `[NSScreen mainScreen]`. This fixes that issue by combining a suggestion by @cdavis5e in which we take the absolute super layer of the swap chain's layer so that we actually have the top layer of the window. This should now cover all edge cases.