### PR TITLE
Emit primitiveRestartEnable disabled warning only for strip topology.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdRendering.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRendering.h
@@ -584,6 +584,8 @@ public:
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
+
+	VkBool32 _primitiveRestartEnable;
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRendering.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRendering.mm
@@ -524,19 +524,13 @@ void MVKCmdSetPrimitiveTopology::encode(MVKCommandEncoder* cmdEncoder) {
 
 VkResult MVKCmdSetPrimitiveRestartEnable::setContent(MVKCommandBuffer* cmdBuff,
 													 VkBool32 primitiveRestartEnable) {
-	// Validate
-	// In Metal, primitive restart cannot be disabled.
-	// Just issue warning here, as it is very likely the app is not actually expecting 
-	// to use primitive restart at all, and is just setting this as a "just-in-case",
-	// and forcing an error here would be unexpected to the app (including CTS).
-	if ( !primitiveRestartEnable ) {
-		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Metal does not support disabling primitive restart.");
-	}
-
+	_primitiveRestartEnable = primitiveRestartEnable;
 	return VK_SUCCESS;
 }
 
-void MVKCmdSetPrimitiveRestartEnable::encode(MVKCommandEncoder* cmdEncoder) {}
+void MVKCmdSetPrimitiveRestartEnable::encode(MVKCommandEncoder* cmdEncoder) {
+	cmdEncoder->_renderingState.setPrimitiveRestartEnable(_primitiveRestartEnable, true);
+}
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -312,6 +312,8 @@ public:
 	void setViewports(const MVKArrayRef<VkViewport> viewports, uint32_t firstViewport, bool isDynamic);
 	void setScissors(const MVKArrayRef<VkRect2D> scissors, uint32_t firstScissor, bool isDynamic);
 
+	void setPrimitiveRestartEnable(VkBool32 primitiveRestartEnable, bool isDynamic);
+
 	void setRasterizerDiscardEnable(VkBool32 rasterizerDiscardEnable, bool isDynamic);
 
 	void beginMetalRenderPass() override;
@@ -345,6 +347,7 @@ protected:
 	MVKRenderStateFlags _dirtyStates;
 	MVKRenderStateFlags _modifiedStates;
 	bool _mtlDepthBiasEnable[StateScope::Count] = {};
+	bool _mtlPrimitiveRestartEnable[StateScope::Count] = {};
 	bool _mtlRasterizerDiscardEnable[StateScope::Count] = {};
 	bool _cullBothFaces[StateScope::Count] = {};
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -427,6 +427,7 @@ protected:
 	uint32_t _tessCtlPatchOutputBufferIndex = 0;
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
+	bool _primitiveRestartEnable = true;
 	bool _hasRasterInfo = false;
 	bool _needsVertexSwizzleBuffer = false;
 	bool _needsVertexBufferSizeBuffer = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -295,6 +295,7 @@ void MVKGraphicsPipeline::encode(MVKCommandEncoder* cmdEncoder, uint32_t stage) 
 
             // Rasterization
 			cmdEncoder->_renderingState.setPrimitiveTopology(_vkPrimitiveTopology, false);
+			cmdEncoder->_renderingState.setPrimitiveRestartEnable(_primitiveRestartEnable, false);
 			cmdEncoder->_renderingState.setBlendConstants(_blendConstants, false);
 			cmdEncoder->_renderingState.setStencilReferenceValues(_depthStencilInfo);
             cmdEncoder->_renderingState.setViewports(_viewports.contents(), 0, false);
@@ -507,13 +508,7 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 				   ? pCreateInfo->pInputAssemblyState->topology
 				   : VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
 
-		// In Metal, primitive restart cannot be disabled.
-		// Just issue warning here, as it is very likely the app is not actually expecting
-		// to use primitive restart at all, and is just setting this as a "just-in-case",
-		// and forcing an error here would be unexpected to the app (including CTS).
-	if (pCreateInfo->pInputAssemblyState && !pCreateInfo->pInputAssemblyState->primitiveRestartEnable) {
-		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateGraphicsPipeline(): Metal does not support disabling primitive restart.");
-	}
+	_primitiveRestartEnable = pCreateInfo->pInputAssemblyState ? pCreateInfo->pInputAssemblyState->primitiveRestartEnable : true;
 
 	// Rasterization
 	_hasRasterInfo = mvkSetOrClear(&_rasterInfo, pCreateInfo->pRasterizationState);


### PR DESCRIPTION
- Move check and warning to `MVKRenderingCommandEncoderState`.
- Pass `primitiveRestartEnable` to `MVKRenderingCommandEncoderState`.
- Warn only if `primitiveRestartEnable` disabled and strip topology is used.

Fixes issue #2045.