### PR TITLE
Do not fail on request for timestamp query pool that is too large.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -26,6 +26,7 @@ Released TBD
 - Fix memory leak when waiting on timeline semaphores.
 - Fix race condition when updating values in `VkPastPresentationTimingGOOGLE`,
   and ensure swapchain image presented time is always populated when requested.
+- Report error, but do not fail on request for timestamp query pool that is too large for `MTLCounterSampleBuffer`.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
 - Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.
 - Add `MVK_ENABLE_EXPLICIT_LOD_WORKAROUND` environment variable to selectively 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -316,7 +316,9 @@ MVKOcclusionQueryPool::MVKOcclusionQueryPool(MVKDevice* device,
         VkDeviceSize newBuffLen = min(reqBuffLen, maxBuffLen);
 
         if (reqBuffLen > maxBuffLen) {
-            reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkCreateQueryPool(): Each query pool can support a maximum of %d queries.", uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes));
+			reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+						"vkCreateQueryPool(): Each occlusion query pool can support a maximum of %d queries.",
+						uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes));
         }
 
         NSUInteger mtlBuffLen = mvkAlignByteCount(newBuffLen, _device->_pMetalFeatures->mtlBufferAlignment);
@@ -356,9 +358,9 @@ void MVKGPUCounterQueryPool::initMTLCounterSampleBuffer(const VkQueryPoolCreateI
 		NSError* err = nil;
 		_mtlCounterBuffer = [getMTLDevice() newCounterSampleBufferWithDescriptor: tsDesc error: &err];
 		if (err) {
-			setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
-											   "Could not create MTLCounterSampleBuffer for query pool of type %s. Reverting to emulated behavior. (Error code %li): %s",
-											   queryTypeName, (long)err.code, err.localizedDescription.UTF8String));
+			reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+						"Could not create MTLCounterSampleBuffer of size %llu, for %d queries, in query pool of type %s. Reverting to emulated behavior. (Error code %li): %s",
+						(VkDeviceSize)pCreateInfo->queryCount * kMVKQuerySlotSizeInBytes, pCreateInfo->queryCount, queryTypeName, (long)err.code, err.localizedDescription.UTF8String);
 		}
 	}
 };


### PR DESCRIPTION
- Report error, but do not fail on request for timestamp query pool that is too large for `MTLCounterSampleBuffer`.
- Change reported error to `VK_ERROR_OUT_OF_DEVICE_MEMORY` and clarify text of error reported when timestamp query pool is too large.
- Clarify error reported for occlusion query pool errors (unrelated).