### PR TITLE
Make the GitHub Actions release workflow more lenient.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,5 +125,15 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
+          # Allow updating existing releases if the workflow is triggered by release creation or re-run.
+          allowUpdates: true
+          # When the release is updated, delete the existing artifacts for replacement.
+          removeArtifacts: true
+          # If a release is being replaced, omit updating the name and body.
+          # Allows for creating a release and filling these in before the workflow runs.
+          # Then, the workflow will populate the release with the artifacts.
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          # Upload all MoltenVK CI artifacts as release assets.
           artifacts: "MoltenVK*/*"
           artifactErrorsFailBuild: true


### PR DESCRIPTION
Adds some parameters to make the release workflow more lenient in how it can be executed, along with some comments to explain each parameter's purpose.

Brief explanation:
* allowUpdates: This allows the release workflow to update an existing release for the tag. This allows you to cut a tag by creating a release in the GitHub UI, as they will no longer conflict.
* removeArtifacts: When a release is updated, delete any existing assets first. This way if a release workflow is re-run you won't end up with a large build-up of release assets from multiple runs.
* omit(Name/Body)DuringUpdate: When the release already exists, don't set the name or body. This allows filling in the name and body info when creating the release in the GitHub UI, without the release workflow then overwriting it all.

Test run passed, successfully updated the existing release with new artifacts and commit: https://github.com/Steveice10/MoltenVK/actions/runs/4961351131