### PR TITLE
Add support for RG11B10 and RGB9E5 vertex formats

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -34,7 +34,7 @@ static const uint32_t _vkFormatCount = 256;
 static const uint32_t _vkFormatCoreCount = VK_FORMAT_ASTC_12x12_SRGB_BLOCK + 1;
 static const uint32_t _mtlPixelFormatCount = 256;
 static const uint32_t _mtlPixelFormatCoreCount = MTLPixelFormatX32_Stencil8 + 2;     // The actual last enum value is not available on iOS
-static const uint32_t _mtlVertexFormatCount = MTLVertexFormatHalf + 1;
+static const uint32_t _mtlVertexFormatCount = MTLVertexFormatHalf + 3;     // The actual last enum value is not available before Xcode 15
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -148,6 +148,11 @@ using namespace std;
 #       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
 #endif
 
+#if !MVK_XCODE_15
+#   define MTLVertexFormatFloatRG11B10              MTLVertexFormatInvalid
+#   define MTLVertexFormatFloatRGB9E5               MTLVertexFormatInvalid
+#endif
+
 
 #pragma mark -
 #pragma mark MVKPixelFormats
@@ -976,9 +981,9 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 	addVkFormatDesc( R64G64B64A64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat );
 	addVkFormatDesc( R64G64B64A64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat );
 
-	addVkFormatDesc( B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-
+	addVkFormatDesc( B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid, FloatRG11B10, Invalid, 1, 1, 4, ColorFloat );
+	addVkFormatDesc( E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, FloatRGB9E5, Invalid, 1, 1, 4, ColorFloat );
+	
 	addVkFormatDesc( D32_SFLOAT, Depth32Float, Invalid, Invalid, Invalid, 1, 1, 4, DepthStencil );
 	addVkFormatDesc( D32_SFLOAT_S8_UINT, Depth32Float_Stencil8, Invalid, Invalid, Invalid, 1, 1, 5, DepthStencil );
 
@@ -1392,6 +1397,11 @@ void MVKPixelFormats::initMTLVertexFormatCapabilities() {
 	addMTLVertexFormatDesc( Half, None, None );
 
 	addMTLVertexFormatDesc( UChar4Normalized_BGRA, None, None );
+	
+#if MVK_XCODE_15
+	addMTLVertexFormatDesc( FloatRG11B10, None, None );
+	addMTLVertexFormatDesc( FloatRGB9E5, None, None );
+#endif
 
 	// When adding to this list, be sure to ensure _mtlVertexFormatCount is large enough for the format count
 }
@@ -1683,6 +1693,11 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 	addFeatSetMTLVtxFmtCaps( macOS_GPUFamily1_v3, Short, Vertex );
 	addFeatSetMTLVtxFmtCaps( macOS_GPUFamily1_v3, Half, Vertex );
 	addFeatSetMTLVtxFmtCaps( macOS_GPUFamily1_v3, UChar4Normalized_BGRA, Vertex );
+	
+#if MVK_XCODE_15
+	addGPUOSMTLVtxFmtCaps( Apple5, 14.0, FloatRG11B10, Vertex );
+	addGPUOSMTLVtxFmtCaps( Apple5, 14.0, FloatRGB9E5, Vertex );
+#endif
 #endif
 
 #if MVK_TVOS
@@ -1776,6 +1791,11 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 	addFeatSetMTLVtxFmtCaps( tvOS_GPUFamily1_v3, Short, Vertex );
 	addFeatSetMTLVtxFmtCaps( tvOS_GPUFamily1_v3, Half, Vertex );
 	addFeatSetMTLVtxFmtCaps( tvOS_GPUFamily1_v3, UChar4Normalized_BGRA, Vertex );
+	
+#if MVK_XCODE_15
+	addGPUOSMTLVtxFmtCaps( Apple5, 17.0, FloatRG11B10, Vertex );
+	addGPUOSMTLVtxFmtCaps( Apple5, 17.0, FloatRGB9E5, Vertex );
+#endif
 
 	// Disable for tvOS simulator last.
 #if MVK_OS_SIMULATOR
@@ -1933,6 +1953,11 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 	addFeatSetMTLVtxFmtCaps( iOS_GPUFamily1_v4, Short, Vertex );
 	addFeatSetMTLVtxFmtCaps( iOS_GPUFamily1_v4, Half, Vertex );
 	addFeatSetMTLVtxFmtCaps( iOS_GPUFamily1_v4, UChar4Normalized_BGRA, Vertex );
+	
+#if MVK_XCODE_15
+	addGPUOSMTLVtxFmtCaps( Apple5, 17.0, FloatRG11B10, Vertex );
+	addGPUOSMTLVtxFmtCaps( Apple5, 17.0, FloatRGB9E5, Vertex );
+#endif
 
 // Disable for iOS simulator last.
 #if MVK_OS_SIMULATOR


### PR DESCRIPTION
Metal 3.1 and iOS 17/macOS 14 add support for these two new vertex/attribute formats.

I also put in all of the necessary fixes (afaik) for Xcode 15 into this PR.