### PR TITLE
Support Xcode 14.0 Beta 3.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1695,7 +1695,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		case MTLLanguageVersion1_1:
 			setMSLVersion(1, 1);
 			break;
-#if MVK_IOS_OR_TVOS || MVK_XCODE_14
+#if MVK_IOS_OR_TVOS
 		case MTLLanguageVersion1_0:
 			setMSLVersion(1, 0);
 			break;


### PR DESCRIPTION
- Revert to avoid `MTLLanguageVersion1_0` on macOS (Xcode 14.0 Beta 2 had erroneously indicated support).

Fixes issue #1634.