### PR TITLE
Log more info about SPIR-V to MSL conversion errors.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,8 +22,9 @@ Released TBD
 	- `VK_EXT_shader_demote_to_helper_invocation`
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
 - Support `VK_PRESENT_MODE_IMMEDIATE_KHR` if `VkPresentTimeGOOGLE::desiredPresentTime` is zero.
+- Support maximizing the concurrent executing compilation tasks via `MVKConfiguration::shouldMaximizeConcurrentCompilation`
 - Add support for `VK_PRESENT_MODE_IMMEDIATE_KHR` to macOS Cube demo.
-- Allows maximizing the concurrent executing compilation tasks via `MVKConfiguration::shouldMaximizeConcurrentCompilation`
+- Log more info about SPIR-V to MSL conversion errors.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -111,8 +111,6 @@ MVKMTLFunction MVKShaderLibrary::getMTLFunction(const VkSpecializationInfo* pSpe
 						mtlFunc = [fs.newMTLFunction(_mtlLibrary, mtlFuncName, mtlFCVals) autorelease];
 					}
 				}
-			} else {
-				reportError(VK_ERROR_INVALID_SHADER_NV, "Shader module does not contain an entry point named '%s'.", mtlFuncName.UTF8String);
 			}
 
 			// Set the debug name. First try name of shader module, otherwise try name of owner.

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
@@ -344,7 +344,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverter::convert(SPIRVToMSLConversionConfigur
 
 #ifndef SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS
 	} catch (CompilerError& ex) {
-		string errMsg("MSL conversion error: ");
+		string errMsg("SPIR-V to MSL conversion error: ");
 		errMsg += ex.what();
 		logError(conversionResult.resultLog, errMsg.data());
         if (shouldLogMSL && pMSLCompiler) {
@@ -446,6 +446,7 @@ void SPIRVToMSLConverter::logMsg(string& log, const char* logMsg) {
 // Appends the error text to the result log, and returns false to indicate an error.
 bool SPIRVToMSLConverter::logError(string& log, const char* errMsg) {
 	logMsg(log, errMsg);
+	fprintf(stderr, "[mvk-error] %s\n", errMsg);
 	return false;
 }
 


### PR DESCRIPTION
Remove unhelpful "Shader module does not contain
an entry point named 'main0'" error message.