### PR TITLE
Advertise the `VK_KHR_shader_non_semantic_info` extension.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -341,6 +341,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_shader_draw_parameters`
 - `VK_KHR_shader_float_controls`
 - `VK_KHR_shader_float16_int8`
+- `VK_KHR_shader_non_semantic_info`
 - `VK_KHR_shader_subgroup_extended_types` *(requires Metal 2.1 on Mac or Metal 2.2 and Apple family 4 on iOS)*
 - `VK_KHR_spirv_1_4`
 - `VK_KHR_storage_buffer_storage_class`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.5
 Released TBD
 
 - Add support for extensions:
+	- `VK_KHR_shader_non_semantic_info`
 	- `VK_EXT_4444_formats`
 	- `VK_EXT_shader_demote_to_helper_invocation`
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -83,6 +83,7 @@ MVK_EXTENSION(KHR_shader_atomic_int64,                KHR_SHADER_ATOMIC_INT64,  
 MVK_EXTENSION(KHR_shader_draw_parameters,             KHR_SHADER_DRAW_PARAMETERS,             DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_float_controls,              KHR_SHADER_FLOAT_CONTROLS,              DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_float16_int8,                KHR_SHADER_FLOAT16_INT8,                DEVICE,   10.11,  8.0)
+MVK_EXTENSION(KHR_shader_non_semantic_info,           KHR_SHADER_NON_SEMANTIC_INFO,           DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_shader_subgroup_extended_types,     KHR_SHADER_SUBGROUP_EXTENDED_TYPES,     DEVICE,   10.14, 13.0)
 MVK_EXTENSION(KHR_spirv_1_4,                          KHR_SPIRV_1_4,                          DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_storage_buffer_storage_class,       KHR_STORAGE_BUFFER_STORAGE_CLASS,       DEVICE,   10.11,  8.0)


### PR DESCRIPTION
This just provides support for the `SPV_KHR_non_semantic_info` extension, which supports extended instruction sets that do not affect the semantics of a SPIR-V shader (e.g. debug info). SPIRV-Cross already handles these instruction sets, so no additional work is required on our part to support this extension.