### PR TITLE
fix for wrong version number in icd json

### DIFF
--- a/MoltenVK/icd/MoltenVK_icd.json
+++ b/MoltenVK/icd/MoltenVK_icd.json
@@ -2,7 +2,7 @@
     "file_format_version" : "1.0.0",
     "ICD": {
         "library_path": "./libMoltenVK.dylib",
-        "api_version" : "1.1.0",
+        "api_version" : "1.2.0",
         "is_portability_driver" : true
     }
 }


### PR DESCRIPTION
Minor change. The icd json file still listed MoltenVK as supporting version 1.1 of the API. This changes updates that to 1.2.