### PR TITLE
Ensure swapchain image presented time is always populated when requested.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,7 +24,8 @@ Released TBD
 - Support separate depth and stencil attachments during dynamic rendering.
 - Deprecate the obsolete and non-standard `VK_MVK_moltenvk` extension.
 - Fix memory leak when waiting on timeline semaphores.
-- Fix race condition when updating values in `VkPastPresentationTimingGOOGLE`.
+- Fix race condition when updating values in `VkPastPresentationTimingGOOGLE`,
+  and ensure swapchain image presented time is always populated when requested.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
 - Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.
 - Add `MVK_ENABLE_EXPLICIT_LOD_WORKAROUND` environment variable to selectively 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -565,8 +565,11 @@ void MVKSwapchain::recordPresentTime(const MVKImagePresentInfo& presentInfo, uin
 		_presentHistoryHeadIndex = (_presentHistoryHeadIndex + 1) % kMaxPresentationHistory;
 	}
 
-	// If actual time not supplied, use desired time instead
+	// If actual present time is not available, use desired time instead, and if that
+	// hasn't been set, use the current time, which should be reasonably accurate (sub-ms),
+	// since we are here as part of the addPresentedHandler: callback.
 	if (actualPresentTime == 0) { actualPresentTime = presentInfo.desiredPresentTime; }
+	if (actualPresentTime == 0) { actualPresentTime = CACurrentMediaTime() * 1.0e9; }
 
 	_presentTimingHistory[_presentHistoryIndex].presentID = presentInfo.presentID;
 	_presentTimingHistory[_presentHistoryIndex].desiredPresentTime = presentInfo.desiredPresentTime;


### PR DESCRIPTION
If Metal reports zero `presentedTime`, and desired presentation time has not been set by app, use the current time.

Fixes second part of #1882.