### PR TITLE
Fix query pool wait block when query is not encoded to be written to.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -27,6 +27,7 @@ Released TBD
 - Work around MTLCounterSet crash on additional Intel Iris Plus Graphics drivers.
 - Check `MTLDevice` to enable support for `VK_KHR_fragment_shader_barycentric` 
   and `VK_NV_fragment_shader_barycentric` extensions.
+- Fix query pool wait block when query is not encoded to be written to.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -107,12 +107,16 @@ bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQu
     return true;
 }
 
-// Returns whether all the queries between the start (inclusive) and end (exclusive) queries are available.
+// Returns whether any queries between the start (inclusive) and end (exclusive) queries,
+// that were encoded to be written to by an earlier EndQuery or Timestamp command, are now available.
+// Queries that were not encoded to be written, will be in Initial state.
+// Queries that were encoded to be written, and are available, will be in Available state.
+// Queries that were encoded to be written, but are not available, will be in DeviceAvailable state.
 bool MVKQueryPool::areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuery) {
     // If we lost the device, stop waiting immediately.
     if (_device->getConfigurationResult() != VK_SUCCESS) { return true; }
     for (uint32_t query = firstQuery; query < endQuery; query++) {
-        if ( _availability[query] < Available ) { return false; }
+        if (_availability[query] == DeviceAvailable) { return false; }
     }
     return true;
 }


### PR DESCRIPTION
When checking query wait completion, all queries were previously checked for `Available` status, and blocked until all became `Available`. However, only queries that were encoded to be written should be checked. It is okay for queries that are not encoded to be written to remain in `Initial` state, and not block the wait.