### PR TITLE
Don't enable PixelFormatView just in case we need it to copy

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -310,7 +310,10 @@ public:
      * attempting to copy a depth image with a substituted format to and from a buffer.
      */
     inline bool hasExpectedTexelSize() { return _hasExpectedTexelSize; }
-    
+
+	/** Returns whether the texture has the PixelFormatView usage flag, allowing it to be reinterpreted. */
+	inline bool hasPixelFormatView(uint32_t planeIndex) { return mvkIsAnyFlagEnabled(getMTLTexture(planeIndex).usage, MTLTextureUsagePixelFormatView); }
+
 	/** Returns the Metal resource options for this image. */
     MTLStorageMode getMTLStorageMode();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1763,6 +1763,13 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 		}
 	}
 
+	if (!_imageView->_image->hasPixelFormatView(_planeIndex)) {
+		if (!enableSwizzling()) {
+			MVKAssert(0, "Image without PixelFormatView usage couldn't enable swizzling!");
+		}
+		return VK_SUCCESS;
+	}
+
 	switch (_mtlPixFmt) {
 		case MTLPixelFormatR8Unorm:
 			if (SWIZZLE_MATCHES(ZERO, ANY, ANY, R)) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -737,23 +737,23 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 		mvkEnableFlags(mtlUsage, samples == VK_SAMPLE_COUNT_1_BIT ? MTLTextureUsageShaderWrite : MTLTextureUsageShaderRead);
 	}
 
-	// Create view on, but only on color formats, or combined depth-stencil formats if supported by the GPU...
-	if ((mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT)) || 		// May use temp view if transfer involves format change
-		 (needsReinterpretation &&
-		  mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_SAMPLED_BIT |
-												  VK_IMAGE_USAGE_STORAGE_BIT |
-												  VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
-												  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)))) &&
-		isColorFormat) {
+	bool pfv = false;
 
-		mvkEnableFlags(mtlUsage, MTLTextureUsagePixelFormatView);
-	}
-	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | 		// May use temp view if transfer involves format change
-		 										VK_IMAGE_USAGE_SAMPLED_BIT |
-												VK_IMAGE_USAGE_STORAGE_BIT |
-												VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) &&
-		isCombinedDepthStencilFmt && supportsStencilViews) {
+	// Swizzle emulation may need to reinterpret
+	needsReinterpretation |= !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle;
 
+	pfv |= isColorFormat && needsReinterpretation &&
+	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_SAMPLED_BIT |
+	                                               VK_IMAGE_USAGE_STORAGE_BIT |
+	                                               VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+	                                               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
+	pfv |= isCombinedDepthStencilFmt && supportsStencilViews &&
+	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | // May use temp view if transfer involves format change
+	                                               VK_IMAGE_USAGE_SAMPLED_BIT |
+	                                               VK_IMAGE_USAGE_STORAGE_BIT |
+	                                               VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
+
+	if (pfv) {
 		mvkEnableFlags(mtlUsage, MTLTextureUsagePixelFormatView);
 	}
 


### PR DESCRIPTION
PixelFormatView disables compression on color textures, and shouldn't be applied to every texture that can be used as a copy source / dst (which includes all textures in translation libraries like DXVK and vkd3d)

Improves performance in games like Diablo IV on M1

This does mean we may need an extra copy if something attempts to reinterpret-copy between two images with different formats, but hopefully that's less common than using the images normally.