### PR TITLE
Potential fix for Argument Buffer Invalid Resource errors

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -580,6 +580,7 @@ protected:
 
     ResourceBindings<8> _shaderStageResourceBindings[kMVKShaderStageFragment + 1];
 	std::unordered_map<id<MTLResource>, MTLRenderStages> _renderUsageStages;
+	std::unordered_map<id<MTLResource>, MTLResourceUsage> _renderResourceUsage;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -760,6 +760,7 @@ void MVKGraphicsResourcesCommandEncoderState::offsetZeroDivisorVertexBuffers(MVK
 void MVKGraphicsResourcesCommandEncoderState::endMetalRenderPass() {
 	MVKResourcesCommandEncoderState::endMetalRenderPass();
 	_renderUsageStages.clear();
+	_renderResourceUsage.clear();
 }
 
 // Mark everything as dirty
@@ -983,12 +984,17 @@ void MVKGraphicsResourcesCommandEncoderState::encodeResourceUsage(MVKShaderStage
 			if ([mtlRendEnc respondsToSelector: @selector(useResource:usage:stages:)]) {
 				// Within a renderpass, a resource may be used by multiple descriptor bindings,
 				// each of which may assign a different usage stage. Dynamically accumulate
-				// usage stages across all descriptor bindings using the resource.
+				// usage stages and resouce usage across all descriptor bindings using the resource.
 				auto& accumStages = _renderUsageStages[mtlResource];
 				accumStages |= mtlStages;
-				[mtlRendEnc useResource: mtlResource usage: mtlUsage stages: accumStages];
+                
+				auto& accumUsage = _renderResourceUsage[mtlResource];
+				accumUsage |= mtlUsage;
+				[mtlRendEnc useResource: mtlResource usage: accumUsage stages: accumStages];
 			} else {
-				[mtlRendEnc useResource: mtlResource usage: mtlUsage];
+				auto& accumUsage = _renderResourceUsage[mtlResource];
+				accumUsage |= mtlUsage;
+				[mtlRendEnc useResource: mtlResource usage: accumUsage];
 			}
 		}
 	}


### PR DESCRIPTION
Potential fix for #1870

Peri noticed that while the stages for resource usage were accumulated, the resource usage mode itself was not. It is possible that this results in the usage mode being reset every time the resource is added to the encoder. This attempts to remedy that by also accumulating resource usage.

Not confirmed to be working yet.