### PR TITLE
Fix system memory size of tvOS

### DIFF
--- a/Common/MVKOSExtensions.mm
+++ b/Common/MVKOSExtensions.mm
@@ -23,6 +23,7 @@
 #include <mach/mach_time.h>
 #include <mach/task.h>
 #include <os/proc.h>
+#include <sys/sysctl.h>
 
 #import <Foundation/Foundation.h>
 
@@ -100,17 +101,12 @@ double mvkGetEnvVarNumber(const char* varName, double defaultValue) {
 #pragma mark System memory
 
 uint64_t mvkGetSystemMemorySize() {
-#if MVK_MACOS_OR_IOS_OR_VISIONOS
-	mach_msg_type_number_t host_size = HOST_BASIC_INFO_COUNT;
-	host_basic_info_data_t info;
-	if (host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t)&info, &host_size) == KERN_SUCCESS) {
-		return info.max_mem;
+	uint64_t host_memsize = 0;
+	size_t size = sizeof(host_memsize);
+	if (sysctlbyname("hw.memsize", &host_memsize, &size, NULL, 0) == KERN_SUCCESS) {
+		return host_memsize;
 	}
 	return 0;
-#endif
-#if MVK_TVOS
-	return 0;
-#endif
 }
 
 uint64_t mvkGetAvailableMemorySize() {


### PR DESCRIPTION
use sysctlbyname("hw.memsize") to get sytem memory size instead of host_info, host_info is not available on tvOS, so we change to sysctlbyname which support all apple platforms

the sytem memory size of tvOS is hardcoded as 0 currently, found this [bug](https://github.com/haasn/libplacebo/issues/229#issuecomment-1857622686) while using libplacebo's vulkan render to play video on tvOS 

apple [document](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname
) didn't stat this API is available on tvOS though

