### PR TITLE
Several simple maintenance fixes.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,21 @@ Copyright (c) 2015-2023 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.4
+--------------
+
+Released TBD
+
+- Add support for extensions:
+	- `VK_KHR_map_memory2`
+- Fix memory leak when waiting on timeline semaphores.
+- Add `MVK_ENABLE_EXPLICIT_LOD_WORKAROUND` environment variable to selectively 
+  disable recent fixes to handling LOD for arrayed depth images in shaders, 
+  on Apple Silicon, when those fixes cause regression in rendering behavior.
+- For correctness, set `VkPhysicalDeviceLimits::lineWidthGranularity` to `1`.
+
+
+
 MoltenVK 1.2.3
 --------------
 

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -51,7 +51,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   3
+#define MVK_VERSION_PATCH   4
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2547,7 +2547,7 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.pointSizeGranularity = 1;
     _properties.limits.lineWidthRange[0] = 1;
     _properties.limits.lineWidthRange[1] = 1;
-    _properties.limits.lineWidthGranularity = 0;
+    _properties.limits.lineWidthGranularity = 1;
 
     _properties.limits.standardSampleLocations = VK_TRUE;
     _properties.limits.strictLines = _properties.vendorID == kIntelVendorId || _properties.vendorID == kNVVendorId;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
@@ -459,6 +459,8 @@ public:
 
 	MVKFenceSitter(bool waitAll) : _blocker(waitAll, 0) {}
 
+	~MVKFenceSitter() override { [_listener release]; }
+
 private:
 	friend class MVKFence;
 	friend class MVKTimelineSemaphoreMTLEvent;


### PR DESCRIPTION
- Fix memory leak when waiting on timeline semaphores.
- For correctness, set `VkPhysicalDeviceLimits::lineWidthGranularity` to `1`.
- Update MoltenVK to version 1.2.4.
- Update `Whats_New.md` document with recent changes.

Fixes issue  #1860.