### PR TITLE
Add support for extension VK_KHR_synchronization2

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -350,6 +350,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_surface`
 - `VK_KHR_swapchain`
 - `VK_KHR_swapchain_mutable_format`
+- `VK_KHR_synchronization2`
 - `VK_KHR_timeline_semaphore`
 - `VK_KHR_uniform_buffer_standard_layout`
 - `VK_KHR_variable_pointers`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,8 @@ MoltenVK 1.2.6
 
 Released TBD
 
+- Add support for extensions:
+	- `VK_KHR_synchronization2`
 - Fix rare case where vertex attribute buffers are not bound to Metal 
   when no other bindings change between pipelines.
 - Ensure objects retained for life of `MTLCommandBuffer` during `vkCmdBlitImage()` & `vkQueuePresentKHR()`.

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -414,13 +414,13 @@ MTLWinding mvkMTLWindingFromSpvExecutionMode(uint32_t spvMode);
 MTLTessellationPartitionMode mvkMTLTessellationPartitionModeFromSpvExecutionMode(uint32_t spvMode);
 
 /**
- * Returns the combination of Metal MTLRenderStage bits corresponding to the specified Vulkan VkPiplineStageFlags,
+ * Returns the combination of Metal MTLRenderStage bits corresponding to the specified Vulkan VkPipelineStageFlags2,
  * taking into consideration whether the barrier is to be placed before or after the specified pipeline stages.
  */
-MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags vkStages, bool placeBarrierBefore);
+MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags2 vkStages, bool placeBarrierBefore);
 
-/** Returns the combination of Metal MTLBarrierScope bits corresponding to the specified Vulkan VkAccessFlags. */
-MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags vkAccess);
+/** Returns the combination of Metal MTLBarrierScope bits corresponding to the specified Vulkan VkAccessFlags2. */
+MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags2 vkAccess);
 
 #pragma mark -
 #pragma mark Geometry conversions

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -42,6 +42,9 @@ class MVKCmdPipelineBarrier : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
+						const VkDependencyInfo* pDependencyInfo);
+
+	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						VkPipelineStageFlags srcStageMask,
 						VkPipelineStageFlags dstStageMask,
 						VkDependencyFlags dependencyFlags,
@@ -59,8 +62,6 @@ protected:
 	bool coversTextures();
 
 	MVKSmallVector<MVKPipelineBarrier, N> _barriers;
-	VkPipelineStageFlags _srcStageMask;
-	VkPipelineStageFlags _dstStageMask;
 	VkDependencyFlags _dependencyFlags;
 };
 
@@ -281,34 +282,26 @@ protected:
 
 
 #pragma mark -
-#pragma mark MVKCmdSetResetEvent
+#pragma mark MVKCmdSetEvent
 
-/** Abstract Vulkan command to set or reset an event. */
-class MVKCmdSetResetEvent : public MVKCommand {
+/** Vulkan command to set an event. */
+class MVKCmdSetEvent : public MVKCommand {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						VkEvent event,
+						const VkDependencyInfo* pDependencyInfo);
+
+	VkResult setContent(MVKCommandBuffer* cmdBuff,
+						VkEvent event,
 						VkPipelineStageFlags stageMask);
 
-protected:
-	MVKEvent* _mvkEvent;
-
-};
-
-
-#pragma mark -
-#pragma mark MVKCmdSetEvent
-
-/** Vulkan command to set an event. */
-class MVKCmdSetEvent : public MVKCmdSetResetEvent {
-
-public:
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
+	MVKEvent* _mvkEvent;
 };
 
 
@@ -316,14 +309,19 @@ protected:
 #pragma mark MVKCmdResetEvent
 
 /** Vulkan command to reset an event. */
-class MVKCmdResetEvent : public MVKCmdSetResetEvent {
+class MVKCmdResetEvent : public MVKCommand {
 
 public:
+	VkResult setContent(MVKCommandBuffer* cmdBuff,
+						VkEvent event,
+						VkPipelineStageFlags2 stageMask);
+
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
+	MVKEvent* _mvkEvent;
 };
 
 
@@ -339,6 +337,11 @@ template <size_t N>
 class MVKCmdWaitEvents : public MVKCommand {
 
 public:
+	VkResult setContent(MVKCommandBuffer* cmdBuff,
+						uint32_t eventCount,
+						const VkEvent* pEvents,
+						const VkDependencyInfo* pDependencyInfos);
+
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
 						uint32_t eventCount,
 						const VkEvent* pEvents,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -31,6 +31,29 @@
 
 template <size_t N>
 VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
+											  const VkDependencyInfo* pDependencyInfo) {
+	_dependencyFlags = pDependencyInfo->dependencyFlags;
+
+	_barriers.clear();	// Clear for reuse
+	_barriers.reserve(pDependencyInfo->memoryBarrierCount + 
+					  pDependencyInfo->bufferMemoryBarrierCount +
+					  pDependencyInfo->imageMemoryBarrierCount);
+
+	for (uint32_t i = 0; i < pDependencyInfo->memoryBarrierCount; i++) {
+		_barriers.emplace_back(pDependencyInfo->pMemoryBarriers[i]);
+	}
+	for (uint32_t i = 0; i < pDependencyInfo->bufferMemoryBarrierCount; i++) {
+		_barriers.emplace_back(pDependencyInfo->pBufferMemoryBarriers[i]);
+	}
+	for (uint32_t i = 0; i < pDependencyInfo->imageMemoryBarrierCount; i++) {
+		_barriers.emplace_back(pDependencyInfo->pImageMemoryBarriers[i]);
+	}
+
+	return VK_SUCCESS;
+}
+
+template <size_t N>
+VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
 											  VkPipelineStageFlags srcStageMask,
 											  VkPipelineStageFlags dstStageMask,
 											  VkDependencyFlags dependencyFlags,
@@ -40,21 +63,19 @@ VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
 											  const VkBufferMemoryBarrier* pBufferMemoryBarriers,
 											  uint32_t imageMemoryBarrierCount,
 											  const VkImageMemoryBarrier* pImageMemoryBarriers) {
-	_srcStageMask = srcStageMask;
-	_dstStageMask = dstStageMask;
 	_dependencyFlags = dependencyFlags;
 
 	_barriers.clear();	// Clear for reuse
 	_barriers.reserve(memoryBarrierCount + bufferMemoryBarrierCount + imageMemoryBarrierCount);
 
 	for (uint32_t i = 0; i < memoryBarrierCount; i++) {
-		_barriers.emplace_back(pMemoryBarriers[i]);
+		_barriers.emplace_back(pMemoryBarriers[i], srcStageMask, dstStageMask);
 	}
 	for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++) {
-		_barriers.emplace_back(pBufferMemoryBarriers[i]);
+		_barriers.emplace_back(pBufferMemoryBarriers[i], srcStageMask, dstStageMask);
 	}
 	for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) {
-		_barriers.emplace_back(pImageMemoryBarriers[i]);
+		_barriers.emplace_back(pImageMemoryBarriers[i], srcStageMask, dstStageMask);
 	}
 
 	return VK_SUCCESS;
@@ -67,13 +88,9 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	// Calls below invoke MTLBlitCommandEncoder so must apply this first.
 	// Check if pipeline barriers are available and we are in a renderpass.
 	if (cmdEncoder->getDevice()->_pMetalFeatures->memoryBarriers && cmdEncoder->_mtlRenderEncoder) {
-		MTLRenderStages srcStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_srcStageMask, false);
-		MTLRenderStages dstStages = mvkMTLRenderStagesFromVkPipelineStageFlags(_dstStageMask, true);
-
-		id<MTLResource> resources[_barriers.size()];
-		uint32_t rezCnt = 0;
-
 		for (auto& b : _barriers) {
+			MTLRenderStages srcStages = mvkMTLRenderStagesFromVkPipelineStageFlags(b.srcStageMask, false);
+			MTLRenderStages dstStages = mvkMTLRenderStagesFromVkPipelineStageFlags(b.dstStageMask, true);
 			switch (b.type) {
 				case MVKPipelineBarrier::Memory: {
 					MTLBarrierScope scope = (mvkMTLBarrierScopeFromVkAccessFlags(b.srcAccessMask) |
@@ -84,26 +101,29 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 					break;
 				}
 
-				case MVKPipelineBarrier::Buffer:
-					resources[rezCnt++] = b.mvkBuffer->getMTLBuffer();
+				case MVKPipelineBarrier::Buffer: {
+					id<MTLResource> mtlRez = b.mvkBuffer->getMTLBuffer();
+					[cmdEncoder->_mtlRenderEncoder memoryBarrierWithResources: &mtlRez
+																		count: 1
+																  afterStages: srcStages
+																 beforeStages: dstStages];
 					break;
-
-				case MVKPipelineBarrier::Image:
-                    for (uint8_t planeIndex = 0; planeIndex < b.mvkImage->getPlaneCount(); planeIndex++) {
-                        resources[rezCnt++] = b.mvkImage->getMTLTexture(planeIndex);
-                    }
+				}
+				case MVKPipelineBarrier::Image: {
+					uint32_t plnCnt = b.mvkImage->getPlaneCount();
+					id<MTLResource> mtlRezs[plnCnt];
+					for (uint8_t plnIdx = 0; plnIdx < plnCnt; plnIdx++) {
+						mtlRezs[plnIdx] = b.mvkImage->getMTLTexture(plnIdx);
+					}
+					[cmdEncoder->_mtlRenderEncoder memoryBarrierWithResources: mtlRezs
+																		count: plnCnt
+																  afterStages: srcStages
+																 beforeStages: dstStages];
 					break;
-
+				}
 				default:
 					break;
 			}
-		}
-
-		if (rezCnt) {
-			[cmdEncoder->_mtlRenderEncoder memoryBarrierWithResources: resources
-																count: rezCnt
-														  afterStages: srcStages
-														 beforeStages: dstStages];
 		}
 	} else if (cmdEncoder->getDevice()->_pMetalFeatures->textureBarriers) {
 #if !MVK_MACCAT
@@ -138,15 +158,15 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	for (auto& b : _barriers) {
 		switch (b.type) {
 			case MVKPipelineBarrier::Memory:
-				mvkDvc->applyMemoryBarrier(_srcStageMask, _dstStageMask, b, cmdEncoder, cmdUse);
+				mvkDvc->applyMemoryBarrier(b, cmdEncoder, cmdUse);
 				break;
 
 			case MVKPipelineBarrier::Buffer:
-				b.mvkBuffer->applyBufferMemoryBarrier(_srcStageMask, _dstStageMask, b, cmdEncoder, cmdUse);
+				b.mvkBuffer->applyBufferMemoryBarrier(b, cmdEncoder, cmdUse);
 				break;
 
 			case MVKPipelineBarrier::Image:
-				b.mvkImage->applyImageMemoryBarrier(_srcStageMask, _dstStageMask, b, cmdEncoder, cmdUse);
+				b.mvkImage->applyImageMemoryBarrier(b, cmdEncoder, cmdUse);
 				break;
 
 			default:
@@ -493,19 +513,23 @@ MVKCmdPushDescriptorSetWithTemplate::~MVKCmdPushDescriptorSetWithTemplate() {
 
 
 #pragma mark -
-#pragma mark MVKCmdSetResetEvent
+#pragma mark MVKCmdSetEvent
 
-VkResult MVKCmdSetResetEvent::setContent(MVKCommandBuffer* cmdBuff,
-										 VkEvent event,
-										 VkPipelineStageFlags stageMask) {
+VkResult MVKCmdSetEvent::setContent(MVKCommandBuffer* cmdBuff,
+									VkEvent event,
+									VkPipelineStageFlags stageMask) {
 	_mvkEvent = (MVKEvent*)event;
 
 	return VK_SUCCESS;
 }
 
+VkResult MVKCmdSetEvent::setContent(MVKCommandBuffer* cmdBuff,
+									VkEvent event,
+									const VkDependencyInfo* pDependencyInfo) {
+	_mvkEvent = (MVKEvent*)event;
 
-#pragma mark -
-#pragma mark MVKCmdSetEvent
+	return VK_SUCCESS;
+}
 
 void MVKCmdSetEvent::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->signalEvent(_mvkEvent, true);
@@ -515,6 +539,14 @@ void MVKCmdSetEvent::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdResetEvent
 
+VkResult MVKCmdResetEvent::setContent(MVKCommandBuffer* cmdBuff,
+									  VkEvent event,
+									  VkPipelineStageFlags2 stageMask) {
+	_mvkEvent = (MVKEvent*)event;
+
+	return VK_SUCCESS;
+}
+
 void MVKCmdResetEvent::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->signalEvent(_mvkEvent, false);
 }
@@ -522,6 +554,20 @@ void MVKCmdResetEvent::encode(MVKCommandEncoder* cmdEncoder) {
 
 #pragma mark -
 #pragma mark MVKCmdWaitEvents
+
+template <size_t N>
+VkResult MVKCmdWaitEvents<N>::setContent(MVKCommandBuffer* cmdBuff,
+										 uint32_t eventCount,
+										 const VkEvent* pEvents,
+										 const VkDependencyInfo* pDependencyInfos) {
+	_mvkEvents.clear();	// Clear for reuse
+	_mvkEvents.reserve(eventCount);
+	for (uint32_t i = 0; i < eventCount; i++) {
+		_mvkEvents.push_back((MVKEvent*)pEvents[i]);
+	}
+
+	return VK_SUCCESS;
+}
 
 template <size_t N>
 VkResult MVKCmdWaitEvents<N>::setContent(MVKCommandBuffer* cmdBuff,

--- a/MoltenVK/MoltenVK/Commands/MVKCmdQueries.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdQueries.h
@@ -85,7 +85,7 @@ class MVKCmdWriteTimestamp : public MVKCmdQuery {
 
 public:
 	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkPipelineStageFlagBits pipelineStage,
+						VkPipelineStageFlags2 stage,
 						VkQueryPool queryPool,
 						uint32_t query);
 
@@ -94,7 +94,7 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-    VkPipelineStageFlagBits _pipelineStage;
+	VkPipelineStageFlags2 _stage;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdQueries.mm
@@ -77,13 +77,13 @@ void MVKCmdEndQuery::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark MVKCmdWriteTimestamp
 
 VkResult MVKCmdWriteTimestamp::setContent(MVKCommandBuffer* cmdBuff,
-										  VkPipelineStageFlagBits pipelineStage,
+										  VkPipelineStageFlags2 stage,
 										  VkQueryPool queryPool,
 										  uint32_t query) {
 
 	VkResult rslt = MVKCmdQuery::setContent(cmdBuff, queryPool, query);
 
-	_pipelineStage = pipelineStage;
+	_stage = stage;
 
 	cmdBuff->recordTimestampCommand();
 

--- a/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLResourceBindings.h
@@ -112,8 +112,10 @@ typedef struct MVKPipelineBarrier {
 	} MVKPipelineBarrierType;
 
 	MVKPipelineBarrierType type = None;
-	VkAccessFlags srcAccessMask = 0;
-	VkAccessFlags dstAccessMask = 0;
+	VkPipelineStageFlags2 srcStageMask = 0;
+	VkAccessFlags2 srcAccessMask = 0;
+	VkPipelineStageFlags2 dstStageMask = 0;
+	VkAccessFlags2 dstAccessMask = 0;
 	uint8_t srcQueueFamilyIndex = 0;
 	uint8_t dstQueueFamilyIndex = 0;
 	union { MVKBuffer* mvkBuffer = nullptr; MVKImage* mvkImage; MVKResource* mvkResource; };
@@ -136,15 +138,29 @@ typedef struct MVKPipelineBarrier {
 	bool isBufferBarrier() { return type == Buffer; }
 	bool isImageBarrier() { return type == Image; }
 
-	MVKPipelineBarrier(const VkMemoryBarrier& vkBarrier) :
+	MVKPipelineBarrier(const VkMemoryBarrier2& vkBarrier) :
 		type(Memory),
+		srcStageMask(vkBarrier.srcStageMask),
 		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(vkBarrier.dstStageMask),
 		dstAccessMask(vkBarrier.dstAccessMask)
 		{}
 
-	MVKPipelineBarrier(const VkBufferMemoryBarrier& vkBarrier) :
-		type(Buffer),
+	MVKPipelineBarrier(const VkMemoryBarrier& vkBarrier,
+					   VkPipelineStageFlags srcStageMask,
+					   VkPipelineStageFlags dstStageMask) :
+		type(Memory),
+		srcStageMask(srcStageMask),
 		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(dstStageMask),
+		dstAccessMask(vkBarrier.dstAccessMask)
+		{}
+
+	MVKPipelineBarrier(const VkBufferMemoryBarrier2& vkBarrier) :
+		type(Buffer),
+		srcStageMask(vkBarrier.srcStageMask),
+		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(vkBarrier.dstStageMask),
 		dstAccessMask(vkBarrier.dstAccessMask),
 		srcQueueFamilyIndex(vkBarrier.srcQueueFamilyIndex),
 		dstQueueFamilyIndex(vkBarrier.dstQueueFamilyIndex),
@@ -153,9 +169,45 @@ typedef struct MVKPipelineBarrier {
 		size(vkBarrier.size)
 		{}
 
-	MVKPipelineBarrier(const VkImageMemoryBarrier& vkBarrier) :
-		type(Image),
+	MVKPipelineBarrier(const VkBufferMemoryBarrier& vkBarrier,
+					   VkPipelineStageFlags srcStageMask,
+					   VkPipelineStageFlags dstStageMask) :
+		type(Buffer),
+		srcStageMask(srcStageMask),
 		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(dstStageMask),
+		dstAccessMask(vkBarrier.dstAccessMask),
+		srcQueueFamilyIndex(vkBarrier.srcQueueFamilyIndex),
+		dstQueueFamilyIndex(vkBarrier.dstQueueFamilyIndex),
+		mvkBuffer((MVKBuffer*)vkBarrier.buffer),
+		offset(vkBarrier.offset),
+		size(vkBarrier.size)
+		{}
+
+	MVKPipelineBarrier(const VkImageMemoryBarrier2& vkBarrier) :
+		type(Image),
+		srcStageMask(vkBarrier.srcStageMask),
+		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(vkBarrier.dstStageMask),
+		dstAccessMask(vkBarrier.dstAccessMask),
+		srcQueueFamilyIndex(vkBarrier.srcQueueFamilyIndex),
+		dstQueueFamilyIndex(vkBarrier.dstQueueFamilyIndex),
+		mvkImage((MVKImage*)vkBarrier.image),
+		newLayout(vkBarrier.newLayout),
+		aspectMask(vkBarrier.subresourceRange.aspectMask),
+		baseArrayLayer(vkBarrier.subresourceRange.baseArrayLayer),
+		layerCount(vkBarrier.subresourceRange.layerCount),
+		baseMipLevel(vkBarrier.subresourceRange.baseMipLevel),
+		levelCount(vkBarrier.subresourceRange.levelCount)
+		{}
+
+	MVKPipelineBarrier(const VkImageMemoryBarrier& vkBarrier,
+					   VkPipelineStageFlags srcStageMask,
+					   VkPipelineStageFlags dstStageMask) :
+		type(Image),
+		srcStageMask(srcStageMask),
+		srcAccessMask(vkBarrier.srcAccessMask),
+		dstStageMask(dstStageMask),
 		dstAccessMask(vkBarrier.dstAccessMask),
 		srcQueueFamilyIndex(vkBarrier.srcQueueFamilyIndex),
 		dstQueueFamilyIndex(vkBarrier.dstQueueFamilyIndex),

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -52,16 +52,12 @@ public:
 	VkResult bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo);
 
 	/** Applies the specified global memory barrier. */
-	void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
-							VkPipelineStageFlags dstStageMask,
-							MVKPipelineBarrier& barrier,
+	void applyMemoryBarrier(MVKPipelineBarrier& barrier,
 							MVKCommandEncoder* cmdEncoder,
 							MVKCommandUse cmdUse) override;
 
 	/** Applies the specified buffer memory barrier. */
-	void applyBufferMemoryBarrier(VkPipelineStageFlags srcStageMask,
-								  VkPipelineStageFlags dstStageMask,
-								  MVKPipelineBarrier& barrier,
+	void applyBufferMemoryBarrier(MVKPipelineBarrier& barrier,
 								  MVKCommandEncoder* cmdEncoder,
 								  MVKCommandUse cmdUse);
 
@@ -95,9 +91,7 @@ protected:
 	friend class MVKDeviceMemory;
 
 	void propagateDebugName() override;
-	bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
-						   VkPipelineStageFlags dstStageMask,
-						   MVKPipelineBarrier& barrier);
+	bool needsHostReadSync(MVKPipelineBarrier& barrier);
     bool overlaps(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize &overlapOffset, VkDeviceSize &overlapSize);
 	bool shouldFlushHostMemory();
 	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -94,25 +94,21 @@ VkResult MVKBuffer::bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo) {
 	return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset);
 }
 
-void MVKBuffer::applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
-								   VkPipelineStageFlags dstStageMask,
-								   MVKPipelineBarrier& barrier,
+void MVKBuffer::applyMemoryBarrier(MVKPipelineBarrier& barrier,
                                    MVKCommandEncoder* cmdEncoder,
                                    MVKCommandUse cmdUse) {
 #if MVK_MACOS
-	if ( needsHostReadSync(srcStageMask, dstStageMask, barrier) ) {
+	if ( needsHostReadSync(barrier) ) {
 		[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeResource: getMTLBuffer()];
 	}
 #endif
 }
 
-void MVKBuffer::applyBufferMemoryBarrier(VkPipelineStageFlags srcStageMask,
-										 VkPipelineStageFlags dstStageMask,
-										 MVKPipelineBarrier& barrier,
+void MVKBuffer::applyBufferMemoryBarrier(MVKPipelineBarrier& barrier,
                                          MVKCommandEncoder* cmdEncoder,
                                          MVKCommandUse cmdUse) {
 #if MVK_MACOS
-	if ( needsHostReadSync(srcStageMask, dstStageMask, barrier) ) {
+	if ( needsHostReadSync(barrier) ) {
 		[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeResource: getMTLBuffer()];
 	}
 #endif
@@ -120,11 +116,9 @@ void MVKBuffer::applyBufferMemoryBarrier(VkPipelineStageFlags srcStageMask,
 
 // Returns whether the specified buffer memory barrier requires a sync between this
 // buffer and host memory for the purpose of the host reading texture memory.
-bool MVKBuffer::needsHostReadSync(VkPipelineStageFlags srcStageMask,
-								  VkPipelineStageFlags dstStageMask,
-								  MVKPipelineBarrier& barrier) {
+bool MVKBuffer::needsHostReadSync(MVKPipelineBarrier& barrier) {
 #if MVK_MACOS
-	return (mvkIsAnyFlagEnabled(dstStageMask, (VK_PIPELINE_STAGE_HOST_BIT)) &&
+	return (mvkIsAnyFlagEnabled(barrier.dstStageMask, (VK_PIPELINE_STAGE_HOST_BIT)) &&
 			mvkIsAnyFlagEnabled(barrier.dstAccessMask, (VK_ACCESS_HOST_READ_BIT)) &&
 			isMemoryHostAccessible() && (!isMemoryHostCoherent() || _isHostCoherentTexelBuffer));
 #endif

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -681,9 +681,7 @@ public:
 	void removeTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value);
 
 	/** Applies the specified global memory barrier to all resource issued by this device. */
-	void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
-							VkPipelineStageFlags dstStageMask,
-							MVKPipelineBarrier& barrier,
+	void applyMemoryBarrier(MVKPipelineBarrier& barrier,
 							MVKCommandEncoder* cmdEncoder,
 							MVKCommandUse cmdUse);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -55,6 +55,7 @@ MVK_DEVICE_FEATURE(ShaderAtomicInt64,                 SHADER_ATOMIC_INT64,      
 MVK_DEVICE_FEATURE(ShaderFloat16Int8,                 SHADER_FLOAT16_INT8,                    2)
 MVK_DEVICE_FEATURE(ShaderSubgroupExtendedTypes,       SHADER_SUBGROUP_EXTENDED_TYPES,         1)
 MVK_DEVICE_FEATURE(SubgroupSizeControl,               SUBGROUP_SIZE_CONTROL,                  2)
+MVK_DEVICE_FEATURE(Synchronization2,                  SYNCHRONIZATION_2,                      1)
 MVK_DEVICE_FEATURE(TextureCompressionASTCHDR,         TEXTURE_COMPRESSION_ASTC_HDR,           1)
 MVK_DEVICE_FEATURE(TimelineSemaphore,                 TIMELINE_SEMAPHORE,                     1)
 MVK_DEVICE_FEATURE(UniformBufferStandardLayout,       UNIFORM_BUFFER_STANDARD_LAYOUT,         1)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -74,9 +74,7 @@ protected:
 	bool overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset, VkDeviceSize size);
     void propagateDebugName();
     MVKImageMemoryBinding* getMemoryBinding() const;
-	void applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
-								 VkPipelineStageFlags dstStageMask,
-								 MVKPipelineBarrier& barrier,
+	void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
 								 MVKCommandEncoder* cmdEncoder,
 								 MVKCommandUse cmdUse);
 	void pullFromDeviceOnCompletion(MVKCommandEncoder* cmdEncoder,
@@ -119,9 +117,7 @@ public:
     VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
 
     /** Applies the specified global memory barrier. */
-    void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
-                            VkPipelineStageFlags dstStageMask,
-                            MVKPipelineBarrier& barrier,
+    void applyMemoryBarrier(MVKPipelineBarrier& barrier,
                             MVKCommandEncoder* cmdEncoder,
                             MVKCommandUse cmdUse) override;
 
@@ -133,9 +129,7 @@ protected:
     friend MVKImage;
 
     void propagateDebugName() override;
-    bool needsHostReadSync(VkPipelineStageFlags srcStageMask,
-                           VkPipelineStageFlags dstStageMask,
-                           MVKPipelineBarrier& barrier);
+    bool needsHostReadSync(MVKPipelineBarrier& barrier);
     bool shouldFlushHostMemory();
     VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
     VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);
@@ -251,9 +245,7 @@ public:
 	virtual VkResult bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo);
 
 	/** Applies the specified image memory barrier. */
-	void applyImageMemoryBarrier(VkPipelineStageFlags srcStageMask,
-								 VkPipelineStageFlags dstStageMask,
-								 MVKPipelineBarrier& barrier,
+	void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
 								 MVKCommandEncoder* cmdEncoder,
 								 MVKCommandUse cmdUse);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -265,6 +265,22 @@ protected:
 #pragma mark -
 #pragma mark MVKRenderPass
 
+/** Collects together VkSubpassDependency and VkMemoryBarrier2. */
+typedef struct MVKSubpassDependency {
+	uint32_t              srcSubpass;
+	uint32_t              dstSubpass;
+	VkPipelineStageFlags2 srcStageMask;
+	VkPipelineStageFlags2 dstStageMask;
+	VkAccessFlags2        srcAccessMask;
+	VkAccessFlags2        dstAccessMask;
+	VkDependencyFlags     dependencyFlags;
+	int32_t               viewOffset;
+
+	MVKSubpassDependency(const VkSubpassDependency& spDep, int32_t viewOffset);
+	MVKSubpassDependency(const VkSubpassDependency2& spDep, const VkMemoryBarrier2* pMemBar);
+
+} MVKSubpassDependency;
+
 /** Represents a Vulkan render pass. */
 class MVKRenderPass : public MVKVulkanAPIDeviceObject {
 
@@ -308,7 +324,7 @@ protected:
 
 	MVKSmallVector<MVKAttachmentDescription> _attachments;
 	MVKSmallVector<MVKRenderSubpass> _subpasses;
-	MVKSmallVector<VkSubpassDependency2> _subpassDependencies;
+	MVKSmallVector<MVKSubpassDependency> _subpassDependencies;
 	VkRenderingFlags _renderingFlags = 0;
 
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
@@ -60,9 +60,7 @@ public:
 	}
 
 	/** Applies the specified global memory barrier. */
-	virtual void applyMemoryBarrier(VkPipelineStageFlags srcStageMask,
-									VkPipelineStageFlags dstStageMask,
-									MVKPipelineBarrier& barrier,
+	virtual void applyMemoryBarrier(MVKPipelineBarrier& barrier,
 									MVKCommandEncoder* cmdEncoder,
 									MVKCommandUse cmdUse) = 0;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -43,7 +43,7 @@ using namespace mvk;
 typedef struct MVKMTLFunction {
 	SPIRVToMSLConversionResultInfo shaderConversionResults;
 	MTLSize threadGroupSize;
-	inline id<MTLFunction> getMTLFunction() { return _mtlFunction; }
+	id<MTLFunction> getMTLFunction() { return _mtlFunction; }
 
 	MVKMTLFunction(id<MTLFunction> mtlFunc, const SPIRVToMSLConversionResultInfo scRslts, MTLSize tgSize);
 	MVKMTLFunction(const MVKMTLFunction& other);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -36,10 +36,11 @@ MVKMTLFunction::MVKMTLFunction(const MVKMTLFunction& other) {
 }
 
 MVKMTLFunction& MVKMTLFunction::operator=(const MVKMTLFunction& other) {
-	if (_mtlFunction != other._mtlFunction) {
-		[_mtlFunction release];
-		_mtlFunction = [other._mtlFunction retain];		// retained
-	}
+	// Retain new object first in case it's the same object
+	[other._mtlFunction retain];
+	[_mtlFunction release];
+	_mtlFunction = other._mtlFunction;
+
 	shaderConversionResults = other.shaderConversionResults;
 	threadGroupSize = other.threadGroupSize;
 	return *this;

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -91,6 +91,7 @@ MVK_EXTENSION(KHR_storage_buffer_storage_class,       KHR_STORAGE_BUFFER_STORAGE
 MVK_EXTENSION(KHR_surface,                            KHR_SURFACE,                            INSTANCE, 10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_swapchain,                          KHR_SWAPCHAIN,                          DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_swapchain_mutable_format,           KHR_SWAPCHAIN_MUTABLE_FORMAT,           DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_synchronization2,                   KHR_SYNCHRONIZATION_2,                  DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_timeline_semaphore,                 KHR_TIMELINE_SEMAPHORE,                 DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_uniform_buffer_standard_layout,     KHR_UNIFORM_BUFFER_STANDARD_LAYOUT,     DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_variable_pointers,                  KHR_VARIABLE_POINTERS,                  DEVICE,   10.11,  8.0,  1.0)

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -728,40 +728,50 @@ MTLTessellationPartitionMode mvkMTLTessellationPartitionModeFromSpvExecutionMode
 	}
 }
 
-MVK_PUBLIC_SYMBOL MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags vkStages,
+MVK_PUBLIC_SYMBOL MTLRenderStages mvkMTLRenderStagesFromVkPipelineStageFlags(VkPipelineStageFlags2 vkStages,
 																			 bool placeBarrierBefore) {
 	// Although there are many combined render/compute/host stages in Vulkan, there are only two render
 	// stages in Metal. If the Vulkan stage did not map ONLY to a specific Metal render stage, then if the
 	// barrier is to be placed before the render stages, it should come before the vertex stage, otherwise
 	// if the barrier is to be placed after the render stages, it should come after the fragment stage.
 	if (placeBarrierBefore) {
-		bool placeBeforeFragment = mvkIsOnlyAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
-																		VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT |
-																		VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT |
-																		VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
-																		VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
+		bool placeBeforeFragment = mvkIsOnlyAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT |
+																		VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT |
+																		VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT |
+																		VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT |
+																		VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT));
 		return placeBeforeFragment ? MTLRenderStageFragment : MTLRenderStageVertex;
 	} else {
-		bool placeAfterVertex = mvkIsOnlyAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT |
-																	 VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT |
-																	 VK_PIPELINE_STAGE_VERTEX_INPUT_BIT |
-																	 VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
-																	 VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT |
-																	 VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT));
+		bool placeAfterVertex = mvkIsOnlyAnyFlagEnabled(vkStages, (VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT |
+																	 VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT |
+																	 VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT |
+																	 VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT |
+																	 VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
+																	 VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT));
 		return placeAfterVertex ? MTLRenderStageVertex : MTLRenderStageFragment;
 	}
 }
 
-MVK_PUBLIC_SYMBOL MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags vkAccess) {
+MVK_PUBLIC_SYMBOL MTLBarrierScope mvkMTLBarrierScopeFromVkAccessFlags(VkAccessFlags2 vkAccess) {
 	MTLBarrierScope mtlScope = MTLBarrierScope(0);
-	if ( mvkIsAnyFlagEnabled(vkAccess, VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_INDEX_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_UNIFORM_READ_BIT) ) {
+	if ( mvkIsAnyFlagEnabled(vkAccess, (VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT | 
+										VK_ACCESS_2_INDEX_READ_BIT |
+										VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT | 
+										VK_ACCESS_2_UNIFORM_READ_BIT)) ) {
 		mtlScope |= MTLBarrierScopeBuffers;
 	}
-	if ( mvkIsAnyFlagEnabled(vkAccess, VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT) ) {
+	if ( mvkIsAnyFlagEnabled(vkAccess, (VK_ACCESS_2_SHADER_READ_BIT | 
+										VK_ACCESS_2_SHADER_WRITE_BIT |
+										VK_ACCESS_2_MEMORY_READ_BIT | 
+										VK_ACCESS_2_MEMORY_WRITE_BIT)) ) {
 		mtlScope |= MTLBarrierScopeBuffers | MTLBarrierScopeTextures;
 	}
 #if MVK_MACOS
-	if ( mvkIsAnyFlagEnabled(vkAccess, VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT) ) {
+	if ( mvkIsAnyFlagEnabled(vkAccess, (VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT | 
+										VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT |
+										VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | 
+										VK_ACCESS_2_MEMORY_READ_BIT |
+										VK_ACCESS_2_MEMORY_WRITE_BIT)) ) {
 		mtlScope |= MTLBarrierScopeRenderTargets;
 	}
 #endif

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2517,8 +2517,8 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkWaitSemaphores(
 #pragma mark Vulkan 1.3 calls
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdBeginRendering(
-        VkCommandBuffer                             commandBuffer,
-        const VkRenderingInfo*                      pRenderingInfo) {
+    VkCommandBuffer                             commandBuffer,
+    const VkRenderingInfo*                      pRenderingInfo) {
 
     MVKTraceVulkanCallStart();
     MVKAddCmdFrom3Thresholds(BeginRendering, pRenderingInfo->colorAttachmentCount,
@@ -2527,7 +2527,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdBeginRendering(
 }
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdEndRendering(
-        VkCommandBuffer                             commandBuffer) {
+    VkCommandBuffer                             commandBuffer) {
 
     MVKTraceVulkanCallStart();
     MVKAddCmd(EndRendering, commandBuffer);
@@ -2537,56 +2537,79 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdEndRendering(
 MVK_PUBLIC_VULKAN_STUB(vkCmdBindVertexBuffers2, void, VkCommandBuffer, uint32_t, uint32_t, const VkBuffer*, const VkDeviceSize*, const VkDeviceSize*, const VkDeviceSize*)
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdBlitImage2(
-        VkCommandBuffer                             commandBuffer,
-        const VkBlitImageInfo2*                     pBlitImageInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer                             commandBuffer,
+    const VkBlitImageInfo2*                     pBlitImageInfo) {
+
+	MVKTraceVulkanCallStart();
     MVKAddCmdFromThreshold(BlitImage, pBlitImageInfo->regionCount, 1, commandBuffer,
                            pBlitImageInfo);
     MVKTraceVulkanCallEnd();
 }
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyBuffer2(
-        VkCommandBuffer commandBuffer,
-        const VkCopyBufferInfo2* pCopyBufferInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer commandBuffer,
+    const VkCopyBufferInfo2* pCopyBufferInfo) {
+    
+	MVKTraceVulkanCallStart();
     MVKAddCmdFromThreshold(CopyBuffer, pCopyBufferInfo->regionCount, 1, commandBuffer, pCopyBufferInfo);
     MVKTraceVulkanCallEnd();
 }
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyBufferToImage2(
-        VkCommandBuffer                             commandBuffer,
-        const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer                             commandBuffer,
+    const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) {
+
+	MVKTraceVulkanCallStart();
     MVKAddCmdFrom3Thresholds(BufferImageCopy, pCopyBufferToImageInfo->regionCount, 1, 4, 8, commandBuffer,
                              pCopyBufferToImageInfo);
     MVKTraceVulkanCallEnd();
 }
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyImage2(
-        VkCommandBuffer                             commandBuffer,
-        const VkCopyImageInfo2*                     pCopyImageInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer                             commandBuffer,
+    const VkCopyImageInfo2*                     pCopyImageInfo) {
+
+	MVKTraceVulkanCallStart();
     MVKAddCmdFromThreshold(CopyImage, pCopyImageInfo->regionCount, 1, commandBuffer,
                            pCopyImageInfo);
     MVKTraceVulkanCallEnd();
 }
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdCopyImageToBuffer2(
-        VkCommandBuffer                             commandBuffer,
-        const VkCopyImageToBufferInfo2*             pCopyImageInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer                             commandBuffer,
+    const VkCopyImageToBufferInfo2*             pCopyImageInfo) {
+
+	MVKTraceVulkanCallStart();
     MVKAddCmdFrom3Thresholds(BufferImageCopy, pCopyImageInfo->regionCount, 1, 4, 8, commandBuffer,
                              pCopyImageInfo);
     MVKTraceVulkanCallEnd();
 }
 
-MVK_PUBLIC_VULKAN_STUB(vkCmdPipelineBarrier2, void, VkCommandBuffer, const VkDependencyInfo*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdResetEvent2, void, VkCommandBuffer, VkEvent, VkPipelineStageFlags2 stageMask)
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPipelineBarrier2(
+    VkCommandBuffer                             commandBuffer,
+    const VkDependencyInfo*                     pDependencyInfo) {
+
+	MVKTraceVulkanCallStart();
+	uint32_t barrierCount = pDependencyInfo->memoryBarrierCount + pDependencyInfo->bufferMemoryBarrierCount + pDependencyInfo->imageMemoryBarrierCount;
+	MVKAddCmdFrom2Thresholds(PipelineBarrier, barrierCount, 1, 4, commandBuffer, pDependencyInfo);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdResetEvent2(
+    VkCommandBuffer                             commandBuffer,
+    VkEvent                                     event,
+    VkPipelineStageFlags2                       stageMask) {
+
+	MVKTraceVulkanCallStart();
+	MVKAddCmd(ResetEvent, commandBuffer, event, stageMask);
+	MVKTraceVulkanCallEnd();
+}
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdResolveImage2(
-        VkCommandBuffer commandBuffer,
-        const VkResolveImageInfo2* pResolveImageInfo) {
-    MVKTraceVulkanCallStart();
+    VkCommandBuffer commandBuffer,
+    const VkResolveImageInfo2* pResolveImageInfo) {
+
+	MVKTraceVulkanCallStart();
     MVKAddCmdFromThreshold(ResolveImage, pResolveImageInfo->regionCount, 1, commandBuffer,
                            pResolveImageInfo);
     MVKTraceVulkanCallEnd();
@@ -2598,7 +2621,17 @@ MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthBoundsTestEnable, void, VkCommandBuffer, VkB
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthCompareOp, void, VkCommandBuffer, VkCompareOp)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthTestEnable, void, VkCommandBuffer, VkBool32)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetDepthWriteEnable, void, VkCommandBuffer, VkBool32)
-MVK_PUBLIC_VULKAN_STUB(vkCmdSetEvent2, void, VkCommandBuffer, VkEvent, const VkDependencyInfo*)
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdSetEvent2(
+    VkCommandBuffer                             commandBuffer,
+    VkEvent                                     event,
+    const VkDependencyInfo*                     pDependencyInfo) {
+
+	MVKTraceVulkanCallStart();
+	MVKAddCmd(SetEvent, commandBuffer, event, pDependencyInfo);
+	MVKTraceVulkanCallEnd();
+}
+
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetFrontFace, void, VkCommandBuffer, VkFrontFace)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetPrimitiveRestartEnable, void, VkCommandBuffer, VkBool32)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetPrimitiveTopology, void, VkCommandBuffer, VkPrimitiveTopology)
@@ -2607,8 +2640,29 @@ MVK_PUBLIC_VULKAN_STUB(vkCmdSetScissorWithCount, void, VkCommandBuffer, uint32_t
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetStencilOp, void, VkCommandBuffer, VkStencilFaceFlags, VkStencilOp, VkStencilOp, VkStencilOp, VkCompareOp)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetStencilTestEnable, void, VkCommandBuffer, VkBool32)
 MVK_PUBLIC_VULKAN_STUB(vkCmdSetViewportWithCount, void, VkCommandBuffer, uint32_t, const VkViewport*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdWaitEvents2, void, VkCommandBuffer, uint32_t, const VkEvent*, const VkDependencyInfo*)
-MVK_PUBLIC_VULKAN_STUB(vkCmdWriteTimestamp2, void, VkCommandBuffer, VkPipelineStageFlags2, VkQueryPool, uint32_t)
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdWaitEvents2(
+    VkCommandBuffer                             commandBuffer,
+    uint32_t                                    eventCount,
+    const VkEvent*                              pEvents,
+    const VkDependencyInfo*                     pDependencyInfos) {
+
+	MVKTraceVulkanCallStart();
+	MVKAddCmdFromThreshold(WaitEvents, eventCount, 1, commandBuffer, eventCount, pEvents, pDependencyInfos);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdWriteTimestamp2(
+    VkCommandBuffer                             commandBuffer,
+    VkPipelineStageFlags2                       stage,
+    VkQueryPool                                 queryPool,
+    uint32_t                                    query) {
+
+	MVKTraceVulkanCallStart();
+	MVKAddCmd(WriteTimestamp, commandBuffer, stage, queryPool, query);
+	MVKTraceVulkanCallEnd();
+}
+
 MVK_PUBLIC_VULKAN_STUB_VKRESULT(vkCreatePrivateDataSlot, VkDevice, const VkPrivateDataSlotCreateInfo*, const VkAllocationCallbacks*, VkPrivateDataSlot*)
 MVK_PUBLIC_VULKAN_STUB(vkDestroyPrivateDataSlot, void, VkDevice, VkPrivateDataSlot, const VkAllocationCallbacks*)
 MVK_PUBLIC_VULKAN_STUB(vkGetDeviceBufferMemoryRequirements, void, VkDevice, const VkDeviceBufferMemoryRequirements*, VkMemoryRequirements2*)
@@ -2616,7 +2670,20 @@ MVK_PUBLIC_VULKAN_STUB(vkGetDeviceImageMemoryRequirements, void, VkDevice, const
 MVK_PUBLIC_VULKAN_STUB(vkGetDeviceImageSparseMemoryRequirements, void, VkDevice, const VkDeviceImageMemoryRequirements*, uint32_t*, VkSparseImageMemoryRequirements2*)
 MVK_PUBLIC_VULKAN_STUB_VKRESULT(vkGetPhysicalDeviceToolProperties, VkPhysicalDevice, uint32_t*, VkPhysicalDeviceToolProperties*)
 MVK_PUBLIC_VULKAN_STUB(vkGetPrivateData, void, VkDevice, VkObjectType, uint64_t, VkPrivateDataSlot, uint64_t*)
-MVK_PUBLIC_VULKAN_STUB_VKRESULT(vkQueueSubmit2, VkQueue, uint32_t, const VkSubmitInfo2*, VkFence)
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkQueueSubmit2(
+    VkQueue                                     queue,
+    uint32_t                                    submitCount,
+    const VkSubmitInfo2*                        pSubmits,
+    VkFence                                     fence) {
+
+	MVKTraceVulkanCallStart();
+	MVKQueue* mvkQ = MVKQueue::getMVKQueue(queue);
+	VkResult rslt = mvkQ->submit(submitCount, pSubmits, fence, kMVKCommandUseQueueSubmit);
+	MVKTraceVulkanCallEnd();
+	return rslt;
+}
+
 MVK_PUBLIC_VULKAN_STUB_VKRESULT(vkSetPrivateData, VkDevice, VkObjectType, uint64_t, VkPrivateDataSlot, uint64_t)
 
 #pragma mark -
@@ -3100,6 +3167,17 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetPhysicalDeviceSurfaceFormats2KHR(
 	MVKTraceVulkanCallEnd();
 	return rslt;
 }
+
+
+#pragma mark -
+#pragma mark VK_KHR_synchronization2
+
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPipelineBarrier2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdResetEvent2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdSetEvent2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdWaitEvents2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdWriteTimestamp2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkQueueSubmit2, KHR);
 
 
 #pragma mark -


### PR DESCRIPTION
- `MVKPhysicalDevice` add support for `VkPhysicalDeviceSynchronization2Features`.
- Pass sync2 structs to `MVKPipelineBarrier`, `MVKCmdPipelineBarrier`, `MVKCmdSetEvent`, `MVKCmdResetEvent`, `MVKCmdWaitEvents`, `MVKRenderPass`, `MVKQueue` & `MVKQueueSubmission`.
- Replace use of `VkPipelineStageFlags` & `VkAccessFlags` with `VkPipelineStageFlags2` & `VkAccessFlags2`.
- Add stage masks to `MVKPipelineBarrier`, and redefine `apply*MemoryBarrier()` functions to remove separately passing stage masks.
- Add `MVKSemaphoreSubmitInfo` to track semaphores in `MVKQueueSubmission`.
- Add `MVKCommandBufferSubmitInfo` to track command buffers in `MVKQueueCommandBufferSubmission`.
- Add `MVKSubpassDependency` to combine `VkSubpassDependency` & `VkMemoryBarrier2` in `MVKRenderPass`.
- Remove abstract `MVKCmdSetResetEvent` superclass.
- Streamline code in `MVKMTLFunction::operator=` (unrelated).

Implements issue #1514.