### PR TITLE
Support the `VK_KHR_incremental_present` extension.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -434,6 +434,12 @@ VkExtent2D mvkVkExtent2DFromCGSize(CGSize cgSize);
 /** Returns a CGSize that corresponds to the specified VkExtent2D. */
 CGSize mvkCGSizeFromVkExtent2D(VkExtent2D vkExtent);
 
+/** Returns a CGPoint that corresponds to the specified VkOffset2D. */
+CGPoint mvkCGPointFromVkOffset2D(VkOffset2D vkOffset);
+
+/** Returns a CGRect that corresponds to the specified VkRectLayerKHR. The layer is ignored. */
+CGRect mvkCGRectFromVkRectLayerKHR(VkRectLayerKHR vkRect);
+
 /** Returns a Metal MTLOrigin constructed from a VkOffset3D. */
 static inline MTLOrigin mvkMTLOriginFromVkOffset3D(VkOffset3D vkOffset) {
 	return MTLOriginMake(vkOffset.x, vkOffset.y, vkOffset.z);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -99,6 +99,9 @@ public:
 	/** VK_GOOGLE_display_timing - returns past presentation times */
 	VkResult getPastPresentationTiming(uint32_t *pCount, VkPastPresentationTimingGOOGLE *pPresentationTimings);
 
+	/** Marks parts of the underlying CAMetalLayer as needing update. */
+	void setLayerNeedsDisplay(const VkPresentRegionKHR* pRegion);
+
 	void destroy() override;
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -68,6 +68,7 @@ MVK_EXTENSION(KHR_get_physical_device_properties2,    KHR_GET_PHYSICAL_DEVICE_PR
 MVK_EXTENSION(KHR_get_surface_capabilities2,          KHR_GET_SURFACE_CAPABILITIES_2,         INSTANCE, 10.11,  8.0)
 MVK_EXTENSION(KHR_imageless_framebuffer,              KHR_IMAGELESS_FRAMEBUFFER,              DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_image_format_list,                  KHR_IMAGE_FORMAT_LIST,                  DEVICE,   10.11,  8.0)
+MVK_EXTENSION(KHR_incremental_present,                KHR_INCREMENTAL_PRESENT,                DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_maintenance1,                       KHR_MAINTENANCE1,                       DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_maintenance2,                       KHR_MAINTENANCE2,                       DEVICE,   10.11,  8.0)
 MVK_EXTENSION(KHR_maintenance3,                       KHR_MAINTENANCE3,                       DEVICE,   10.11,  8.0)

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -780,10 +780,15 @@ MVK_PUBLIC_SYMBOL VkExtent2D mvkVkExtent2DFromCGSize(CGSize cgSize) {
 }
 
 MVK_PUBLIC_SYMBOL CGSize mvkCGSizeFromVkExtent2D(VkExtent2D vkExtent) {
-	CGSize cgSize;
-	cgSize.width = vkExtent.width;
-	cgSize.height = vkExtent.height;
-	return cgSize;
+	return CGSizeMake(vkExtent.width, vkExtent.height);
+}
+
+MVK_PUBLIC_SYMBOL CGPoint mvkCGPointFromVkOffset2D(VkOffset2D vkOffset) {
+	return CGPointMake(vkOffset.x, vkOffset.y);
+}
+
+MVK_PUBLIC_SYMBOL CGRect mvkCGRectFromVkRectLayerKHR(VkRectLayerKHR vkRect) {
+	return { mvkCGPointFromVkOffset2D(vkRect.offset), mvkCGSizeFromVkExtent2D(vkRect.extent) };
 }
 
 


### PR DESCRIPTION
This extension allows apps to provide a hint to the presentation engine indicating which parts of the surface need updating. To provide this hint, we call `-[CALayer setNeedsDisplayInRect:]`, which indicates that only the given rectangle needs updating.

I'm not sure if this will have any effect, especially if `CAMetalLayer.presentsWithTransaction` is `NO`. Luckily for us, this is only a hint, and it is permissible for the presentation engine to do nothing with the hint.

The tests don't work because they apparently can't handle `VK_SUBOPTIMAL_KHR` being returned.