### PR TITLE
Improve performance of vkResetDescriptorPool().

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -31,6 +31,7 @@ Released TBD
 - Fix query pool wait block when query is not encoded to be written to.
 - Fix `vkUpdateDescriptorSetWithTemplate()` for inline block descriptors.
 - Fix retrieval of accurate `vkGetRefreshCycleDurationGOOGLE()` across multiple display screens.
+- Improve performance of `vkResetDescriptorPool()`.
 - Report appropriate values of `VkDebugUtilsMessageTypeFlagsEXT` for debug util messages generated within MoltenVK.
 - Update _macOS Cube_ demo to demonstrate optimizing the swapchain across multiple display screens.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `35`.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -377,7 +377,7 @@ void MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool signalCo
 			// the physical device, always mark both the device and physical device as lost.
 			// If the error is local to this command buffer, optionally mark the device (but not the
 			// physical device) as lost, depending on the value of MVKConfiguration::resumeLostDevice.
-			getVulkanAPIObject()->reportError(VK_ERROR_DEVICE_LOST, "Command buffer %p \"%s\" execution failed (code %li): %s", mtlCB, mtlCB.label ? mtlCB.label.UTF8String : "", mtlCB.error.code, mtlCB.error.localizedDescription.UTF8String);
+			getVulkanAPIObject()->reportError(VK_ERROR_DEVICE_LOST, "MTLCommandBuffer \"%s\" execution failed (code %li): %s", mtlCB.label ? mtlCB.label.UTF8String : "", mtlCB.error.code, mtlCB.error.localizedDescription.UTF8String);
 			switch (mtlCB.error.code) {
 				case MTLCommandBufferErrorBlacklisted:
 				case MTLCommandBufferErrorNotPermitted:	// May also be used for command buffers executed in the background without the right entitlement.


### PR DESCRIPTION
- `MVKDescriptorPool::reset()` don't waste time freeing descriptor sets that were never allocated.
- If descriptor set could not be allocated, set availability bit (unrelated).
- `MVKBitArray` add `_lowestNeverClearedBitIndex` to track the lowest bit index that has not been cleared since last reset.
- `MVKBitArray` rename `_minUnclearedSectionIndex` to `_clearedSectionCount` for clarity.
- `MVKBitArray` use `_clearedSectionCount` and `_lowestNeverClearedBitIndex` to optimize operation of setting or clearing all bits.
- `MVKBitArray::setBit()` ensure we don't try to change a bit that is out of range.
- `MVKBitArray::resize()` no-op if size doesn't actually change.
- `MVKQueue` don't include object pointer in error log, so CTS log results are consistent across multiple CTS runs (unrelated).

Fixes issue #1628 and possibly #1646.