### PR TITLE
MVKPixelFormats: Handle the `B4G4R4A4` format.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1660,6 +1660,14 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 			adjustAnyComponentSwizzleValue(a, R, A, B, G, R);
 			break;
 
+		case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
+			// Metal doesn't support this directly, so use a swizzle to get the ordering right.
+			adjustAnyComponentSwizzleValue(r, B, B, G, R, A);
+			adjustAnyComponentSwizzleValue(g, G, B, G, R, A);
+			adjustAnyComponentSwizzleValue(b, R, B, G, R, A);
+			adjustAnyComponentSwizzleValue(a, A, B, G, R, A);
+			break;
+
 		default:
 			break;
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -529,6 +529,7 @@ MTLClearColor MVKPixelFormats::getMTLClearColor(VkClearValue vkClearValue, VkFor
 #define OFFSET_SNORM(COLOR, BIT_WIDTH)    OFFSET_NORM(-1.0, COLOR, BIT_WIDTH - 1)
 				switch (vkFormat) {
 					case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+					case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
 					case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
 					case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
 						OFFSET_UNORM(red, 4)
@@ -831,7 +832,7 @@ void MVKPixelFormats::initVkFormatCapabilities() {
 
 	addVkFormatDesc( R4G4_UNORM_PACK8, Invalid, Invalid, Invalid, Invalid, 1, 1, 1, ColorFloat );
 	addVkFormatDesc( R4G4B4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( B4G4R4A4_UNORM_PACK16, Invalid, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
+	addVkFormatDescSwizzled( B4G4R4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, B, G, R, A );
 	addVkFormatDescSwizzled( A4R4G4B4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, G, B, A, R );
 	addVkFormatDescSwizzled( A4B4G4R4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, A, B, G, R );
 


### PR DESCRIPTION
Handle it similarly to the `A4R4B4G4` and `A4B4G4R4` formats, with a swizzle. Vulkan requires support for this format.

Fixes the following tests:
* `dEQP-VK.api.info.format_properties.b4g4r4a4_unorm_pack16`.
* `dEQP-VK.texture.explicit_lod.2d.formats.b4g4r4a4*`