### PR TITLE
Support VK_PRESENT_MODE_IMMEDIATE_KHR if VkPresentTimeGOOGLE::desiredPresentTime is zero.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.5
 Released TBD
 
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
+- Support `VK_PRESENT_MODE_IMMEDIATE_KHR` if `VkPresentTimeGOOGLE::desiredPresentTime` is zero.
 - Add support for `VK_PRESENT_MODE_IMMEDIATE_KHR` to macOS Cube demo.
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1313,8 +1313,9 @@ void MVKPresentableSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffer> m
 			mtlDrwbl.layer.displaySyncEnabledMVK = (presentInfo.presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
 		}
 		if (presentInfo.hasPresentTime) {
-			// Convert from nsecs to seconds for Metal
 			addPresentedHandler(mtlDrwbl, presentInfo);
+		}
+		if (presentInfo.desiredPresentTime) {
 			[mtlDrwbl presentAtTime: (double)presentInfo.desiredPresentTime * 1.0e-9];
 		} else {
 			[mtlDrwbl present];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -621,7 +621,7 @@ MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKQueue* que
 	_presentInfo.reserve(scCnt);
 	for (uint32_t scIdx = 0; scIdx < scCnt; scIdx++) {
 		MVKSwapchain* mvkSC = (MVKSwapchain*)pPresentInfo->pSwapchains[scIdx];
-		MVKImagePresentInfo presentInfo = {};
+		MVKImagePresentInfo presentInfo = {};	// Start with everything zeroed
 		presentInfo.presentableImage = mvkSC->getPresentableImage(pPresentInfo->pImageIndices[scIdx]);
 		presentInfo.presentMode = pPresentModes ? pPresentModes[scIdx] : VK_PRESENT_MODE_MAX_ENUM_KHR;
 		presentInfo.fence = pFences ? (MVKFence*)pFences[scIdx] : nullptr;
@@ -629,8 +629,6 @@ MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKQueue* que
 			presentInfo.hasPresentTime = true;
 			presentInfo.presentID = pPresentTimes[scIdx].presentID;
 			presentInfo.desiredPresentTime = pPresentTimes[scIdx].desiredPresentTime;
-		} else {
-			presentInfo.hasPresentTime = false;
 		}
 		_presentInfo.push_back(presentInfo);
 		VkResult scRslt = mvkSC->getSurfaceStatus();


### PR DESCRIPTION
- `[MTLDrawable presentAtTime:]` syncs to display vsync. To support `VK_PRESENT_MODE_IMMEDIATE_KHR` while using `VkPresentTimeGOOGLE::presentID`, only call `presentAtTime:` if `VkPresentTimeGOOGLE::desiredPresentTime` has been explicitly set to a non-zero value.
- Clarify initially clearing `MVKImagePresentInfo` to all zeros.

Fixes issue #1925.