### PR TITLE
Misc small fixes - Xcode 13 linkage fix & Intel Iris Plus Graphics driver workaround

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released TBD
 
 - Fix crash on descriptor update with out-of-bounds descriptor count data.
 - Fix Obj-C linkage failures when linking to an app with Xcode 13 or earlier.
+- Work around `MTLCounterSet` crash on additional Intel Iris Plus Graphics devices.
 
 
 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.1
 Released TBD
 
 - Fix crash on descriptor update with out-of-bounds descriptor count data.
+- Fix Obj-C linkage failures when linking to an app with Xcode 13 or earlier.
 
 
 

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -1623,11 +1623,15 @@
 				MVK_SKIP_DYLIB = "";
 				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
 				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
+				OTHER_CFLAGS = "-fno-objc-msgsend-selector-stubs";
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
 				PRODUCT_NAME = MoltenVK;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
-				WARNING_CFLAGS = "-Wreorder";
+				WARNING_CFLAGS = (
+					"-Wreorder",
+					"-Wno-unused-command-line-argument",
+				);
 			};
 			name = Debug;
 		};
@@ -1694,12 +1698,16 @@
 				MVK_SKIP_DYLIB = "";
 				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
 				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
+				OTHER_CFLAGS = "-fno-objc-msgsend-selector-stubs";
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
 				PRODUCT_NAME = MoltenVK;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_PRODUCT = YES;
-				WARNING_CFLAGS = "-Wreorder";
+				WARNING_CFLAGS = (
+					"-Wreorder",
+					"-Wno-unused-command-line-argument",
+				);
 			};
 			name = Release;
 		};

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3168,6 +3168,8 @@ bool MVKPhysicalDevice::needsCounterSetRetained() {
 		case 0x8a51:
 		case 0x8a52:
 		case 0x8a53:
+		case 0x8a5a:
+		case 0x8a5c:
 			return true;
 		default:
 			return false;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter.xcodeproj/project.pbxproj
@@ -639,10 +639,14 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				OTHER_CFLAGS = "-fno-objc-msgsend-selector-stubs";
 				PRODUCT_NAME = MoltenVKShaderConverter;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
-				WARNING_CFLAGS = "-Wreorder";
+				WARNING_CFLAGS = (
+					"-Wreorder",
+					"-Wno-unused-command-line-argument",
+				);
 			};
 			name = Debug;
 		};
@@ -699,11 +703,15 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				OTHER_CFLAGS = "-fno-objc-msgsend-selector-stubs";
 				PRODUCT_NAME = MoltenVKShaderConverter;
 				SKIP_INSTALL = YES;
 				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_PRODUCT = YES;
-				WARNING_CFLAGS = "-Wreorder";
+				WARNING_CFLAGS = (
+					"-Wreorder",
+					"-Wno-unused-command-line-argument",
+				);
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Fix Obj-C linkage failures when linking to an app with Xcode 13 or earlier.

- Xcode 14 introduced a new Clang compilation optimization option, enabled by default, that generates Obj-C `msgsend` stubs that cannot be processed by previous Xcode versions (13 and earlier), resulting in a very large number of linker issues.
- This fix adds `-fno-objc-msgsend-selector-stubs` to the OTHER_CFLAGS build setting, and also adds `-Wno-unused-command-line-argument` to the `WARNING_CFLAGS` build setting, to suppress compiler warnings about using `-fno-objc-msgsend-selector-stubs`.
-  Fixes #1756.

Work around `MTLCounterSet` crash on additional _Intel Iris Plus Graphics_ devices.

- Add `0x8a5a` and `0x8a5c` to list of Intel _Iris Plus Graphics_ device IDs requiring workaround.
-  Fixes #1761.