### PR TITLE
Accumulate render stages when a resource is used by multiple descriptor bindings.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -31,6 +31,7 @@ Released 2023/05/23
   large for `MTLCounterSampleBuffer`, and fall back to emulation via CPU timestamps.
 - Ensure shaders that use `PhysicalStorageBufferAddresses` encode the use of the associated `MTLBuffer`.
 - Disable pipeline cache compression prior to macOS 10.15 and iOS/tvOS 13.0.
+- Accumulate render stages when a resource is used by multiple descriptor bindings.
 - Respect the bind point supplied to `vkCmdBindDescriptorSets()` / `vkCmdPushDescriptorSets()`.
 - Check if shader compiled before adding it to a pipeline, to avoid Metal validation error.
 - Identify each unsupported device feature flag that the app attempts to enable.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -565,6 +565,8 @@ public:
 	/** Marks any overridden buffer indexes as dirty. */
 	void markOverriddenBufferIndexesDirty();
 
+	void endMetalRenderPass() override;
+
 	void markDirty() override;
 
 #pragma mark Construction
@@ -577,6 +579,7 @@ protected:
 	void bindMetalArgumentBuffer(MVKShaderStage stage, MVKMTLBufferBinding& buffBind) override;
 
     ResourceBindings<8> _shaderStageResourceBindings[kMVKShaderStageFragment + 1];
+	std::unordered_map<id<MTLResource>, MTLRenderStages> _renderUsageStages;
 };
 
 


### PR DESCRIPTION
Should fix issues #1870 & #1811.