### PR TITLE
Fix MVKBitArray::getIndexOfFirstSetBit() skipping over entries.

### DIFF
--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -90,7 +90,11 @@ public:
 	 * and optionally clears that bit. If no bits are set, returns the size() of this bit array.
 	 */
 	size_t getIndexOfFirstSetBit(size_t startIndex, bool shouldClear) {
-		size_t startSecIdx = std::max(getIndexOfSection(startIndex), _clearedSectionCount);
+		size_t startSecIdx = getIndexOfSection(startIndex);
+		if (startSecIdx < _clearedSectionCount) {
+			startSecIdx = _clearedSectionCount;
+			startIndex = 0;
+		}
 		size_t bitIdx = startSecIdx << SectionMaskSize;
 		size_t secCnt = getSectionCount();
 		for (size_t secIdx = startSecIdx; secIdx < secCnt; secIdx++) {
@@ -101,6 +105,7 @@ public:
 				if (shouldClear) { clearBit(bitIdx); }
 				return std::min(bitIdx, _bitCount);
 			}
+			startIndex = 0;
 		}
 		return std::min(bitIdx, _bitCount);
 	}


### PR DESCRIPTION
Reset startIndex so that we only skip over bits in the section that contains it.