### PR TITLE
Only wait on emulated semaphores once...

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -220,6 +220,7 @@ protected:
 	MVKFence* _fence;
 	id<MTLCommandBuffer> _activeMTLCommandBuffer;
 	MVKCommandUse _commandUse;
+	bool _emulatedWaitDone; //Used to track if we've already waited for emulated semaphores.
 };
 
 


### PR DESCRIPTION
… to prevent freezing when using prefilled command buffers.

fix #1764