### PR TITLE
Rework workaround to force incomplete CAMetalDrawable presentations to complete.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -260,7 +260,7 @@ bool MVKCommandBuffer::canExecute() {
 	}
 
 	_wasExecuted = true;
-	return true;
+	return wasConfigurationSuccessful();
 }
 
 // Return the number of bits set in the view mask, with a minimum value of 1.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -460,10 +460,9 @@ public:
 	void beginPresentation(const MVKImagePresentInfo& presentInfo);
 
 	/** Called via callback when the presentation completes. */
-	void endPresentation(const MVKImagePresentInfo& presentInfo, uint64_t actualPresentTime = 0);
-
-	/** If this image is stuck in-flight, attempt to force it to complete. */
-	void forcePresentationCompletion();
+	void endPresentation(const MVKImagePresentInfo& presentInfo,
+						 const MVKSwapchainSignaler& signaler,
+						 uint64_t actualPresentTime = 0);
 
 #pragma mark Construction
 
@@ -478,12 +477,13 @@ protected:
 	friend MVKSwapchain;
 
 	id<CAMetalDrawable> getCAMetalDrawable() override;
-	void addPresentedHandler(id<CAMetalDrawable> mtlDrawable, MVKImagePresentInfo presentInfo);
+	void addPresentedHandler(id<CAMetalDrawable> mtlDrawable, MVKImagePresentInfo presentInfo, MVKSwapchainSignaler signaler);
 	void releaseMetalDrawable();
 	MVKSwapchainImageAvailability getAvailability();
 	void makeAvailable(const MVKSwapchainSignaler& signaler);
 	void makeAvailable();
 	VkResult acquireAndSignalWhenAvailable(MVKSemaphore* semaphore, MVKFence* fence);
+	MVKSwapchainSignaler getPresentationSignaler();
 
 	id<CAMetalDrawable> _mtlDrawable = nil;
 	MVKSwapchainImageAvailability _availability;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -100,13 +100,6 @@ public:
 	/** Block the current thread until this queue is idle. */
 	VkResult waitIdle(MVKCommandUse cmdUse);
 
-	/** Mark the beginning of a swapchain image presentation. */
-	void beginPresentation(const MVKImagePresentInfo& presentInfo);
-
-	/** Mark the end of a swapchain image presentation. */
-	void endPresentation(const MVKImagePresentInfo& presentInfo);
-
-
 #pragma mark Metal
 
 	/** Returns the Metal queue underlying this queue. */
@@ -150,11 +143,8 @@ protected:
 	VkResult submit(MVKQueueSubmission* qSubmit);
 	NSString* getMTLCommandBufferLabel(MVKCommandUse cmdUse);
 	void handleMTLCommandBufferError(id<MTLCommandBuffer> mtlCmdBuff);
-	void waitSwapchainPresentations(MVKCommandUse cmdUse);
 
 	MVKQueueFamily* _queueFamily;
-	MVKSemaphoreImpl _presentationCompletionBlocker;
-	std::unordered_map<MVKPresentableSwapchainImage*, uint32_t> _presentedImages;
 	std::string _name;
 	dispatch_queue_t _execQueue;
 	id<MTLCommandQueue> _mtlQueue = nil;
@@ -166,7 +156,6 @@ protected:
 	NSString* _mtlCmdBuffLabelAcquireNextImage = nil;
 	NSString* _mtlCmdBuffLabelInvalidateMappedMemoryRanges = nil;
 	MVKGPUCaptureScope* _submissionCaptureScope = nil;
-	std::mutex _presentedImagesLock;
 	float _priority;
 	uint32_t _index;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -43,11 +43,14 @@ public:
 	/** Returns the debug report object type of this object. */
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT; }
 
+	/** Returns the CAMetalLayer underlying the surface used by this swapchain. */
+	CAMetalLayer* getCAMetalLayer();
+
 	/** Returns the number of images in this swapchain. */
-	inline uint32_t getImageCount() { return (uint32_t)_presentableImages.size(); }
+	uint32_t getImageCount() { return (uint32_t)_presentableImages.size(); }
 
 	/** Returns the image at the specified index. */
-	inline MVKPresentableSwapchainImage* getPresentableImage(uint32_t index) { return _presentableImages[index]; }
+	MVKPresentableSwapchainImage* getPresentableImage(uint32_t index) { return _presentableImages[index]; }
 
 	/**
 	 * Returns the array of presentable images associated with this swapchain.
@@ -112,6 +115,7 @@ protected:
     void markFrameInterval();
 	void beginPresentation(const MVKImagePresentInfo& presentInfo);
 	void endPresentation(const MVKImagePresentInfo& presentInfo, uint64_t actualPresentTime = 0);
+	void forceUnpresentedImageCompletion();
 
 	MVKSurface* _surface = nullptr;
     MVKWatermark* _licenseWatermark = nullptr;
@@ -123,6 +127,7 @@ protected:
 	std::mutex _presentHistoryLock;
 	uint64_t _lastFrameTime = 0;
 	VkExtent2D _mtlLayerDrawableExtent = {0, 0};
+	std::atomic<uint32_t> _unpresentedImageCount = 0;
 	uint32_t _currentPerfLogFrameCount = 0;
 	uint32_t _presentHistoryCount = 0;
 	uint32_t _presentHistoryIndex = 0;


### PR DESCRIPTION
- To force any incomplete CAMetalDrawable presentations to complete, don't force the creation of another transient drawable, as this can stall the creation of future drawables. Instead, when a swapchain is destroyed, or replaced by a new swapchain, set the `CAMetalLayer drawableSize`, which will force presentation completion.
- Add presentation completion handler in command buffer scheduling callback, move marking available to presentation completion handler, and minimize mutex locking.
- `MVKQueue::waitIdle()` remove wait for swapchain presentations, and remove callbacks to MVKQueue from drawable completions.
- `MVKQueue::submit()` don't bypass submitting a misconfigured submission, so that semaphores and fences will be signalled, and ensure misconfigured submissions are well behaved.
- Add `MVKSwapchain::getCAMetalLayer()` to streamline layer access (unrelated).

Potentially fixes issue #2019.