### PR TITLE
Fix retention of MVKSwapchain for future drawable presentations.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,16 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.1.12
+--------------
+
+Released TBD
+
+- Fix occassional crash from retention of `MVKSwapchain` for future drawable presentations.
+- Add `MVK_USE_CEREAL` build setting to avoid use of Cereal external library (for pipeline caching).
+
+
+
 MoltenVK 1.1.11
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -51,7 +51,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   1
-#define MVK_VERSION_PATCH   11
+#define MVK_VERSION_PATCH   12
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -393,20 +393,21 @@ public:
 
 #pragma mark Construction
 
-	/** Constructs an instance for the specified device and swapchain. */
 	MVKSwapchainImage(MVKDevice* device,
 					  const VkImageCreateInfo* pCreateInfo,
 					  MVKSwapchain* swapchain,
 					  uint32_t swapchainIndex);
 
-	~MVKSwapchainImage() override;
+	void destroy() override;
 
 protected:
 	friend class MVKPeerSwapchainImage;
 
 	virtual id<CAMetalDrawable> getCAMetalDrawable() = 0;
+	void detachSwapchain();
 
 	MVKSwapchain* _swapchain;
+	std::mutex _swapchainLock;
 	uint32_t _swapchainIndex;
 };
 
@@ -452,7 +453,6 @@ public:
 
 #pragma mark Construction
 
-	/** Constructs an instance for the specified device and swapchain. */
 	MVKPresentableSwapchainImage(MVKDevice* device,
 								 const VkImageCreateInfo* pCreateInfo,
 								 MVKSwapchain* swapchain,
@@ -464,7 +464,7 @@ protected:
 	friend MVKSwapchain;
 
 	id<CAMetalDrawable> getCAMetalDrawable() override;
-	void presentCAMetalDrawable(id<CAMetalDrawable> mtlDrawable, MVKPresentTimingInfo presentTimingInfo);
+	void addPresentedHandler(id<CAMetalDrawable> mtlDrawable, MVKPresentTimingInfo presentTimingInfo);
 	void releaseMetalDrawable();
 	MVKSwapchainImageAvailability getAvailability();
 	void makeAvailable(const MVKSwapchainSignaler& signaler);
@@ -498,7 +498,6 @@ public:
 
 #pragma mark Construction
 
-	/** Constructs an instance for the specified device and swapchain. */
 	MVKPeerSwapchainImage(MVKDevice* device,
 						  const VkImageCreateInfo* pCreateInfo,
 						  MVKSwapchain* swapchain,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
@@ -58,7 +58,7 @@ public:
 
     /** Returns the CAMetalLayer underlying this surface.  */
     inline CAMetalLayer* getCAMetalLayer() {
-        std::lock_guard<std::mutex> lock(_lock);
+        std::lock_guard<std::mutex> lock(_layerLock);
         return _mtlCAMetalLayer;
     }
 
@@ -78,10 +78,11 @@ public:
 protected:
 	void propagateDebugName() override {}
 	void initLayerObserver();
+	void releaseLayer();
 
 	MVKInstance* _mvkInstance;
 	CAMetalLayer* _mtlCAMetalLayer;
-	std::mutex _lock;
 	MVKBlockObserver* _layerObserver;
+	std::mutex _layerLock;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -21,6 +21,7 @@
 #include "MVKDevice.h"
 #include "MVKImage.h"
 #include "MVKSmallVector.h"
+#include <mutex>
 
 #import "CAMetalLayer+MoltenVK.h"
 #import <Metal/Metal.h>
@@ -111,6 +112,7 @@ protected:
 	void propagateDebugName() override;
 	void initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt);
 	void initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt);
+	void releaseLayer();
 	void releaseUndisplayedSurfaces();
 	uint64_t getNextAcquisitionID();
     void willPresentSurface(id<MTLTexture> mtlTexture, id<MTLCommandBuffer> mtlCmdBuff);
@@ -126,6 +128,7 @@ protected:
     uint32_t _currentPerfLogFrameCount;
     std::atomic<bool> _surfaceLost;
     MVKBlockObserver* _layerObserver;
+	std::mutex _layerLock;
 	static const int kMaxPresentationHistory = 60;
 	VkPastPresentationTimingGOOGLE _presentTimingHistory[kMaxPresentationHistory];
 	uint32_t _presentHistoryCount;


### PR DESCRIPTION
When presenting drawables in the future, the `MVKPresentableSwapchainImage`and `MVKSwapchain` were both being retained by the drawable-presented callback, so that the presentation timing info can be recorded on the swapchain. Unfortunately, in the case where the presentation timing is set far enough into the future (I'm looking at you CTS), the swapchain, and even the `CAMetalLayer's` view may be destroyed, causing occasional bad access crashes.

- `MVKSwapchainImage` don't retain() the swapchain, and move clearing the swapchain from the destructor to destroy(), so the `MVKSwapchain` is not necessarily retained by the `MVKSwapchainImage`, for a drawable being presented in the future.
- `MVKSwapchainImage` add a lock around clearing swapchain and accessing it from callbacks.
- Add lockable `releaseLayer()` function in both `MVKSwapchain` and `MVKSurface`, which is called from both layer observer and destructor, to handle race conditions better.
- `MVKSwapchain::initCAMetalLayer()` call `MVKSurface::getCAMetalLayer()` only once.
- Update MoltenVK version to 1.1.12.
- Update What's New document.

Fix #1679.