### PR TITLE
Fix rare case where vertex attribute buffers are not bound to Metal.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,16 @@ Copyright (c) 2015-2023 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.6
+--------------
+
+Released TBD
+
+- Fix rare case where vertex attribute buffers are not bound to Metal 
+  when no other bindings change between pipelines.
+
+
+
 MoltenVK 1.2.5
 --------------
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -81,6 +81,8 @@ public:
     /**
      * If the content of this instance is dirty, marks this instance as no longer dirty
      * and calls the encodeImpl() function to encode the content onto the Metal encoder.
+	 * Marking dirty is done in advance so that subclass encodeImpl() implementations
+	 * can override to leave this instance in a dirty state.
      * Subclasses must override the encodeImpl() function to do the actual work.
      */
     void encode(uint32_t stage = 0) {
@@ -430,7 +432,8 @@ protected:
 
     // Template function that executes a lambda expression on each dirty element of
     // a vector of bindings, and marks the bindings and the vector as no longer dirty.
-	// Clear isDirty flag before operation to allow operation to possibly override.
+	// Clear binding isDirty flag before operation to allow operation to possibly override.
+	// If it does override, leave both the bindings and this instance as dirty.
 	template<class T, class V>
 	void encodeBinding(V& bindings,
 					   bool& bindingsDirtyFlag,
@@ -441,7 +444,7 @@ protected:
 				if (b.isDirty) {
 					b.isDirty = false;
 					mtlOperation(_cmdEncoder, b);
-					if (b.isDirty) { bindingsDirtyFlag = true; }
+					if (b.isDirty) { _isDirty = bindingsDirtyFlag = true; }
 				}
 			}
 		}


### PR DESCRIPTION
In the rare case where vertex attribute buffers are bound to `MVKCommandEncoder`, are not used by first pipeline, but are used by a subsequent pipeline, and no other bindings are changed, the `MVKResourcesCommandEncoderState` will not appear to be dirty to the second pipeline, and the buffer will not be bound to Metal.

When reverting a binding to dirty if it is not used by a pipeline, also revert the enclosing `MVKResourcesCommandEncoderState` to dirty state.

Update MoltenVK to version 1.2.6 (unrelated).

Fixes issue #1931.