### PR TITLE
Allow to disable Explicit LOD Workaround for Apple silicon.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1645,7 +1645,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			break;
 		case kAppleVendorId:
 			// TODO: Other GPUs?
-			_metalFeatures.needsSampleDrefLodArrayWorkaround = true;
+            MVK_SET_FROM_ENV_OR_BUILD_BOOL(_metalFeatures.needsSampleDrefLodArrayWorkaround, MVK_ENABLE_EXPLICIT_LOD_WORKAROUND);
 			// fallthrough
 		case kIntelVendorId:
 		case kNVVendorId:

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -294,3 +294,8 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig);
 #ifndef MVK_CONFIG_SHADER_COMPRESSION_ALGORITHM
 #  	define MVK_CONFIG_SHADER_COMPRESSION_ALGORITHM    MVK_CONFIG_COMPRESSION_ALGORITHM_NONE
 #endif
+
+/** Enables Explicit LOD workaround defaults to true. */
+#ifndef MVK_ENABLE_EXPLICIT_LOD_WORKAROUND
+#   define MVK_ENABLE_EXPLICIT_LOD_WORKAROUND    1
+#endif


### PR DESCRIPTION
This is related to issue #1838.
Since there's a fix being worked, and it could take some time, and probably not a priority for now, it'd be nice to give at least the possibility to disable the workaround via an ENV variable like it's done with other features in the codebase.
I was thinking something like MVK_CONFIG_ENABLE_EXPLICIT_LOD_WORKAROUND=0 to disable it and have it set to 1 by default so that it doesn't change anything compared to the current state of the codebase.