### PR TITLE
Add: Recognize Apple9

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2926,6 +2926,9 @@ uint32_t MVKPhysicalDevice::getHighestGPUCapability() {
 #if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
 	if (supportsMTLGPUFamily(Apple8)) { gpuFam = MTLGPUFamilyApple8; }
 #endif
+#if MVK_XCODE_15 && (MVK_IOS || MVK_MACOS)
+    if (supportsMTLGPUFamily(Apple9)) { gpuFam = MTLGPUFamilyApple9; }
+#endif
 
 	// Combine OS major (8 bits), OS minor (8 bits), and GPU family (16 bits)
 	// into one 32-bit value summarizing highest GPU capability.
@@ -3326,6 +3329,9 @@ void MVKPhysicalDevice::logGPUInfo() {
 	logMsg += "\n\tsupports the following Metal Versions, GPU's and Feature Sets:";
 	logMsg += "\n\t\tMetal Shading Language %s";
 
+#if MVK_XCODE_15 && (MVK_IOS || MVK_MACOS)
+    if (supportsMTLGPUFamily(Apple9)) { logMsg += "\n\t\tGPU Family Apple 9"; }
+#endif
 #if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
 	if (supportsMTLGPUFamily(Apple8)) { logMsg += "\n\t\tGPU Family Apple 8"; }
 #endif

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1682,6 +1682,12 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 	addGPUOSMTLPixFmtCaps( Apple5, 11.0, BGR10_XR, All );
 	addGPUOSMTLPixFmtCaps( Apple5, 11.0, BGR10_XR_sRGB, All );
 #endif
+    
+#if MVK_XCODE_15
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, R32Float, All );
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, RG32Float, All );
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, RGBA32Float, All );
+#endif
 
 	addFeatSetMTLVtxFmtCaps( macOS_GPUFamily1_v3, UCharNormalized, Vertex );
 	addFeatSetMTLVtxFmtCaps( macOS_GPUFamily1_v3, CharNormalized, Vertex );
@@ -1941,6 +1947,12 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(id<MTLDevice> mtlDevice) {
 
 	addGPUOSMTLPixFmtCaps( Apple1, 13.0, Depth16Unorm, DRFM );
 	addGPUOSMTLPixFmtCaps( Apple3, 13.0, Depth16Unorm, DRFMR );
+    
+#if MVK_XCODE_15
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, R32Float, All );
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, RG32Float, All );
+    addGPUOSMTLPixFmtCaps( Apple9, 14.0, RGBA32Float, All );
+#endif
 
 	// Vertex formats
 	addFeatSetMTLVtxFmtCaps( iOS_GPUFamily1_v4, UCharNormalized, Vertex );


### PR DESCRIPTION
Tiny fix to recognize Apple9 and some format changes.

The [feature set tables](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) list 'All' for every 32-bit format on Apple9.

I also noticed that `RG32Uint` and `RG32Sint` have MSAA (since Apple7) and Atomic (since Apple8). The Atomic one is not listed in the MVK code at all, while MSAA relies on the `supports32bitMSAA` function. Though I am not sure that's correct, since the MSAA capabilities don't line up with the other formats. Is this intended?