### PR TITLE
Fix unreachable code in MVKDeferredOperation::join().

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2676,7 +2676,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetDeferredOperationResultKHR(
     
     MVKTraceVulkanCallStart();
     MVKDeferredOperation* mvkDeferredOperation = (MVKDeferredOperation*)operation;
-    VkResult rslt = mvkDeferredOperation->getResult();
+    VkResult rslt = mvkDeferredOperation->getOperationResult();
     MVKTraceVulkanCallEnd();
     return rslt;
 }


### PR DESCRIPTION
- Fix unreachable code in `MVKDeferredOperation::join()`.
- Refactor code so deferred functions call back to `MVKDeferredOperation` instance to update current status, and deferred function execution returns result of individual thread execution.
- `MVKDeferredOperation` use `MVKSmallVector` for `_functionParameters`.
- `MVKDeferredOperation` use a single mutex lock.
- Add additional comments explaining design to developers of future extensions that use deferred operations.

@AntarticCoder Please review as changes to your original code. Most of it is just clean up and documentation, but the way that deferred functions interact with `MVKDeferredOperation::join()` functionally has changed. I also did not have any trouble with `MVKSmallVector` on either Xcode 14 or 15, so I've reverted to using that as originally planned.