### PR TITLE
Fixes to dynamic rendering and occlusion queries.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,8 +21,13 @@ Released TBA
 - Add support for extensions:
 	- `VK_EXT_swapchain_maintenance1`
 	- `VK_EXT_surface_maintenance1`
-- Fix issue where extension `VK_KHR_fragment_shader_barycentric` 
-  was sometimes incorrectly disabled due to a Metal driver bug.
+- Fix crash when `VkCommandBufferInheritanceInfo::renderPass` is `VK_NULL_HANDLE` during dynamic rendering.
+- Do not clear attachments when dynamic rendering is resumed.
+- Allow ending dynamic rendering to trigger next multiview pass if needed.
+- Fix premature caching of occlusion query results during tessellation rendering.
+- `vkCmdCopyQueryPoolResults()`: Fix loss of queries when query count is not a multiple of GPU threadgroup execution width.
+- Disable occlusion recording while clearing attachments or render area.
+- Fix issue where extension `VK_KHR_fragment_shader_barycentric` was sometimes incorrectly disabled due to a Metal driver bug.
 - Detect when size of surface has changed under the covers.
 - Change rounding of surface size provided by Metal from truncation to rounding-with-half-to-even.
 - Queue submissions retain wait semaphores until `MTLCommandBuffer` finishes.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -299,12 +299,13 @@ typedef struct {
 	uint32_t maxActiveMetalCommandBuffersPerQueue;
 
 	/**
-	 * Metal allows only 8192 occlusion queries per MTLBuffer. If enabled, MoltenVK
-	 * allocates a MTLBuffer for each query pool, allowing each query pool to support
-	 * 8192 queries, which may slow performance or cause unexpected behaviour if the query
-	 * pool is not established prior to a Metal renderpass, or if the query pool is changed
-	 * within a renderpass. If disabled, one MTLBuffer will be shared by all query pools,
-	 * which improves performance, but limits the total device queries to 8192.
+	 * Depending on the GPU, Metal allows 8192 or 32768 occlusion queries per MTLBuffer.
+	 * If enabled, MoltenVK allocates a MTLBuffer for each query pool, allowing each query
+	 * pool to support that permitted number of queries. This may slow performance or cause
+	 * unexpected behaviour if the query pool is not established prior to a Metal renderpass,
+	 * or if the query pool is changed within a renderpass. If disabled, one MTLBuffer will
+	 * be shared by all query pools, which improves performance, but limits the total device
+	 * queries to the permitted number.
 	 *
 	 * The value of this parameter may be changed at any time during application runtime,
 	 * and the changed value will immediately effect subsequent MoltenVK behaviour.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -136,10 +136,7 @@ VkResult MVKCmdNextSubpass::setContent(MVKCommandBuffer* cmdBuff,
 }
 
 void MVKCmdNextSubpass::encode(MVKCommandEncoder* cmdEncoder) {
-	if (cmdEncoder->getMultiviewPassIndex() + 1 < cmdEncoder->getSubpass()->getMultiviewMetalPassCount())
-		cmdEncoder->beginNextMultiviewPass();
-	else
-		cmdEncoder->beginNextSubpass(this, _contents);
+	cmdEncoder->beginNextSubpass(this, _contents);
 }
 
 
@@ -156,10 +153,7 @@ VkResult MVKCmdEndRenderPass::setContent(MVKCommandBuffer* cmdBuff,
 }
 
 void MVKCmdEndRenderPass::encode(MVKCommandEncoder* cmdEncoder) {
-	if (cmdEncoder->getMultiviewPassIndex() + 1 < cmdEncoder->getSubpass()->getMultiviewMetalPassCount())
-		cmdEncoder->beginNextMultiviewPass();
-	else
-		cmdEncoder->endRenderpass();
+	cmdEncoder->endRenderpass();
 }
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -61,6 +61,8 @@ VkResult MVKCmdBeginRenderPassBase::setContent(MVKCommandBuffer* cmdBuff,
 		}
 	}
 
+	cmdBuff->_currentSubpassInfo.beginRenderpass(_renderPass);
+
 	return VK_SUCCESS;
 }
 
@@ -126,6 +128,8 @@ VkResult MVKCmdNextSubpass::setContent(MVKCommandBuffer* cmdBuff,
 									   VkSubpassContents contents) {
 	_contents = contents;
 
+	cmdBuff->_currentSubpassInfo.nextSubpass();
+
 	return VK_SUCCESS;
 }
 
@@ -144,12 +148,13 @@ void MVKCmdNextSubpass::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark MVKCmdEndRenderPass
 
 VkResult MVKCmdEndRenderPass::setContent(MVKCommandBuffer* cmdBuff) {
+	cmdBuff->_currentSubpassInfo = {};
 	return VK_SUCCESS;
 }
 
 VkResult MVKCmdEndRenderPass::setContent(MVKCommandBuffer* cmdBuff,
 										 const VkSubpassEndInfo* pEndSubpassInfo) {
-	return VK_SUCCESS;
+	return setContent(cmdBuff);
 }
 
 void MVKCmdEndRenderPass::encode(MVKCommandEncoder* cmdEncoder) {
@@ -178,6 +183,8 @@ VkResult MVKCmdBeginRendering<N>::setContent(MVKCommandBuffer* cmdBuff,
 		_renderingInfo.pStencilAttachment = &_stencilAttachment;
 	}
 
+	cmdBuff->_currentSubpassInfo.beginRendering(pRenderingInfo->viewMask);
+
 	return VK_SUCCESS;
 }
 
@@ -196,6 +203,7 @@ template class MVKCmdBeginRendering<8>;
 #pragma mark MVKCmdEndRendering
 
 VkResult MVKCmdEndRendering::setContent(MVKCommandBuffer* cmdBuff) {
+	cmdBuff->_currentSubpassInfo = {};
 	return VK_SUCCESS;
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -263,7 +263,8 @@ public:
 						uint32_t attachmentCount,
 						const VkClearAttachment* pAttachments,
 						uint32_t rectCount,
-						const VkClearRect* pRects);
+						const VkClearRect* pRects,
+						MVKCommandUse cmdUse = kMVKCommandUseClearAttachments);
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
@@ -276,13 +277,15 @@ protected:
 							  float attWidth, float attHeight);
 	virtual VkClearValue& getClearValue(uint32_t attIdx) = 0;
 	virtual void setClearValue(uint32_t attIdx, const VkClearValue& clearValue) = 0;
+	NSString* getMTLDebugGroupLabel();
 
 	MVKSmallVector<VkClearRect, N> _clearRects;
     MVKRPSKeyClearAtt _rpsKey;
+	float _mtlDepthVal;
+	uint32_t _mtlStencilValue;
+	MVKCommandUse _commandUse;
 	bool _isClearingDepth;
 	bool _isClearingStencil;
-	float _mtlDepthVal;
-    uint32_t _mtlStencilValue;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1254,8 +1254,10 @@ VkResult MVKCmdClearAttachments<N>::setContent(MVKCommandBuffer* cmdBuff,
 											   uint32_t attachmentCount,
 											   const VkClearAttachment* pAttachments,
 											   uint32_t rectCount,
-											   const VkClearRect* pRects) {
+											   const VkClearRect* pRects,
+											   MVKCommandUse cmdUse) {
 	_rpsKey.reset();
+	_commandUse = cmdUse;
 	_mtlDepthVal = 0.0;
     _mtlStencilValue = 0;
     _isClearingDepth = false;
@@ -1463,7 +1465,7 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     // Render the clear colors to the attachments
 	MVKCommandEncodingPool* cmdEncPool = cmdEncoder->getCommandEncodingPool();
     id<MTLRenderCommandEncoder> mtlRendEnc = cmdEncoder->_mtlRenderEncoder;
-    [mtlRendEnc pushDebugGroup: @"vkCmdClearAttachments"];
+    [mtlRendEnc pushDebugGroup: getMTLDebugGroupLabel()];
     [mtlRendEnc setRenderPipelineState: cmdEncPool->getCmdClearMTLRenderPipelineState(_rpsKey)];
     [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(isClearingDepth, isClearingStencil)];
     [mtlRendEnc setStencilReferenceValue: _mtlStencilValue];
@@ -1472,6 +1474,8 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     [mtlRendEnc setDepthBias: 0 slopeScale: 0 clamp: 0];
     [mtlRendEnc setViewport: {0, 0, (double) fbExtent.width, (double) fbExtent.height, 0.0, 1.0}];
     [mtlRendEnc setScissorRect: {0, 0, fbExtent.width, fbExtent.height}];
+	[mtlRendEnc setVisibilityResultMode: MTLVisibilityResultModeDisabled
+								 offset: cmdEncoder->_pEncodingContext->mtlVisibilityResultOffset];
 
     cmdEncoder->setVertexBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0, true);
     cmdEncoder->setFragmentBytes(mtlRendEnc, clearColors, sizeof(clearColors), 0, true);
@@ -1504,6 +1508,17 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     cmdEncoder->_depthBiasState.markDirty();
     cmdEncoder->_viewportState.markDirty();
     cmdEncoder->_scissorState.markDirty();
+}
+
+template <size_t N>
+NSString* MVKCmdClearAttachments<N>::getMTLDebugGroupLabel() {
+	switch (_commandUse) {
+		case kMVKCommandUseClearAttachments:    return @"vkCmdClearAttachments";
+		case kMVKCommandUseBeginRenderPass:     return @"Clear Render Area on Begin Renderpass";
+		case kMVKCommandUseBeginRendering:      return @"Clear Render Area on Begin Rendering";
+		case kMVKCommandUseNextSubpass:         return @"Clear Render Area on Next Subpass";
+		default:                                return @"Unknown Use Clear Attachments";
+	}
 }
 
 template class MVKCmdClearAttachments<1>;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -66,6 +66,24 @@ private:
 
 
 #pragma mark -
+#pragma mark MVKCurrentSubpassInfo
+
+/** Tracks current render subpass information. */
+typedef struct MVKCurrentSubpassInfo {
+	MVKRenderPass* renderpass;
+	uint32_t subpassIndex;
+	uint32_t subpassViewMask;
+
+	void beginRenderpass(MVKRenderPass* rp);
+	void nextSubpass();
+	void beginRendering(uint32_t viewMask);
+
+private:
+	void updateViewMask();
+} MVKCurrentSubpassInfo;
+
+
+#pragma mark -
 #pragma mark MVKCommandBuffer
 
 /** Represents a Vulkan command pool. */
@@ -112,6 +130,9 @@ public:
 	 * from the primary command buffer. If this is a primary command buffer, returns 1.
 	 */
 	uint32_t getViewCount() const;
+
+	/** Updated as renderpass commands are added. */
+	MVKCurrentSubpassInfo _currentSubpassInfo;
 
     /**
      * Metal requires that a visibility buffer is established when a render pass is created, 
@@ -176,7 +197,7 @@ protected:
 	MVKSmallVector<VkFormat, kMVKDefaultAttachmentCount> _colorAttachmentFormats;
 	MVKCommandPool* _commandPool;
 	VkCommandBufferInheritanceInfo _secondaryInheritanceInfo;
-	VkCommandBufferInheritanceRenderingInfo _secondaryInerhitanceRenderingInfo;
+	VkCommandBufferInheritanceRenderingInfo _secondaryInheritanceRenderingInfo;
 	id<MTLCommandBuffer> _prefilledMTLCmdBuffer = nil;
     MVKCommandEncodingContext* _immediateCmdEncodingContext = nullptr;
     MVKCommandEncoder* _immediateCmdEncoder = nullptr;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -64,8 +64,7 @@ public:
     /**
      * Called automatically when a Metal render pass begins. If the contents have been
      * modified from the default values, this instance is marked as dirty, so the contents
-     * will be encoded to Metal, otherwise it is marked as clean, so the contents will NOT
-     * be encoded. Default state can be left unencoded on a new Metal encoder.
+     * will be encoded to Metal. Default state can be left unencoded on a new Metal encoder.
      */
 	virtual void beginMetalRenderPass() { if (_isModified) { markDirty(); } }
 
@@ -75,8 +74,7 @@ public:
 	/**
 	 * Called automatically when a Metal compute pass begins. If the contents have been
 	 * modified from the default values, this instance is marked as dirty, so the contents
-	 * will be encoded to Metal, otherwise it is marked as clean, so the contents will NOT
-	 * be encoded. Default state can be left unencoded on a new Metal encoder.
+	 * will be encoded to Metal. Default state can be left unencoded on a new Metal encoder.
 	 */
 	virtual void beginMetalComputeEncoding() { if (_isModified) { markDirty(); } }
 
@@ -673,6 +671,7 @@ protected:
 
 	MVKSmallVector<OcclusionQueryLocation> _mtlRenderPassQueries;
     MTLVisibilityResultMode _mtlVisibilityResultMode = MTLVisibilityResultModeDisabled;
+	bool _hasRasterized = false;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -116,7 +116,7 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	id<MTLFunction> vtxFunc = newClearVertFunction(attKey);						// temp retain
 	id<MTLFunction> fragFunc = newClearFragFunction(attKey);					// temp retain
 	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// temp retain
-    plDesc.label = @"vkCmdClearAttachments";
+    plDesc.label = @"ClearRenderAttachments";
 	plDesc.vertexFunction = vtxFunc;
     plDesc.fragmentFunction = fragFunc;
 	plDesc.sampleCount = attKey.mtlSampleCount;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -161,6 +161,8 @@ void MVKQueryPool::encodeCopyResults(MVKCommandEncoder* cmdEncoder,
 									 VkDeviceSize stride,
 									 VkQueryResultFlags flags) {
 
+	if (queryCount == 0) { return; }
+
 	// If this asked for 64-bit results with no availability and packed stride, then we can do
 	// a straight copy. Otherwise, we need a shader.
 	if (mvkIsAnyFlagEnabled(flags, VK_QUERY_RESULT_64_BIT) &&
@@ -183,9 +185,16 @@ void MVKQueryPool::encodeCopyResults(MVKCommandEncoder* cmdEncoder,
 		_availabilityLock.lock();
 		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, _availability.data(), _availability.size() * sizeof(Status), 5);
 		_availabilityLock.unlock();
+
 		// Run one thread per query. Try to fill up a subgroup.
-		[mtlComputeCmdEnc dispatchThreadgroups: MTLSizeMake(max(queryCount / mtlCopyResultsState.threadExecutionWidth, NSUInteger(1)), 1, 1)
-						  threadsPerThreadgroup: MTLSizeMake(min(NSUInteger(queryCount), mtlCopyResultsState.threadExecutionWidth), 1, 1)];
+		NSUInteger threadCount = NSUInteger(queryCount);
+		NSUInteger threadExecutionWidth = mtlCopyResultsState.threadExecutionWidth;
+		NSUInteger tgWidth = min(threadCount, threadExecutionWidth);
+		NSUInteger tgCount = threadCount / threadExecutionWidth;
+		if(threadCount > (tgCount * threadExecutionWidth)) tgCount++;	// Round up
+
+		[mtlComputeCmdEnc dispatchThreadgroups: MTLSizeMake(tgCount, 1, 1)
+						 threadsPerThreadgroup: MTLSizeMake(tgWidth, 1, 1)];
 	}
 }
 
@@ -281,12 +290,9 @@ id<MTLComputeCommandEncoder> MVKOcclusionQueryPool::encodeComputeCopyResults(MVK
 }
 
 void MVKOcclusionQueryPool::beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) {
+	// In multiview passes, one query is used for each view.
+	NSUInteger queryCount = cmdBuffer->getViewCount();
     NSUInteger offset = getVisibilityResultOffset(query);
-    NSUInteger queryCount = 1;
-    if (cmdBuffer->getLastMultiviewSubpass()) {
-        // In multiview passes, one query is used for each view.
-        queryCount = cmdBuffer->getLastMultiviewSubpass()->getViewCount();
-    }
     NSUInteger maxOffset = getDevice()->_pMetalFeatures->maxQueryBufferSize - kMVKQuerySlotSizeInBytes * queryCount;
     if (offset > maxOffset) {
         cmdBuffer->setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkCmdBeginQuery(): The query offset value %lu is larger than the maximum offset value %lu available on this device.", offset, maxOffset));

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -84,8 +84,8 @@ public:
 	/** Returns whether or not this is a multiview subpass. */
 	bool isMultiview() const { return _pipelineRenderingCreateInfo.viewMask != 0; }
 
-	/** Returns the total number of views to be rendered. */
-	uint32_t getViewCount() const { return __builtin_popcount(_pipelineRenderingCreateInfo.viewMask); }
+	/** Returns the multiview view mask. */
+	uint32_t getViewMask() const { return _pipelineRenderingCreateInfo.viewMask; }
 
 	/** Returns the number of Metal render passes needed to render all views. */
 	uint32_t getMultiviewMetalPassCount() const;

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -118,7 +118,7 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig);
 #   define MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE    64
 #endif
 
-/** Support more than 8192 occlusion queries per buffer. Enabled by default. */
+/** Support more than 8192 or 32768 occlusion queries per device. Enabled by default. */
 #ifndef MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS
 #   define MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS    1
 #endif

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -71,6 +71,7 @@ typedef enum : uint8_t {
     kMVKCommandUseQueueWaitIdle,                /**< vkQueueWaitIdle. */
     kMVKCommandUseDeviceWaitIdle,               /**< vkDeviceWaitIdle. */
 	kMVKCommandUseInvalidateMappedMemoryRanges, /**< vkInvalidateMappedMemoryRanges. */
+	kMVKCommandUseBeginRendering,               /**< vkCmdBeginRendering. */
     kMVKCommandUseBeginRenderPass,              /**< vkCmdBeginRenderPass. */
     kMVKCommandUseNextSubpass,                  /**< vkCmdNextSubpass. */
 	kMVKCommandUseRestartSubpass,               /**< Restart a subpass because of explicit or implicit barrier. */
@@ -85,6 +86,7 @@ typedef enum : uint8_t {
     kMVKCommandUseCopyImageToBuffer,            /**< vkCmdCopyImageToBuffer. */
     kMVKCommandUseFillBuffer,                   /**< vkCmdFillBuffer. */
     kMVKCommandUseUpdateBuffer,                 /**< vkCmdUpdateBuffer. */
+	kMVKCommandUseClearAttachments,             /**< vkCmdClearAttachments. */
     kMVKCommandUseClearColorImage,              /**< vkCmdClearColorImage. */
     kMVKCommandUseClearDepthStencilImage,       /**< vkCmdClearDepthStencilImage. */
     kMVKCommandUseResetQueryPool,               /**< vkCmdResetQueryPool. */


### PR DESCRIPTION
This PR fixes some issues with dynamic rendering and occlusion queries, and modifies the some Metal debug labelling to make it easier to distinguish attachment clearing activities within a GPU capture.

- Fix crash when `VkCommandBufferInheritanceInfo::renderPass` is `VK_NULL_HANDLE`.
- Do not clear attachments when dynamic rendering is resumed.
- Allow ending dynamic rendering to trigger next multiview pass if needed.
- Move deciding to begin next multiview pass to `MVKCommandEncoder`.
- Fix premature caching of occlusion query results during tessellation rendering. Tessellation ends Metal renderpass for compute control and eval stages. Wait until end of Metal renderpass after rasterization stage.
- `vkCmdCopyQueryPoolResults()`: Fix loss of queries when query count is not a multiple of GPU threadgroup execution width.
- Disable occlusion recording while clearing attachments or render area.
- `MVKCmdClearAttachments` improve labelling of `MTLDebugGroup` to better distinguish clearing renderpass render area from `vkCmdClearAttachments()` in an Xcode GPU capture (unrelated but helpful during debugging).
- `MVKCmdClearAttachments` re-order member variables to optimize memory requirements (unrelated).
- `MVKCommandBuffer` remove unused renderpass tracking functions (unrelated).