### PR TITLE
WIP: Fix missing render area when rendering without attachments.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -213,7 +213,7 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 				}
                 // Running this stage prematurely ended the render pass, so we have to start it up again.
                 // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
                 break;
 			}
             case kMVKGraphicsStageRasterization:
@@ -416,7 +416,7 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 				}
                 // Running this stage prematurely ended the render pass, so we have to start it up again.
                 // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
                 break;
 			}
             case kMVKGraphicsStageRasterization:
@@ -686,7 +686,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                                       threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
                 }
                 // Switch back to rendering now, since we don't have compute stages to run anyway.
-                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
             cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
@@ -749,7 +749,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                     mtlIndBuffOfst += sizeof(MTLDispatchThreadgroupsIndirectArguments);
                     // Running this stage prematurely ended the render pass, so we have to start it up again.
                     // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                    cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                    cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {
@@ -1019,7 +1019,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 									  threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
 				}
 				// Switch back to rendering now, since we don't have compute stages to run anyway.
-                cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
 	        cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
@@ -1084,7 +1084,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                     mtlTempIndBuffOfst += sizeof(MTLDispatchThreadgroupsIndirectArguments);
                     // Running this stage prematurely ended the render pass, so we have to start it up again.
                     // TODO: On iOS, maybe we could use a tile shader to avoid this.
-                    cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+                    cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -129,7 +129,7 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		}
 		if (needsRenderpassRestart) {
 			cmdEncoder->encodeStoreActions(true);
-			cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
+			cmdEncoder->enqueueNextMetalRenderPass(kMVKCommandUseRestartSubpass);
 		}
 	}
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -263,7 +263,8 @@ public:
 						uint32_t attachmentCount,
 						const VkClearAttachment* pAttachments,
 						uint32_t rectCount,
-						const VkClearRect* pRects);
+						const VkClearRect* pRects,
+						bool isSubpassRenderAreaClear = false);
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
@@ -279,10 +280,11 @@ protected:
 
 	MVKSmallVector<VkClearRect, N> _clearRects;
     MVKRPSKeyClearAtt _rpsKey;
-	bool _isClearingDepth;
-	bool _isClearingStencil;
 	float _mtlDepthVal;
     uint32_t _mtlStencilValue;
+	bool _isClearingDepth;
+	bool _isClearingStencil;
+	bool _isSubpassRenderAreaClear;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -256,8 +256,14 @@ public:
 	/** Begins dynamic rendering. */
 	void beginRendering(MVKCommand* rendCmd, const VkRenderingInfo* pRenderingInfo);
 
-	/** Begins a Metal render pass for the current render subpass. */
-	void beginMetalRenderPass(MVKCommandUse cmdUse);
+	/** Enqueue the next Metal render pass for the current render subpass. */
+	void enqueueNextMetalRenderPass(MVKCommandUse cmdUse);
+
+	/**
+	 * If a Metal render encoder has been enqueued, ensure it has been created,
+	 * lazily doing so if necessary, and return the corresponding MTLRenderCommandEncoder.
+	 */
+	id<MTLRenderCommandEncoder> ensureMetalRenderPass();
 
 	/** If a render encoder is active, encodes store actions for all attachments to it. */
 	void encodeStoreActions(bool storeOverride = false);
@@ -485,6 +491,7 @@ protected:
 	void encodeTimestampStageCounterSamples();
 	id<MTLFence> getStageCountersMTLFence();
 	MVKArrayRef<MTLSamplePosition> getCustomSamplePositions();
+	void beginMetalRenderPass();
 	NSString* getMTLRenderCommandEncoderName(MVKCommandUse cmdUse);
 	template<typename T> void retainIfImmediatelyEncoding(T& mtlEnc);
 	template<typename T> void endMetalEncoding(T& mtlEnc);
@@ -516,6 +523,7 @@ protected:
 	uint32_t _renderSubpassIndex;
 	uint32_t _multiviewPassIndex;
     uint32_t _flushCount;
+	MVKCommandUse _mtlRenderEncoderUse;
 	MVKCommandUse _mtlComputeEncoderUse;
 	MVKCommandUse _mtlBlitEncoderUse;
 	bool _isRenderingEntireAttachment;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -147,6 +147,12 @@ public:
 					  uint32_t firstViewport,
 					  bool isSettingDynamically);
 
+	/** Returns whether at least one viewport has been set. */
+	bool hasViewport() { return !_viewports.empty() || !_dynamicViewports.empty(); }
+
+	/** Returns the smallest render area rect that contains all the viewports.*/
+	VkRect2D getUnionVkRect();
+
     /** Constructs this instance for the specified command encoder. */
     MVKViewportCommandEncoderState(MVKCommandEncoder* cmdEncoder)
         : MVKCommandEncoderState(cmdEncoder) {}
@@ -174,6 +180,12 @@ public:
 	void setScissors(const MVKArrayRef<VkRect2D> scissors,
 					 uint32_t firstScissor,
 					 bool isSettingDynamically);
+
+	/** Returns whether at least one scissor rectangle has been set. */
+	bool hasScissor() { return !_scissors.empty() || !_dynamicScissors.empty(); }
+
+	/** Returns the smallest render area rect that contains all the scissor rects.*/
+	VkRect2D getUnionVkRect();
 
     /** Constructs this instance for the specified command encoder. */
     MVKScissorCommandEncoderState(MVKCommandEncoder* cmdEncoder)

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -103,6 +103,19 @@ void MVKViewportCommandEncoderState::encodeImpl(uint32_t stage) {
     }
 }
 
+VkRect2D MVKViewportCommandEncoderState::getUnionVkRect() {
+	VkRect2D rslt = {};
+	auto& usingViewports = _viewports.size() > 0 ? _viewports : _dynamicViewports;
+	if ( !usingViewports.empty() ) {
+		rslt = mvkVkRectFromVkViewport(usingViewports[0]);
+		size_t vpCnt = usingViewports.size();
+		for (uint32_t vpIdx = 1; vpIdx < vpCnt; vpIdx++) {
+			rslt = mvkVkRect2DUnion(rslt, mvkVkRectFromVkViewport(usingViewports[vpIdx]));
+		}
+	}
+	return rslt;
+}
+
 
 #pragma mark -
 #pragma mark MVKScissorCommandEncoderState
@@ -154,6 +167,19 @@ void MVKScissorCommandEncoderState::encodeImpl(uint32_t stage) {
 	} else {
 		[_cmdEncoder->_mtlRenderEncoder setScissorRect: mvkMTLScissorRectFromVkRect2D(_cmdEncoder->clipToRenderArea(usingScissors[0]))];
 	}
+}
+
+VkRect2D MVKScissorCommandEncoderState::getUnionVkRect() {
+	VkRect2D rslt = {};
+	auto& usingScissors = _scissors.size() > 0 ? _scissors : _dynamicScissors;
+	if ( !usingScissors.empty() ) {
+		rslt = usingScissors[0];
+		size_t sCnt = usingScissors.size();
+		for (uint32_t sIdx = 1; sIdx < sCnt; sIdx++) {
+			rslt = mvkVkRect2DUnion(rslt, usingScissors[sIdx]);
+		}
+	}
+	return rslt;
 }
 
 

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -285,6 +285,53 @@ static inline VkOffset3D mvkVkOffset3DDifference(VkOffset3D minuend, VkOffset3D 
 	return rslt;
 }
 
+/** Returns a VkRect constructed from an offset and extent.*/
+static inline VkRect2D mvkMakeVkRect(VkOffset2D offset, VkExtent2D extent) {
+	return {offset, extent};
+}
+
+/** Returns a VkRect constructed from an offset and extent.*/
+static inline VkRect2D mvkMakeVkRect(int32_t x, int32_t y, uint32_t width, uint32_t height) {
+	return { {x, y}, {width, height} };
+}
+
+/** Returns a VkRect2D from the 2D part of a VkViewport.*/
+static inline VkRect2D mvkVkRectFromVkViewport(VkViewport vkViewport) {
+	return mvkMakeVkRect(vkViewport.x, vkViewport.y, vkViewport.width, vkViewport.height);
+}
+
+/** Returns a rect that defines the intersection of both rects.*/
+static inline VkRect2D mvkVkRect2DIntersection(VkRect2D r1, VkRect2D r2) {
+	int32_t leftEdge   = std::max(r1.offset.x, r2.offset.x);
+	int32_t bottomEdge = std::max(r1.offset.y, r2.offset.y);
+	int32_t rightEdge  = std::min(r1.offset.x + (int32_t)r1.extent.width, r2.offset.x + (int32_t)r2.extent.width);
+	int32_t topEdge    = std::min(r1.offset.y + (int32_t)r1.extent.height, r2.offset.y + (int32_t)r2.extent.height);
+
+	VkRect2D rslt = {};
+	if (rightEdge > leftEdge && topEdge > bottomEdge) {
+		rslt.offset.x = leftEdge;
+		rslt.offset.y = bottomEdge;
+		rslt.extent.width = rightEdge - leftEdge;
+		rslt.extent.height = topEdge - bottomEdge;
+	}
+	return rslt;
+}
+
+/** Returns the smallest rect that contains both rects.*/
+static inline VkRect2D mvkVkRect2DUnion(VkRect2D r1, VkRect2D r2) {
+	int32_t leftEdge   = std::min(r1.offset.x, r2.offset.x);
+	int32_t bottomEdge = std::min(r1.offset.y, r2.offset.y);
+	int32_t rightEdge  = std::max(r1.offset.x + (int32_t)r1.extent.width, r2.offset.x + (int32_t)r2.extent.width);
+	int32_t topEdge    = std::max(r1.offset.y + (int32_t)r1.extent.height, r2.offset.y + (int32_t)r2.extent.height);
+
+	VkRect2D rslt = {};
+	rslt.offset.x = leftEdge;
+	rslt.offset.y = bottomEdge;
+	rslt.extent.width = rightEdge - leftEdge;
+	rslt.extent.height = topEdge - bottomEdge;
+	return rslt;
+}
+
 /** Packs the four swizzle components into a single 32-bit word. */
 static inline uint32_t mvkPackSwizzle(VkComponentMapping components) {
 	return ((components.r & 0xFF) << 0) | ((components.g & 0xFF) << 8) |

--- a/MoltenVKPackaging.xcodeproj/project.pbxproj
+++ b/MoltenVKPackaging.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 		A90B2B1D1A9B6170008EE819 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1410;
 				TargetAttributes = {
 					A9FEADBC1F3517480010240E = {
 						DevelopmentTeam = VU3TCKU48B;


### PR DESCRIPTION
- Rewrite logic for setting `MTLRenderPassDescriptor` properties `renderTargetWidth`, `renderTargetHeight`, and `renderTargetArrayLength` to reduce render area to viewport area when rendering without attachments, and ensure that some kind of render area is always defined.
- Since viewport area is possibly not available until drawing, defer calling `MVKCommandEncoder::beginMetalRenderPass()` until the first `finalizeDrawState()` of the renderpass.
- Add `MVKCommandEncoder::enqueueNextMetalRenderPass()` to end current render encoding, but does not start a new render pass, and call it wherever `beginMetalRenderPass()` was being called.
- Add `MVKCommandEncoder::ensureMetalRenderPass()` to call `beginMetalRenderPass()` if it hasn't been invoked since `enqueueNextMetalRenderPass()` was last called.
- Add convenience functions `mvkMakeVkRect()`, `mvkVkRectFromVkViewport()`, `mvkVkRect2DIntersection()`, and `mvkVkRect2DUnion()`.
- Set label for render area clear different from clear attachments.
- Update MoltenVKPackaging.xcodeproj build settings to Xcode 14.1 (unrelated).

- Rewinds and replaces PR #1797.
- Fixes issue #1650.