### PR TITLE
Allow M1 formats on non-arm64 driver builds

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -96,6 +96,10 @@ extern "C" {
 #	define MVK_XCODE_13 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || \
 									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 150000))	// Also covers tvOS
 #endif
+#ifndef MVK_XCODE_12_2
+#	define MVK_XCODE_12_2 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 110000) || \
+									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140200))	// Also covers tvOS
+#endif
 #ifndef MVK_XCODE_12
 #	define MVK_XCODE_12 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600) || \
 									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000))	// Also covers tvOS

--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -96,10 +96,6 @@ extern "C" {
 #	define MVK_XCODE_13 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || \
 									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 150000))	// Also covers tvOS
 #endif
-#ifndef MVK_XCODE_12_2
-#	define MVK_XCODE_12_2 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 110000) || \
-									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140200))	// Also covers tvOS
-#endif
 #ifndef MVK_XCODE_12
 #	define MVK_XCODE_12 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 101600) || \
 									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000))	// Also covers tvOS

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2789,7 +2789,7 @@ uint32_t MVKPhysicalDevice::getHighestGPUCapability() {
 #if (MVK_IOS || MVK_MACOS) && MVK_XCODE_12
 	if (supportsMTLGPUFamily(Apple7)) { gpuFam = MTLGPUFamilyApple7; }
 #endif
-#if MVK_IOS && MVK_XCODE_13
+#if (MVK_IOS || MVK_MACOS) && MVK_XCODE_13
 	if (supportsMTLGPUFamily(Apple8)) { gpuFam = MTLGPUFamilyApple8; }
 #endif
 
@@ -3205,7 +3205,7 @@ void MVKPhysicalDevice::logGPUInfo() {
 	logMsg += "\n\tsupports the following Metal Versions, GPU's and Feature Sets:";
 	logMsg += "\n\t\tMetal Shading Language %s";
 
-#if MVK_IOS && MVK_XCODE_13
+#if (MVK_IOS || MVK_MACOS) && MVK_XCODE_13
 	if (supportsMTLGPUFamily(Apple8)) { logMsg += "\n\t\tGPU Family Apple 8"; }
 #endif
 #if (MVK_IOS || MVK_MACOS) && MVK_XCODE_12
@@ -4752,8 +4752,8 @@ uint64_t mvkGetRegistryID(id<MTLDevice> mtlDevice) {
 bool mvkSupportsBCTextureCompression(id<MTLDevice> mtlDevice) {
 #if MVK_IOS || MVK_TVOS || MVK_MACCAT
 	return false;
-#endif
-#if MVK_MACOS && !MVK_MACCAT
+ #endif
+ #if MVK_MACOS && !MVK_MACCAT
 #if MVK_XCODE_12
 	if ([mtlDevice respondsToSelector: @selector(supportsBCTextureCompression)]) {
 		return mtlDevice.supportsBCTextureCompression;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2789,7 +2789,7 @@ uint32_t MVKPhysicalDevice::getHighestGPUCapability() {
 #if (MVK_IOS || MVK_MACOS) && MVK_XCODE_12
 	if (supportsMTLGPUFamily(Apple7)) { gpuFam = MTLGPUFamilyApple7; }
 #endif
-#if (MVK_IOS || MVK_MACOS) && MVK_XCODE_13
+#if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
 	if (supportsMTLGPUFamily(Apple8)) { gpuFam = MTLGPUFamilyApple8; }
 #endif
 
@@ -3205,7 +3205,7 @@ void MVKPhysicalDevice::logGPUInfo() {
 	logMsg += "\n\tsupports the following Metal Versions, GPU's and Feature Sets:";
 	logMsg += "\n\t\tMetal Shading Language %s";
 
-#if (MVK_IOS || MVK_MACOS) && MVK_XCODE_13
+#if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
 	if (supportsMTLGPUFamily(Apple8)) { logMsg += "\n\t\tGPU Family Apple 8"; }
 #endif
 #if (MVK_IOS || MVK_MACOS) && MVK_XCODE_12
@@ -4752,8 +4752,8 @@ uint64_t mvkGetRegistryID(id<MTLDevice> mtlDevice) {
 bool mvkSupportsBCTextureCompression(id<MTLDevice> mtlDevice) {
 #if MVK_IOS || MVK_TVOS || MVK_MACCAT
 	return false;
- #endif
- #if MVK_MACOS && !MVK_MACCAT
+#endif
+#if MVK_MACOS && !MVK_MACCAT
 #if MVK_XCODE_12
 	if ([mtlDevice respondsToSelector: @selector(supportsBCTextureCompression)]) {
 		return mtlDevice.supportsBCTextureCompression;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -28,7 +28,7 @@ using namespace std;
 
 // Add stub defs for unsupported MTLPixelFormats per platform
 #if MVK_MACOS
-#	if !MVK_XCODE_12_2 // macOS 11.0 / iOS 14.2
+#	if !MVK_XCODE_12 // macOS 11.0 / iOS 14.2
 #       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
 #       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
 #       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
@@ -1491,7 +1491,7 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 
 	addFeatSetMTLPixFmtCaps( macOS_GPUFamily1_v3, BGR10A2Unorm, RFCMRB );
 
-#if MVK_XCODE_12_2
+#if MVK_XCODE_12
 	if ([mtlDevice respondsToSelector: @selector(supports32BitMSAA)] &&
 		!mtlDevice.supports32BitMSAA) {
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -23,27 +23,43 @@
 
 using namespace std;
 
+// Some Metal formats are not supported by the headers on certain platforms. However, formats have
+// been 'unlocked' on some platforms with newer versions of Xcode.
 
 // Add stub defs for unsupported MTLPixelFormats per platform
 #if MVK_MACOS
-#   if !MVK_MACOS_APPLE_SILICON
+#	if !MVK_XCODE_12_2 // macOS 11.0 / iOS 14.2
+#       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
+#       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
 #       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
 #       define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
 #       define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
 #       define MTLPixelFormatBGR5A1Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
-#       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
 
-#       define MTLPixelFormatETC2_RGB8              MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8A1            MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8A1_sRGB       MTLPixelFormatInvalid
+#       define MTLPixelFormatBGR10_XR				MTLPixelFormatInvalid
+#       define MTLPixelFormatBGR10_XR_sRGB			MTLPixelFormatInvalid
+#       define MTLPixelFormatBGRA10_XR				MTLPixelFormatInvalid
+#       define MTLPixelFormatBGRA10_XR_sRGB			MTLPixelFormatInvalid
+
+#       define MTLPixelFormatPVRTC_RGB_2BPP         MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGB_2BPP_sRGB    MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGB_4BPP         MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGB_4BPP_sRGB    MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGBA_2BPP        MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGBA_2BPP_sRGB   MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGBA_4BPP        MTLPixelFormatInvalid
+#       define MTLPixelFormatPVRTC_RGBA_4BPP_sRGB   MTLPixelFormatInvalid
+
 #       define MTLPixelFormatEAC_RGBA8              MTLPixelFormatInvalid
 #       define MTLPixelFormatEAC_RGBA8_sRGB         MTLPixelFormatInvalid
 #       define MTLPixelFormatEAC_R11Unorm           MTLPixelFormatInvalid
 #       define MTLPixelFormatEAC_R11Snorm           MTLPixelFormatInvalid
 #       define MTLPixelFormatEAC_RG11Unorm          MTLPixelFormatInvalid
 #       define MTLPixelFormatEAC_RG11Snorm          MTLPixelFormatInvalid
+#       define MTLPixelFormatETC2_RGB8              MTLPixelFormatInvalid
+#       define MTLPixelFormatETC2_RGB8_sRGB         MTLPixelFormatInvalid
+#       define MTLPixelFormatETC2_RGB8A1            MTLPixelFormatInvalid
+#       define MTLPixelFormatETC2_RGB8A1_sRGB       MTLPixelFormatInvalid
 
 #       define MTLPixelFormatASTC_4x4_HDR           MTLPixelFormatInvalid
 #       define MTLPixelFormatASTC_4x4_LDR           MTLPixelFormatInvalid
@@ -87,20 +103,6 @@ using namespace std;
 #       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
 #       define MTLPixelFormatASTC_12x12_LDR         MTLPixelFormatInvalid
 #       define MTLPixelFormatASTC_12x12_sRGB        MTLPixelFormatInvalid
-
-#       define MTLPixelFormatPVRTC_RGB_2BPP         MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_2BPP_sRGB    MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_4BPP         MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_4BPP_sRGB    MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_2BPP        MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_2BPP_sRGB   MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_4BPP        MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_4BPP_sRGB   MTLPixelFormatInvalid
-
-#       define MTLPixelFormatBGRA10_XR				MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRA10_XR_sRGB			MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR10_XR				MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR10_XR_sRGB			MTLPixelFormatInvalid
 #   endif
 
 #   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth24Unorm_Stencil8
@@ -1489,7 +1491,7 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 
 	addFeatSetMTLPixFmtCaps( macOS_GPUFamily1_v3, BGR10A2Unorm, RFCMRB );
 
-#if MVK_MACOS_APPLE_SILICON
+#if MVK_XCODE_12_2
 	if ([mtlDevice respondsToSelector: @selector(supports32BitMSAA)] &&
 		!mtlDevice.supports32BitMSAA) {
 


### PR DESCRIPTION
Fixes #1814.

MoltenVK currently assumes that all the formats the M1 brings to the table (because it's based from the Apple A family which supported other formats than the macOS GPUs) are only available when building for arm64. However, the SDK is currently built as x86_64 and some games might ship with x86_64 binaries of MoltenVK. The aforementioned formats are actually still available on that architecture, and this PR changes the code to allow all the new formats on any architecture.

Also, side question, but is there any reason MoltenVK does not use things like std::array, as MoltenVK is set to use C++17 anyway? Is this because of debug performance?