### PR TITLE
MVKDevice: Don't enable sample LoD depth array workaround for macOS S…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1693,7 +1693,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			break;
 		case kAppleVendorId:
 			// TODO: Other GPUs?
-			_metalFeatures.needsSampleDrefLodArrayWorkaround = true;
+			if (!mvkOSVersionIsAtLeast(14.0, 17.0)) {
+				_metalFeatures.needsSampleDrefLodArrayWorkaround = true;
+			}
 			// fallthrough
 		case kIntelVendorId:
 		case kNVVendorId:


### PR DESCRIPTION
…onoma and up.

Apple have indicated to me that they have fixed the bug. I've confirmed this.