### PR TITLE
Support automatically enable Metal argument buffers when VK_EXT_descriptor_indexing extension is enabled.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -303,7 +303,9 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_EXT_debug_marker`
 - `VK_EXT_debug_report`
 - `VK_EXT_debug_utils`
-- `VK_EXT_descriptor_indexing` *(initial release limited to Metal Tier 1: 96/128 textures, 16 samplers)*
+- `VK_EXT_descriptor_indexing` *(initial release limited to Metal Tier 1: 96/128 textures, 
+  16 samplers, except macOS 11.0 (Big Sur) or later, or on older versions of macOS using 
+  an Intel GPU, and if Metal argument buffers enabled in config)*
 - `VK_EXT_fragment_shader_interlock` *(requires Metal 2.0 and Raster Order Groups)*
 - `VK_EXT_host_query_reset`
 - `VK_EXT_image_robustness`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,8 +20,12 @@ Released TBD
 
 - Add support for extensions:
 	- `VK_KHR_shader_float_controls`
+- Support config option to automatically use Metal argument buffers when `VK_EXT_descriptor_indexing` 
+  extension is enabled. `MVKConfiguration::useMetalArgumentBuffers` (`MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS`) 
+  is now an enum field. The use of Metal argument buffers is still disabled by default (`MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER`).
 - Fix occassional crash from retention of `MVKSwapchain` for future drawable presentations.
 - Add `MVK_USE_CEREAL` build setting to avoid use of Cereal external library (for pipeline caching).
+- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `36`.
 
 
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -56,7 +56,7 @@ typedef unsigned long MTLArgumentBuffersTier;
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)
 
-#define VK_MVK_MOLTENVK_SPEC_VERSION            35
+#define VK_MVK_MOLTENVK_SPEC_VERSION            36
 #define VK_MVK_MOLTENVK_EXTENSION_NAME          "VK_MVK_moltenvk"
 
 /** Identifies the level of logging MoltenVK should be limited to outputting. */
@@ -95,6 +95,14 @@ typedef enum MVKConfigAdvertiseExtensionBits {
 	MVK_CONFIG_ADVERTISE_EXTENSIONS_MAX_ENUM    = 0x7FFFFFFF
 } MVKConfigAdvertiseExtensionBits;
 typedef VkFlags MVKConfigAdvertiseExtensions;
+
+/** Identifies the use of Metal Argument Buffers. */
+typedef enum MVKUseMetalArgumentBuffers {
+	MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER               = 0,	/**< Don't use Metal Argument Buffers. */
+	MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_ALWAYS              = 1,	/**< Use Metal Argument Buffers for all pipelines. */
+	MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_DESCRIPTOR_INDEXING = 2,	/**< Use Metal Argument Buffers only if VK_EXT_descriptor_indexing extension is enabled. */
+	MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_MAX_ENUM            = 0x7FFFFFFF
+} MVKUseMetalArgumentBuffers;
 
 /**
  * MoltenVK configuration settings.
@@ -809,25 +817,26 @@ typedef struct {
 	 * Controls whether MoltenVK should use Metal argument buffers for resources defined in
 	 * descriptor sets, if Metal argument buffers are supported on the platform. Using Metal
 	 * argument buffers dramatically increases the number of buffers, textures and samplers
-	 * that can be bound to a pipeline shader, and in most cases improves performance. If this
-	 * setting is enabled, MoltenVK will use Metal argument buffers to bind resources to the
-	 * shaders. If this setting is disabled, MoltenVK will bind resources to shaders discretely.
+	 * that can be bound to a pipeline shader, and in most cases improves performance.
+	 * This setting is an enumeration that specifies the conditions under which MoltenVK
+	 * will use Metal argument buffers.
 	 *
 	 * NOTE: Currently, Metal argument buffer support is in beta stage, and is only supported
 	 * on macOS 11.0 (Big Sur) or later, or on older versions of macOS using an Intel GPU.
 	 * Metal argument buffers support is not available on iOS. Development to support iOS
 	 * and a wider combination of GPU's on older macOS versions is under way.
 	 *
-	 * The value of this parameter must be changed before creating a VkInstance,
+	 * The value of this parameter must be changed before creating a VkDevice,
 	 * for the change to take effect.
 	 *
 	 * The initial value or this parameter is set by the
 	 * MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS
 	 * runtime environment variable or MoltenVK compile-time build setting.
-	 * If neither is set, this setting is enabled by default, and MoltenVK will not
-	 * use Metal argument buffers, and will bind resources to shaders discretely.
+	 * If neither is set, this setting is set to
+	 * MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER by default,
+	 * and MoltenVK will not use Metal argument buffers.
 	 */
-	VkBool32 useMetalArgumentBuffers;
+	MVKUseMetalArgumentBuffers useMetalArgumentBuffers;
 
 } MVKConfiguration;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -90,6 +90,17 @@ typedef NSUInteger MTLTimestamp;
 #pragma mark -
 #pragma mark MVKPhysicalDevice
 
+/** VkPhysicalDeviceVulkan12Features entries that didn't originate in a prior extension. */
+typedef struct MVKPhysicalDeviceVulkan12FeaturesNoExt {
+	VkBool32 samplerMirrorClampToEdge;
+	VkBool32 drawIndirectCount;
+	VkBool32 descriptorIndexing;
+	VkBool32 samplerFilterMinmax;
+	VkBool32 shaderOutputViewportIndex;
+	VkBool32 shaderOutputLayer;
+	VkBool32 subgroupBroadcastDynamicId;
+} MVKPhysicalDeviceVulkan12FeaturesNoExt;
+
 /** Represents a Vulkan physical GPU device. */
 class MVKPhysicalDevice : public MVKDispatchableVulkanAPIObject {
 
@@ -333,8 +344,10 @@ public:
 	/** Returns whether the MSL version is supported on this device. */
 	bool mslVersionIsAtLeast(MTLLanguageVersion minVer) { return _metalFeatures.mslVersionEnum >= minVer; }
 
-	/** Returns whether this device is using Metal argument buffers. */
-	bool isUsingMetalArgumentBuffers() const  { return _metalFeatures.argumentBuffers && mvkConfig().useMetalArgumentBuffers; };
+	/** Returns whether this physical device supports Metal argument buffers. */
+	bool supportsMetalArgumentBuffers() const  {
+		return _metalFeatures.argumentBuffers && mvkConfig().useMetalArgumentBuffers != MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER;
+	};
 
 	/**
 	 * Returns the start timestamps of a timestamp correlation.
@@ -406,6 +419,7 @@ protected:
 	MVKInstance* _mvkInstance;
 	const MVKExtensionList _supportedExtensions;
 	VkPhysicalDeviceFeatures _features;
+	MVKPhysicalDeviceVulkan12FeaturesNoExt _vulkan12FeaturesNoExt;
 	MVKPhysicalDeviceMetalFeatures _metalFeatures;
 	VkPhysicalDeviceProperties _properties;
 	VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT _texelBuffAlignProperties;
@@ -694,6 +708,9 @@ public:
 	/** Returns the underlying Metal device. */
 	inline id<MTLDevice> getMTLDevice() { return _physicalDevice->getMTLDevice(); }
 
+	/** Returns whether this device is using Metal argument buffers. */
+	bool isUsingMetalArgumentBuffers() { return _isUsingMetalArgumentBuffers; };
+
 	/**
 	 * Returns an autoreleased options object to be used when compiling MSL shaders.
 	 * The useFastMath parameter is and-combined with MVKConfiguration::fastMathEnabled
@@ -786,6 +803,9 @@ public:
 	VkPhysicalDevice##structName##Features##extnSfx _enabled##structName##Features;
 #include "MVKDeviceFeatureStructs.def"
 
+	/** Vulkan 1.2 features that did originate in a prior extension available and enabled. */
+	MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
+
 	/** Pointer to the Metal-specific features of the underlying physical device. */
 	const MVKPhysicalDeviceMetalFeatures* _pMetalFeatures;
 
@@ -849,8 +869,8 @@ protected:
 														   VkDescriptorSetLayoutSupport* pSupport,
 														   VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* pVarDescSetCountSupport);
 
-	MVKPhysicalDevice* _physicalDevice;
-    MVKCommandResourceFactory* _commandResourceFactory;
+	MVKPhysicalDevice* _physicalDevice = nullptr;
+    MVKCommandResourceFactory* _commandResourceFactory = nullptr;
 	MVKSmallVector<MVKSmallVector<MVKQueue*, kMVKQueueCountPerQueueFamily>, kMVKQueueFamilyCount> _queuesByQueueFamilyIndex;
 	MVKSmallVector<MVKResource*, 256> _resources;
 	MVKSmallVector<MVKPrivateDataSlot*> _privateDataSlots;
@@ -869,6 +889,7 @@ protected:
 	bool _logActivityPerformanceInline = false;
 	bool _isPerformanceTracking = false;
 	bool _isCurrentlyAutoGPUCapturing = false;
+	bool _isUsingMetalArgumentBuffers = false;
 
 };
 
@@ -888,25 +909,25 @@ class MVKDeviceTrackingMixin {
 public:
 
 	/** Returns the device for which this object was created. */
-	inline MVKDevice* getDevice() { return _device; }
+	MVKDevice* getDevice() { return _device; }
 
 	/** Returns the physical device underlying this logical device. */
-	inline MVKPhysicalDevice* getPhysicalDevice() { return _device->getPhysicalDevice(); }
+	MVKPhysicalDevice* getPhysicalDevice() { return _device->getPhysicalDevice(); }
 
 	/** Returns the underlying Metal device. */
-	inline id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
+	id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
 
 	/** Returns info about the pixel format supported by the physical device. */
-	inline MVKPixelFormats* getPixelFormats() { return _device->getPixelFormats(); }
+	MVKPixelFormats* getPixelFormats() { return _device->getPixelFormats(); }
 
 	/** Returns whether this device is using Metal argument buffers. */
-	inline bool isUsingMetalArgumentBuffers() { return getPhysicalDevice()->isUsingMetalArgumentBuffers(); };
+	bool isUsingMetalArgumentBuffers() { return _device->isUsingMetalArgumentBuffers(); };
 
 	/** Returns whether this device is using one Metal argument buffer for each descriptor set, on multiple pipeline and pipeline stages. */
-	inline bool isUsingDescriptorSetMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && _device->_pMetalFeatures->descriptorSetArgumentBuffers; };
+	bool isUsingDescriptorSetMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && _device->_pMetalFeatures->descriptorSetArgumentBuffers; };
 
 	/** Returns whether this device is using one Metal argument buffer for each descriptor set-pipeline-stage combination. */
-	inline bool isUsingPipelineStageMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && !_device->_pMetalFeatures->descriptorSetArgumentBuffers; };
+	bool isUsingPipelineStageMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && !_device->_pMetalFeatures->descriptorSetArgumentBuffers; };
 
 	/** Constructs an instance for the specified device. */
     MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) { assert(_device); }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -90,7 +90,7 @@ typedef NSUInteger MTLTimestamp;
 #pragma mark -
 #pragma mark MVKPhysicalDevice
 
-/** VkPhysicalDeviceVulkan12Features entries that didn't originate in a prior extension. */
+/** VkPhysicalDeviceVulkan12Features entries that did not originate in a prior extension. */
 typedef struct MVKPhysicalDeviceVulkan12FeaturesNoExt {
 	VkBool32 samplerMirrorClampToEdge;
 	VkBool32 drawIndirectCount;
@@ -803,7 +803,7 @@ public:
 	VkPhysicalDevice##structName##Features##extnSfx _enabled##structName##Features;
 #include "MVKDeviceFeatureStructs.def"
 
-	/** Vulkan 1.2 features that did originate in a prior extension available and enabled. */
+	/** VkPhysicalDeviceVulkan12Features entries that did not originate in a prior extension available and enabled. */
 	MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
 
 	/** Pointer to the Metal-specific features of the underlying physical device. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1988,15 +1988,6 @@ void MVKPhysicalDevice::initFeatures() {
 
 	_features.drawIndirectFirstInstance = _metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing;
 
-	mvkClear(&_vulkan12FeaturesNoExt);	// Start with everything cleared
-	_vulkan12FeaturesNoExt.samplerMirrorClampToEdge = _metalFeatures.samplerMirrorClampToEdge;
-	_vulkan12FeaturesNoExt.drawIndirectCount = false;
-	_vulkan12FeaturesNoExt.descriptorIndexing = true;
-	_vulkan12FeaturesNoExt.samplerFilterMinmax = false;
-	_vulkan12FeaturesNoExt.shaderOutputViewportIndex = true;
-	_vulkan12FeaturesNoExt.shaderOutputLayer = true;
-	_vulkan12FeaturesNoExt.subgroupBroadcastDynamicId = true;
-
 #if MVK_TVOS
     _features.textureCompressionETC2 = true;
     _features.textureCompressionASTC_LDR = true;
@@ -2094,6 +2085,17 @@ void MVKPhysicalDevice::initFeatures() {
         _features.textureCompressionASTC_LDR = true;
     }
 #endif
+
+	// Additional non-extension Vulkan 1.2 features.
+	mvkClear(&_vulkan12FeaturesNoExt);		// Start with everything cleared
+	_vulkan12FeaturesNoExt.samplerMirrorClampToEdge = _metalFeatures.samplerMirrorClampToEdge;
+	_vulkan12FeaturesNoExt.drawIndirectCount = false;
+	_vulkan12FeaturesNoExt.descriptorIndexing = true;
+	_vulkan12FeaturesNoExt.samplerFilterMinmax = false;
+	_vulkan12FeaturesNoExt.shaderOutputViewportIndex = _features.multiViewport;
+	_vulkan12FeaturesNoExt.shaderOutputLayer = _metalFeatures.layeredRendering;
+	_vulkan12FeaturesNoExt.subgroupBroadcastDynamicId = _metalFeatures.simdPermute || _metalFeatures.quadPermute;
+
 }
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -116,8 +116,8 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 	VkPhysicalDeviceVulkan12Features supportedFeats12 = {
 		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
 		.pNext = nullptr,
-		.samplerMirrorClampToEdge = _metalFeatures.samplerMirrorClampToEdge,
-		.drawIndirectCount = false,
+		.samplerMirrorClampToEdge = _vulkan12FeaturesNoExt.samplerMirrorClampToEdge,
+		.drawIndirectCount = _vulkan12FeaturesNoExt.drawIndirectCount,
 		.storageBuffer8BitAccess = true,
 		.uniformAndStorageBuffer8BitAccess = true,
 		.storagePushConstant8 = true,
@@ -125,7 +125,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 		.shaderSharedInt64Atomics = false,
 		.shaderFloat16 = true,
 		.shaderInt8 = true,
-		.descriptorIndexing = false,		// Requires _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers && shaderStorageBufferArrayNonUniformIndexing
+		.descriptorIndexing = _vulkan12FeaturesNoExt.descriptorIndexing,
 		.shaderInputAttachmentArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
 		.shaderUniformTexelBufferArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
 		.shaderStorageTexelBufferArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
@@ -146,7 +146,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 		.descriptorBindingPartiallyBound = true,
 		.descriptorBindingVariableDescriptorCount = true,
 		.runtimeDescriptorArray = true,
-		.samplerFilterMinmax = false,
+		.samplerFilterMinmax = _vulkan12FeaturesNoExt.samplerFilterMinmax,
 		.scalarBlockLayout = true,
 		.imagelessFramebuffer = true,
 		.uniformBufferStandardLayout = true,
@@ -160,9 +160,9 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 		.vulkanMemoryModel = false,
 		.vulkanMemoryModelDeviceScope = false,
 		.vulkanMemoryModelAvailabilityVisibilityChains = false,
-		.shaderOutputViewportIndex = true,
-		.shaderOutputLayer = true,
-		.subgroupBroadcastDynamicId = true,
+		.shaderOutputViewportIndex = _vulkan12FeaturesNoExt.shaderOutputViewportIndex,
+		.shaderOutputLayer = _vulkan12FeaturesNoExt.shaderOutputLayer,
+		.subgroupBroadcastDynamicId = _vulkan12FeaturesNoExt.subgroupBroadcastDynamicId,
 	};
 
 	features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
@@ -414,7 +414,7 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties* properties) {
 void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	uint32_t uintMax = std::numeric_limits<uint32_t>::max();
 	uint32_t maxSamplerCnt = getMaxSamplerCount();
-	bool isTier2 = isUsingMetalArgumentBuffers() && (_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2);
+	bool isTier2 = supportsMetalArgumentBuffers() && (_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2);
 
 	// Create a SSOT for these Vulkan 1.1 properties, which can be queried via two mechanisms here.
 	VkPhysicalDeviceVulkan11Properties supportedProps11;
@@ -1986,9 +1986,16 @@ void MVKPhysicalDevice::initFeatures() {
 	_features.shaderSampledImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
 	_features.textureCompressionBC = mvkSupportsBCTextureCompression(_mtlDevice);
 
-    if (_metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing) {
-        _features.drawIndirectFirstInstance = true;
-    }
+	_features.drawIndirectFirstInstance = _metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing;
+
+	mvkClear(&_vulkan12FeaturesNoExt);	// Start with everything cleared
+	_vulkan12FeaturesNoExt.samplerMirrorClampToEdge = _metalFeatures.samplerMirrorClampToEdge;
+	_vulkan12FeaturesNoExt.drawIndirectCount = false;
+	_vulkan12FeaturesNoExt.descriptorIndexing = true;
+	_vulkan12FeaturesNoExt.samplerFilterMinmax = false;
+	_vulkan12FeaturesNoExt.shaderOutputViewportIndex = true;
+	_vulkan12FeaturesNoExt.shaderOutputLayer = true;
+	_vulkan12FeaturesNoExt.subgroupBroadcastDynamicId = true;
 
 #if MVK_TVOS
     _features.textureCompressionETC2 = true;
@@ -2751,7 +2758,7 @@ void MVKPhysicalDevice::initPipelineCacheUUID() {
 	// Next 4 bytes contains flags based on enabled Metal features that
 	// might affect the contents of the pipeline cache (mostly MSL content).
 	uint32_t mtlFeatures = 0;
-	mtlFeatures |= isUsingMetalArgumentBuffers() << 0;
+	mtlFeatures |= supportsMetalArgumentBuffers() << 0;
 	*(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] = NSSwapHostIntToBig(mtlFeatures);
 	uuidComponentOffset += sizeof(mtlFeatures);
 }
@@ -3005,7 +3012,7 @@ uint64_t MVKPhysicalDevice::getCurrentAllocatedSize() {
 // objects that can be created within the app. When not using argument buffers, no such
 // limit is imposed. This has been verified with testing up to 1M MTLSamplerStates.
 uint32_t MVKPhysicalDevice::getMaxSamplerCount() {
-	if (isUsingMetalArgumentBuffers()) {
+	if (supportsMetalArgumentBuffers()) {
 		return ([_mtlDevice respondsToSelector: @selector(maxArgumentBufferSamplerCount)]
 				? (uint32_t)_mtlDevice.maxArgumentBufferSamplerCount : 1024);
 	} else {
@@ -4179,7 +4186,7 @@ id<MTLSamplerState> MVKDevice::getDefaultMTLSamplerState() {
 		if ( !_defaultMTLSamplerState ) {
 			@autoreleasepool {
 				MTLSamplerDescriptor* mtlSampDesc = [[MTLSamplerDescriptor new] autorelease];
-				mtlSampDesc.supportArgumentBuffers = _physicalDevice->isUsingMetalArgumentBuffers();
+				mtlSampDesc.supportArgumentBuffers = isUsingMetalArgumentBuffers();
 				_defaultMTLSamplerState = [getMTLDevice() newSamplerStateWithDescriptor: mtlSampDesc];	// retained
 			}
 		}
@@ -4344,7 +4351,8 @@ void MVKDevice::getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) 
 
 MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo) : _enabledExtensions(this) {
 
-		// If the physical device is lost, bail.
+	// If the physical device is lost, bail.
+	// Must have initialized everything accessed in destructor to null.
 	if (physicalDevice->getConfigurationResult() != VK_SUCCESS) {
 		setConfigurationResult(physicalDevice->getConfigurationResult());
 		return;
@@ -4357,11 +4365,13 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 	initQueues(pCreateInfo);
 	reservePrivateData(pCreateInfo);
 
-    _globalVisibilityResultMTLBuffer = nil;
-    _globalVisibilityQueryCount = 0;
-
-	_defaultMTLSamplerState = nil;
-	_dummyBlitMTLBuffer = nil;
+	// After enableExtensions && enableFeatures
+	// Use Metal arg buffs if available, and either config wants them always,
+	// or config wants them with descriptor indexing and descriptor indexing has been enabled.
+	_isUsingMetalArgumentBuffers = (_physicalDevice->supportsMetalArgumentBuffers() &&
+									(mvkConfig().useMetalArgumentBuffers == MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_ALWAYS ||
+									 (mvkConfig().useMetalArgumentBuffers == MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_DESCRIPTOR_INDEXING &&
+									  (_enabledVulkan12FeaturesNoExt.descriptorIndexing || _enabledExtensions.vk_EXT_descriptor_indexing.enabled))));
 
 	_commandResourceFactory = new MVKCommandResourceFactory(this);
 
@@ -4476,6 +4486,8 @@ void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
 
 #include "MVKDeviceFeatureStructs.def"
 
+	mvkClear(&_enabledVulkan12FeaturesNoExt);
+
 	sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 	mvkClear(&_enabledFeatures);
 	VkPhysicalDeviceFeatures2 pdFeats2;
@@ -4524,7 +4536,11 @@ void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
 				break;
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
+				auto& pdvulkan12FeaturesNoExt = _physicalDevice->_vulkan12FeaturesNoExt;
 				auto* requestedFeatures = (VkPhysicalDeviceVulkan12Features*)next;
+				enableFeatures(&_enabledVulkan12FeaturesNoExt.samplerMirrorClampToEdge,
+							   &requestedFeatures->samplerMirrorClampToEdge,
+							   &pdvulkan12FeaturesNoExt.samplerMirrorClampToEdge, 2);
 				enableFeatures(&_enabled8BitStorageFeatures.storageBuffer8BitAccess,
 							   &requestedFeatures->storageBuffer8BitAccess,
 							   &pd8BitStorageFeatures.storageBuffer8BitAccess, 3);
@@ -4534,9 +4550,15 @@ void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
 				enableFeatures(&_enabledShaderFloat16Int8Features.shaderFloat16,
 							   &requestedFeatures->shaderFloat16,
 							   &pdShaderFloat16Int8Features.shaderFloat16, 2);
+				enableFeatures(&_enabledVulkan12FeaturesNoExt.descriptorIndexing,
+							   &requestedFeatures->descriptorIndexing,
+							   &pdvulkan12FeaturesNoExt.descriptorIndexing, 1);
 				enableFeatures(&_enabledDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing,
 							   &requestedFeatures->shaderInputAttachmentArrayDynamicIndexing,
 							   &pdDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing, 20);
+				enableFeatures(&_enabledVulkan12FeaturesNoExt.samplerFilterMinmax,
+							   &requestedFeatures->samplerFilterMinmax,
+							   &pdvulkan12FeaturesNoExt.samplerFilterMinmax, 1);
 				enableFeatures(&_enabledScalarBlockLayoutFeatures.scalarBlockLayout,
 							   &requestedFeatures->scalarBlockLayout,
 							   &pdScalarBlockLayoutFeatures.scalarBlockLayout, 1);
@@ -4564,6 +4586,9 @@ void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
 				enableFeatures(&_enabledVulkanMemoryModelFeatures.vulkanMemoryModel,
 							   &requestedFeatures->vulkanMemoryModel,
 							   &pdVulkanMemoryModelFeatures.vulkanMemoryModel, 3);
+				enableFeatures(&_enabledVulkan12FeaturesNoExt.shaderOutputViewportIndex,
+							   &requestedFeatures->shaderOutputViewportIndex,
+							   &pdvulkan12FeaturesNoExt.shaderOutputViewportIndex, 3);
 				break;
 			}
 
@@ -4663,7 +4688,7 @@ MVKDevice::~MVKDevice() {
 	for (auto& queues : _queuesByQueueFamilyIndex) {
 		mvkDestroyContainerContents(queues);
 	}
-	_commandResourceFactory->destroy();
+	if (_commandResourceFactory) { _commandResourceFactory->destroy(); }
 
     [_globalVisibilityResultMTLBuffer release];
 	[_defaultMTLSamplerState release];

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -61,7 +61,7 @@ static void mvkInitConfigFromEnvVars() {
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.apiVersionToAdvertise,                  MVK_CONFIG_API_VERSION_TO_ADVERTISE);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.advertiseExtensions,                    MVK_CONFIG_ADVERTISE_EXTENSIONS);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.resumeLostDevice,                       MVK_CONFIG_RESUME_LOST_DEVICE);
-	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.useMetalArgumentBuffers,                MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS);
+	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.useMetalArgumentBuffers,                MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS);
 
 	mvkSetConfig(evCfg);
 }

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -280,5 +280,5 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig);
 
 /** Support Metal argument buffers. Disabled by default. */
 #ifndef MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS
-#   define MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS    0
+#   define MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS    MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER
 #endif

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
@@ -109,12 +109,16 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-XS"
+            argument = "-mab"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-l"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-XS"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-p"

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/MoltenVKShaderConverterTool.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/MoltenVKShaderConverterTool.h
@@ -123,6 +123,7 @@ namespace mvk {
 		bool _shouldReportPerformance;
 		bool _shouldOutputAsHeaders;
 		bool _quietMode;
+		bool _useMetalArgumentBuffers;
 	};
 
 

--- a/Scripts/runcts
+++ b/Scripts/runcts
@@ -106,7 +106,7 @@ export MVK_DEBUG=0
 # editing below, or can be set before calling this script.
 export MVK_CONFIG_RESUME_LOST_DEVICE=1
 export MVK_CONFIG_FAST_MATH_ENABLED=1
-export MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0
+export MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=0  #(2 = VK_EXT_descriptor_indexing enabled)
 export MVK_CONFIG_FORCE_LOW_POWER_GPU=0
 
 


### PR DESCRIPTION
- Change `MVKConfiguration::useMetalArgumentBuffers` to enum instead of boolean and default to enabling Metal argument buffers for VK_EXT_descriptor_indexing.
- **_However, leave Metal argument buffers disabled by default until they are improved._**
- Enable `VkPhysicalDeviceVulkan12Features::descriptorIndexing`.
- Add `MVKPhysicalDeviceVulkan12FeaturesNoExt` to track and enable Vulkan 1.2 features not part of any prior extensions absorbed by Vulkan 1.2.
- Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `36`.
- `MVKDeviceTrackingMixin` remove unnecessary inline declarations.
- `MoltenShaderConveter` tool support Metal Argument Buffers and MSL 3.0.

Fixes #1689.