### PR TITLE
Respect the bind point supplied to vkCmdBindDescriptorSets / vkCmdPushDescriptorSets

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -393,7 +393,7 @@ VkResult MVKCmdPushDescriptorSet::setContent(MVKCommandBuffer* cmdBuff,
 }
 
 void MVKCmdPushDescriptorSet::encode(MVKCommandEncoder* cmdEncoder) {
-	_pipelineLayout->pushDescriptorSet(cmdEncoder, _descriptorWrites.contents(), _set);
+	_pipelineLayout->pushDescriptorSet(cmdEncoder, _pipelineBindPoint, _descriptorWrites.contents(), _set);
 }
 
 MVKCmdPushDescriptorSet::~MVKCmdPushDescriptorSet() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -120,6 +120,7 @@ public:
 
 	/** Encodes the descriptors in the descriptor set that are specified by this layout, */
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSet* descSet,
 			  MVKShaderResourceBinding& dslMTLRezIdxOffsets,
 			  MVKArrayRef<uint32_t> dynamicOffsets,
@@ -127,6 +128,7 @@ public:
 
     /** Encodes this binding layout and the specified descriptor on the specified command encoder immediately. */
     void push(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
               uint32_t& dstArrayElement,
               uint32_t& descriptorCount,
               uint32_t& descriptorsPushed,
@@ -207,6 +209,7 @@ public:
 
 	/** Encodes this descriptor (based on its layout binding index) on the the command encoder. */
 	virtual void bind(MVKCommandEncoder* cmdEncoder,
+					  VkPipelineBindPoint pipelineBindPoint,
 					  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 					  uint32_t elementIndex,
 					  bool stages[],
@@ -273,6 +276,7 @@ class MVKBufferDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -362,6 +366,7 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -411,6 +416,7 @@ class MVKImageDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -491,6 +497,7 @@ class MVKSamplerDescriptorMixin {
 
 protected:
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -538,6 +545,7 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_SAMPLER; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -585,6 +593,7 @@ public:
 	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; }
 
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],
@@ -630,6 +639,7 @@ class MVKTexelBufferDescriptor : public MVKDescriptor {
 
 public:
 	void bind(MVKCommandEncoder* cmdEncoder,
+			  VkPipelineBindPoint pipelineBindPoint,
 			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  uint32_t elementIndex,
 			  bool stages[],

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -81,6 +81,7 @@ public:
 
 	/** Encodes this descriptor set layout and the specified descriptor updates on the specified command encoder immediately. */
 	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+						   VkPipelineBindPoint pipelineBindPoint,
 						   MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
 						   MVKShaderResourceBinding& dslMTLRezIdxOffsets);
 
@@ -338,6 +339,9 @@ public:
 	/** Get the type of this template. */
 	VkDescriptorUpdateTemplateType getType() const;
 
+	/** Get the bind point of this template */
+	VkPipelineBindPoint getBindPoint() const { return _pipelineBindPoint; }
+
 	/** Constructs an instance for the specified device. */
 	MVKDescriptorUpdateTemplate(MVKDevice* device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo);
 
@@ -347,6 +351,7 @@ public:
 protected:
 	void propagateDebugName() override {}
 
+	VkPipelineBindPoint _pipelineBindPoint;
 	VkDescriptorUpdateTemplateType _type;
 	MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -43,7 +43,7 @@ void MVKDescriptorSetLayout::bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
 													dynamicOffsets, dynamicOffsetIndex); }
 	if ( !isUsingMetalArgumentBuffers() ) {
 		for (auto& dslBind : _bindings) {
-			dslBind.bind(cmdEncoder, descSet, dslMTLRezIdxOffsets, dynamicOffsets, dynamicOffsetIndex);
+			dslBind.bind(cmdEncoder, pipelineBindPoint, descSet, dslMTLRezIdxOffsets, dynamicOffsets, dynamicOffsetIndex);
 		}
 	}
 }
@@ -91,6 +91,7 @@ static const void* getWriteParameters(VkDescriptorType type, const VkDescriptorI
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                                               VkPipelineBindPoint pipelineBindPoint,
                                                MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
                                                MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
 
@@ -127,7 +128,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
                                                    pBufferInfo, pTexelBufferView, pInlineUniformBlock, stride);
             uint32_t descriptorsPushed = 0;
             uint32_t bindIdx = _bindingToIndex[dstBinding];
-            _bindings[bindIdx].push(cmdEncoder, dstArrayElement, descriptorCount,
+            _bindings[bindIdx].push(cmdEncoder, pipelineBindPoint, dstArrayElement, descriptorCount,
                                     descriptorsPushed, descWrite.descriptorType,
                                     stride, pData, dslMTLRezIdxOffsets);
             pBufferInfo += descriptorsPushed;
@@ -148,6 +149,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
         return;
 
 	if (!cmdEncoder) { clearConfigurationResult(); }
+	VkPipelineBindPoint bindPoint = descUpdateTemplate->getBindPoint();
     for (uint32_t i = 0; i < descUpdateTemplate->getNumberOfEntries(); i++) {
         const VkDescriptorUpdateTemplateEntry* pEntry = descUpdateTemplate->getEntry(i);
         uint32_t dstBinding = pEntry->dstBinding;
@@ -161,7 +163,7 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
             if (!_bindingToIndex.count(dstBinding)) continue;
             uint32_t descriptorsPushed = 0;
             uint32_t bindIdx = _bindingToIndex[dstBinding];
-            _bindings[bindIdx].push(cmdEncoder, dstArrayElement, descriptorCount,
+            _bindings[bindIdx].push(cmdEncoder, bindPoint, dstArrayElement, descriptorCount,
                                     descriptorsPushed, pEntry->descriptorType,
                                     pEntry->stride, pCurData, dslMTLRezIdxOffsets);
             pCurData = (const char*)pCurData + pEntry->stride * descriptorsPushed;
@@ -876,7 +878,7 @@ VkDescriptorUpdateTemplateType MVKDescriptorUpdateTemplate::getType() const {
 
 MVKDescriptorUpdateTemplate::MVKDescriptorUpdateTemplate(MVKDevice* device,
 														 const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo) :
-	MVKVulkanAPIDeviceObject(device), _type(pCreateInfo->templateType) {
+	MVKVulkanAPIDeviceObject(device), _type(pCreateInfo->templateType), _pipelineBindPoint(pCreateInfo->pipelineBindPoint) {
 
 	for (uint32_t i = 0; i < pCreateInfo->descriptorUpdateEntryCount; i++)
 		_entries.push_back(pCreateInfo->pDescriptorUpdateEntries[i]);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -63,6 +63,7 @@ public:
 
 	/** Updates a descriptor set in a command encoder. */
 	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+						   VkPipelineBindPoint pipelineBindPoint,
 						   MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
 						   uint32_t set);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -64,11 +64,12 @@ void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKPipelineLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                                          VkPipelineBindPoint pipelineBindPoint,
                                           MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
                                           uint32_t set) {
 	if (!cmdEncoder) { clearConfigurationResult(); }
 	MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
-	dsl->pushDescriptorSet(cmdEncoder, descriptorWrites, _dslMTLResourceIndexOffsets[set]);
+	dsl->pushDescriptorSet(cmdEncoder, pipelineBindPoint, descriptorWrites, _dslMTLResourceIndexOffsets[set]);
 	if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
 }
 


### PR DESCRIPTION
Prevents calls to `vkCmdPushDescriptorSetKHR` with layouts that specify `VK_SHADER_STAGE_ALL` from applying to things they shouldn't (e.g. having `VK_PIPELINE_BIND_POINT_COMPUTE` binds trash the graphics bindings)