### PR TITLE
Fix initial value of VkPhysicalDeviceLimits::timestampPeriod on non-Apple Silicon GPUs.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
 - Fix regression in marking rendering state dirty after `vkCmdClearAttachments()`.
 - Reduce disk space consumed after running `fetchDependencies` script by removing intermediate file caches.
 - Fix rare deadlock during launch via `dlopen()`.
+- Fix initial value of `VkPhysicalDeviceLimits::timestampPeriod` on non-Apple Silicon GPUs.
 - Update to latest SPIRV-Cross:
   - MSL: Fix regression error in argument buffer runtime arrays.
 


### PR DESCRIPTION
- Don't update value of `timestampPeriod` on first measurement.
- Force that first measurement upon creation of `MVKPhysicalDevice`, so an accurate value for `timestampPeriod` will be calculated when next queried.

Adds further fix to #2040.