### PR TITLE
Vulkan semaphore fallback to using single queue if `MTLEvents` unusable.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3118,12 +3118,13 @@ void MVKPhysicalDevice::initCounterSets() {
 // Determine whether Vulkan semaphores should use a MTLEvent, CPU callbacks, or should limit
 // Vulkan to a single queue and use Metal's implicit guarantees that all operations submitted
 // to a queue will give the same result as if they had been run in submission order.
-// MTLEvents for semaphores can sometimes prove troublesome on some platforms,
-// and so may optionally be disabled on those platforms.
+// MTLEvents for semaphores are preferred, but can sometimes prove troublesome on some platforms,
+// and so may be disabled on those platforms, unless explicitly requested. If MTLEvents are
+// unusable, 
 void MVKPhysicalDevice::initVkSemaphoreStyle() {
 
-	// Default to CPU callback if other options unavailable.
-	_vkSemaphoreStyle = MVKSemaphoreStyleUseEmulation;
+	// Default to single queue if other options unavailable.
+	_vkSemaphoreStyle = MVKSemaphoreStyleSingleQueue;
 
 	switch (mvkConfig().semaphoreSupportStyle) {
 		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS_WHERE_SAFE: {
@@ -3135,10 +3136,10 @@ void MVKPhysicalDevice::initVkSemaphoreStyle() {
 		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS:
 			if (_metalFeatures.events) { _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent; }
 			break;
-		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE:
-			_vkSemaphoreStyle = MVKSemaphoreStyleSingleQueue;
-			break;
 		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK:
+			_vkSemaphoreStyle = MVKSemaphoreStyleUseEmulation;
+			break;
+		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE:
 		default:
 			break;
 	}

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -66,12 +66,12 @@ static void mvkInitConfigFromEnvVars() {
 	// Legacy MVK_ALLOW_METAL_EVENTS is covered by MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE,
 	// but for backwards compatibility, if legacy MVK_ALLOW_METAL_EVENTS is explicitly
 	// disabled, disable semaphoreUseMTLEvent (aliased as semaphoreSupportStyle value
-	// MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK), and let mvkSetConfig() further
-	// process legacy behavior based on the value of legacy semaphoreUseMTLFence).
+	// MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE), and let mvkSetConfig()
+	// further process legacy behavior of MVK_ALLOW_METAL_FENCES.
 	bool sem4UseMTLEvent;
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL(sem4UseMTLEvent, MVK_ALLOW_METAL_EVENTS);
 	if ( !sem4UseMTLEvent ) {
-		evCfg.semaphoreUseMTLEvent = (MVKVkSemaphoreSupportStyle)false;		// Disabled. Also semaphoreSupportStyle MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK.
+		evCfg.semaphoreUseMTLEvent = (MVKVkSemaphoreSupportStyle)false;		// Disabled. Also semaphoreSupportStyle MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE.
 	}
 
 	mvkSetConfig(evCfg);
@@ -102,11 +102,12 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig) {
 													   VK_VERSION_MINOR(_mvkConfig.apiVersionToAdvertise),
 													   VK_HEADER_VERSION);
 
-	// Deprecated legacy support for specific case where semaphoreUseMTLFence is enabled and legacy
-	// semaphoreUseMTLEvent (now aliased to semaphoreSupportStyle) is disabled. In this case the user
-	// had been using the legacy MTLFence, so use MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE now.
-	if (_mvkConfig.semaphoreUseMTLFence && !_mvkConfig.semaphoreUseMTLEvent) {
-		_mvkConfig.semaphoreSupportStyle = MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE;
+	// Deprecated legacy support for specific case where both legacy semaphoreUseMTLEvent
+	// (now aliased to semaphoreSupportStyle) and legacy semaphoreUseMTLFence are explicitly
+	// disabled by the app. In this case the app had been using CPU emulation, so use
+	// MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK.
+	if ( !_mvkConfig.semaphoreUseMTLEvent && !_mvkConfig.semaphoreUseMTLFence ) {
+		_mvkConfig.semaphoreSupportStyle = MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK;
 	}
 
 	// Set capture file path string

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -241,7 +241,7 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig);
 #   define MVK_ALLOW_METAL_EVENTS    1
 #endif
 #ifndef MVK_ALLOW_METAL_FENCES		// Deprecated
-#   define MVK_ALLOW_METAL_FENCES    0
+#   define MVK_ALLOW_METAL_FENCES    1
 #endif
 
 /** Substitute Metal 2D textures for Vulkan 1D images. Enabled by default. */


### PR DESCRIPTION
- If `MTLEvents` are unusable, fallback to single queue.
- Adjust values of `MVKVkSemaphoreSupportStyle` enumeration.
- For legacy compatibility, if legacy `semaphoreUseMTLEvent` and `semaphoreUseMTLFence` are both disabled, use CPU callback emulation.
- Update and expand related documentation in `vk_mvk_moltenvk.h`.

This PR is an expansion of, and replaces, PR #1735, based on a suggestion from @marzent in that PR.

This PR makes `MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE` the default in all cases where `MTLEvents` are unusable, provides legacy consistency with `semaphoreUseMTLEvent` and `semaphoreUseMTLFence`, and clarifies documentation.

@marzent @Gcenx Please review relative to #1735 & regression fix request in issue #1736.