### PR TITLE
GitHub CI improvements.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,9 +15,9 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: [ "14.2" ]
-        platform: [ "macos", "maccat", "ios", "tvos" ]
-        os: [ "macos-latest" ]
+        xcode: [ "14.3" ]
+        platform: [ "all" ]
+        os: [ "macos-13" ]
         upload_artifacts: [ true ]
         # additional specific configurations
         include:
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Select Xcode version
         run: sudo xcode-select -switch "${XCODE_DEV_PATH}"
@@ -54,12 +54,12 @@ jobs:
           echo "${XCODE_VERSION}"
           XCODE_VERSION="$(echo "${XCODE_VERSION}" | tr '\t\r\n ' '_')"
           echo "${XCODE_VERSION}"
-          echo "::set-output name=XCODE_VERSION::${XCODE_VERSION}"
+          echo "XCODE_VERSION=${XCODE_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Cache Dependencies
         id: cache-dependencies
         if: success() && !(github.event_name == 'push' && contains(github.ref, 'refs/tags/')) # never cache dependencies for pushed tags
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             External/build
@@ -94,11 +94,11 @@ jobs:
       - name: Tar Artifacts
         if: success() && matrix.upload_artifacts == true
         # See: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
-        run: tar -cvf "${{ matrix.platform }}.tar" Package/Release/
+        run: tar -C Package -s/Release/MoltenVK/ -cvf "MoltenVK.tar" Release/
 
       - name: Upload Artifacts
         if: success() && matrix.upload_artifacts == true
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.platform }}
-          path: "${{ matrix.platform }}.tar"
+          name: "MoltenVK"
+          path: "MoltenVK.tar"

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -31,6 +31,7 @@ Released TBD
   disable recent fixes to handling LOD for arrayed depth images in shaders, 
   on Apple Silicon, when those fixes cause regression in rendering behavior.
 - For correctness, set `VkPhysicalDeviceLimits::lineWidthGranularity` to `1`.
+- Modify GitHub CI to build and create a single universal binary artifact.
 
 
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Copyright (c) 2015-2023 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 Table of Contents
 -----------------
 
-- [Developing Vulkan Applications on *macOS, iOS, and tvOS*](#developing_vulkan)
 - [Introduction to **MoltenVK**](#intro)
+- [Developing Vulkan Applications on *macOS, iOS, and tvOS*](#developing_vulkan)
+	- [Using the *Vulkan SDK*](#sdk)
+	- [Using MoltenVK Directly](#download)
 - [Fetching **MoltenVK** Source Code](#install)
 - [Building **MoltenVK**](#building)
 - [Running **MoltenVK** Demo Applications](#demos)
@@ -27,41 +29,6 @@ Table of Contents
 - [**MoltenVK** and *Vulkan* Compliance](#compliance)
 - [Getting Support](#support)
 - [Contributing to **MoltenVK** Development](#contributing)
-
-
-
-<a name="developing_vulkan"></a>
-Developing Vulkan Applications for *macOS, iOS, and tvOS*
----------------------------------------------------------
-
-The recommended method for developing a *Vulkan* application for *macOS* is to use the 
-[*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home).
-
-The *Vulkan SDK* includes a **MoltenVK** runtime library for *macOS*. *Vulkan* is a layered 
-architecture that allows applications to add additional functionality without modifying the 
-application itself. The *Validation Layers* included in the *Vulkan SDK* are an essential debugging
-tool for application developers because they identify inappropriate use of the *Vulkan API*. 
-If you are developing a *Vulkan* application for *macOS*, it is highly recommended that you use the
-[*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home) and the **MoltenVK** library included in it.
-Refer to the *Vulkan SDK [Getting Started](https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html)* 
-document for more info.
-
-Because **MoltenVK** supports the `VK_KHR_portability_subset` extension, when using the 
-*Vulkan Loader* from the *Vulkan SDK* to run **MoltenVK** on *macOS*, the *Vulkan Loader* 
-will only include **MoltenVK** `VkPhysicalDevices` in the list returned by 
-`vkEnumeratePhysicalDevices()` if the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` 
-flag is enabled in `vkCreateInstance()`. See the description of the `VK_KHR_portability_enumeration` 
-extension in the *Vulkan* specification for more information about the use of the 
-`VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag.
-
-If you are developing a *Vulkan* application for *iOS* or *tvOS*, or are developing a *Vulkan* 
-application for *macOS* and want to use a different version of the **MoltenVK** runtime library 
-provided in the *macOS Vulkan SDK*, you can use this document to learn how to build a **MoltenVK** 
-runtime library from source code.
-
-To learn how to integrate the **MoltenVK** runtime library into a game or application, 
-see the [`MoltenVK_Runtime_UserGuide.md `](Docs/MoltenVK_Runtime_UserGuide.md) 
-document in the `Docs` directory. 
 
 
 
@@ -96,6 +63,52 @@ The **MoltenVK** runtime package contains two products:
   runtime to automatically convert *SPIR-V* shaders to their *MSL* equivalents. In addition, 
   both the *SPIR-V* and *GLSL* converters are packaged into a stand-alone command-line 
   `MoltenVKShaderConverter` *macOS* tool for converting shaders at development time from the command line.
+
+
+
+<a name="developing_vulkan"></a>
+Developing *Vulkan* Applications for *macOS, iOS, and tvOS*
+---------------------------------------------------------
+
+<a name="sdk"></a>
+### Using the *Vulkan SDK*
+
+The recommended method for developing a *Vulkan* application for *macOS* is to use the 
+[*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home).
+
+The *Vulkan SDK* includes a **MoltenVK** runtime library for *macOS*. *Vulkan* is a layered 
+architecture that allows applications to add additional functionality without modifying the 
+application itself. The *Validation Layers* included in the *Vulkan SDK* are an essential debugging
+tool for application developers because they identify inappropriate use of the *Vulkan API*. 
+If you are developing a *Vulkan* application for *macOS*, it is highly recommended that you use the
+[*Vulkan SDK*](https://vulkan.lunarg.com/sdk/home) and the **MoltenVK** library included in it.
+Refer to the *Vulkan SDK [Getting Started](https://vulkan.lunarg.com/doc/sdk/latest/mac/getting_started.html)* 
+document for more info.
+
+Because **MoltenVK** supports the `VK_KHR_portability_subset` extension, when using the 
+*Vulkan Loader* from the *Vulkan SDK* to run **MoltenVK** on *macOS*, the *Vulkan Loader* 
+will only include **MoltenVK** `VkPhysicalDevices` in the list returned by 
+`vkEnumeratePhysicalDevices()` if the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` 
+flag is enabled in `vkCreateInstance()`. See the description of the `VK_KHR_portability_enumeration` 
+extension in the *Vulkan* specification for more information about the use of the 
+`VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag.
+
+<a name="download"></a>
+### Using MoltenVK Directly
+
+If you are developing a *Vulkan* application for *iOS* or *tvOS*, or are developing a
+*Vulkan* application for *macOS* and want to use a different version or build of the
+**MoltenVK** runtime library than provided in the *macOS Vulkan SDK*, you can access
+a pre-built MoltenVK binary library from the **MoltenVK** repository, by
+[selecting a repository commit from the list](https://github.com/KhronosGroup/MoltenVK/actions),
+and downloading the associated **MoltenVK** runtime library artifact.
+
+Finally, if you want a customized build of **MoltenVK**, you can follow the [instructions below](#install)
+to create a **MoltenVK** runtime library by fetching and building the **MoltenVK** source code.
+
+To learn how to integrate the **MoltenVK** runtime library into a game or application,
+see the [`MoltenVK_Runtime_UserGuide.md `](Docs/MoltenVK_Runtime_UserGuide.md) 
+document in the `Docs` directory. 
 
 
 
@@ -293,7 +306,7 @@ or it can be included in any of the `make` build commands. For example:
 or
 
 	make macos MVK_HIDE_VULKAN_SYMBOLS=1
-	
+
 ...etc.
 
 


### PR DESCRIPTION
- Build one universal build, instead of per-platform.
- Upload this single build artifact to GitHub.
- Upgrade to v3 of action dependencies to remove _Node.js_ deprecation warnings.
- Use macOS 13 and Xcode 14.3.
- `README.md` document access to binary artifacts.