### PR TITLE
Ignore sampler update in descriptor set bindings that use immutable samplers.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,7 @@ Released TBD
 - Check `MTLDevice` to enable support for `VK_KHR_fragment_shader_barycentric` 
   and `VK_NV_fragment_shader_barycentric` extensions.
 - Fix query pool wait block when query is not encoded to be written to.
+- Ignore sampler update in descriptor set bindings that use immutable samplers.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -114,7 +114,9 @@ public:
 	bool usesImmutableSamplers() { return !_immutableSamplers.empty(); }
 
 	/** Returns the immutable sampler at the index, or nullptr if immutable samplers are not used. */
-	MVKSampler* getImmutableSampler(uint32_t index);
+	MVKSampler* getImmutableSampler(uint32_t index) {
+		return (index < _immutableSamplers.size()) ? _immutableSamplers[index] : nullptr;
+	}
 
 	/** Encodes the descriptors in the descriptor set that are specified by this layout, */
 	void bind(MVKCommandEncoder* cmdEncoder,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -193,10 +193,6 @@ uint32_t MVKDescriptorSetLayoutBinding::getDescriptorCount(MVKDescriptorSet* des
 	return _info.descriptorCount;
 }
 
-MVKSampler* MVKDescriptorSetLayoutBinding::getImmutableSampler(uint32_t index) {
-	return (index < _immutableSamplers.size()) ? _immutableSamplers[index] : nullptr;
-}
-
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKDescriptorSetLayoutBinding::bind(MVKCommandEncoder* cmdEncoder,
 										 MVKDescriptorSet* descSet,
@@ -1107,6 +1103,9 @@ void MVKSamplerDescriptorMixin::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 									  uint32_t srcIndex,
 									  size_t stride,
 									  const void* pData) {
+
+	if (mvkDSLBind->usesImmutableSamplers()) { return; }
+
 	auto* oldSamp = _mvkSampler;
 
 	const auto* pImgInfo = &get<VkDescriptorImageInfo>(pData, stride, srcIndex);


### PR DESCRIPTION
- Plus inline `MVKDescriptorSetLayoutBinding::getImmutableSampler()` for consistency with `usesImmutableSamplers()`.