### PR TITLE
Fix excessive Metal tile memory preallocation when rendering without attachments.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,15 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.2
+--------------
+
+Released TBD
+
+- Fix excessive Metal tile memory preallocation when rendering without attachments.
+
+
+
 MoltenVK 1.2.1
 --------------
 
@@ -51,6 +60,7 @@ Released 2022/12/08
   - MSL: Don't dereference forwarded copies of `OpVariable` pointers.
   - MSL: Refactor member reference in terms of one boolean.
   - Fix MSL Access Chain.
+
 
 
 MoltenVK 1.2.0

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -51,7 +51,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   1
+#define MVK_VERSION_PATCH   2
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)


### PR DESCRIPTION
Metal uses `MTLRenderPassDescriptor` properties `renderTargetWidth`, `renderTargetHeight`, and `renderTargetArrayLength` to preallocate tile memory storage on machines using tiled rendering. This memory preallocation is not necessary if we are not rendering to attachments, and some apps actively define extremely oversized framebuffers when they know they are not rendering to actual attachments, making this internal tile memory allocation even more wasteful, occasionally to the point of triggering OOM crashes.

Update MoltenVK version to 1.2.2.

- Fixes issue #1650.