### PR TITLE
Add GitHub Actions workflow for automatically creating releases.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,3 +102,25 @@ jobs:
         with:
           name: "MoltenVK"
           path: "MoltenVK.tar"
+
+  release:
+    name: 'Release'
+
+    needs: [build]
+
+    runs-on: ubuntu-latest
+
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "MoltenVK/*"
+          artifactErrorsFailBuild: true


### PR DESCRIPTION
Implements a GitHub Actions workflow for creating releases when a tag is pushed. The workflow will upload any files uploaded to the artifact "MoltenVK" by the CI build as release assets.

Example workflow execution: https://github.com/Steveice10/MoltenVK/actions/runs/4932936369

Example release created by this workflow: https://github.com/Steveice10/MoltenVK/releases/tag/v1.2.4

Note that the title and description will still need to be manually customized after the release is created. By default it creates the release with the tag as the release name and the commit description as the release details.