### PR TITLE
Use a different visibility buffer for each MTLCommandBuffer in a queue submit.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -31,6 +31,7 @@ Released TBA
 - Detect when size of surface has changed under the covers.
 - Change rounding of surface size provided by Metal from truncation to rounding-with-half-to-even.
 - Queue submissions retain wait semaphores until `MTLCommandBuffer` finishes.
+- Use a different visibility buffer for each `MTLCommandBuffer` in a queue submit.
 - Work around problems with using explicit LoD with arrayed depth images on Apple Silicon.
 - Update `VK_MVK_MOLTENVK_SPEC_VERSION` to version `37`.
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -199,7 +199,10 @@ protected:
 #pragma mark -
 #pragma mark MVKQueueCommandBufferSubmission
 
-/** Submits the commands in a set of command buffers to the queue. */
+/**
+ * Submits an empty set of command buffers to the queue.
+ * Used for fence-only command submissions.
+ */
 class MVKQueueCommandBufferSubmission : public MVKQueueSubmission {
 
 public:
@@ -218,6 +221,7 @@ protected:
 	void finish() override;
 	virtual void submitCommandBuffers() {}
 
+	MVKCommandEncodingContext _encodingContext;
 	MVKSmallVector<std::pair<MVKSemaphore*, uint64_t>> _signalSemaphores;
 	MVKFence* _fence;
 	id<MTLCommandBuffer> _activeMTLCommandBuffer;


### PR DESCRIPTION
Fixes issue #1837.