### PR TITLE
Advertise support for extension VK_KHR_spirv_1_4.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,14 +21,14 @@ jobs:
         upload_artifacts: [ true ]
         # additional specific configurations
         include:
-          # "Legacy" Xcode 11.7 & 12.5.1 macOS builds
-          - xcode: "11.7"
-            platform: "macos"
-            os: "macos-10.15" 
-            upload_artifacts: false
+          # "Legacy" Xcode 12.5.1 & 11.7 macOS builds
           - xcode: "12.5.1"
             platform: "macos"
-            os: "macos-11" 
+            os: "macos-11"
+            upload_artifacts: false
+          - xcode: "11.7"
+            platform: "macos"
+            os: "macos-11"
             upload_artifacts: false
       fail-fast: false
 

--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -292,6 +292,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_shader_float_controls`
 - `VK_KHR_shader_float16_int8`
 - `VK_KHR_shader_subgroup_extended_types` *(requires Metal 2.1 on Mac or Metal 2.2 and Apple family 4 on iOS)*
+- `VK_KHR_spirv_1_4`
 - `VK_KHR_storage_buffer_storage_class`
 - `VK_KHR_surface`
 - `VK_KHR_swapchain`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released TBD
 
 - Add support for extensions:
 	- `VK_KHR_shader_float_controls`
+	- `VK_KHR_spirv_1_4`
 - Vulkan semaphore functional improvements:
 	- Replace use of `MTLFence` with an option to limit to a single Vulkan queue and use Metal's implicit submisison order guarantees.
 	- Support option to force use of `MTLEvents` for Vulkan semaphores on NVIDIA and Rosetta2.
@@ -29,7 +30,9 @@ Released TBD
   is now an enum field. The use of Metal argument buffers is still disabled by default (`MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER`).
 - Fix occassional crash from retention of `MVKSwapchain` for future drawable presentations.
 - Fix undefined reference to `vkGetBufferDeviceAddressEXT` when building with `MVK_HIDE_VULKAN_SYMBOLS=1`.
+- Update `Makefile` to forward any build setting declared on the command line to Xcode.
 - Add `MVK_USE_CEREAL` build setting to avoid use of Cereal external library (for pipeline caching).
+- `MoltenVKShaderConverter` tool automatically map bindings when converting _GLSL_.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `36`.
 
 

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -81,6 +81,7 @@ MVK_EXTENSION(KHR_shader_draw_parameters,          KHR_SHADER_DRAW_PARAMETERS,  
 MVK_EXTENSION(KHR_shader_float_controls,           KHR_SHADER_FLOAT_CONTROLS,            DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_float16_int8,             KHR_SHADER_FLOAT16_INT8,              DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_subgroup_extended_types,  KHR_SHADER_SUBGROUP_EXTENDED_TYPES,   DEVICE,   10.14, 13.0)
+MVK_EXTENSION(KHR_spirv_1_4,                       KHR_SPIRV_1_4,                        DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_storage_buffer_storage_class,    KHR_STORAGE_BUFFER_STORAGE_CLASS,     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_surface,                         KHR_SURFACE,                          INSTANCE, 10.11,  8.0)
 MVK_EXTENSION(KHR_swapchain,                       KHR_SWAPCHAIN,                        DEVICE,   10.11,  8.0)

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/xcshareddata/xcschemes/MoltenVKShaderConverter.xcscheme
@@ -97,7 +97,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "2.1"
+            argument = "2.4"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/GLSLToSPIRVConverter.cpp
@@ -76,6 +76,7 @@ MVK_PUBLIC_SYMBOL bool GLSLToSPIRVConverter::convert(MVKGLSLConversionShaderStag
 		// Create and compile a shader from the source code
 		glslShaders.emplace_back(new glslang::TShader(stage));
 		glslShaders.back()->setStrings(glslStrings, 1);
+		glslShaders.back()->setAutoMapBindings(true);
 		if (glslShaders.back()->parse(&glslCompilerResources, 100, false, messages)) {
 			if (shouldLogGLSL) {
 				logMsg(glslShaders.back()->getInfoLog());


### PR DESCRIPTION
- Advertise support for extension `VK_KHR_spirv_1_4`.
- `MoltenVKShaderConverter` automatically map bindings when converting GLSL.
- `MoltenVKShaderConverter` improvements to diagnostic logging.
- Update `Whats_New.md` document.

Support for _SPIR-V 1.4_ features added in [recent updates](https://github.com/KhronosGroup/SPIRV-Cross/issues/2004) to `SPRIV-Cross`.