### PR TITLE
Fix regression caused by #1922

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -839,6 +839,10 @@ void MVKCommandEncoder::endMetalRenderEncoding() {
 void MVKCommandEncoder::endCurrentMetalEncoding() {
 	endMetalRenderEncoding();
 
+	_computePipelineState.markDirty();
+	_computePushConstants.markDirty();
+	_computeResourcesState.markDirty();
+
 	if (_mtlComputeEncoder && _cmdBuffer->_hasStageCounterTimestampCommand) { [_mtlComputeEncoder updateFence: getStageCountersMTLFence()]; }
 	endMetalEncoding(_mtlComputeEncoder);
 	_mtlComputeEncoderUse = kMVKCommandUseNone;
@@ -856,7 +860,7 @@ id<MTLComputeCommandEncoder> MVKCommandEncoder::getMTLComputeEncoder(MVKCommandU
 		_mtlComputeEncoder = [_mtlCmdBuffer computeCommandEncoder];
 		retainIfImmediatelyEncoding(_mtlComputeEncoder);
 		beginMetalComputeEncoding(cmdUse);
-		markCurrentComputeStateDirty = true;	// Always mark current compute state dirty for new encoder
+		markCurrentComputeStateDirty = false;	// Already marked dirty above in endCurrentMetalEncoding()
 	}
 	if(markCurrentComputeStateDirty) {
 		_computePipelineState.markDirty();


### PR DESCRIPTION
Needed to complete fix for #1874

We can't wait until getMTLComputeEncoder() is called to dirty the state, because this call will be avoided by dirty checks themselves. Those checks are comparing against leftover and now incorrect state since the previous encoder has already ended.
It needs to be dirtied on encoder end.