### PR TITLE
Support separate depth and stencil attachments during dynamic rendering

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,6 +21,7 @@ Released TBD
 - Add support for extensions:
 	- `VK_KHR_map_memory2`
 - Support BC compression on iOS/tvOS where available (iOS/tvOS 16.4 and above and supported by the GPU).
+- Support separate depth and stencil attachments during dynamic rendering.
 - Fix memory leak when waiting on timeline semaphores.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
 - Add `MVK_ENABLE_EXPLICIT_LOD_WORKAROUND` environment variable to selectively 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.h
@@ -262,7 +262,7 @@ protected:
 
 // Concrete template class implementations.
 typedef MVKCmdSetViewport<1> MVKCmdSetViewport1;
-typedef MVKCmdSetViewport<kMVKCachedViewportScissorCount> MVKCmdSetViewportMulti;
+typedef MVKCmdSetViewport<kMVKMaxViewportScissorCount> MVKCmdSetViewportMulti;
 
 
 #pragma mark -
@@ -292,7 +292,7 @@ protected:
 
 // Concrete template class implementations.
 typedef MVKCmdSetScissor<1> MVKCmdSetScissor1;
-typedef MVKCmdSetScissor<kMVKCachedViewportScissorCount> MVKCmdSetScissorMulti;
+typedef MVKCmdSetScissor<kMVKMaxViewportScissorCount> MVKCmdSetScissorMulti;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRenderPass.mm
@@ -282,7 +282,7 @@ void MVKCmdSetViewport<N>::encode(MVKCommandEncoder* cmdEncoder) {
 }
 
 template class MVKCmdSetViewport<1>;
-template class MVKCmdSetViewport<kMVKCachedViewportScissorCount>;
+template class MVKCmdSetViewport<kMVKMaxViewportScissorCount>;
 
 
 #pragma mark -
@@ -309,7 +309,7 @@ void MVKCmdSetScissor<N>::encode(MVKCommandEncoder* cmdEncoder) {
 }
 
 template class MVKCmdSetScissor<1>;
-template class MVKCmdSetScissor<kMVKCachedViewportScissorCount>;
+template class MVKCmdSetScissor<kMVKMaxViewportScissorCount>;
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.h
@@ -284,8 +284,6 @@ protected:
 	float _mtlDepthVal;
 	uint32_t _mtlStencilValue;
 	MVKCommandUse _commandUse;
-	bool _isClearingDepth;
-	bool _isClearingStencil;
 };
 
 
@@ -326,7 +324,7 @@ protected:
 	VkClearValue& getClearValue(uint32_t attIdx) override { return _vkClearValues[attIdx]; }
 	void setClearValue(uint32_t attIdx, const VkClearValue& clearValue) override { _vkClearValues[attIdx] = clearValue; }
 
-	VkClearValue _vkClearValues[kMVKCachedColorAttachmentCount];
+	VkClearValue _vkClearValues[kMVKMaxColorAttachmentCount];
 };
 
 typedef MVKCmdClearMultiAttachments<1> MVKCmdClearMultiAttachments1;

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1446,15 +1446,17 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     // The depth value (including vertex position Z value) is held in the last index.
     clearColors[kMVKClearAttachmentDepthStencilIndex] = { _mtlDepthVal, _mtlDepthVal, _mtlDepthVal, _mtlDepthVal };
 
+	MTLPixelFormat mtlDSFmt = pixFmts->getMTLPixelFormat(subpass->isStencilAttachmentUsed()
+														 ? subpass->getStencilFormat()
+														 : subpass->getDepthFormat());
+	_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex] = mtlDSFmt;
+
+	// If neither the depth or stencil attachments are being cleared, nor being used, don't try to clear them.
 	bool isClearingDepth = _isClearingDepth && subpass->isDepthAttachmentUsed();
 	bool isClearingStencil = _isClearingStencil && subpass->isStencilAttachmentUsed();
-	if (isClearingDepth) {
-		_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex] = pixFmts->getMTLPixelFormat(subpass->getDepthFormat());
-	} else if (isClearingStencil) {
-		_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex] = pixFmts->getMTLPixelFormat(subpass->getStencilFormat());
-	} else {
-        _rpsKey.disableAttachment(kMVKClearAttachmentDepthStencilIndex);
-    }
+	if ( !isClearingDepth && !isClearingStencil ) {
+		_rpsKey.disableAttachment(kMVKClearAttachmentDepthStencilIndex);
+	}
 
 	if ( !_rpsKey.isAnyAttachmentEnabled() ) { return; }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1260,8 +1260,6 @@ VkResult MVKCmdClearAttachments<N>::setContent(MVKCommandBuffer* cmdBuff,
 	_commandUse = cmdUse;
 	_mtlDepthVal = 0.0;
     _mtlStencilValue = 0;
-    _isClearingDepth = false;
-    _isClearingStencil = false;
 	MVKPixelFormats* pixFmts = cmdBuff->getPixelFormats();
 
     // For each attachment to be cleared, mark it so in the render pipeline state
@@ -1279,14 +1277,12 @@ VkResult MVKCmdClearAttachments<N>::setContent(MVKCommandBuffer* cmdBuff,
         }
 
         if (mvkIsAnyFlagEnabled(clrAtt.aspectMask, VK_IMAGE_ASPECT_DEPTH_BIT)) {
-            _isClearingDepth = true;
-            _rpsKey.enableAttachment(kMVKClearAttachmentDepthStencilIndex);
+            _rpsKey.enableAttachment(kMVKClearAttachmentDepthIndex);
             _mtlDepthVal = pixFmts->getMTLClearDepthValue(clrAtt.clearValue);
         }
 
         if (mvkIsAnyFlagEnabled(clrAtt.aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT)) {
-            _isClearingStencil = true;
-            _rpsKey.enableAttachment(kMVKClearAttachmentDepthStencilIndex);
+            _rpsKey.enableAttachment(kMVKClearAttachmentStencilIndex);
             _mtlStencilValue = pixFmts->getMTLClearStencilValue(clrAtt.clearValue);
         }
     }
@@ -1443,20 +1439,14 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		clearColors[caIdx] = { (float)mtlCC.red, (float)mtlCC.green, (float)mtlCC.blue, (float)mtlCC.alpha};
     }
 
-    // The depth value (including vertex position Z value) is held in the last index.
-    clearColors[kMVKClearAttachmentDepthStencilIndex] = { _mtlDepthVal, _mtlDepthVal, _mtlDepthVal, _mtlDepthVal };
+    // The depth value is the vertex position Z value.
+    clearColors[kMVKClearAttachmentDepthIndex] = { _mtlDepthVal, _mtlDepthVal, _mtlDepthVal, _mtlDepthVal };
 
-	MTLPixelFormat mtlDSFmt = pixFmts->getMTLPixelFormat(subpass->isStencilAttachmentUsed()
-														 ? subpass->getStencilFormat()
-														 : subpass->getDepthFormat());
-	_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex] = mtlDSFmt;
+	_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthIndex] = pixFmts->getMTLPixelFormat(subpass->getDepthFormat());
+	if ( !subpass->isDepthAttachmentUsed() ) { _rpsKey.disableAttachment(kMVKClearAttachmentDepthIndex); }
 
-	// If neither the depth or stencil attachments are being cleared, nor being used, don't try to clear them.
-	bool isClearingDepth = _isClearingDepth && subpass->isDepthAttachmentUsed();
-	bool isClearingStencil = _isClearingStencil && subpass->isStencilAttachmentUsed();
-	if ( !isClearingDepth && !isClearingStencil ) {
-		_rpsKey.disableAttachment(kMVKClearAttachmentDepthStencilIndex);
-	}
+	_rpsKey.attachmentMTLPixelFormats[kMVKClearAttachmentStencilIndex] = pixFmts->getMTLPixelFormat(subpass->getStencilFormat());
+	if ( !subpass->isStencilAttachmentUsed() ) { _rpsKey.disableAttachment(kMVKClearAttachmentStencilIndex); }
 
 	if ( !_rpsKey.isAnyAttachmentEnabled() ) { return; }
 
@@ -1465,7 +1455,8 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
     id<MTLRenderCommandEncoder> mtlRendEnc = cmdEncoder->_mtlRenderEncoder;
     [mtlRendEnc pushDebugGroup: getMTLDebugGroupLabel()];
     [mtlRendEnc setRenderPipelineState: cmdEncPool->getCmdClearMTLRenderPipelineState(_rpsKey)];
-    [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(isClearingDepth, isClearingStencil)];
+    [mtlRendEnc setDepthStencilState: cmdEncPool->getMTLDepthStencilState(_rpsKey.isAttachmentUsed(kMVKClearAttachmentDepthIndex),
+																		  _rpsKey.isAttachmentUsed(kMVKClearAttachmentStencilIndex))];
     [mtlRendEnc setStencilReferenceValue: _mtlStencilValue];
     [mtlRendEnc setCullMode: MTLCullModeNone];
     [mtlRendEnc setTriangleFillMode: MTLTriangleFillModeFill];

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -401,10 +401,17 @@ void MVKCommandEncoder::beginRendering(MVKCommand* rendCmd, const VkRenderingInf
 								  ? VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS
 								  : VK_SUBPASS_CONTENTS_INLINE);
 
-	uint32_t maxAttCnt = (pRenderingInfo->colorAttachmentCount + 1) * 2;
-	MVKImageView* attachments[maxAttCnt];
+	uint32_t maxAttCnt = (pRenderingInfo->colorAttachmentCount + 2) * 2;
+	MVKImageView* imageViews[maxAttCnt];
 	VkClearValue clearValues[maxAttCnt];
-	uint32_t attCnt = mvkGetAttachments(pRenderingInfo, attachments, clearValues);
+
+	uint32_t attCnt = 0;
+	MVKRenderingAttachmentIterator attIter(pRenderingInfo);
+	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void {
+		imageViews[attCnt] = (MVKImageView*)(isResolveAttachment ? pAttInfo->resolveImageView : pAttInfo->imageView);
+		clearValues[attCnt] = pAttInfo->clearValue;
+		attCnt++;
+	});
 
 	// If we're resuming a suspended renderpass, continue to use the existing renderpass
 	// (with updated rendering flags) and framebuffer. Otherwise, create new transient
@@ -419,13 +426,14 @@ void MVKCommandEncoder::beginRendering(MVKCommand* rendCmd, const VkRenderingInf
 		mvkRP->setRenderingFlags(pRenderingInfo->flags);
 		mvkFB = _pEncodingContext->getFramebuffer();
 	} else {
-		mvkRP = mvkCreateRenderPass(getDevice(), pRenderingInfo);
-		mvkFB = mvkCreateFramebuffer(getDevice(), pRenderingInfo, mvkRP);
+		auto* mvkDev = getDevice();
+		mvkRP = mvkDev->createRenderPass(pRenderingInfo, nullptr);
+		mvkFB = mvkDev->createFramebuffer(pRenderingInfo, nullptr);
 	}
 	beginRenderpass(rendCmd, contents, mvkRP, mvkFB,
 					pRenderingInfo->renderArea,
 					MVKArrayRef(clearValues, attCnt),
-					MVKArrayRef(attachments, attCnt),
+					MVKArrayRef(imageViews, attCnt),
 					MVKArrayRef<MVKArrayRef<MTLSamplePosition>>(),
 					kMVKCommandUseBeginRendering);
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -152,7 +152,7 @@ public:
 protected:
     void encodeImpl(uint32_t stage) override;
 
-    MVKSmallVector<VkViewport, kMVKCachedViewportScissorCount> _viewports, _dynamicViewports;
+    MVKSmallVector<VkViewport, kMVKMaxViewportScissorCount> _viewports, _dynamicViewports;
 };
 
 
@@ -180,7 +180,7 @@ public:
 protected:
     void encodeImpl(uint32_t stage) override;
 
-    MVKSmallVector<VkRect2D, kMVKCachedViewportScissorCount> _scissors, _dynamicScissors;
+    MVKSmallVector<VkRect2D, kMVKMaxViewportScissorCount> _scissors, _dynamicScissors;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -328,15 +328,12 @@ void MVKDepthStencilCommandEncoderState::beginMetalRenderPass() {
     MVKCommandEncoderState::beginMetalRenderPass();
 
 	MVKRenderSubpass* mvkSubpass = _cmdEncoder->getSubpass();
-	MVKPixelFormats* pixFmts = _cmdEncoder->getPixelFormats();
-	MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(mvkSubpass->getDepthStencilFormat());
-
 	bool prevHasDepthAttachment = _hasDepthAttachment;
-	_hasDepthAttachment = pixFmts->isDepthFormat(mtlDSFormat);
+	_hasDepthAttachment = mvkSubpass->isDepthAttachmentUsed();
 	if (_hasDepthAttachment != prevHasDepthAttachment) { markDirty(); }
 
 	bool prevHasStencilAttachment = _hasStencilAttachment;
-	_hasStencilAttachment = pixFmts->isStencilFormat(mtlDSFormat);
+	_hasStencilAttachment = mvkSubpass->isStencilAttachmentUsed();
 	if (_hasStencilAttachment != prevHasStencilAttachment) { markDirty(); }
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -107,9 +107,11 @@ namespace std {
 #pragma mark -
 #pragma mark MVKRPSKeyClearAtt
 
-#define kMVKClearAttachmentCount						(kMVKCachedColorAttachmentCount + 1)
-#define kMVKClearAttachmentDepthStencilIndex			(kMVKClearAttachmentCount - 1)
-#define kMVKClearAttachmentLayeredRenderingBitIndex		kMVKClearAttachmentCount
+const static uint32_t kMVKClearColorAttachmentCount = kMVKMaxColorAttachmentCount;
+const static uint32_t kMVKClearAttachmentDepthIndex = kMVKClearColorAttachmentCount;
+const static uint32_t kMVKClearAttachmentStencilIndex = kMVKClearAttachmentDepthIndex + 1;
+const static uint32_t kMVKClearAttachmentCount = kMVKClearAttachmentStencilIndex + 1;
+const static uint32_t kMVKClearAttachmentLayeredRenderingBitIndex = kMVKClearAttachmentStencilIndex + 1;
 
 /**
  * Key to use for looking up cached MTLRenderPipelineState instances.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -113,6 +113,8 @@ id<MTLSamplerState> MVKCommandResourceFactory::newCmdBlitImageMTLSamplerState(MT
 
 id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipelineState(MVKRPSKeyClearAtt& attKey,
 																						MVKVulkanAPIDeviceObject* owner) {
+	MVKPixelFormats* pixFmts = getPixelFormats();
+
 	id<MTLFunction> vtxFunc = newClearVertFunction(attKey);						// temp retain
 	id<MTLFunction> fragFunc = newClearFragFunction(attKey);					// temp retain
 	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// temp retain
@@ -122,15 +124,17 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	plDesc.sampleCount = attKey.mtlSampleCount;
 	plDesc.inputPrimitiveTopologyMVK = MTLPrimitiveTopologyClassTriangle;
 
-    for (uint32_t caIdx = 0; caIdx < kMVKClearAttachmentDepthStencilIndex; caIdx++) {
+    for (uint32_t caIdx = 0; caIdx < kMVKClearColorAttachmentCount; caIdx++) {
         MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[caIdx];
         colorDesc.pixelFormat = (MTLPixelFormat)attKey.attachmentMTLPixelFormats[caIdx];
         colorDesc.writeMask = attKey.isAttachmentEnabled(caIdx) ? MTLColorWriteMaskAll : MTLColorWriteMaskNone;
     }
-	MVKPixelFormats* pixFmts = getPixelFormats();
-    MTLPixelFormat mtlDSFormat = (MTLPixelFormat)attKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthStencilIndex];
-    if (pixFmts->isDepthFormat(mtlDSFormat)) { plDesc.depthAttachmentPixelFormat = mtlDSFormat; }
-    if (pixFmts->isStencilFormat(mtlDSFormat)) { plDesc.stencilAttachmentPixelFormat = mtlDSFormat; }
+
+	MTLPixelFormat mtlDepthFormat = (MTLPixelFormat)attKey.attachmentMTLPixelFormats[kMVKClearAttachmentDepthIndex];
+    if (pixFmts->isDepthFormat(mtlDepthFormat)) { plDesc.depthAttachmentPixelFormat = mtlDepthFormat; }
+
+	MTLPixelFormat mtlStencilFormat = (MTLPixelFormat)attKey.attachmentMTLPixelFormats[kMVKClearAttachmentStencilIndex];
+	if (pixFmts->isStencilFormat(mtlStencilFormat)) { plDesc.stencilAttachmentPixelFormat = mtlStencilFormat; }
 
     MTLVertexDescriptor* vtxDesc = plDesc.vertexDescriptor;
 
@@ -273,7 +277,7 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		[msl appendLineMVK: @"    return out;"];
 		[msl appendLineMVK: @"}"];
 
-//		MVKLogDebug("\n%s", msl.UTF8String);
+//		MVKLogInfo("\n%s", msl.UTF8String);
 
 		return newMTLFunction(msl, funcName);
 	}
@@ -300,15 +304,16 @@ id<MTLFunction> MVKCommandResourceFactory::newClearVertFunction(MVKRPSKeyClearAt
 		[msl appendLineMVK];
 
 		NSString* funcName = @"vertClear";
-		[msl appendFormat: @"vertex VaryingsPos %@(AttributesPos attributes [[stage_in]], constant ClearColorsIn& ccIn [[buffer(0)]]) {", funcName];
+		[msl appendFormat:  @"vertex VaryingsPos %@(AttributesPos attributes [[stage_in]], constant ClearColorsIn& ccIn [[buffer(0)]]) {", funcName];
 		[msl appendLineMVK];
 		[msl appendLineMVK: @"    VaryingsPos varyings;"];
-		[msl appendLineMVK: @"    varyings.v_position = float4(attributes.a_position.x, -attributes.a_position.y, ccIn.colors[8].r, 1.0);"];
+		[msl appendFormat:  @"    varyings.v_position = float4(attributes.a_position.x, -attributes.a_position.y, ccIn.colors[%d].r, 1.0);", kMVKClearAttachmentDepthIndex];
+		[msl appendLineMVK];
 		[msl appendLineMVK: @"    varyings.layer = uint(attributes.a_position.w);"];
 		[msl appendLineMVK: @"    return varyings;"];
 		[msl appendLineMVK: @"}"];
 
-//		MVKLogDebug("\n%s", msl.UTF8String);
+//		MVKLogInfo("\n%s", msl.UTF8String);
 
 		return newMTLFunction(msl, funcName);
 	}
@@ -329,7 +334,7 @@ id<MTLFunction> MVKCommandResourceFactory::newClearFragFunction(MVKRPSKeyClearAt
 		[msl appendLineMVK: @"} ClearColorsIn;"];
 		[msl appendLineMVK];
 		[msl appendLineMVK: @"typedef struct {"];
-		for (uint32_t caIdx = 0; caIdx < kMVKClearAttachmentDepthStencilIndex; caIdx++) {
+		for (uint32_t caIdx = 0; caIdx < kMVKClearColorAttachmentCount; caIdx++) {
 			if (attKey.isAttachmentUsed(caIdx)) {
 				NSString* typeStr = getMTLFormatTypeString((MTLPixelFormat)attKey.attachmentMTLPixelFormats[caIdx]);
 				[msl appendFormat: @"    %@4 color%u [[color(%u)]];", typeStr, caIdx, caIdx];
@@ -343,7 +348,7 @@ id<MTLFunction> MVKCommandResourceFactory::newClearFragFunction(MVKRPSKeyClearAt
 		[msl appendFormat: @"fragment ClearColorsOut %@(VaryingsPos varyings [[stage_in]], constant ClearColorsIn& ccIn [[buffer(0)]]) {", funcName];
 		[msl appendLineMVK];
 		[msl appendLineMVK: @"    ClearColorsOut ccOut;"];
-		for (uint32_t caIdx = 0; caIdx < kMVKClearAttachmentDepthStencilIndex; caIdx++) {
+		for (uint32_t caIdx = 0; caIdx < kMVKClearColorAttachmentCount; caIdx++) {
 			if (attKey.isAttachmentUsed(caIdx)) {
 				NSString* typeStr = getMTLFormatTypeString((MTLPixelFormat)attKey.attachmentMTLPixelFormats[caIdx]);
 				[msl appendFormat: @"    ccOut.color%u = %@4(ccIn.colors[%u]);", caIdx, typeStr, caIdx];
@@ -353,7 +358,7 @@ id<MTLFunction> MVKCommandResourceFactory::newClearFragFunction(MVKRPSKeyClearAt
 		[msl appendLineMVK: @"    return ccOut;"];
 		[msl appendLineMVK: @"}"];
 
-//		MVKLogDebug("\n%s", msl.UTF8String);
+//		MVKLogInfo("\n%s", msl.UTF8String);
 
 		return newMTLFunction(msl, funcName);
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -631,12 +631,16 @@ public:
 
 	MVKFramebuffer* createFramebuffer(const VkFramebufferCreateInfo* pCreateInfo,
 									  const VkAllocationCallbacks* pAllocator);
+	MVKFramebuffer* createFramebuffer(const VkRenderingInfo* pRenderingInfo,
+									  const VkAllocationCallbacks* pAllocator);
 	void destroyFramebuffer(MVKFramebuffer* mvkFB,
 							const VkAllocationCallbacks* pAllocator);
 
 	MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo* pCreateInfo,
 									const VkAllocationCallbacks* pAllocator);
 	MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
+									const VkAllocationCallbacks* pAllocator);
+	MVKRenderPass* createRenderPass(const VkRenderingInfo* pRenderingInfo,
 									const VkAllocationCallbacks* pAllocator);
 	void destroyRenderPass(MVKRenderPass* mvkRP,
 						   const VkAllocationCallbacks* pAllocator);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -80,8 +80,8 @@ const static uint32_t kMVKQueueFamilyCount = 4;
 const static uint32_t kMVKQueueCountPerQueueFamily = 1;		// Must be 1. See comments in MVKPhysicalDevice::getQueueFamilies()
 const static uint32_t kMVKMinSwapchainImageCount = 2;
 const static uint32_t kMVKMaxSwapchainImageCount = 3;
-const static uint32_t kMVKCachedViewportScissorCount = 16;
-const static uint32_t kMVKCachedColorAttachmentCount = 8;
+const static uint32_t kMVKMaxColorAttachmentCount = 8;
+const static uint32_t kMVKMaxViewportScissorCount = 16;
 const static uint32_t kMVKMaxDescriptorSetCount = SPIRV_CROSS_NAMESPACE::kMaxArgumentBuffers;
 
 #if !MVK_XCODE_12

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2269,17 +2269,17 @@ void MVKPhysicalDevice::initFeatures() {
 void MVKPhysicalDevice::initLimits() {
 
 #if MVK_TVOS
-    _properties.limits.maxColorAttachments = kMVKCachedColorAttachmentCount;
+    _properties.limits.maxColorAttachments = kMVKMaxColorAttachmentCount;
 #endif
 #if MVK_IOS
     if (supportsMTLFeatureSet(iOS_GPUFamily2_v1)) {
-        _properties.limits.maxColorAttachments = kMVKCachedColorAttachmentCount;
+        _properties.limits.maxColorAttachments = kMVKMaxColorAttachmentCount;
     } else {
-        _properties.limits.maxColorAttachments = 4;		// < kMVKCachedColorAttachmentCount
+        _properties.limits.maxColorAttachments = 4;		// < kMVKMaxColorAttachmentCount
     }
 #endif
 #if MVK_MACOS
-    _properties.limits.maxColorAttachments = kMVKCachedColorAttachmentCount;
+    _properties.limits.maxColorAttachments = kMVKMaxColorAttachmentCount;
 #endif
 
     _properties.limits.maxFragmentOutputAttachments = _properties.limits.maxColorAttachments;
@@ -2309,7 +2309,7 @@ void MVKPhysicalDevice::initLimits() {
     float maxVPDim = max(_properties.limits.maxViewportDimensions[0], _properties.limits.maxViewportDimensions[1]);
     _properties.limits.viewportBoundsRange[0] = (-2.0 * maxVPDim);
     _properties.limits.viewportBoundsRange[1] = (2.0 * maxVPDim) - 1;
-    _properties.limits.maxViewports = _features.multiViewport ? kMVKCachedViewportScissorCount : 1;
+    _properties.limits.maxViewports = _features.multiViewport ? kMVKMaxViewportScissorCount : 1;
 
 	_properties.limits.maxImageDimension3D = _metalFeatures.maxTextureLayers;
 	_properties.limits.maxImageArrayLayers = _metalFeatures.maxTextureLayers;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3893,6 +3893,11 @@ MVKFramebuffer* MVKDevice::createFramebuffer(const VkFramebufferCreateInfo* pCre
 	return new MVKFramebuffer(this, pCreateInfo);
 }
 
+MVKFramebuffer* MVKDevice::createFramebuffer(const VkRenderingInfo* pRenderingInfo,
+											 const VkAllocationCallbacks* pAllocator) {
+	return new MVKFramebuffer(this, pRenderingInfo);
+}
+
 void MVKDevice::destroyFramebuffer(MVKFramebuffer* mvkFB,
 								   const VkAllocationCallbacks* pAllocator) {
 	if (mvkFB) { mvkFB->destroy(); }
@@ -3906,6 +3911,11 @@ MVKRenderPass* MVKDevice::createRenderPass(const VkRenderPassCreateInfo* pCreate
 MVKRenderPass* MVKDevice::createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
 										   const VkAllocationCallbacks* pAllocator) {
 	return new MVKRenderPass(this, pCreateInfo);
+}
+
+MVKRenderPass* MVKDevice::createRenderPass(const VkRenderingInfo* pRenderingInfo,
+										   const VkAllocationCallbacks* pAllocator) {
+	return new MVKRenderPass(this, pRenderingInfo);
 }
 
 void MVKDevice::destroyRenderPass(MVKRenderPass* mvkRP,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
@@ -58,6 +58,8 @@ public:
 
 	MVKFramebuffer(MVKDevice* device, const VkFramebufferCreateInfo* pCreateInfo);
 
+	MVKFramebuffer(MVKDevice* device, const VkRenderingInfo* pRenderingInfo);
+
 	~MVKFramebuffer() override;
 
 protected:
@@ -69,12 +71,3 @@ protected:
 	VkExtent2D _extent;
 	uint32_t _layerCount;
 };
-
-
-#pragma mark -
-#pragma mark Support functions
-
-/** Returns an image-less MVKFramebuffer object created from the rendering info. */
-MVKFramebuffer* mvkCreateFramebuffer(MVKDevice* device,
-									 const VkRenderingInfo* pRenderingInfo,
-									 MVKRenderPass* mvkRenderPass);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -560,6 +560,9 @@ public:
 	/**  Returns the 3D extent of this image at the specified mipmap level. */
 	VkExtent3D getExtent3D(uint8_t planeIndex = 0, uint32_t mipLevel = 0) { return _image->getExtent3D(planeIndex, mipLevel); }
 
+	/** Return the underlying image. */
+	MVKImage* getImage() { return _image; }
+
 #pragma mark Metal
 
 	/** Returns the Metal texture underlying this image view.  */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -346,11 +346,6 @@ protected:
 	void markIfUsingPhysicalStorageBufferAddressesCapability(SPIRVToMSLConversionResultInfo& resultsInfo,
 															 MVKShaderStage stage);
 
-	const VkPipelineShaderStageCreateInfo* _pVertexSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* _pTessCtlSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* _pTessEvalSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* _pFragmentSS = nullptr;
-
 	VkPipelineTessellationStateCreateInfo _tessInfo;
 	VkPipelineRasterizationStateCreateInfo _rasterInfo;
 	VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
@@ -364,7 +359,12 @@ protected:
 	MVKSmallVector<MVKStagedMTLArgumentEncoders> _mtlArgumentEncoders;
 	MVKSmallVector<MVKStagedDescriptorBindingUse> _descriptorBindingUse;
 	MVKSmallVector<MVKShaderStage> _stagesUsingPhysicalStorageBufferAddressesCapability;
+	std::unordered_map<uint32_t, id<MTLRenderPipelineState>> _multiviewMTLPipelineStates;
 
+	const VkPipelineShaderStageCreateInfo* _pVertexSS = nullptr;
+	const VkPipelineShaderStageCreateInfo* _pTessCtlSS = nullptr;
+	const VkPipelineShaderStageCreateInfo* _pTessEvalSS = nullptr;
+	const VkPipelineShaderStageCreateInfo* _pFragmentSS = nullptr;
 	MTLComputePipelineDescriptor* _mtlTessVertexStageDesc = nil;
 	id<MTLFunction> _mtlTessVertexFunctions[3] = {nil, nil, nil};
 
@@ -373,18 +373,17 @@ protected:
 	id<MTLComputePipelineState> _mtlTessVertexStageIndex32State = nil;
 	id<MTLComputePipelineState> _mtlTessControlStageState = nil;
 	id<MTLRenderPipelineState> _mtlPipelineState = nil;
-	std::unordered_map<uint32_t, id<MTLRenderPipelineState>> _multiviewMTLPipelineStates;
+
+    float _blendConstants[4] = { 0.0, 0.0, 0.0, 1.0 };
 	MTLCullMode _mtlCullMode;
 	MTLWinding _mtlFrontWinding;
 	MTLTriangleFillMode _mtlFillMode;
 	MTLDepthClipMode _mtlDepthClipMode;
 	MTLPrimitiveType _mtlPrimitiveType;
-
-    float _blendConstants[4] = { 0.0, 0.0, 0.0, 1.0 };
-    uint32_t _outputControlPointCount;
 	MVKShaderImplicitRezBinding _reservedVertexAttributeBufferCount;
 	MVKShaderImplicitRezBinding _viewRangeBufferIndex;
 	MVKShaderImplicitRezBinding _outputBufferIndex;
+	uint32_t _outputControlPointCount;
 	uint32_t _tessCtlPatchOutputBufferIndex = 0;
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
@@ -408,7 +407,6 @@ protected:
 	bool _needsFragmentViewRangeBuffer = false;
 	bool _isRasterizing = false;
 	bool _isRasterizingColor = false;
-	bool _isRasterizingDepthStencil = false;
 	bool _isUsingCustomSamplePositions = false;
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -350,8 +350,8 @@ protected:
 	VkPipelineRasterizationStateCreateInfo _rasterInfo;
 	VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
 
-	MVKSmallVector<VkViewport, kMVKCachedViewportScissorCount> _viewports;
-	MVKSmallVector<VkRect2D, kMVKCachedViewportScissorCount> _scissors;
+	MVKSmallVector<VkViewport, kMVKMaxViewportScissorCount> _viewports;
+	MVKSmallVector<VkRect2D, kMVKMaxViewportScissorCount> _scissors;
 	MVKSmallVector<VkDynamicState> _dynamicState;
 	MVKSmallVector<MTLSamplePosition> _customSamplePositions;
 	MVKSmallVector<MVKTranslatedVertexBinding> _translatedVertexBindings;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -340,14 +340,17 @@ public:
 	/** Iterates the attachments with the specified lambda function. */
 	void iterate(MVKRenderingAttachmentInfoOperation attOperation);
 
-	MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo) : _pRenderingInfo(pRenderingInfo) {}
+	MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo);
 
 protected:
 	void handleAttachment(const VkRenderingAttachmentInfo* pAttInfo,
 						  VkImageAspectFlagBits aspect,
 						  MVKRenderingAttachmentInfoOperation attOperation);
+	const VkRenderingAttachmentInfo* getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
+													   const VkRenderingAttachmentInfo* pAltAtt,
+													   bool isStencil);
 
-	const VkRenderingInfo* _pRenderingInfo;
+	VkRenderingInfo _renderingInfo;
 };
 
 

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -70,7 +70,7 @@ MVK_EXTENSION(KHR_image_format_list,               KHR_IMAGE_FORMAT_LIST,       
 MVK_EXTENSION(KHR_maintenance1,                    KHR_MAINTENANCE1,                     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_maintenance2,                    KHR_MAINTENANCE2,                     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_maintenance3,                    KHR_MAINTENANCE3,                     DEVICE,   10.11,  8.0)
-MVK_EXTENSION(KHR_map_memory2,                     KHR_MAP_MEMORY_2,                        DEVICE,   10.11,  8.0)
+MVK_EXTENSION(KHR_map_memory2,                     KHR_MAP_MEMORY_2,                     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_multiview,                       KHR_MULTIVIEW,                        DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_portability_subset,              KHR_PORTABILITY_SUBSET,               DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_push_descriptor,                 KHR_PUSH_DESCRIPTOR,                  DEVICE,   10.11,  8.0)


### PR DESCRIPTION
With the introduction of `VK_KHR_dynamic_rendering`, Vulkan permitted separate depth and stencil attachments, which Metal always supported, although in Vulkan, the two attachments are, for the time being, restricted to the same pixel format and image view.

This PR implements depth and stencil attachments as separate attachments, and fixes attachment Metal validation errors in the process. This PR is more than strictly necessary to fix the reported Metal validation issues, but better aligns MoltenVK with Metal depth and stencil handling, and is positioned for a potential future enhancement to Vulkan, where separate depth and stencil formats might be supported in the future.

- `MVKRenderSubpass` add separate `getDepthFormat()` & `getStencilFormat()`, and `isDepthAttachmentUsed()` & `isStencilAttachmentUsed()` and use instead of testing pixel format for depth and stencil components.
- Add `MVKRenderingAttachmentIterator` class to consistently iterate, and take actions, on the attachments in VkRenderingInfo to create synthetic `MVKRenderPass` and extract image views and clear colors.
- Remove `mvkCreateRenderPass()` and `mvkCreateFramebuffer()` in favor of additional constructors, and remove `mvkGetDepthStencilFormat()` in favor of retrieving formats for separate depth and stencil attachments.
- `MVKRenderpass` constructors reorganize order of adding attachments and subpasses, and connecting the two.
- Renmame `MVKRenderPassAttachment` to `MVKAttachmentDescription`.
- `MVKPipeline` reorganize member variables to minimize gaps in content and remove unnecessary `_isRasterizingDepthStencil` member var (unrelated).
- Fix Metal validation errors with dynamic rendering.
- `MVKPipeline` validate depth & stencil formats before setting frag shader depth and stencil builtins, and before setting formats in `MTLRenderPipelineDescriptor`.
- `MVKCmdClearAttachments` always set depth/stencil format if subpass includes a depth or stencil attachment, even if they are not being cleared.
- `MVKRenderingAttachmentIterator` add synthetic attachment if depth or stencil attachment is not provided, but image format of underlying `MVKImage` supports both depth and stencil.

This PR fixes issue #1579.
