### PR TITLE
Check if shader compiled before adding it to a pipeline

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1050,8 +1050,8 @@ bool MVKGraphicsPipeline::addTessCtlShaderToPipeline(MTLComputePipelineDescripto
 
 	MVKMTLFunction func = getMTLFunction(shaderConfig, _pTessCtlSS, "Tessellation control");
 	id<MTLFunction> mtlFunc = func.getMTLFunction();
-	plDesc.computeFunction = mtlFunc;
 	if ( !mtlFunc ) { return false; }
+	plDesc.computeFunction = mtlFunc;
 
 	auto& funcRslts = func.shaderConversionResults;
 	_needsTessCtlSwizzleBuffer = funcRslts.needsSwizzleBuffer;


### PR DESCRIPTION
Prevents Metal from aborting when you try to set a null function on the descriptor, which is pretty annoying when you're trying to run CTS