### PR TITLE
Added Enum for MSL Version 3.1

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -88,6 +88,10 @@ extern "C" {
 #endif
 
 /** Building with Xcode versions. iOS version also covers tvOS. */
+#ifndef MVK_XCODE_15
+#   define MVK_XCODE_15             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) || \
+                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000))
+#endif
 #ifndef MVK_XCODE_14_3
 #	define MVK_XCODE_14_3			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130300) || \
 									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160400))

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1780,6 +1780,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	}
 #endif
 
+#if MVK_XCODE_15
+    if ( mvkOSVersionIsAtLeast(17.0) ) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+    }
+#endif
+
 #endif
 
 #if MVK_IOS
@@ -1897,6 +1903,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
 	}
 #endif
+#if MVK_XCODE_15
+    if ( mvkOSVersionIsAtLeast(17.0) ) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+    }
+#endif
 
 #endif
 
@@ -1981,6 +1992,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	if ( mvkOSVersionIsAtLeast(13.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
 	}
+#endif
+#if MVK_XCODE_15
+    if ( mvkOSVersionIsAtLeast(14.0) ) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+    }
 #endif
 
 	// This is an Apple GPU--treat it accordingly.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2097,6 +2097,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj, min);
 
 	switch (_metalFeatures.mslVersionEnum) {
+#if MVK_XCODE_15
+        case MTLLanguageVersion3_1:
+            setMSLVersion(3, 1);
+            break;
+#endif
 #if MVK_XCODE_14
 		case MTLLanguageVersion3_0:
 			setMSLVersion(3, 0);

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -71,6 +71,11 @@ bool mvk::compile(const string& mslSourceCode,
 #define mslVer(MJ, MN, PT)	mslVersionMajor == MJ && mslVersionMinor == MN && mslVersionPoint == PT
 
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
+#if MVK_XCODE_15
+    if (mslVer(3, 1, 0)) {
+        mslVerEnum = MTLLanguageVersion3_1;
+    } else
+#endif
 #if MVK_XCODE_14
 	if (mslVer(3, 0, 0)) {
 		mslVerEnum = MTLLanguageVersion3_0;


### PR DESCRIPTION
In this PR, I've added support for Xcode 15, and added a case for MSL version 3.1. I added this because I noticed xcode was throwing some warnings about an unhandled switch case.