### PR TITLE
Work around MTLCounterSet crash on additional Intel Iris Plus Graphics drivers

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
 - Reducing redundant state changes to improve command encoding performance.
 - Update minimum Xcode deployment targets to macOS 10.13, iOS 11, and tvOS 11,
   to avoid Xcode build warnings in Xcode 14.
+- Work around MTLCounterSet crash on additional Intel Iris Plus Graphics drivers.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -393,6 +393,7 @@ protected:
 	void initExternalMemoryProperties();
 	void initExtensions();
 	void initCounterSets();
+	bool needsCounterSetRetained();
 	MVKArrayRef<MVKQueueFamily*> getQueueFamilies();
 	void initPipelineCacheUUID();
 	uint32_t getHighestGPUCapability();


### PR DESCRIPTION
- Add `0x8a51` and `0x8a52` to list of device IDs requiring workaround.

Fixes issue #1642.