### PR TITLE
Fix crash in vkCreateSwapchainKHR() on macOS 10.14 and earlier

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -402,10 +402,12 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 		_presentableImages.push_back(_device->createPresentableSwapchainImage(&imgInfo, this, imgIdx, NULL));
 	}
 
-#if MVK_MACOS && !MVK_MACCAT
-	NSString* screenName = _mtlLayer.screenMVK.localizedName;
-#else
 	NSString* screenName = @"Main Screen";
+#if MVK_MACOS && !MVK_MACCAT
+	if ([_mtlLayer.screenMVK respondsToSelector:@selector(localizedName)])
+	{
+		screenName = _mtlLayer.screenMVK.localizedName;
+	}
 #endif
     MVKLogInfo("Created %d swapchain images with initial size (%d, %d) and contents scale %.1f for screen %s.",
 			   imgCnt, imgExtent.width, imgExtent.height, _mtlLayer.contentsScale, screenName.UTF8String);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -404,8 +404,7 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
 
 	NSString* screenName = @"Main Screen";
 #if MVK_MACOS && !MVK_MACCAT
-	if ([_mtlLayer.screenMVK respondsToSelector:@selector(localizedName)])
-	{
+	if ([_mtlLayer.screenMVK respondsToSelector:@selector(localizedName)]) {
 		screenName = _mtlLayer.screenMVK.localizedName;
 	}
 #endif


### PR DESCRIPTION
NSScreen's `localizedName` property is only available on macOS 10.15+, so check before use.