### PR TITLE
Advertise VK_KHR_depth_stencil_resolve extension on all devices.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -40,6 +40,7 @@ Released 2023/05/23
 - Populate `deviceLUID` from `MTLDevice.registryID`. 
 - Avoid Metal validation warning when depth component swizzled away.
 - Fix depth clamp and texture swizzle feature discovery on simulator builds.
+- Advertise `VK_KHR_depth_stencil_resolve` extension on all devices.
 - For correctness, set `VkPhysicalDeviceLimits::lineWidthGranularity` to `1`.
 - Improve GitHub CI production of binary artifacts on submission and release.
 - Update dependency libraries to match _Vulkan SDK 1.3.250_.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3050,11 +3050,6 @@ void MVKPhysicalDevice::initExtensions() {
 	MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_supportedExtensions;
 	pWritableExtns->disableAllButEnabledDeviceExtensions();
 
-#if MVK_IOS_OR_TVOS
-	if (!_metalFeatures.depthResolve) {
-		pWritableExtns->vk_KHR_depth_stencil_resolve.enabled = false;
-	}
-#endif
 	if (!_metalFeatures.samplerMirrorClampToEdge) {
 		pWritableExtns->vk_KHR_sampler_mirror_clamp_to_edge.enabled = false;
 	}


### PR DESCRIPTION
Advertise `VK_KHR_depth_stencil_resolve` extension on early iOS devices, since `VK_RESOLVE_MODE_SAMPLE_ZERO_BIT` is supported on all devices, even if other resolve modes are not, and makes it consistent with Vulkan 1.2 mandatory support for `VK_RESOLVE_MODE_SAMPLE_ZERO_BIT`.

Fixes #1875.