### PR TITLE
Reduce disk space consumed after running fetchDependencies.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,12 +10,12 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # See the following, which includes links to supported macOS versions, including supported Xcode versions
-# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
 jobs:
   build:
     strategy:
       matrix:
-        xcode: [ "14.3.1" ]
+        xcode: [ "15.0" ]
         platform: [ "all", "macos", "ios" ]
         os: [ "macos-13" ]
         upload_artifacts: [ true ]

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,15 @@ Copyright (c) 2015-2023 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.7
+--------------
+
+Released TBD
+
+- Reduce disk space consumed after running `fetchDependencies` script by removing intermediate file caches.
+
+
+
 MoltenVK 1.2.6
 --------------
 

--- a/MoltenVK/MoltenVK/API/mvk_config.h
+++ b/MoltenVK/MoltenVK/API/mvk_config.h
@@ -45,7 +45,7 @@ extern "C" {
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   6
+#define MVK_VERSION_PATCH   7
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2506,7 +2506,8 @@ namespace SPIRV_CROSS_NAMESPACE {
 				opt.force_sample_rate_shading,
 				opt.manual_helper_invocation_updates,
 				opt.check_discarded_frag_stores,
-				opt.sample_dref_lod_array_as_grad);
+				opt.sample_dref_lod_array_as_grad,
+				opt.replace_recursive_inputs);
 	}
 
 	template<class Archive>

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ platforms and simulators. The `--visionos` and `--visionossim` selections must b
 with a separate invocation of `fetchDependencies`, because those selections require 
 Xcode 15+, and will cause a multi-platform build on older versions of Xcode to abort.
 
-Running `fetchDependencies` repeatedly with different platforms will accumulate 
-targets in the `XCFramework`.
+Running `fetchDependencies` repeatedly with different platforms will accumulate targets 
+in the `XCFramework`, if the `--keep-cache` option is used on each invocation.
 
 For more information about the external open-source libraries used by **MoltenVK**,
 see the [`ExternalRevisions/README.md`](ExternalRevisions/README.md) document.

--- a/Scripts/create_ext_lib_xcframeworks.sh
+++ b/Scripts/create_ext_lib_xcframeworks.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+if [ "${SKIP_PACKAGING}" = "Y" ]; then exit 0; fi
+
 . "${PROJECT_DIR}/Scripts/create_xcframework_func.sh"
 
 export MVK_EXT_DIR="${PROJECT_DIR}/External"

--- a/Scripts/package_ext_libs_finish.sh
+++ b/Scripts/package_ext_libs_finish.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+if [ "${SKIP_PACKAGING}" = "Y" ]; then exit 0; fi
+
 set -e
 
 export MVK_EXT_LIB_DST_PATH="${PROJECT_DIR}/External/build/"
 
 # Assign symlink to Latest
 ln -sfn "${CONFIGURATION}" "${MVK_EXT_LIB_DST_PATH}/Latest"
+
+# Remove the large Intermediates directory if no longer needed
+if [ "${KEEP_CACHE}" != "Y" ]; then
+	echo Removing Intermediates library at "${MVK_EXT_LIB_DST_PATH}/Intermediates"
+	rm -rf "${MVK_EXT_LIB_DST_PATH}/Intermediates"
+fi
 
 # Clean MoltenVK to ensure the next MoltenVK build will use the latest external library versions.
 make --quiet clean

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -67,6 +67,12 @@
 #      --no-parallel-build
 #              Build the external libraries serially instead of in parallel. This is the default.
 #
+#      --keep-cache
+#              Do not remove the External/build/Intermediates cache directory after building.
+#              Removing the Intermediates directory returns significant disk space after the
+#              build, and is the default behaviour. Use this option if you intend to run this
+#              script repeatedly to incrementally build one platform at a time.
+#
 #      --glslang-root path
 #              "path" specifies a directory path to a KhronosGroup/glslang repository.
 #              This repository does need to be built and the build directory must be in the
@@ -117,6 +123,7 @@ V_HEADERS_ROOT=""
 SPIRV_CROSS_ROOT=""
 GLSLANG_ROOT=""
 BLD_SPV_TLS=""
+export KEEP_CACHE=""
 
 while (( "$#" )); do
   case "$1" in
@@ -189,6 +196,10 @@ while (( "$#" )); do
          ;;
        --no-parallel-build)
          XC_USE_BCKGND=""
+         shift 1
+         ;;
+       --keep-cache)
+         KEEP_CACHE="Y"
          shift 1
          ;;
        -v)
@@ -410,7 +421,6 @@ function execute_xcodebuild_command () {
 # 2 - Platform
 # 3 - Destination (Optional. Defaults to same as platform)
 function build_impl() {
-    BLD_SPECIFIED="Y"
 	XC_OS=${1}
 	XC_PLTFM=${2}
 	if [ "${3}" != "" ]; then
@@ -442,7 +452,9 @@ function build_impl() {
 # Select whether or not to run the build in parallel.
 # 1 - OS
 # 2 - platform
+# 3 - Destination (Optional. Defaults to same as platform)
 function build() {
+    BLD_SPECIFIED="Y"
 	if [ "$XC_USE_BCKGND" != "" ]; then
 		build_impl "${1}" "${2}" "${3}" &
 	else
@@ -453,6 +465,7 @@ function build() {
 EXT_DEPS=ExternalDependencies
 XC_PROJ="${EXT_DEPS}.xcodeproj"
 XC_DD_PATH="${EXT_DIR}/build"
+export SKIP_PACKAGING="Y"
 
 # Determine if xcpretty is present
 XCPRETTY_PATH=$(command -v xcpretty 2> /dev/null || true) # ignore failures
@@ -512,9 +525,10 @@ if [ "$XC_USE_BCKGND" != "" ]; then
 fi
 
 if [ "$BLD_SPECIFIED" != "" ]; then
-	# Build XCFrameworks, update latest symlink, and clean MoltenVK for rebuild
+	# Build XCFrameworks, update latest symlink, remove intermediates, and clean MoltenVK for rebuild
 	PROJECT_DIR="."
 	CONFIGURATION=${XC_CONFIG}
+	SKIP_PACKAGING=""
 	. "./Scripts/create_ext_lib_xcframeworks.sh"
 	. "./Scripts/package_ext_libs_finish.sh"
 else


### PR DESCRIPTION
- Add `--keep-cache` option to control whether or not to retain the `External/build/Intermediates` directory (default not retained).
- Export `KEEP_CACHE` & `SKIP_PACKAGING` to be available within scripts used by `ExternalDependencies` Xcode builds.
- Move `BLD_SPECIFIED` to `build()` instead of `build_impl()` to avoid updating it from background thread (which will fail).
- Update MoltenVK version to 1.2.7 (unrelated).
- Add `CompilerMSL::Options::replace_recursive_inputs` to pipeline cache (unrelated).
- Update GitHub CI to Xcode 15.0.
- Update `Whats_new.md` document.