### PR TITLE
Fix prefer MTLEvent semaphore fallback

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3130,6 +3130,7 @@ void MVKPhysicalDevice::initVkSemaphoreStyle() {
 			bool isNVIDIA = _properties.vendorID == kNVVendorId;
 			bool isRosetta2 = _properties.vendorID == kAppleVendorId && !MVK_APPLE_SILICON;
 			if (_metalFeatures.events && !(isRosetta2 || isNVIDIA)) { _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent; }
+			else { _vkSemaphoreStyle = MVKSemaphoreStyleSingleQueue; }
 			break;
 		}
 		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS:


### PR DESCRIPTION
The current behaviour does not align with the description here
https://github.com/KhronosGroup/MoltenVK/blob/c2e9f1d876584f664aef19744332737e78bf8f93/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h#L595

This makes it so the single queue semaphore style is used as fallback in the `MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS_WHERE_SAFE` case for Nvidia and Apple Silicon instead of using CPU callbacks.