### PR TITLE
Update release action artifact glob.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,5 +125,5 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "MoltenVK/*"
+          artifacts: "MoltenVK*/*"
           artifactErrorsFailBuild: true


### PR DESCRIPTION
Simple update to the release workflow for the build CI updates. Since we have ```MoltenVK-all```, ```MoltenVK-macos```, and ```MoltenVK-ios``` artifacts in the build workflow, we can capture all of these and upload their artifacts with the glob pattern ```MoltenVK*/*```.

Resulting release: https://github.com/Steveice10/MoltenVK/releases/tag/v1.2.4