### PR TITLE
VK_EXT_metal_objects fix issue where timeline event incorrectly created.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3400,9 +3400,7 @@ MVKSemaphore* MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInf
 		}
 	}
 
-	if ((pTypeCreateInfo && pTypeCreateInfo->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE) ||
-		(pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) ||
-		 pImportInfo) {
+	if (pTypeCreateInfo && pTypeCreateInfo->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE) {
 		if (_pMetalFeatures->events) {
 			return new MVKTimelineSemaphoreMTLEvent(this, pCreateInfo, pTypeCreateInfo, pExportInfo, pImportInfo);
 		} else {
@@ -3410,9 +3408,9 @@ MVKSemaphore* MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInf
 		}
 	} else {
 		switch (_vkSemaphoreStyle) {
-			case MVKSemaphoreStyleUseMTLEvent:  return new MVKSemaphoreMTLEvent(this, pCreateInfo);
-			case MVKSemaphoreStyleUseMTLFence:  return new MVKSemaphoreMTLFence(this, pCreateInfo);
-			case MVKSemaphoreStyleUseEmulation: return new MVKSemaphoreEmulated(this, pCreateInfo);
+			case MVKSemaphoreStyleUseMTLEvent:  return new MVKSemaphoreMTLEvent(this, pCreateInfo, pExportInfo, pImportInfo);
+			case MVKSemaphoreStyleUseMTLFence:  return new MVKSemaphoreMTLFence(this, pCreateInfo, pExportInfo, pImportInfo);
+			case MVKSemaphoreStyleUseEmulation: return new MVKSemaphoreEmulated(this, pCreateInfo, pExportInfo, pImportInfo);
 		}
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
@@ -213,7 +213,10 @@ public:
 	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
 	bool isUsingCommandEncoding() override { return true; }
 
-	MVKSemaphoreMTLFence(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo);
+	MVKSemaphoreMTLFence(MVKDevice* device,
+						 const VkSemaphoreCreateInfo* pCreateInfo,
+						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+						 const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
 	~MVKSemaphoreMTLFence() override;
 
@@ -235,7 +238,10 @@ public:
 	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t deferToken) override;
 	bool isUsingCommandEncoding() override { return true; }
 
-	MVKSemaphoreMTLEvent(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo);
+	MVKSemaphoreMTLEvent(MVKDevice* device,
+						 const VkSemaphoreCreateInfo* pCreateInfo,
+						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+						 const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
 	~MVKSemaphoreMTLEvent() override;
 
@@ -258,7 +264,10 @@ public:
 	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
 	bool isUsingCommandEncoding() override { return false; }
 
-	MVKSemaphoreEmulated(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo);
+	MVKSemaphoreEmulated(MVKDevice* device,
+						 const VkSemaphoreCreateInfo* pCreateInfo,
+						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+						 const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
 protected:
 	MVKSemaphoreImpl _blocker;
@@ -296,12 +305,7 @@ public:
 
 #pragma mark Construction
 
-	MVKTimelineSemaphore(MVKDevice* device,
-						 const VkSemaphoreCreateInfo* pCreateInfo,
-						 const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
-						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-						 const VkImportMetalSharedEventInfoEXT* pImportInfo)
-        : MVKSemaphore(device, pCreateInfo) {}
+	MVKTimelineSemaphore(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo) : MVKSemaphore(device, pCreateInfo) {}
 
 };
 


### PR DESCRIPTION
- `vkCreateSemaphore()` create binary semaphore, unless timeline explicitly requested. Previously, timeline semaphore was always created when `exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT`.
- `vkCreateSemaphore()` record error when `MTLSharedEvent` imported or marked for export, and MoltenVK configured for VkSemaphore using `MTLFence` or CPU emulation.
- `MVKTimelineSemaphore` elide unused constructor arguments.

Fixes issue #1631.