### PR TITLE
Check MTLDevice for barycentric coordinate support.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,9 @@ Released TBD
 - Update minimum Xcode deployment targets to macOS 10.13, iOS 11, and tvOS 11,
   to avoid Xcode build warnings in Xcode 14.
 - Work around MTLCounterSet crash on additional Intel Iris Plus Graphics drivers.
+- Check `MTLDevice` to enable support for `VK_KHR_fragment_shader_barycentric` 
+  and `VK_NV_fragment_shader_barycentric` extensions.
+- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.
 
 
 
@@ -38,7 +41,7 @@ Released 2022/06/06
 	  updated to indicate the impact of the `VK_KHR_portability_enumeration` extension during 
 	  runtime loading on *macOS* via the *Vulkan Loader*.
 	- `VK_KHR_dynamic_rendering`
-	- `VK_KHR_fragment_shader_barycentric`
+	- `VK_KHR_fragment_shader_barycentric` and `VK_NV_fragment_shader_barycentric`
 	- `VK_KHR_separate_depth_stencil_layouts`
 	- `VK_EXT_separate_stencil_usage`
 - Implement `vkGetRefreshCycleDurationGOOGLE()` for _macOS_.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -55,7 +55,7 @@ typedef unsigned long MTLLanguageVersion;
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            34
+#define VK_MVK_MOLTENVK_SPEC_VERSION            35
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /** Identifies the level of logging MoltenVK should be limited to outputting. */
@@ -930,6 +930,7 @@ typedef struct {
 	MVKFloatRounding clearColorFloatRounding;		/**< Identifies the type of rounding Metal uses for MTLClearColor float to integer conversions. */
 	MVKCounterSamplingFlags counterSamplingPoints;	/**< Identifies the points where pipeline GPU counter sampling may occur. */
 	VkBool32 programmableSamplePositions;			/**< If true, programmable MSAA sample positions are supported. */
+	VkBool32 shaderBarycentricCoordinates;			/**< If true, fragment shader barycentric coordinates are supported. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1609,6 +1609,13 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.pullModelInterpolation = _mtlDevice.supportsPullModelInterpolation;
 	}
 #endif
+
+#if (MVK_MACOS && !MVK_MACCAT) || (MVK_MACCAT && MVK_XCODE_14) || (MVK_IOS && MVK_XCODE_12)
+	if ( [_mtlDevice respondsToSelector: @selector(supportsShaderBarycentricCoordinates)] ) {
+		_metalFeatures.shaderBarycentricCoordinates = _mtlDevice.supportsShaderBarycentricCoordinates;
+	}
+#endif
+
     if ( [_mtlDevice respondsToSelector: @selector(maxBufferLength)] ) {
         _metalFeatures.maxMTLBufferSize = _mtlDevice.maxBufferLength;
     }
@@ -2841,6 +2848,10 @@ void MVKPhysicalDevice::initExtensions() {
 	}
 	if (!_metalFeatures.simdPermute && !_metalFeatures.quadPermute) {
 		pWritableExtns->vk_KHR_shader_subgroup_extended_types.enabled = false;
+	}
+	if (!_metalFeatures.shaderBarycentricCoordinates) {
+		pWritableExtns->vk_KHR_fragment_shader_barycentric.enabled = false;
+		pWritableExtns->vk_NV_fragment_shader_barycentric.enabled = false;
 	}
 #if MVK_MACOS
 	if (!supportsMTLGPUFamily(Apple5)) {


### PR DESCRIPTION
- Add `MVKPhysicalDeviceMetalFeatures::shaderBarycentricCoordinates`, enable it based on `[MTLDevice supportsShaderBarycentricCoordinates]`, and subsequently enable support for `VK_KHR_fragment_shader_barycentric` and `VK_NV_fragment_shader_barycentric` extensions, based on it.
- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.