### PR TITLE
Fix heapUsage query for non-unified memory devices

### DIFF
--- a/Common/MVKOSExtensions.mm
+++ b/Common/MVKOSExtensions.mm
@@ -134,7 +134,11 @@ uint64_t mvkGetUsedMemorySize() {
 	task_vm_info_data_t task_vm_info;
 	mach_msg_type_number_t task_size = TASK_VM_INFO_COUNT;
 	if (task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&task_vm_info, &task_size) == KERN_SUCCESS) {
+#ifdef TASK_VM_INFO_REV3_COUNT	// check for rev3 version of task_vm_info
+		return task_vm_info.ledger_tag_graphics_footprint;
+#else
 		return task_vm_info.phys_footprint;
+#endif
 	}
 	return 0;
 }

--- a/Common/MVKOSExtensions.mm
+++ b/Common/MVKOSExtensions.mm
@@ -135,10 +135,12 @@ uint64_t mvkGetUsedMemorySize() {
 	mach_msg_type_number_t task_size = TASK_VM_INFO_COUNT;
 	if (task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&task_vm_info, &task_size) == KERN_SUCCESS) {
 #ifdef TASK_VM_INFO_REV3_COUNT	// check for rev3 version of task_vm_info
-		return task_vm_info.ledger_tag_graphics_footprint;
-#else
-		return task_vm_info.phys_footprint;
+		if (task_size >= TASK_VM_INFO_REV3_COUNT) {
+			return task_vm_info.ledger_tag_graphics_footprint;
+		}
+		else
 #endif
+			return task_vm_info.phys_footprint;
 	}
 	return 0;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1650,12 +1650,12 @@ VkResult MVKPhysicalDevice::getMemoryProperties(VkPhysicalDeviceMemoryProperties
 				auto* budgetProps = (VkPhysicalDeviceMemoryBudgetPropertiesEXT*)next;
 				mvkClear(budgetProps->heapBudget, VK_MAX_MEMORY_HEAPS);
 				mvkClear(budgetProps->heapUsage, VK_MAX_MEMORY_HEAPS);
-				budgetProps->heapBudget[0] = (VkDeviceSize)getRecommendedMaxWorkingSetSize();
-				budgetProps->heapUsage[0] = (VkDeviceSize)getCurrentAllocatedSize();
 				if (!getHasUnifiedMemory()) {
 					budgetProps->heapBudget[1] = (VkDeviceSize)mvkGetAvailableMemorySize();
 					budgetProps->heapUsage[1] = (VkDeviceSize)mvkGetUsedMemorySize();
 				}
+				budgetProps->heapBudget[0] = (VkDeviceSize)getRecommendedMaxWorkingSetSize();
+				budgetProps->heapUsage[0] = (VkDeviceSize)getCurrentAllocatedSize() - budgetProps->heapUsage[1];
 				break;
 			}
 			default:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1655,7 +1655,12 @@ VkResult MVKPhysicalDevice::getMemoryProperties(VkPhysicalDeviceMemoryProperties
 					budgetProps->heapUsage[1] = (VkDeviceSize)mvkGetUsedMemorySize();
 				}
 				budgetProps->heapBudget[0] = (VkDeviceSize)getRecommendedMaxWorkingSetSize();
-				budgetProps->heapUsage[0] = (VkDeviceSize)getCurrentAllocatedSize() - budgetProps->heapUsage[1];
+				uint64_t currentAllocatedSize = (VkDeviceSize)getCurrentAllocatedSize();
+				if (budgetProps->heapUsage[1] > currentAllocatedSize) {
+					// mapped memory can't be larger than total memory, so ignore and zero-out
+					budgetProps->heapUsage[1] = 0;
+				}
+				budgetProps->heapUsage[0] = currentAllocatedSize - budgetProps->heapUsage[1];
 				break;
 			}
 			default:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1655,7 +1655,7 @@ VkResult MVKPhysicalDevice::getMemoryProperties(VkPhysicalDeviceMemoryProperties
 					budgetProps->heapUsage[1] = (VkDeviceSize)mvkGetUsedMemorySize();
 				}
 				budgetProps->heapBudget[0] = (VkDeviceSize)getRecommendedMaxWorkingSetSize();
-				uint64_t currentAllocatedSize = (VkDeviceSize)getCurrentAllocatedSize();
+				auto currentAllocatedSize = (VkDeviceSize)getCurrentAllocatedSize();
 				if (budgetProps->heapUsage[1] > currentAllocatedSize) {
 					// mapped memory can't be larger than total memory, so ignore and zero-out
 					budgetProps->heapUsage[1] = 0;


### PR DESCRIPTION
Fixes #2082 for non-unified memory machines.  No change for unified memory machines.

1. Replaces `task_vm_info.phys_footprint` with `task_vm_info.ledger_tag_graphics_footprint` in `mvkGetUsedMemorySize()`.  This provides a more accurate estimate of mapped memory for `heapUsage[1]` on non-unified memory machines.  As an aside, it also provides a more accurate fall-back within `MVKPhysicalDevice::getCurrentAllocatedSize()` if the selector is not available for any machine.
2. Fixes the calculation for `heapUsge[0]` on non-unified memory machines, where it represents the device-only memory.  The calculation remains the same for unified memory machines (where `heapUsage[1] = 0`).

The only edge case I see is for non-unified memory machines where the `currentAllocatedSize` selector is not available.  In this case `heapUsage[0]` will return 0 for device memory and `heapUsage[1]` will return mapped memory.  I think this is a reasonable fallback if the total memory information is not available from Metal.