### PR TITLE
Don't make texture views where not necessary

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -91,7 +91,10 @@ id<MTLTexture> MVKImagePlane::getMTLTexture(MTLPixelFormat mtlPixFmt) {
         lock_guard<mutex> lock(_image->_lock);
         mtlTex = _mtlTextureViews[mtlPixFmt];
         if ( !mtlTex ) {
-            mtlTex = [baseTexture newTextureViewWithPixelFormat: mtlPixFmt];    // retained
+            if ([baseTexture pixelFormat] == mtlPixFmt)
+                mtlTex = [baseTexture retain];
+            else
+                mtlTex = [baseTexture newTextureViewWithPixelFormat: mtlPixFmt];    // retained
             _mtlTextureViews[mtlPixFmt] = mtlTex;
         }
     }


### PR DESCRIPTION
This is mainly to work around a bug in macOS Sonoma where Radeon Pro 580Xs read black if you attempt to sample a D24S8 texture through a texture view that was previously copied from (so texture goes from copy source → shader read with texture view) [FB13342692]

But less texture views also makes things easier to track in the Xcode shader debugger, so might as well apply it always