### PR TITLE
Support the `VK_EXT_4444_formats` extension.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -350,6 +350,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_timeline_semaphore`
 - `VK_KHR_uniform_buffer_standard_layout`
 - `VK_KHR_variable_pointers`
+- `VK_EXT_4444_formats` *(requires 16-bit formats and either native texture swizzling or manual swizzling to be enabled)*
 - `VK_EXT_buffer_device_address` *(requires GPU Tier 2 argument buffers support)*
 - `VK_EXT_debug_marker`
 - `VK_EXT_debug_report`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.5
 Released TBD
 
 - Add support for extensions:
+	- `VK_EXT_4444_formats`
 	- `VK_EXT_shader_demote_to_helper_invocation`
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
 - Support `VK_PRESENT_MODE_IMMEDIATE_KHR` if `VkPresentTimeGOOGLE::desiredPresentTime` is zero.

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -227,6 +227,15 @@ MTLTextureSwizzle mvkMTLTextureSwizzleFromVkComponentSwizzle(VkComponentSwizzle 
 /** Returns all four Metal texture swizzles from the Vulkan component mapping. */
 MTLTextureSwizzleChannels mvkMTLTextureSwizzleChannelsFromVkComponentMapping(VkComponentMapping vkMapping);
 
+/** Maps a clear color according to the specified VkComponentSwizzle. */
+float mvkVkClearColorFloatValueFromVkComponentSwizzle(float *colors, uint32_t index, VkComponentSwizzle vkSwizzle);
+
+/** Maps a clear color according to the specified VkComponentSwizzle. */
+uint32_t mvkVkClearColorUIntValueFromVkComponentSwizzle(uint32_t *colors, uint32_t index, VkComponentSwizzle vkSwizzle);
+
+/** Maps a clear color according to the specified VkComponentSwizzle. */
+int32_t mvkVkClearColorIntValueFromVkComponentSwizzle(int32_t *colors, uint32_t index, VkComponentSwizzle vkSwizzle);
+
 
 #pragma mark Mipmaps
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -37,20 +37,31 @@ class MVKQueryPool;
  * This structure can be used as a key in a std::map and std::unordered_map.
  */
 typedef struct MVKRPSKeyBlitImg {
-	uint16_t srcMTLPixelFormat = 0;			/**< as MTLPixelFormat */
-	uint16_t dstMTLPixelFormat = 0;			/**< as MTLPixelFormat */
-	uint8_t srcMTLTextureType = 0;			/**< as MTLTextureType */
+	uint16_t srcMTLPixelFormat : 12;		/**< as MTLPixelFormat */
+	uint16_t dstMTLPixelFormat : 12;		/**< as MTLPixelFormat */
+	uint8_t srcMTLTextureType : 4;			/**< as MTLTextureType */
+	uint8_t srcFilter : 4;					/**< as MTLSamplerMinMagFilter */
 	uint8_t srcAspect = 0;					/**< as VkImageAspectFlags */
-	uint8_t srcFilter = 0;					/**< as MTLSamplerMinMagFilter */
 	uint8_t dstSampleCount = 0;
+	uint8_t srcSwizzleR : 4;				/**< as VkComponentSwizzle */
+	uint8_t srcSwizzleG : 4;				/**< as VkComponentSwizzle */
+	uint8_t srcSwizzleB : 4;				/**< as VkComponentSwizzle */
+	uint8_t srcSwizzleA : 4;				/**< as VkComponentSwizzle */
+
+	MVKRPSKeyBlitImg() : srcMTLPixelFormat(0), dstMTLPixelFormat(0), srcMTLTextureType(0), srcFilter(0),
+		srcSwizzleR(0), srcSwizzleG(0), srcSwizzleB(0), srcSwizzleA(0) {}
 
 	bool operator==(const MVKRPSKeyBlitImg& rhs) const {
 		if (srcMTLPixelFormat != rhs.srcMTLPixelFormat) { return false; }
 		if (dstMTLPixelFormat != rhs.dstMTLPixelFormat) { return false; }
 		if (srcMTLTextureType != rhs.srcMTLTextureType) { return false; }
-		if (srcAspect != rhs.srcAspect) { return false; }
 		if (srcFilter != rhs.srcFilter) { return false; }
+		if (srcAspect != rhs.srcAspect) { return false; }
 		if (dstSampleCount != rhs.dstSampleCount) { return false; }
+		if (srcSwizzleR != rhs.srcSwizzleR) { return false; }
+		if (srcSwizzleG != rhs.srcSwizzleG) { return false; }
+		if (srcSwizzleB != rhs.srcSwizzleB) { return false; }
+		if (srcSwizzleA != rhs.srcSwizzleA) { return false; }
 		return true;
 	}
 
@@ -70,23 +81,40 @@ typedef struct MVKRPSKeyBlitImg {
 				srcMTLTextureType == MTLTextureType1DArray);
 	}
 
+	VkComponentMapping getSrcSwizzle() {
+		return { (VkComponentSwizzle)srcSwizzleR, (VkComponentSwizzle)srcSwizzleG,
+			 (VkComponentSwizzle)srcSwizzleB, (VkComponentSwizzle)srcSwizzleA };
+	}
+
 	std::size_t hash() const {
 		std::size_t hash = srcMTLPixelFormat;
 
-		hash <<= 16;
+		hash <<= 12;
 		hash |= dstMTLPixelFormat;
 
-		hash <<= 8;
+		hash <<= 4;
 		hash |= srcMTLTextureType;
+
+		hash <<= 4;
+		hash |= srcFilter;
 
 		hash <<= 8;
 		hash |= srcAspect;
 
 		hash <<= 8;
-		hash |= srcFilter;
-
-		hash <<= 8;
 		hash |= dstSampleCount;
+
+		hash <<= 4;
+		hash |= srcSwizzleR;
+
+		hash <<= 4;
+		hash |= srcSwizzleG;
+
+		hash <<= 4;
+		hash |= srcSwizzleB;
+
+		hash <<= 4;
+		hash |= srcSwizzleA;
 		return hash;
 	}
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -167,6 +167,25 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	return rps;
 }
 
+static char getSwizzleChar(char defaultChar, VkComponentSwizzle vkSwizzle) {
+	switch (vkSwizzle) {
+		case VK_COMPONENT_SWIZZLE_IDENTITY: return defaultChar;
+		// FIXME: 0 and 1 (currently not used in any default swizzles)
+		case VK_COMPONENT_SWIZZLE_R:		return 'x';
+		case VK_COMPONENT_SWIZZLE_G:		return 'y';
+		case VK_COMPONENT_SWIZZLE_B:		return 'z';
+		case VK_COMPONENT_SWIZZLE_A:		return 'w';
+		default:							return defaultChar;
+	}
+}
+
+static void getSwizzleString(char swizzleStr[4], VkComponentMapping vkMapping) {
+	swizzleStr[0] = getSwizzleChar('x', vkMapping.r);
+	swizzleStr[1] = getSwizzleChar('y', vkMapping.g);
+	swizzleStr[2] = getSwizzleChar('z', vkMapping.b);
+	swizzleStr[3] = getSwizzleChar('w', vkMapping.a);
+}
+
 id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg& blitKey) {
 	@autoreleasepool {
 		bool isLayeredBlit = blitKey.dstSampleCount > 1 ? _device->_pMetalFeatures->multisampleLayeredRendering : _device->_pMetalFeatures->layeredRendering;
@@ -177,6 +196,7 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		NSString* typePrefix = @"texture";
 		NSString* typeSuffix;
 		NSString* coordArg;
+		char swizzleArg[4] = { 'x', 'y', 'z', 'w' };
 		if (mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT))) {
 			typePrefix = @"depth";
 		}
@@ -208,6 +228,9 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		}
 		NSString* sliceArg = isArrayType ? (isLayeredBlit ? @", subRez.slice + varyings.v_layer" : @", subRez.slice") : @"";
 		NSString* srcFilter = isLinearFilter ? @"linear" : @"nearest";
+		if (!getDevice()->_pMetalFeatures->nativeTextureSwizzle) {
+			getSwizzleString(swizzleArg, blitKey.getSrcSwizzle());
+		}
 
 		NSMutableString* msl = [NSMutableString stringWithCapacity: (2 * KIBI) ];
 		[msl appendLineMVK: @"#include <metal_stdlib>"];
@@ -263,15 +286,15 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		[msl appendLineMVK: @"                         constant TexSubrez& subRez [[buffer(0)]]) {"];
 		[msl appendLineMVK: @"    FragmentOutputs out;"];
 		if (mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT))) {
-			[msl appendFormat: @"    out.depth = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod));", coordArg, sliceArg];
+			[msl appendFormat: @"    out.depth = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).%c;", coordArg, sliceArg, swizzleArg[0]];
 			[msl appendLineMVK];
 		}
 		if (mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_STENCIL_BIT))) {
-			[msl appendFormat: @"    out.stencil = stencilTex.sample(ce_stencil_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).x;", coordArg, sliceArg];
+			[msl appendFormat: @"    out.stencil = stencilTex.sample(ce_stencil_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).%c;", coordArg, sliceArg, swizzleArg[0]];
 			[msl appendLineMVK];
 		}
 		if (!mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-			[msl appendFormat: @"    out.color = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod));", coordArg, sliceArg];
+			[msl appendFormat: @"    out.color = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).%.4s;", coordArg, sliceArg, swizzleArg];
 			[msl appendLineMVK];
 		}
 		[msl appendLineMVK: @"    return out;"];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -371,6 +371,15 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				portabilityFeatures->vertexAttributeAccessBeyondStride = true;	// Costs additional buffers. Should make configuration switch.
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
+				auto* formatFeatures = (VkPhysicalDevice4444FormatsFeaturesEXT*)next;
+				bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering &&
+									  (_metalFeatures.nativeTextureSwizzle ||
+									   mvkConfig().fullImageViewSwizzle);
+				formatFeatures->formatA4R4G4B4 = canSupport4444;
+				formatFeatures->formatA4B4G4R4 = canSupport4444;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: {
 				auto* interlockFeatures = (VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*)next;
 				interlockFeatures->fragmentShaderSampleInterlock = _metalFeatures.rasterOrderGroups;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -62,6 +62,7 @@ MVK_DEVICE_FEATURE(VariablePointer,                   VARIABLE_POINTER,         
 MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,                    3)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
+MVK_DEVICE_FEATURE_EXTN(4444Formats,                  4444_FORMATS,                    EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderInterlock,      FRAGMENT_SHADER_INTERLOCK,       EXT,   3)
 MVK_DEVICE_FEATURE_EXTN(PipelineCreationCacheControl, PIPELINE_CREATION_CACHE_CONTROL, EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(Robustness2,                  ROBUSTNESS_2,                    EXT,   3)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -224,6 +224,9 @@ public:
     /** Returns the number of planes of this image view. */
     uint8_t getPlaneCount() { return _planes.size(); }
 
+	/** Returns whether or not the image format requires swizzling. */
+	bool needsSwizzle() { return getPixelFormats()->needsSwizzle(_vkFormat); }
+
 	/** Populates the specified layout for the specified sub-resource. */
 	VkResult getSubresourceLayout(const VkImageSubresource* pSubresource,
 								  VkSubresourceLayout* pLayout);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1575,6 +1575,26 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
 
 #define adjustComponentSwizzleValue(comp, currVal, newVal)    if (_componentSwizzle.comp == VK_COMPONENT_SWIZZLE_ ##currVal) { _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_ ##newVal; }
+#define adjustAnyComponentSwizzleValue(comp, I, R, G, B, A) \
+	switch (_componentSwizzle.comp) { \
+		case VK_COMPONENT_SWIZZLE_IDENTITY: \
+			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##I; \
+			break; \
+		case VK_COMPONENT_SWIZZLE_R: \
+			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##R; \
+			break; \
+		case VK_COMPONENT_SWIZZLE_G: \
+			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##G; \
+			break; \
+		case VK_COMPONENT_SWIZZLE_B: \
+			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##B; \
+			break; \
+		case VK_COMPONENT_SWIZZLE_A: \
+			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##A; \
+			break; \
+		default: \
+			break; \
+	}
 
 	// Use swizzle adjustment to bridge some differences between Vulkan and Metal pixel formats.
 	// Do this ahead of other tests and adjustments so that swizzling will be enabled by tests below.
@@ -1587,6 +1607,24 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 			adjustComponentSwizzleValue(b, A, ONE);
 			adjustComponentSwizzleValue(a, A, ONE);
 			adjustComponentSwizzleValue(a, IDENTITY, ONE);
+			break;
+
+		case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
+			// Metal doesn't (publicly) support this directly, so use a swizzle to get the ordering right.
+			// n.b. **Do NOT use adjustComponentSwizzleValue if multiple values need substitution,
+			// and some of the substitutes are keys for other substitutions!**
+			adjustAnyComponentSwizzleValue(r, G, G, B, A, R);
+			adjustAnyComponentSwizzleValue(g, B, G, B, A, R);
+			adjustAnyComponentSwizzleValue(b, A, G, B, A, R);
+			adjustAnyComponentSwizzleValue(a, R, G, B, A, R);
+			break;
+
+		case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
+			// Metal doesn't support this directly, so use a swizzle to get the ordering right.
+			adjustAnyComponentSwizzleValue(r, A, A, B, G, R);
+			adjustAnyComponentSwizzleValue(g, B, A, B, G, R);
+			adjustAnyComponentSwizzleValue(b, G, A, B, G, R);
+			adjustAnyComponentSwizzleValue(a, R, A, B, G, R);
 			break;
 
 		default:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -148,6 +148,7 @@ typedef struct MVKVkFormatDesc {
 	uint32_t bytesPerBlock;
 	MVKFormatType formatType;
 	VkFormatProperties properties;
+	VkComponentMapping componentMapping;
 	const char* name;
 	bool hasReportedSubstitution;
     
@@ -158,6 +159,13 @@ typedef struct MVKVkFormatDesc {
 
 	inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid); };
 	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); };
+
+	bool needsSwizzle() const {
+		return componentMapping.r != VK_COMPONENT_SWIZZLE_IDENTITY ||
+			componentMapping.g != VK_COMPONENT_SWIZZLE_IDENTITY ||
+			componentMapping.b != VK_COMPONENT_SWIZZLE_IDENTITY ||
+			componentMapping.a != VK_COMPONENT_SWIZZLE_IDENTITY;
+	}
 } MVKVkFormatDesc;
 
 /** Describes the properties of a MTLPixelFormat or MTLVertexFormat. */
@@ -319,6 +327,21 @@ public:
 	 * rounded up if texelRowsPerLayer is not an integer multiple of the compression block height.
 	 */
 	size_t getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
+
+	/** Returns whether or not the specified Vulkan format requires swizzling to use with Metal. */
+	bool needsSwizzle(VkFormat vkFormat);
+
+	/** Returns any VkComponentMapping needed to use the specified Vulkan format. */
+	VkComponentMapping getVkComponentMapping(VkFormat vkFormat);
+
+	/**
+	 * Returns the inverse of the VkComponentMapping needed to use the specified Vulkan format.
+	 * If the original mapping is not a one-to-one function, the behaviour is undefined.
+	 */
+	VkComponentMapping getInverseComponentMapping(VkFormat vkFormat);
+
+	/** Returns any MTLTextureSwizzleChannels needed to use the specified Vulkan format. */
+	MTLTextureSwizzleChannels getMTLTextureSwizzleChannels(VkFormat vkFormat);
 
 	/** Returns the default properties for the specified Vulkan format. */
 	VkFormatProperties& getVkFormatProperties(VkFormat vkFormat);

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -92,6 +92,7 @@ MVK_EXTENSION(KHR_timeline_semaphore,                 KHR_TIMELINE_SEMAPHORE,   
 MVK_EXTENSION(KHR_uniform_buffer_standard_layout,     KHR_UNIFORM_BUFFER_STANDARD_LAYOUT,     DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_variable_pointers,                  KHR_VARIABLE_POINTERS,                  DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_vulkan_memory_model,                KHR_VULKAN_MEMORY_MODEL,                DEVICE,   MVK_NA, MVK_NA)
+MVK_EXTENSION(EXT_4444_formats,                       EXT_4444_FORMATS,                       DEVICE,   11.0,  13.0)
 MVK_EXTENSION(EXT_buffer_device_address,              EXT_BUFFER_DEVICE_ADDRESS,              DEVICE,   13.0,  16.0)
 MVK_EXTENSION(EXT_debug_marker,                       EXT_DEBUG_MARKER,                       DEVICE,   10.11,  8.0)
 MVK_EXTENSION(EXT_debug_report,                       EXT_DEBUG_REPORT,                       INSTANCE, 10.11,  8.0)

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -228,6 +228,45 @@ MVK_PUBLIC_SYMBOL MTLTextureSwizzleChannels mvkMTLTextureSwizzleChannelsFromVkCo
 #undef convert
 }
 
+MVK_PUBLIC_SYMBOL float mvkVkClearColorFloatValueFromVkComponentSwizzle(float *colors, uint32_t index, VkComponentSwizzle vkSwizzle) {
+	switch (vkSwizzle) {
+		case VK_COMPONENT_SWIZZLE_IDENTITY:	return colors[index];
+		case VK_COMPONENT_SWIZZLE_ZERO:		return 0.f;
+		case VK_COMPONENT_SWIZZLE_ONE:		return 1.f;
+		case VK_COMPONENT_SWIZZLE_R:		return colors[0];
+		case VK_COMPONENT_SWIZZLE_G:		return colors[1];
+		case VK_COMPONENT_SWIZZLE_B:		return colors[2];
+		case VK_COMPONENT_SWIZZLE_A:		return colors[3];
+		default:							return colors[index];
+	}
+}
+
+MVK_PUBLIC_SYMBOL uint32_t mvkVkClearColorUIntValueFromVkComponentSwizzle(uint32_t *colors, uint32_t index, VkComponentSwizzle vkSwizzle) {
+	switch (vkSwizzle) {
+		case VK_COMPONENT_SWIZZLE_IDENTITY:	return colors[index];
+		case VK_COMPONENT_SWIZZLE_ZERO:		return 0U;
+		case VK_COMPONENT_SWIZZLE_ONE:		return 1U;
+		case VK_COMPONENT_SWIZZLE_R:		return colors[0];
+		case VK_COMPONENT_SWIZZLE_G:		return colors[1];
+		case VK_COMPONENT_SWIZZLE_B:		return colors[2];
+		case VK_COMPONENT_SWIZZLE_A:		return colors[3];
+		default:							return colors[index];
+	}
+}
+
+MVK_PUBLIC_SYMBOL int32_t mvkVkClearColorIntValueFromVkComponentSwizzle(int32_t *colors, uint32_t index, VkComponentSwizzle vkSwizzle) {
+	switch (vkSwizzle) {
+		case VK_COMPONENT_SWIZZLE_IDENTITY:	return colors[index];
+		case VK_COMPONENT_SWIZZLE_ZERO:		return 0;
+		case VK_COMPONENT_SWIZZLE_ONE:		return 1;
+		case VK_COMPONENT_SWIZZLE_R:		return colors[0];
+		case VK_COMPONENT_SWIZZLE_G:		return colors[1];
+		case VK_COMPONENT_SWIZZLE_B:		return colors[2];
+		case VK_COMPONENT_SWIZZLE_A:		return colors[3];
+		default:							return colors[index];
+	}
+}
+
 
 #pragma mark Mipmaps
 


### PR DESCRIPTION
This turned out to be a little bit more involved than I had hoped. But, with this, we can now use the `VK_FORMAT_A4R4G4B4_UNORM_PACK16` and `VK_FORMAT_A4B4G4R4_UNORM_PACK16` formats from shaders, use them as blit sources, and even clear them. Storage images and render targets of these formats aren't supported, however. To support the latter would require the insertion of a swizzle into the fragment shader before returning. The former cannot be reasonably supported.