### PR TITLE
WIP: Manual Frame Capture

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_config.h
+++ b/MoltenVK/MoltenVK/API/mvk_config.h
@@ -707,6 +707,27 @@ typedef struct {
 	 */
 	const char* autoGPUCaptureOutputFilepath;
 
+    /**
+     * The path to a file where the manual GPU capture should be saved.
+     * In this case, the Xcode scheme must have Metal GPU capture enabled, but does
+     * not need not be run under Xcode's control at all. This is useful in case the app
+     * cannot be run under Xcode's control. A path starting with '~' can be used to place it in a
+     * user's home directory, as in the shell. This feature requires Metal 3.0 (macOS 10.15).
+     *
+     * If this parameter is NULL or an empty string, the capture will not be started.
+     *
+     * Capture will commence with the shortcut CMD + Shift + C, and will stop
+     * when the shortcut is entered a second time.
+     *
+     * The value of this parameter must be changed before creating a VkDevice,
+     * for the change to take effect.
+     *
+     * The initial value or this parameter is set by the
+     * MVK_CONFIG_GPU_CAPTURE_OUTPUT_FILE
+     * runtime environment variable or MoltenVK compile-time build setting.
+     */
+    const char* gpuCaptureOutputFilepath;
+
 	/**
 	 * Controls whether MoltenVK should use a Metal 2D texture with a height of 1 for a
 	 * Vulkan 1D image, or use a native Metal 1D texture. Metal imposes significant restrictions

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -894,6 +894,7 @@ protected:
 	MVKBuffer* removeBuffer(MVKBuffer* mvkBuff);
 	MVKImage* addImage(MVKImage* mvkImg);
 	MVKImage* removeImage(MVKImage* mvkImg);
+    void initManualGPUCapture();
     void initPerformanceTracking();
 	void initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo);
 	void initQueues(const VkDeviceCreateInfo* pCreateInfo);
@@ -908,6 +909,7 @@ protected:
 	void getDescriptorVariableDescriptorCountLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
 														   VkDescriptorSetLayoutSupport* pSupport,
 														   VkDescriptorSetVariableDescriptorCountLayoutSupport* pVarDescSetCountSupport);
+    void handleKeyboardShortcut();
 
 	MVKPhysicalDevice* _physicalDevice = nullptr;
     MVKCommandResourceFactory* _commandResourceFactory = nullptr;
@@ -1090,7 +1092,3 @@ bool mvkSupportsBCTextureCompression(id<MTLDevice> mtlDevice);
 
 #define MTLFeatureSet_macOS_GPUFamily2_v1		MTLGPUFamilyMacCatalyst2
 #endif
-
-@interface MVKDebug : NSObject
-@property MVKDevice *device;
-@end

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -815,9 +815,22 @@ public:
 	 * auto capture scope, and if so, stops capturing.
 	 */
 	void stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope);
+    
+    /**
+     * Start a single-frame GPU capture triggered by keyboard shortcut
+     */
+    void startGPUCapture(id mtlCaptureObject);
+    
+    /**
+     * Start a single-frame GPU capture triggered by keyboard shortcut
+     */
+    void stopGPUCapture();
 
 	/** Returns whether this instance is currently automatically capturing a GPU trace. */
 	inline bool isCurrentlyAutoGPUCapturing() { return _isCurrentlyAutoGPUCapturing; }
+    
+    /** Returns whether this instance is currently automatically capturing an external GPU trace. */
+    inline bool isCurrentGPUCapturing() { return _isCurrentlyGPUCapturing; }
 
 	/** Returns the Metal objects underpinning the Vulkan objects indicated in the pNext chain of pMetalObjectsInfo. */
 	void getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);
@@ -916,6 +929,7 @@ protected:
 	MVKConfigActivityPerformanceLoggingStyle _activityPerformanceLoggingStyle = MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT;
 	bool _isPerformanceTracking = false;
 	bool _isCurrentlyAutoGPUCapturing = false;
+    bool _isCurrentlyGPUCapturing = false;
 	bool _isUsingMetalArgumentBuffers = false;
 
 };
@@ -1076,3 +1090,7 @@ bool mvkSupportsBCTextureCompression(id<MTLDevice> mtlDevice);
 
 #define MTLFeatureSet_macOS_GPUFamily2_v1		MTLGPUFamilyMacCatalyst2
 #endif
+
+@interface MVKDebug : NSObject
+@property MVKDevice *device;
+@end

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4536,7 +4536,7 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 }
 
 void MVKDevice::initManualGPUCapture() {
-#if MVK_MACOS
+#if MVK_MACOS && !MVK_MACCAT
     const char* filePath = mvkConfig().gpuCaptureOutputFilepath;
     if (strlen(filePath)) {
         NSEventModifierFlags shortcutModifierFlags = NSEventModifierFlagCommand | NSEventModifierFlagShift;

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -94,6 +94,7 @@ static void mvkInitConfigFromEnvVars() {
 
 static MVKConfiguration _mvkConfig;
 static std::string _autoGPUCaptureOutputFile;
+static std::string _gpuCaptureOutputFile;
 
 // Returns the MoltenVK config, lazily initializing it if necessary.
 // We initialize lazily instead of in a library constructor function to
@@ -130,4 +131,10 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig) {
 		_autoGPUCaptureOutputFile = _mvkConfig.autoGPUCaptureOutputFilepath;
 	}
 	_mvkConfig.autoGPUCaptureOutputFilepath = (char*)_autoGPUCaptureOutputFile.c_str();
+    
+    // Set capture file path string
+    if (_mvkConfig.gpuCaptureOutputFilepath) {
+        _gpuCaptureOutputFile = _mvkConfig.gpuCaptureOutputFilepath;
+    }
+    _mvkConfig.gpuCaptureOutputFilepath = (char*)_gpuCaptureOutputFile.c_str();
 }

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.cpp
@@ -25,7 +25,8 @@ static void mvkInitConfigFromEnvVars() {
 	_mvkConfigInitialized = true;
 
 	MVKConfiguration evCfg;
-	std::string evGPUCapFileStrObj;
+	std::string evAutoGPUCapFileStrObj;
+    std::string evGPUCapFileStrObj;
 
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.debugMode,                              MVK_DEBUG);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.shaderConversionFlipVertexY,            MVK_CONFIG_SHADER_CONVERSION_FLIP_VERTEX_Y);
@@ -53,7 +54,8 @@ static void mvkInitConfigFromEnvVars() {
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.semaphoreUseMTLFence,                   MVK_ALLOW_METAL_FENCES);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.semaphoreSupportStyle,                  MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE);
 	MVK_SET_FROM_ENV_OR_BUILD_INT32 (evCfg.autoGPUCaptureScope,                    MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE);
-	MVK_SET_FROM_ENV_OR_BUILD_STRING(evCfg.autoGPUCaptureOutputFilepath,           MVK_CONFIG_AUTO_GPU_CAPTURE_OUTPUT_FILE, evGPUCapFileStrObj);
+	MVK_SET_FROM_ENV_OR_BUILD_STRING(evCfg.autoGPUCaptureOutputFilepath,           MVK_CONFIG_AUTO_GPU_CAPTURE_OUTPUT_FILE, evAutoGPUCapFileStrObj);
+    MVK_SET_FROM_ENV_OR_BUILD_STRING(evCfg.gpuCaptureOutputFilepath,               MVK_CONFIG_GPU_CAPTURE_OUTPUT_FILE, evGPUCapFileStrObj);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.texture1DAs2D,                          MVK_CONFIG_TEXTURE_1D_AS_2D);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.preallocateDescriptors,                 MVK_CONFIG_PREALLOCATE_DESCRIPTORS);
 	MVK_SET_FROM_ENV_OR_BUILD_BOOL  (evCfg.useCommandPooling,                      MVK_CONFIG_USE_COMMAND_POOLING);

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -232,6 +232,17 @@ void mvkSetConfig(const MVKConfiguration& mvkConfig);
 #	define MVK_CONFIG_AUTO_GPU_CAPTURE_OUTPUT_FILE	""
 #endif
 
+/**
+ * The file to capture manual GPU traces to. This is
+ * useful when trying to capture a one-shot trace, but the program cannot be run under
+ * Xcode's control. Tilde paths may be used to place the trace document in a user's home
+ * directory. This functionality requires macOS 10.15.
+ */
+#ifndef MVK_CONFIG_GPU_CAPTURE_OUTPUT_FILE
+#    define MVK_CONFIG_GPU_CAPTURE_OUTPUT_FILE    ""
+#endif
+
+
 /** Force the use of a low-power GPU if it exists. Disabled by default. */
 #ifndef MVK_CONFIG_FORCE_LOW_POWER_GPU
 #   define MVK_CONFIG_FORCE_LOW_POWER_GPU    0


### PR DESCRIPTION
**What this adds:**
This PR allows you to trigger a manual frame capture of any length. This capture is started and stopped with the shortcut `CMD + Shift + C`, and saves to the path set in the environment variable `MVK_CONFIG_GPU_CAPTURE_OUTPUT_FILE`. If this environment variable is not set, the keyboard event listener will not be started.

This feature requires both macOS 10.15 or newer and for the GPU capture environment variable to be enabled.

**Why?**
This feature has the potential to be incredibly useful for those debugging games running under Wine, which often do not cooperate well with Xcode, and want the flexibility of starting a frame capture at any point during gameplay.

`Debug Tools` commit was working, my attempt to clean it up introduced segfaults not entirely sure they're coming from I think the added environment variable definition might be to blame.