### PR TITLE
Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
 - Support BC compression on iOS/tvOS where available (iOS/tvOS 16.4 and above and supported by the GPU).
 - Fix memory leak when waiting on timeline semaphores.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
+- Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.
 - Add `MVK_ENABLE_EXPLICIT_LOD_WORKAROUND` environment variable to selectively 
   disable recent fixes to handling LOD for arrayed depth images in shaders, 
   on Apple Silicon, when those fixes cause regression in rendering behavior.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -906,6 +906,8 @@ typedef struct {
 	 * memory. In such a case, this parameter can be used to compress the MSL source code that
 	 * is awaiting export as part of a pipeline cache.
 	 *
+	 * Pipeline cache compression is available for macOS 10.15 and above, and iOS/tvOS 13.0 and above.
+	 *
 	 * The value of this parameter can be changed at any time, and will affect the size of
 	 * the cached MSL from subsequent shader compilations.
 	 *

--- a/MoltenVK/MoltenVK/Utility/MVKCodec.mm
+++ b/MoltenVK/MoltenVK/Utility/MVKCodec.mm
@@ -148,7 +148,9 @@ static size_t mvkCompressDecompress(const uint8_t* srcBytes, size_t srcSize,
 									MVKConfigCompressionAlgorithm compAlgo,
 									bool isCompressing) {
 	size_t dstByteCount = 0;
-	if (compAlgo != MVK_CONFIG_COMPRESSION_ALGORITHM_NONE) {
+	bool compressionSupported = ([NSData instancesRespondToSelector: @selector(compressedDataUsingAlgorithm:error:)] &&
+								 [NSData instancesRespondToSelector: @selector(decompressedDataUsingAlgorithm:error:)]);
+	if (compressionSupported && compAlgo != MVK_CONFIG_COMPRESSION_ALGORITHM_NONE) {
 		@autoreleasepool {
 			NSDataCompressionAlgorithm sysCompAlgo = getSystemCompressionAlgo(compAlgo);
 			NSData* srcData = [NSData dataWithBytesNoCopy: (void*)srcBytes length: srcSize freeWhenDone: NO];


### PR DESCRIPTION
Fixes #1876 