### PR TITLE
Fix crash when buffer binding updates only offset while it is overridden.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released 2022/12/08
 	- `VK_KHR_copy_commands2`
 - Fix crash on descriptor update with out-of-bounds descriptor count data.
 - Fix Metal buffer index binding overrides for push constants and attachment clearing.
+- Fix crash when buffer binding updates only offset while it is overridden.
 - Fix app performance regression triggered by the previous introduction of `VK_KHR_shader_float_controls`.
 - Work around `MTLCounterSet` crash on additional Intel Iris Plus Graphics devices.
 - Fix mistaken YCBCR format support indication.

--- a/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
@@ -86,7 +86,7 @@ typedef struct MVKMTLBufferBinding {
 			isDirty = true;
         } else if (offset != other.offset) {
             offset = other.offset;
-            justOffset = !isDirty || justOffset;
+            justOffset = !isOverridden && (!isDirty || justOffset);
 			isOverridden = false;
             isDirty = true;
         }


### PR DESCRIPTION
`MVKMTLBufferBinding` don't allow `justOffset` if binding was overridden.