### PR TITLE
Ensure Xcode simulator always uses 256B buffer alignment.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,9 +28,10 @@ Released TBD
 - Add support for `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN`.
 - Support building MoltenVK for visionOS.
 - Ensure non-dispatch compute commands don't interfere with compute encoding state used by dispatch commands.
-- Support `VK_PRESENT_MODE_IMMEDIATE_KHR` if `VkPresentTimeGOOGLE::desiredPresentTime` is zero.
 - Support maximizing the concurrent executing compilation tasks via `MVKConfiguration::shouldMaximizeConcurrentCompilation`
+- Support `VK_PRESENT_MODE_IMMEDIATE_KHR` if `VkPresentTimeGOOGLE::desiredPresentTime` is zero.
 - Add support for `VK_PRESENT_MODE_IMMEDIATE_KHR` to macOS Cube demo.
+- Ensure Xcode simulator always uses 256B buffer alignment.
 - Log more info about SPIR-V to MSL conversion errors.
 - Drop official support for using *Xcode 11* to build MoltenVK.
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2157,9 +2157,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 	}
 
-// iOS and tvOS adjustments necessary when running in the simulator on non-Apple GPUs.
-#if MVK_OS_SIMULATOR && !MVK_APPLE_SILICON
-	_metalFeatures.mtlBufferAlignment = 256;
+// iOS and tvOS adjustments necessary when running on the simulator.
+#if MVK_OS_SIMULATOR
+	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
 #endif
 
 	// Currently, Metal argument buffer support is in beta stage, and is only supported


### PR DESCRIPTION
Xcode simulator always requires 256B buffer alignment, even when running on Apple Silicon. Previously, it was assumed that Apple Silicon would use its native 16B buffer alignment.

Fixes issue #1989.