### PR TITLE
Fix issue where VK_KHR_fragment_shader_barycentric incorrectly disabled

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,16 @@ Copyright (c) 2015-2023 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.3
+--------------
+
+Released TBA
+
+- Fix issue where extension `VK_KHR_fragment_shader_barycentric` 
+  was sometimes incorrectly disabled due to a Metal driver bug.
+
+
+
 MoltenVK 1.2.2
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -51,7 +51,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   2
+#define MVK_VERSION_PATCH   3
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1822,9 +1822,17 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 
 #if (MVK_MACOS && !MVK_MACCAT) || (MVK_MACCAT && MVK_XCODE_14) || (MVK_IOS && MVK_XCODE_12)
+	// Both current and deprecated properties are retrieved and OR'd together, due to a
+	// Metal bug that, in some environments, returned true for one and false for the other.
+	bool bcProp1 = false;
+	bool bcProp2 = false;
 	if ( [_mtlDevice respondsToSelector: @selector(supportsShaderBarycentricCoordinates)] ) {
-		_metalFeatures.shaderBarycentricCoordinates = _mtlDevice.supportsShaderBarycentricCoordinates;
+		bcProp1 = _mtlDevice.supportsShaderBarycentricCoordinates;
 	}
+	if ( [_mtlDevice respondsToSelector: @selector(areBarycentricCoordsSupported)] ) {
+		bcProp2 = _mtlDevice.areBarycentricCoordsSupported;
+	}
+	_metalFeatures.shaderBarycentricCoordinates = bcProp1 || bcProp2;
 #endif
 
     if ( [_mtlDevice respondsToSelector: @selector(maxBufferLength)] ) {


### PR DESCRIPTION
- Fix issue where extension `VK_KHR_fragment_shader_barycentric` was sometimes incorrectly disabled due to a Metal driver bug.

- Update MoltenVK version to 1.2.3.

Fixes issue #1831.