### PR TITLE
Drop official support for using Xcode 11 to build MoltenVK.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,18 +15,14 @@ jobs:
   build:
     strategy:
       matrix:
-        xcode: [ "14.3" ]
+        xcode: [ "14.3.1" ]
         platform: [ "all", "macos", "ios" ]
         os: [ "macos-13" ]
         upload_artifacts: [ true ]
-        # additional specific configurations
+
+        # Legacy configurations
         include:
-          # "Legacy" Xcode 12.5.1 & 11.7 macOS builds
           - xcode: "12.5.1"
-            platform: "macos"
-            os: "macos-11"
-            upload_artifacts: false
-          - xcode: "11.7"
             platform: "macos"
             os: "macos-11"
             upload_artifacts: false

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,6 +32,7 @@ Released TBD
 - Support maximizing the concurrent executing compilation tasks via `MVKConfiguration::shouldMaximizeConcurrentCompilation`
 - Add support for `VK_PRESENT_MODE_IMMEDIATE_KHR` to macOS Cube demo.
 - Log more info about SPIR-V to MSL conversion errors.
+- Drop official support for using *Xcode 11* to build MoltenVK.
 
 
 


### PR DESCRIPTION
- Remove Xcode 11 build from GitHub CI.
- Leave `MVK_XCODE_12` guards in place to allow devs to possibly continue to attempt to build existing MoltenVK code using Xcode 11, even though it's not officially supported. Such devs may have to add their own additional `MVK_XCODE_12` guards for any Xcode 12 API features added after this change.