### PR TITLE
Add support for VK_PRESENT_MODE_IMMEDIATE_KHR to macOS Cube demo.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.5
 Released TBD
 
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
+- Add support for `VK_PRESENT_MODE_IMMEDIATE_KHR` to macOS Cube demo.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4114,7 +4114,6 @@ void MVKDevice::logActivityPerformance(MVKPerformanceTracker& activity, MVKPerfo
 }
 
 void MVKDevice::logPerformanceSummary() {
-	if (_activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_IMMEDIATE) { return; }
 
 	// Get a copy to minimize time under lock
 	MVKPerformanceStatistics perfStats;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -175,7 +175,9 @@ void MVKSwapchain::markFrameInterval() {
 				   perfLogCntLimit,
 				   (1000.0 / _device->_performanceStatistics.queue.frameInterval.averageDuration),
 				   mvkGetElapsedMilliseconds() / 1000.0);
-		_device->logPerformanceSummary();
+		if (mvkConfig().activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT) {
+			_device->logPerformanceSummary();
+		}
 	}
 }
 


### PR DESCRIPTION
- Only log performance stats on FPS logging if logging style is explicitly set to `MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT` (unrelated).