### PR TITLE
MVKDevice: Correct some required limits.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2748,7 +2748,7 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.maxComputeWorkGroupCount[1] = kMVKUndefinedLargeUInt32;
     _properties.limits.maxComputeWorkGroupCount[2] = kMVKUndefinedLargeUInt32;
 
-    _properties.limits.maxDrawIndexedIndexValue = numeric_limits<uint32_t>::max() - 1;	// Support both fullDrawIndexUint32 and automatic primitive restart.
+    _properties.limits.maxDrawIndexedIndexValue = numeric_limits<uint32_t>::max();
     _properties.limits.maxDrawIndirectCount = kMVKUndefinedLargeUInt32;
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2692,7 +2692,7 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.pointSizeGranularity = 1;
     _properties.limits.lineWidthRange[0] = 1;
     _properties.limits.lineWidthRange[1] = 1;
-    _properties.limits.lineWidthGranularity = 1;
+    _properties.limits.lineWidthGranularity = 0;
 
     _properties.limits.standardSampleLocations = VK_TRUE;
     _properties.limits.strictLines = _properties.vendorID == kIntelVendorId || _properties.vendorID == kNVVendorId;


### PR DESCRIPTION
If the `wideLines` feature isn't supported, then `lineWidthGranularity`
must be zero.

If the `fullDrawIndexUint32` feature is supported, then
`maxDrawIndexedIndexValue` must be `UINT32_MAX`. I had originally done
this when I turned the feature on, but for a while now, we've been
setting it to one less, because primitive restart can't be disabled and
the value is defined to exclude primitive restart.

The wording in the spec is ambiguous. The description of
`maxDrawIndexedIndexValue` says:

> * `maxDrawIndexedIndexValue` is the maximum index value that **can**
>   be used for indexed draw calls when using 32-bit indices. *This
>   excludes the primitive restart index value of 0xFFFFFFFF.* [emphasis
>   added]

But the description of `fullDrawIndexUint32` says:

> * `fullDrawIndexUint32` specifies the full 32-bit range of indices is
>   supported for indexed draw calls when using a VkIndexType of
>   `VK_INDEX_TYPE_UINT32`. `maxDrawIndexedIndexValue` is the maximum
>   index value that **may** [sic] be used *(aside from the primitive
>   restart index, which is always 2<sup>32</sup>-1 when the VkIndexType
>   is `VK_INDEX_TYPE_UINT32`)*. If this feature is supported,
>   `maxDrawIndexedIndexValue` **must** be 2<sup>32</sup>-1; otherwise
>   it **must** be no smaller than 2<sup>24</sup>-1. [emphasis added]

It's unclear whether it means that the primitive restart index is to be
ignored, or the maximum draw index must account for it.

The alternative is to disable `fullDrawIndexUint32` because we cannot
set `maxDrawIndexedIndexValue` to `UINT32_MAX`; but that might mislead
programs into thinking that we only support 24-bit vertex indices.

Fixes the `dEQP-VK.info.device_properties` test.