### PR TITLE
Fix mistaken YCBCR format support indication.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released TBD
 
 - Fix crash on descriptor update with out-of-bounds descriptor count data.
 - Work around `MTLCounterSet` crash on additional Intel Iris Plus Graphics devices.
+- Fix mistaken YCBCR format support indication.
 - Document new linkage model used by *Xcode 14* and later, and how to link **MoltenVK**
   to an app or game using *Xcode 13* or earlier.
 - Support *Xcode 14.1* build settings.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -154,7 +154,7 @@ typedef struct MVKVkFormatDesc {
     
     inline double bytesPerTexel() const { return (double)bytesPerBlock / (double)(blockTexelSize.width * blockTexelSize.height); };
 
-	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid || chromaSubsamplingPlaneCount > 0); };
+	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid || chromaSubsamplingPlaneCount > 1); };
 	inline bool isSupportedOrSubstitutable() const { return isSupported() || (mtlPixelFormatSubstitute != MTLPixelFormatInvalid); };
 
 	inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid); };


### PR DESCRIPTION
- `MVKVkFormatDesc::chromaSubsamplingPlaneCount` must be `> 1` to be considered supported.

- Fixes mistaken `VK_ERROR_FORMAT_NOT_SUPPORTED ` errors for some `YCBCR` formats found in issue #1760.

- Has the same `YCBCR` CTS test results as before this patch.

@Lichtso Please also review.