### PR TITLE
Fix vkUpdateDescriptorSetWithTemplate() for inline block descriptors.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,7 @@ Released TBD
 - Check `MTLDevice` to enable support for `VK_KHR_fragment_shader_barycentric` 
   and `VK_NV_fragment_shader_barycentric` extensions.
 - Fix query pool wait block when query is not encoded to be written to.
+- Fix `vkUpdateDescriptorSetWithTemplate()` for inline block descriptors.
 - Ignore sampler update in descriptor set bindings that use immutable samplers.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -261,7 +261,7 @@ class MVKCmdPushDescriptorSetWithTemplate : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkDescriptorUpdateTemplateKHR descUpdateTemplate,
+						VkDescriptorUpdateTemplate descUpdateTemplate,
 						VkPipelineLayout layout,
 						uint32_t set,
 						const void* pData);

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -429,7 +429,7 @@ void MVKCmdPushDescriptorSet::clearDescriptorWrites() {
 #pragma mark MVKCmdPushDescriptorSetWithTemplate
 
 VkResult MVKCmdPushDescriptorSetWithTemplate::setContent(MVKCommandBuffer* cmdBuff,
-														 VkDescriptorUpdateTemplateKHR descUpdateTemplate,
+														 VkDescriptorUpdateTemplate descUpdateTemplate,
 														 VkPipelineLayout layout,
 														 uint32_t set,
 														 const void* pData) {
@@ -443,7 +443,7 @@ VkResult MVKCmdPushDescriptorSetWithTemplate::setContent(MVKCommandBuffer* cmdBu
 
 	if (_pData) delete[] (char*)_pData;
 	// Work out how big the memory block in pData is.
-	const VkDescriptorUpdateTemplateEntryKHR* pEntry =
+	const VkDescriptorUpdateTemplateEntry* pEntry =
 		_descUpdateTemplate->getEntry(_descUpdateTemplate->getNumberOfEntries()-1);
 	size_t size = pEntry->offset;
 	// If we were given a stride, use that; otherwise, assume only one info

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -330,16 +330,16 @@ public:
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT; }
 
 	/** Get the nth update template entry. */
-	const VkDescriptorUpdateTemplateEntryKHR* getEntry(uint32_t n) const;
+	const VkDescriptorUpdateTemplateEntry* getEntry(uint32_t n) const;
 
 	/** Get the total number of entries. */
 	uint32_t getNumberOfEntries() const;
 
 	/** Get the type of this template. */
-	VkDescriptorUpdateTemplateTypeKHR getType() const;
+	VkDescriptorUpdateTemplateType getType() const;
 
 	/** Constructs an instance for the specified device. */
-	MVKDescriptorUpdateTemplate(MVKDevice* device, const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo);
+	MVKDescriptorUpdateTemplate(MVKDevice* device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo);
 
 	/** Destructor. */
 	~MVKDescriptorUpdateTemplate() override = default;
@@ -347,8 +347,8 @@ public:
 protected:
 	void propagateDebugName() override {}
 
-	VkDescriptorUpdateTemplateTypeKHR _type;
-	MVKSmallVector<VkDescriptorUpdateTemplateEntryKHR, 1> _entries;
+	VkDescriptorUpdateTemplateType _type;
+	MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
 };
 
 #pragma mark -
@@ -362,5 +362,5 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 
 /** Updates the resource bindings in the given descriptor set from the specified template. */
 void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
-										VkDescriptorUpdateTemplateKHR updateTemplate,
+										VkDescriptorUpdateTemplate updateTemplate,
 										const void* pData);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -924,6 +924,8 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 		// For inline block create a temp buffer of descCnt bytes to hold data during copy.
 		uint8_t dstBuffer[descCnt];
 		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
+		inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+		inlineUniformBlock.pNext = nullptr;
 		inlineUniformBlock.pData = dstBuffer;
 		inlineUniformBlock.dataSize = descCnt;
 
@@ -953,6 +955,16 @@ void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
 	for (uint32_t i = 0; i < pTemplate->getNumberOfEntries(); i++) {
 		const VkDescriptorUpdateTemplateEntryKHR* pEntry = pTemplate->getEntry(i);
 		const void* pCurData = (const char*)pData + pEntry->offset;
+
+		// For inline block, wrap the raw data in in inline update struct.
+		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
+		if (pEntry->descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+			inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+			inlineUniformBlock.pNext = nullptr;
+			inlineUniformBlock.pData = pCurData;
+			inlineUniformBlock.dataSize = pEntry->descriptorCount;
+			pCurData = &inlineUniformBlock;
+		}
 		dstSet->write(pEntry, pEntry->stride, pCurData);
 	}
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -149,7 +149,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
 
 	if (!cmdEncoder) { clearConfigurationResult(); }
     for (uint32_t i = 0; i < descUpdateTemplate->getNumberOfEntries(); i++) {
-        const VkDescriptorUpdateTemplateEntryKHR* pEntry = descUpdateTemplate->getEntry(i);
+        const VkDescriptorUpdateTemplateEntry* pEntry = descUpdateTemplate->getEntry(i);
         uint32_t dstBinding = pEntry->dstBinding;
         uint32_t dstArrayElement = pEntry->dstArrayElement;
         uint32_t descriptorCount = pEntry->descriptorCount;
@@ -856,7 +856,7 @@ MVKDescriptorPool::~MVKDescriptorPool() {
 #pragma mark -
 #pragma mark MVKDescriptorUpdateTemplate
 
-const VkDescriptorUpdateTemplateEntryKHR* MVKDescriptorUpdateTemplate::getEntry(uint32_t n) const {
+const VkDescriptorUpdateTemplateEntry* MVKDescriptorUpdateTemplate::getEntry(uint32_t n) const {
 	return &_entries[n];
 }
 
@@ -864,12 +864,12 @@ uint32_t MVKDescriptorUpdateTemplate::getNumberOfEntries() const {
 	return (uint32_t)_entries.size();
 }
 
-VkDescriptorUpdateTemplateTypeKHR MVKDescriptorUpdateTemplate::getType() const {
+VkDescriptorUpdateTemplateType MVKDescriptorUpdateTemplate::getType() const {
 	return _type;
 }
 
 MVKDescriptorUpdateTemplate::MVKDescriptorUpdateTemplate(MVKDevice* device,
-														 const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo) :
+														 const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo) :
 	MVKVulkanAPIDeviceObject(device), _type(pCreateInfo->templateType) {
 
 	for (uint32_t i = 0; i < pCreateInfo->descriptorUpdateEntryCount; i++)
@@ -924,7 +924,7 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 		// For inline block create a temp buffer of descCnt bytes to hold data during copy.
 		uint8_t dstBuffer[descCnt];
 		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
-		inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+		inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
 		inlineUniformBlock.pNext = nullptr;
 		inlineUniformBlock.pData = dstBuffer;
 		inlineUniformBlock.dataSize = descCnt;
@@ -942,24 +942,24 @@ void mvkUpdateDescriptorSets(uint32_t writeCount,
 
 // Updates the resource bindings in the given descriptor set from the specified template.
 void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
-										VkDescriptorUpdateTemplateKHR updateTemplate,
+										VkDescriptorUpdateTemplate updateTemplate,
 										const void* pData) {
 
 	MVKDescriptorSet* dstSet = (MVKDescriptorSet*)descriptorSet;
 	MVKDescriptorUpdateTemplate* pTemplate = (MVKDescriptorUpdateTemplate*)updateTemplate;
 
-	if (pTemplate->getType() != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET_KHR)
+	if (pTemplate->getType() != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET)
 		return;
 
 	// Perform the updates
 	for (uint32_t i = 0; i < pTemplate->getNumberOfEntries(); i++) {
-		const VkDescriptorUpdateTemplateEntryKHR* pEntry = pTemplate->getEntry(i);
+		const VkDescriptorUpdateTemplateEntry* pEntry = pTemplate->getEntry(i);
 		const void* pCurData = (const char*)pData + pEntry->offset;
 
 		// For inline block, wrap the raw data in in inline update struct.
 		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
 		if (pEntry->descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-			inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK;
+			inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
 			inlineUniformBlock.pNext = nullptr;
 			inlineUniformBlock.pData = pCurData;
 			inlineUniformBlock.dataSize = pEntry->descriptorCount;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -596,7 +596,7 @@ public:
 	void destroyDescriptorPool(MVKDescriptorPool* mvkDP,
 							   const VkAllocationCallbacks* pAllocator);
 
-	MVKDescriptorUpdateTemplate* createDescriptorUpdateTemplate(const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+	MVKDescriptorUpdateTemplate* createDescriptorUpdateTemplate(const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
 																const VkAllocationCallbacks* pAllocator);
 	void destroyDescriptorUpdateTemplate(MVKDescriptorUpdateTemplate* mvkDUT,
 										 const VkAllocationCallbacks* pAllocator);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3617,7 +3617,7 @@ void MVKDevice::destroyDescriptorPool(MVKDescriptorPool* mvkDP,
 }
 
 MVKDescriptorUpdateTemplate* MVKDevice::createDescriptorUpdateTemplate(
-	const VkDescriptorUpdateTemplateCreateInfoKHR* pCreateInfo,
+	const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
 	const VkAllocationCallbacks* pAllocator) {
 	return new MVKDescriptorUpdateTemplate(this, pCreateInfo);
 }

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2513,7 +2513,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetKHR(
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer                            commandBuffer,
-    VkDescriptorUpdateTemplateKHR              descriptorUpdateTemplate,
+    VkDescriptorUpdateTemplate              descriptorUpdateTemplate,
     VkPipelineLayout                           layout,
     uint32_t                                   set,
     const void*                                pData) {


### PR DESCRIPTION
- Fix `vkUpdateDescriptorSetWithTemplate()` for inline block descriptors.
- Rename entities for `VK_KHR_descriptor_update_template` extension since it's promoted to Vulkan 1.1.

First commit contains functional changes. Second commit contains the renaming noise.