### PR TITLE
Check MTLDevice for gpuAddress support.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -263,7 +263,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_16bit_storage`
 - `VK_KHR_8bit_storage`
 - `VK_KHR_bind_memory2`
-- `VK_KHR_buffer_device_address` *(requires Metal 3.0)*
+- `VK_KHR_buffer_device_address` *(requires GPU Tier 2 argument buffers support)*
 - `VK_KHR_create_renderpass2`
 - `VK_KHR_dedicated_allocation`
 - `VK_KHR_depth_stencil_resolve`
@@ -298,7 +298,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_timeline_semaphore`
 - `VK_KHR_uniform_buffer_standard_layout`
 - `VK_KHR_variable_pointers`
-- `VK_EXT_buffer_device_address` *(requires Metal 3.0)*
+- `VK_EXT_buffer_device_address` *(requires GPU Tier 2 argument buffers support)*
 - `VK_EXT_debug_marker`
 - `VK_EXT_debug_report`
 - `VK_EXT_debug_utils`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,7 +20,7 @@ Released TBD
 
 - Add support for extensions:
 	- `VK_EXT_metal_objects`
-	- `VK_KHR_buffer_device_address` and `VK_EXT_buffer_device_address`.
+	- `VK_KHR_buffer_device_address` and `VK_EXT_buffer_device_address` *(requires GPU Tier 2 argument buffers support)*.
 - Reducing redundant state changes to improve command encoding performance.
 - Update minimum Xcode deployment targets to macOS 10.13, iOS 11, and tvOS 11,
   to avoid Xcode build warnings in Xcode 14.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -33,6 +33,7 @@ extern "C" {
 #import <Metal/Metal.h>
 #else
 typedef unsigned long MTLLanguageVersion;
+typedef unsigned long MTLArgumentBuffersTier;
 #endif
 
 
@@ -931,6 +932,7 @@ typedef struct {
 	MVKCounterSamplingFlags counterSamplingPoints;	/**< Identifies the points where pipeline GPU counter sampling may occur. */
 	VkBool32 programmableSamplePositions;			/**< If true, programmable MSAA sample positions are supported. */
 	VkBool32 shaderBarycentricCoordinates;			/**< If true, fragment shader barycentric coordinates are supported. */
+	MTLArgumentBuffersTier argumentBuffersTier;		/**< The argument buffer tier available on this device, as a Metal enumeration. */
 } MVKPhysicalDeviceMetalFeatures;
 
 /** MoltenVK performance of a particular type of activity. */


### PR DESCRIPTION
Support by the `MTLDevice` for Metal Tier 2 argument buffers has an impact on both descriptor indexing and buffer device address support.

Add `MVKPhysicalDeviceMetalFeatures::argumentBuffersTier`, to track the `MTLDevice` argument buffers support tier, set it from `[MTLDevice argumentBuffersSupport]`, and subsequently enable support for `VK_KHR_buffer_device_address` and `VK_EXT_buffer_device_address` extensions, and set descriptor indexing resource counts, based on it.

Update documentation requirements.