### PR TITLE
Fix small memory issues with MVKPresentableSwapchainImage.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,18 @@ Copyright (c) 2015-2022 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.2
+--------------
+
+Released TBD
+
+- Fix Metal validation error caused by `CAMetalDrawable` released before 
+  `MTLCommandBuffer` is finished using it.
+- Fix memory leak of `MVKFences` and `MVKSemaphores` when 
+  a swapchain image is acquired more than it is presented.
+
+
+
 MoltenVK 1.2.1
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -51,7 +51,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   1
+#define MVK_VERSION_PATCH   2
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -473,6 +473,7 @@ protected:
 	void signalPresentationSemaphore(const MVKSwapchainSignaler& signaler, id<MTLCommandBuffer> mtlCmdBuff);
 	static void markAsTracked(const MVKSwapchainSignaler& signaler);
 	static void unmarkAsTracked(const MVKSwapchainSignaler& signaler);
+	void untrackAllSignalers();
 	void renderWatermark(id<MTLCommandBuffer> mtlCmdBuff);
 
 	id<CAMetalDrawable> _mtlDrawable;


### PR DESCRIPTION
- Fix Metal validation error caused by `CAMetalDrawable` released before `MTLCommandBuffer` is finished using it.
- When presenting, `MVKPresentableSwapchainImage` retains in-flight `CAMetalDrawable` until `MTLCommandBuffer` completion.

- Fix memory leak of `MVKFences` and `MVKSemaphores` when a swapchain image is acquired more than it is presented.
- Force `MVKPresentableSwapchainImage` to untrack any tracked fences or semaphores when it is destroyed.

- Update MoltenVK version to 1.2.2.