### PR TITLE
Add: KHR_copy_commands2

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -57,6 +57,7 @@ public:
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
+    VkResult validate(MVKCommandBuffer* cmdBuff, const VkImageCopy2* region);
 
 	MVKSmallVector<VkImageCopy2, N> _vkImageCopies;
 	MVKImage* _srcImage;
@@ -110,6 +111,7 @@ protected:
 	bool canCopyFormats(const VkImageBlit2& region);
 	bool canCopy(const VkImageBlit2& region);
 	void populateVertices(MVKVertexPosTex* vertices, const VkImageBlit2& region);
+    VkResult validate(MVKCommandBuffer* cmdBuff, const VkImageBlit2* region, bool isDestUnwritableLinear);
 
 	MVKSmallVector<VkImageBlit2, N> _vkImageBlits;
 	MVKImage* _srcImage;
@@ -155,6 +157,7 @@ public:
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
+    VkResult validate(MVKCommandBuffer* cmdBuff, const VkImageResolve2* region);
 
 	MVKSmallVector<VkImageResolve2, N> _vkImageResolves;
     MVKImage* _srcImage;
@@ -230,6 +233,8 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 	bool isArrayTexture();
+    VkResult setContent(MVKCommandBuffer* cmdBuff, uint32_t regionCount, const VkBufferImageCopy2* regions);
+    VkResult validate(MVKCommandBuffer* cmdBuff, const VkBufferImageCopy2* region);
 
 	MVKSmallVector<VkBufferImageCopy2, N> _bufferImageCopyRegions;
     MVKBuffer* _buffer;

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -233,8 +233,7 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 	bool isArrayTexture();
-    VkResult setContent(MVKCommandBuffer* cmdBuff, uint32_t regionCount, const VkBufferImageCopy2* regions);
-    VkResult validate(MVKCommandBuffer* cmdBuff, const VkBufferImageCopy2* region);
+    VkResult validate(MVKCommandBuffer* cmdBuff);
 
 	MVKSmallVector<VkBufferImageCopy2, N> _bufferImageCopyRegions;
     MVKBuffer* _buffer;

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -48,6 +48,8 @@ public:
 						VkImageLayout dstImageLayout,
 						uint32_t regionCount,
 						const VkImageCopy* pRegions);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkCopyImageInfo2* pImageInfo);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override { encode(cmdEncoder, kMVKCommandUseCopyImage); }
 
@@ -56,7 +58,7 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-	MVKSmallVector<VkImageCopy, N> _vkImageCopies;
+	MVKSmallVector<VkImageCopy2, N> _vkImageCopies;
 	MVKImage* _srcImage;
 	MVKImage* _dstImage;
 	VkImageLayout _srcLayout;
@@ -76,7 +78,7 @@ typedef MVKCmdCopyImage<4> MVKCmdCopyImageMulti;
 
 /** Combines a VkImageBlit with vertices to render it. */
 typedef struct {
-	VkImageBlit region;
+	VkImageBlit2 region;
 	MVKVertexPosTex vertices[kMVKBlitVertexCount];
 } MVKImageBlitRender;
 
@@ -96,6 +98,8 @@ public:
 						uint32_t regionCount,
 						const VkImageBlit* pRegions,
 						VkFilter filter);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkBlitImageInfo2* pBlitImageInfo);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override { encode(cmdEncoder, kMVKCommandUseBlitImage); }
 
@@ -103,11 +107,11 @@ public:
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-	bool canCopyFormats(const VkImageBlit& region);
-	bool canCopy(const VkImageBlit& region);
-	void populateVertices(MVKVertexPosTex* vertices, const VkImageBlit& region);
+	bool canCopyFormats(const VkImageBlit2& region);
+	bool canCopy(const VkImageBlit2& region);
+	void populateVertices(MVKVertexPosTex* vertices, const VkImageBlit2& region);
 
-	MVKSmallVector<VkImageBlit, N> _vkImageBlits;
+	MVKSmallVector<VkImageBlit2, N> _vkImageBlits;
 	MVKImage* _srcImage;
 	MVKImage* _dstImage;
 	VkImageLayout _srcLayout;
@@ -144,13 +148,15 @@ public:
 						VkImageLayout dstImageLayout,
 						uint32_t regionCount,
 						const VkImageResolve* pRegions);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkResolveImageInfo2* pResolveImageInfo);
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-	MVKSmallVector<VkImageResolve, N> _vkImageResolves;
+	MVKSmallVector<VkImageResolve2, N> _vkImageResolves;
     MVKImage* _srcImage;
 	MVKImage* _dstImage;
     VkImageLayout _srcLayout;
@@ -178,13 +184,15 @@ public:
 						VkBuffer destBuffer,
 						uint32_t regionCount,
 						const VkBufferCopy* pRegions);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkCopyBufferInfo2* pCopyBufferInfo);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-	MVKSmallVector<VkBufferCopy, N> _bufferCopyRegions;
+	MVKSmallVector<VkBufferCopy2, N> _bufferCopyRegions;
 	MVKBuffer* _srcBuffer;
 	MVKBuffer* _dstBuffer;
 };
@@ -212,6 +220,10 @@ public:
 						uint32_t regionCount,
 						const VkBufferImageCopy* pRegions,
 						bool toImage);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkCopyBufferToImageInfo2* pBufferToImageInfo);
+    VkResult setContent(MVKCommandBuffer* cmdBuff,
+                        const VkCopyImageToBufferInfo2* pImageToBufferInfo);
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
@@ -219,7 +231,7 @@ protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 	bool isArrayTexture();
 
-	MVKSmallVector<VkBufferImageCopy, N> _bufferImageCopyRegions;
+	MVKSmallVector<VkBufferImageCopy2, N> _bufferImageCopyRegions;
     MVKBuffer* _buffer;
     MVKImage* _image;
     bool _toImage = false;

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -45,6 +45,7 @@ MVK_EXTENSION(KHR_16bit_storage,                   KHR_16BIT_STORAGE,           
 MVK_EXTENSION(KHR_8bit_storage,                    KHR_8BIT_STORAGE,                     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_bind_memory2,                    KHR_BIND_MEMORY_2,                    DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_buffer_device_address,           KHR_BUFFER_DEVICE_ADDRESS,            DEVICE,   12.05,  16.0)
+MVK_EXTENSION(KHR_copy_commands2,                  KHR_COPY_COMMANDS_2,                  DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_create_renderpass2,              KHR_CREATE_RENDERPASS_2,              DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_dedicated_allocation,            KHR_DEDICATED_ALLOCATION,             DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_depth_stencil_resolve,           KHR_DEPTH_STENCIL_RESOLVE,            DEVICE,   10.11,  8.0)

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2497,14 +2497,63 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdEndRendering(
 }
 
 MVK_PUBLIC_VULKAN_STUB(vkCmdBindVertexBuffers2, void, VkCommandBuffer, uint32_t, uint32_t, const VkBuffer*, const VkDeviceSize*, const VkDeviceSize*, const VkDeviceSize*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdBlitImage2, void, VkCommandBuffer, const VkBlitImageInfo2*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdCopyBuffer2, void, VkCommandBuffer, const VkCopyBufferInfo2*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdCopyBufferToImage2, void, VkCommandBuffer, const VkCopyBufferToImageInfo2*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdCopyImage2, void, VkCommandBuffer, const VkCopyImageInfo2*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdCopyImageToBuffer2, void, VkCommandBuffer, const VkCopyImageToBufferInfo2*)
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdBlitImage2(
+        VkCommandBuffer                             commandBuffer,
+        const VkBlitImageInfo2*                     pBlitImageInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFromThreshold(BlitImage, pBlitImageInfo->regionCount, 1, commandBuffer,
+                           pBlitImageInfo);
+    MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyBuffer2(
+        VkCommandBuffer commandBuffer,
+        const VkCopyBufferInfo2* pCopyBufferInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFromThreshold(CopyBuffer, pCopyBufferInfo->regionCount, 1, commandBuffer, pCopyBufferInfo);
+    MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyBufferToImage2(
+        VkCommandBuffer                             commandBuffer,
+        const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFrom3Thresholds(BufferImageCopy, pCopyBufferToImageInfo->regionCount, 1, 4, 8, commandBuffer,
+                             pCopyBufferToImageInfo);
+    MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyImage2(
+        VkCommandBuffer                             commandBuffer,
+        const VkCopyImageInfo2*                     pCopyImageInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFromThreshold(CopyImage, pCopyImageInfo->regionCount, 1, commandBuffer,
+                           pCopyImageInfo);
+    MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyImageToBuffer2(
+        VkCommandBuffer                             commandBuffer,
+        const VkCopyImageToBufferInfo2*             pCopyImageInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFrom3Thresholds(BufferImageCopy, pCopyImageInfo->regionCount, 1, 4, 8, commandBuffer,
+                             pCopyImageInfo);
+    MVKTraceVulkanCallEnd();
+}
+
 MVK_PUBLIC_VULKAN_STUB(vkCmdPipelineBarrier2, void, VkCommandBuffer, const VkDependencyInfo*)
 MVK_PUBLIC_VULKAN_STUB(vkCmdResetEvent2, void, VkCommandBuffer, VkEvent, VkPipelineStageFlags2 stageMask)
-MVK_PUBLIC_VULKAN_STUB(vkCmdResolveImage2, void, VkCommandBuffer, const VkResolveImageInfo2*)
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdResolveImage2(
+        VkCommandBuffer commandBuffer,
+        const VkResolveImageInfo2* pResolveImageInfo) {
+    MVKTraceVulkanCallStart();
+    MVKAddCmdFromThreshold(ResolveImage, pResolveImageInfo->regionCount, 1, commandBuffer,
+                           pResolveImageInfo);
+    MVKTraceVulkanCallEnd();
+}
+
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetCullMode, void, VkCommandBuffer, VkCullModeFlags)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthBiasEnable, void, VkCommandBuffer, VkBool32)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthBoundsTestEnable, void, VkCommandBuffer, VkBool32)
@@ -2545,6 +2594,17 @@ MVK_PUBLIC_VULKAN_CORE_ALIAS(vkBindImageMemory2, KHR);
 MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetBufferDeviceAddress, KHR);
 MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetBufferOpaqueCaptureAddress, KHR);
 MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetDeviceMemoryOpaqueCaptureAddress, KHR);
+
+
+#pragma mark -
+#pragma mark VK_KHR_copy_commands2 extension
+
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdBlitImage2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdCopyBuffer2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdCopyBufferToImage2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdCopyImage2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdCopyImageToBuffer2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdResolveImage2, KHR);
 
 
 #pragma mark -


### PR DESCRIPTION
Closes #1734.

I've ran the 12809 `dEQP-VK.api.copy_and_blit.copy_commands2.*` CTS tests (note that I have never used the CTS before so not sure if these are the correct tests and if there are more) with these results:
```
  Passed:        3676/12779 (28.8%)
  Failed:        0/12779 (0.0%)
  Not supported: 9103/12779 (71.2%)
  Warnings:      0/12779 (0.0%)
  Waived:        0/12779 (0.0%)
```
With this PR all the relevant commands now use the 2 versions of the structs internally where possible, I've also added some missing `MVKSmallVector::reserve` calls, and we now properly move structs into the vectors where possible.

@billhollings I'd like to request a review from you but can't for some reason.