### PR TITLE
Remove vkGetMoltenVKConfiguration2MVK() and vkSetMoltenVKConfiguration2MVK()

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,8 +23,6 @@ Released TBD
 - Support BC compression on iOS/tvOS where available (iOS/tvOS 16.4 and above and supported by the GPU).
 - Support separate depth and stencil attachments during dynamic rendering.
 - Deprecate the obsolete and non-standard `VK_MVK_moltenvk` extension.
-- Add `vkGetMoltenVKConfiguration2MVK()` and `vkGetMoltenVKConfiguration2MVK()` to clarify 
-  MoltenVK config does not require any Vulkan objects.
 - Fix memory leak when waiting on timeline semaphores.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
 - Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.

--- a/MoltenVK/MoltenVK/API/mvk_config.h
+++ b/MoltenVK/MoltenVK/API/mvk_config.h
@@ -920,8 +920,8 @@ typedef struct {
 #pragma mark -
 #pragma mark Function types
 
-	typedef VkResult (VKAPI_PTR *PFN_vkGetMoltenVKConfiguration2MVK)(MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
-	typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfiguration2MVK)(const MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
+	typedef VkResult (VKAPI_PTR *PFN_vkGetMoltenVKConfigurationMVK)(VkInstance ignored, MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
+	typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkInstance ignored, const MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
 
 
 #pragma mark -
@@ -935,6 +935,10 @@ typedef struct {
  * To change a specific configuration value, call vkGetMoltenVKConfigurationMVK() to retrieve
  * the current configuration, make changes, and call  vkSetMoltenVKConfigurationMVK() to
  * update all of the values.
+ *
+ * The VkInstance object you provide here is ignored, and a VK_NULL_HANDLE value can be provided.
+ * This function can be called before the VkInstance has been created. It is safe to call this function
+ * with a VkInstance retrieved from a different layer in the Vulkan SDK Loader and Layers framework.
  *
  * To be active, some configuration settings must be set before a VkInstance or VkDevice
  * is created. See the description of the MVKConfiguration members for more information.
@@ -958,7 +962,8 @@ typedef struct {
  * to NULL. In that case, this function will set *pConfigurationSize to the size that MoltenVK
  * expects MVKConfiguration to be.
  */
-VKAPI_ATTR VkResult VKAPI_CALL vkGetMoltenVKConfiguration2MVK(
+VKAPI_ATTR VkResult VKAPI_CALL vkGetMoltenVKConfigurationMVK(
+	VkInstance                                  ignored,
 	MVKConfiguration*                           pConfiguration,
 	size_t*                                     pConfigurationSize);
 
@@ -968,6 +973,10 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetMoltenVKConfiguration2MVK(
  * To change a specific configuration value, call vkGetMoltenVKConfigurationMVK()
  * to retrieve the current configuration, make changes, and call
  * vkSetMoltenVKConfigurationMVK() to update all of the values.
+ *
+ * The VkInstance object you provide here is ignored, and a VK_NULL_HANDLE value can be provided.
+ * This function can be called before the VkInstance has been created. It is safe to call this function
+ * with a VkInstance retrieved from a different layer in the Vulkan SDK Loader and Layers framework.
  *
  * To be active, some configuration settings must be set before a VkInstance or VkDevice
  * is created. See the description of the MVKConfiguration members for more information.
@@ -991,7 +1000,8 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetMoltenVKConfiguration2MVK(
  * to NULL. In that case, this function will set *pConfigurationSize to the size that MoltenVK
  * expects MVKConfiguration to be.
  */
-VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKConfiguration2MVK(
+VKAPI_ATTR VkResult VKAPI_CALL vkSetMoltenVKConfigurationMVK(
+	VkInstance                                  ignored,
 	const MVKConfiguration*                     pConfiguration,
 	size_t*                                     pConfigurationSize);
 

--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -49,8 +49,6 @@ extern "C" {
 #pragma mark -
 #pragma mark Function types
 
-typedef VkResult (VKAPI_PTR *PFN_vkGetMoltenVKConfigurationMVK)(VkInstance ignored, MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
-typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkInstance ignored, const MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
 typedef void (VKAPI_PTR *PFN_vkGetVersionStringsMVK)(char* pMoltenVersionStringBuffer, uint32_t moltenVersionStringBufferLength, char* pVulkanVersionStringBuffer, uint32_t vulkanVersionStringBufferLength);
 typedef void (VKAPI_PTR *PFN_vkSetWorkgroupSizeMVK)(VkShaderModule shaderModule, uint32_t x, uint32_t y, uint32_t z);
 typedef VkResult (VKAPI_PTR *PFN_vkUseIOSurfaceMVK)(VkImage image, IOSurfaceRef ioSurface);
@@ -73,20 +71,6 @@ typedef void (VKAPI_PTR *PFN_vkGetMTLCommandQueueMVK)(VkQueue queue, id<MTLComma
 #define MVK_DEPRECATED   VKAPI_ATTR [[deprecated]]
 #define MVK_DEPRECATED_USE_MTL_OBJS   VKAPI_ATTR [[deprecated("Use the VK_EXT_metal_objects extension instead.")]]
 
-
-/** DEPRECATED. Identical functionality to vkGetMoltenVKConfiguration2MVK(). */
-VKAPI_ATTR [[deprecated("Use vkGetMoltenVKConfiguration2MVK() instead.")]]
-VkResult VKAPI_CALL vkGetMoltenVKConfigurationMVK(
-	VkInstance                                  ignored,
-	MVKConfiguration*                           pConfiguration,
-	size_t*                                     pConfigurationSize);
-
-/** DEPRECATED. Identical functionality to vkSetMoltenVKConfiguration2MVK(). */
-VKAPI_ATTR [[deprecated("Use vkSetMoltenVKConfiguration2MVK() instead.")]]
-VkResult VKAPI_CALL vkSetMoltenVKConfigurationMVK(
-	VkInstance                                  ignored,
-	const MVKConfiguration*                     pConfiguration,
-	size_t*                                     pConfigurationSize);
 
 /**
  * DEPRECATED.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -507,16 +507,14 @@ void MVKInstance::initProcAddrs() {
 #endif
 
 	// MoltenVK-specific instannce functions, not tied to a Vulkan API version or an extension.
-	ADD_INST_OPEN_ENTRY_POINT(vkGetMoltenVKConfiguration2MVK);
-	ADD_INST_OPEN_ENTRY_POINT(vkSetMoltenVKConfiguration2MVK);
+	ADD_INST_OPEN_ENTRY_POINT(vkGetMoltenVKConfigurationMVK);
+	ADD_INST_OPEN_ENTRY_POINT(vkSetMoltenVKConfigurationMVK);
 	ADD_INST_OPEN_ENTRY_POINT(vkGetPhysicalDeviceMetalFeaturesMVK);
 	ADD_INST_OPEN_ENTRY_POINT(vkGetPerformanceStatisticsMVK);
 
 	// For deprecated MoltenVK-specific functions, suppress compiler deprecation warning.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	ADD_INST_EXT_ENTRY_POINT(vkGetMoltenVKConfigurationMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkSetMoltenVKConfigurationMVK, MVK_MOLTENVK);
 	ADD_INST_EXT_ENTRY_POINT(vkGetVersionStringsMVK, MVK_MOLTENVK);
 	ADD_INST_EXT_ENTRY_POINT(vkGetMTLDeviceMVK, MVK_MOLTENVK);
 	ADD_INST_EXT_ENTRY_POINT(vkSetMTLTextureMVK, MVK_MOLTENVK);

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
@@ -167,7 +167,7 @@ VkResult MVKExtensionList::enable(uint32_t count, const char* const* names, cons
 			enable(extnName);
 			if (mvkStringsAreEqual(extnName, VK_MVK_MOLTENVK_EXTENSION_NAME)) {
 				reportMessage(MVK_CONFIG_LOG_LEVEL_WARNING, "Extension %s is deprecated. For access to Metal objects, use extension %s. "
-							  "For MoltenVK configuration, use the global vkGetMoltenVKConfiguration2MVK() and vkSetMoltenVKConfiguration2MVK() functions.",
+							  "For MoltenVK configuration, use the global vkGetMoltenVKConfigurationMVK() and vkSetMoltenVKConfigurationMVK() functions.",
 							  VK_MVK_MOLTENVK_EXTENSION_NAME, VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
 			}
 		}

--- a/MoltenVK/MoltenVK/Vulkan/mvk_api.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_api.mm
@@ -55,14 +55,16 @@ VkResult mvkCopyGrowingStruct(S* pDst, const S* pSrc, size_t* pCopySize) {
 #pragma mark -
 #pragma mark mvk_config.h
 
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetMoltenVKConfiguration2MVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetMoltenVKConfigurationMVK(
+	VkInstance                                  ignored,
 	MVKConfiguration*                           pConfiguration,
 	size_t*                                     pConfigurationSize) {
 
 	return mvkCopyGrowingStruct(pConfiguration, &mvkConfig(), pConfigurationSize);
 }
 
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetMoltenVKConfiguration2MVK(
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
+	VkInstance                                  ignored,
 	const MVKConfiguration*                     pConfiguration,
 	size_t*                                     pConfigurationSize) {
 
@@ -99,22 +101,6 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetPerformanceStatisticsMVK(
 
 #pragma mark -
 #pragma mark mvk_deprecated_api.h
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetMoltenVKConfigurationMVK(
-	VkInstance                                  ignored,
-	MVKConfiguration*                           pConfiguration,
-	size_t*                                     pConfigurationSize) {
-
-	return vkGetMoltenVKConfiguration2MVK(pConfiguration, pConfigurationSize);
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetMoltenVKConfigurationMVK(
-	VkInstance                                  ignored,
-	const MVKConfiguration*                     pConfiguration,
-	size_t*                                     pConfigurationSize) {
-
-	return vkSetMoltenVKConfiguration2MVK(pConfiguration, pConfigurationSize);
-}
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkGetVersionStringsMVK(
 	char*										pMoltenVersionStringBuffer,


### PR DESCRIPTION
Remove `vkGetMoltenVKConfiguration2MVK()` and `vkSetMoltenVKConfiguration2MVK()`.

Also undeprecate the original `vkGet/SetMoltenVKConfigurationMVK()`.

In expectation of the upcoming `VK_EXT_layer_settings extension`, it is felt that adding these additional functions at this time would be confusing to app devs.