### PR TITLE
Support Vulkan 1.2 device feature and property structs.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -398,7 +398,8 @@ protected:
 	void initPipelineCacheUUID();
 	uint32_t getHighestGPUCapability();
 	uint32_t getMoltenVKGitRevision();
-	void populate(VkPhysicalDeviceIDProperties* pDevIdProps);
+	void populateDeviceIDProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
+	void populateSubgroupProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
 	void logGPUInfo();
 
 	id<MTLDevice> _mtlDevice;


### PR DESCRIPTION
In preparation for Vulkan 1.2, support the following device feature and property structures, and use them to populate the corresponding device feature and property values originally supplied by Vulkan extensions, to ensure a single source of truth for these values:

- `VkPhysicalDeviceVulkan11Features`
- `VkPhysicalDeviceVulkan11Properties`
- `VkPhysicalDeviceVulkan12Features`
- `VkPhysicalDeviceVulkan12Properties`

Disable `VkPhysicalDeviceVulkan12Features::drawIndirectCount` and `VkPhysicalDeviceVulkan12Features::samplerFilterMinmax`, to indicate that Vulkan 1.2 support will not include extensions `VK_KHR_draw_indirect_count` and `VK_EXT_sampler_filter_minmax`, respectively.

Support enabling device features during `VkDevice` creation using `VkPhysicalDeviceVulkan11Features` and `VkPhysicalDeviceVulkan12Features`.