### PR TITLE
Populate deviceUUID from MTLDevice location and peer group info.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,6 +32,9 @@ Released TBD
   disable recent fixes to handling LOD for arrayed depth images in shaders, 
   on Apple Silicon, when those fixes cause regression in rendering behavior.
 - Identify each unsupported device feature flag that the app attempts to be enable.
+- Populate `deviceUUID` from `MTLDevice` location and peer group info, 
+  which should be unique, and constant across OS reboots.
+- Populate `deviceLUID` from `MTLDevice.registryID`. 
 - For correctness, set `VkPhysicalDeviceLimits::lineWidthGranularity` to `1`.
 - Improve GitHub CI production of binary artifacts on submission and release.
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -1064,6 +1064,14 @@ protected:
 /** Returns the registry ID of the specified device, or zero if the device does not have a registry ID. */
 uint64_t mvkGetRegistryID(id<MTLDevice> mtlDevice);
 
+/**
+ * Returns a value identifying the physical location of the specified device.
+ * The returned value is a hash of the location, locationNumber, peerGroupID,
+ * and peerIndex properties of the device. On devices with only one built-in GPU,
+ * the returned value will be zero.
+ */
+uint64_t mvkGetLocationID(id<MTLDevice> mtlDevice);
+
 /** Returns whether the MTLDevice supports BC texture compression. */
 bool mvkSupportsBCTextureCompression(id<MTLDevice> mtlDevice);
 


### PR DESCRIPTION
`MTLDevice registryID` is not constant across OS reboots, which is not conformant with `deviceUUID` requirements.

Replace with combination of `MTLDevice` `location`, `locationNumber`, `peerGroupID`, and `peerIndex`, which should define uniqueness, and **_should_** be constant across OS reboots.

I've included device peer group because `locationNumber` is [not unique](https://developer.apple.com/documentation/metal/mtldevice/3114006-locationnumber?language=objc) in the case of slots and external ports that support multiple GPUs. However, I am not 100% certain that the peer group info is constant across a reboot, although it will be for cases where a peer group is not defined.

Fixes issue #1880.