### PR TITLE
Fixes for VK_EXT_extended_dynamic_state.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1711,7 +1711,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.maxPerStageStorageTextureCount = 8;
 
 	_metalFeatures.vertexStrideAlignment = supportsMTLGPUFamily(Apple5) ? 1 : 4;
+
+#if MVK_XCODE_15
+	// Dynamic vertex stride needs to have everything aligned - compiled with support for vertex stride calls, and supported by both runtime OS and GPU.
 	_metalFeatures.dynamicVertexStride = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2));
+#endif
 
 	// GPU-specific features
 	switch (_properties.vendorID) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -232,6 +232,7 @@ enum MVKRenderStateType {
 	DepthTestEnable,
 	DepthWriteEnable,
 	FrontFace,
+	LineWidth,
 	LogicOp,
 	LogicOpEnable,
 	PatchControlPoints,


### PR DESCRIPTION
- `MVKPipeline` only work around zero stride if stride is static.
- Ensure dynamic vertex stride is not enabled on builds before Xcode 15.
- Add `MVKRenderStateType::LineWidth` for track all default options (unrelated).

Fixes issue #2041.