### PR TITLE
Revert to disabling MVK_HIDE_VULKAN_SYMBOLS by default.

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -136,7 +136,7 @@ extern "C" {
  * conflicts when bound to a Vulkan Loader that also exports identical symbols.
  */
 #ifndef MVK_HIDE_VULKAN_SYMBOLS
-#	define MVK_HIDE_VULKAN_SYMBOLS		1
+#	define MVK_HIDE_VULKAN_SYMBOLS		0
 #endif
 #if MVK_HIDE_VULKAN_SYMBOLS
 #	define MVK_PUBLIC_VULKAN_SYMBOL

--- a/Demos/Cube/Cube.xcodeproj/project.pbxproj
+++ b/Demos/Cube/Cube.xcodeproj/project.pbxproj
@@ -3,10 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A90998A02B4EE8C3002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */ = {isa = PBXBuildFile; fileRef = A909989F2B4EE8C3002CEF67 /* libMoltenVK.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		A90998A32B4EFB51002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */ = {isa = PBXBuildFile; fileRef = A90998A22B4EFB51002CEF67 /* libMoltenVK.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		A90998A62B4EFBAA002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */ = {isa = PBXBuildFile; fileRef = A90998A52B4EFBAA002CEF67 /* libMoltenVK.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A93DBF3C24A2A4D500079F64 /* Icon.png in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B761C3AAE9800373FFD /* Icon.png */; };
 		A93DBF3E24A2A4D500079F64 /* Default~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B751C3AAE9800373FFD /* Default~ipad.png */; };
 		A93DBF3F24A2A4D500079F64 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B741C3AAE9800373FFD /* Default-568h@2x.png */; };
@@ -14,9 +17,6 @@
 		A93DBF4224A2A4D500079F64 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B67B6C1C3AAE9800373FFD /* AppDelegate.m */; };
 		A93DBF4324A2A4D500079F64 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B67B711C3AAE9800373FFD /* main.m */; };
 		A94D4CB724A2C9A3009C9139 /* MainTV.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A94D4CB624A2C9A3009C9139 /* MainTV.storyboard */; };
-		A991E27624FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A991E27524FD543A00D968D4 /* MoltenVK.xcframework */; };
-		A991E27724FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A991E27524FD543A00D968D4 /* MoltenVK.xcframework */; };
-		A991E27824FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A991E27524FD543A00D968D4 /* MoltenVK.xcframework */; };
 		A9B53B151C3AC0BE00ABC6F6 /* macOS.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B8B1C3AAEA200373FFD /* macOS.xcassets */; };
 		A9B53B161C3AC0BE00ABC6F6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A9B67B8A1C3AAEA200373FFD /* Main.storyboard */; };
 		A9B53B181C3AC0BE00ABC6F6 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B67B831C3AAEA200373FFD /* AppDelegate.m */; };
@@ -31,14 +31,52 @@
 		A9B53B361C3AC15200ABC6F6 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A9B67B711C3AAE9800373FFD /* main.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		A909989E2B4EE849002CEF67 /* Copy MoltenVK Library */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A90998A02B4EE8C3002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */,
+			);
+			name = "Copy MoltenVK Library";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A90998A12B4EFA78002CEF67 /* Copy MoltenVK Library */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A90998A32B4EFB51002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */,
+			);
+			name = "Copy MoltenVK Library";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A90998A42B4EFB81002CEF67 /* Copy MoltenVK Library */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A90998A62B4EFBAA002CEF67 /* libMoltenVK.dylib in Copy MoltenVK Library */,
+			);
+			name = "Copy MoltenVK Library";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		A904B5301C9A08C90008C013 /* cube.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cube.c; sourceTree = "<group>"; };
 		A904B5311C9A08C90008C013 /* cube.frag */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; path = cube.frag; sourceTree = "<group>"; };
 		A904B5331C9A08C90008C013 /* cube.vert */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; path = cube.vert; sourceTree = "<group>"; };
+		A909989F2B4EE8C3002CEF67 /* libMoltenVK.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK.dylib; path = ../../MoltenVK/dylib/macOS/libMoltenVK.dylib; sourceTree = "<group>"; };
+		A90998A22B4EFB51002CEF67 /* libMoltenVK.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK.dylib; path = ../../MoltenVK/dylib/iOS/libMoltenVK.dylib; sourceTree = "<group>"; };
+		A90998A52B4EFBAA002CEF67 /* libMoltenVK.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libMoltenVK.dylib; path = ../../MoltenVK/dylib/tvOS/libMoltenVK.dylib; sourceTree = "<group>"; };
 		A93DBF4B24A2A4D500079F64 /* Cube.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cube.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A94D4CB424A2A95E009C9139 /* InfoTV.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = InfoTV.plist; sourceTree = "<group>"; };
 		A94D4CB624A2C9A3009C9139 /* MainTV.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainTV.storyboard; sourceTree = "<group>"; };
-		A991E27524FD543A00D968D4 /* MoltenVK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MoltenVK.xcframework; path = ../../MoltenVK/MoltenVK.xcframework; sourceTree = "<group>"; };
 		A9B53B271C3AC0BE00ABC6F6 /* Cube.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cube.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9B53B431C3AC15200ABC6F6 /* Cube.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cube.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9B67B6B1C3AAE9800373FFD /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -69,7 +107,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A991E27724FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,7 +114,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A991E27824FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,7 +121,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A991E27624FD543A00D968D4 /* MoltenVK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -181,7 +216,9 @@
 		A9C2ABA82185085B00DDBC03 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A991E27524FD543A00D968D4 /* MoltenVK.xcframework */,
+				A90998A52B4EFBAA002CEF67 /* libMoltenVK.dylib */,
+				A909989F2B4EE8C3002CEF67 /* libMoltenVK.dylib */,
+				A90998A22B4EFB51002CEF67 /* libMoltenVK.dylib */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -195,6 +232,7 @@
 			buildPhases = (
 				A93DBF3B24A2A4D500079F64 /* Resources */,
 				A93DBF4024A2A4D500079F64 /* Sources */,
+				A90998A42B4EFB81002CEF67 /* Copy MoltenVK Library */,
 				A93DBF4424A2A4D500079F64 /* Frameworks */,
 			);
 			buildRules = (
@@ -212,6 +250,7 @@
 			buildPhases = (
 				A9B53B141C3AC0BE00ABC6F6 /* Resources */,
 				A9B53B171C3AC0BE00ABC6F6 /* Sources */,
+				A909989E2B4EE849002CEF67 /* Copy MoltenVK Library */,
 				A9B53B1B1C3AC0BE00ABC6F6 /* Frameworks */,
 			);
 			buildRules = (
@@ -229,6 +268,7 @@
 			buildPhases = (
 				A9B53B2E1C3AC15200ABC6F6 /* Resources */,
 				A9B53B331C3AC15200ABC6F6 /* Sources */,
+				A90998A12B4EFA78002CEF67 /* Copy MoltenVK Library */,
 				A9B53B371C3AC15200ABC6F6 /* Frameworks */,
 			);
 			buildRules = (
@@ -247,6 +287,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					A9B53B0F1C3AC0BE00ABC6F6 = {
+						ProvisioningStyle = Manual;
+					};
+					A9B53B291C3AC15200ABC6F6 = {
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Cube" */;
 			compatibilityVersion = "Xcode 8.0";
@@ -350,6 +398,7 @@
 					MVK_SAMP_CUBE,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/InfoTV.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MARKETING_VERSION = 1;
 				PRODUCT_NAME = Cube;
 				SDKROOT = appletvos;
@@ -369,6 +418,7 @@
 					MVK_SAMP_CUBE,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/InfoTV.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MARKETING_VERSION = 1;
 				PRODUCT_NAME = Cube;
 				SDKROOT = appletvos;
@@ -380,15 +430,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				GCC_PREFIX_HEADER = "$(SRCROOT)/macOS/Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					MVK_SAMP_CUBE,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/macOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_NAME = Cube;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -397,15 +453,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				GCC_PREFIX_HEADER = "$(SRCROOT)/macOS/Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					MVK_SAMP_CUBE,
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/macOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				PRODUCT_NAME = Cube;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -414,7 +476,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Cube.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GCC_PREFIX_HEADER = "$(SRCROOT)/iOS/Prefix.pch";
@@ -425,8 +488,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MARKETING_VERSION = 1;
 				PRODUCT_NAME = Cube;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,6";
@@ -437,7 +502,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Cube.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GCC_PREFIX_HEADER = "$(SRCROOT)/iOS/Prefix.pch";
@@ -448,8 +514,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MARKETING_VERSION = 1;
 				PRODUCT_NAME = Cube;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2,6";

--- a/Demos/README.md
+++ b/Demos/README.md
@@ -36,10 +36,10 @@ The demo can be found in the `Cube` folder, and in the `Cube` group in the
 To run this demo, run the `Cube-macOS`, `Cube-iOS`, or `Cube-tvOS` *Scheme* from within *Xcode*.
 In addition to devices, this demo will also run on the `iOS Simulator` or `tvOS Simulator` destinations.
 
-The `Cube` demo is a simple example of installing **MoltenVK** as an `XCFramework` that is
-statically linked to the application. It supports all platforms, including _Mac Catalyst_, _iOS
-Simulator_ and _tvOS Simulator_, and all architectures including _Apple Silicon_.
-
+The `Cube` demo is a simple example of installing **MoltenVK** as a `libMoltenVK.dylib` library that 
+is dynamically linked to the application, and the _Vulkan_ calls all use _Volk_ to dynamically access 
+function pointers, retrieved from **MoltenVK** using `vkGetInstanceProcAddr()` and `vkGetDeviceProcAddr()`. 
+It supports all platforms, including _Mac Catalyst_, _iOSSimulator_ and _tvOS Simulator_.
 
 
 <a name="khronos-vulkan-samples"></a>

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,7 +25,6 @@ Released 2024/01/08
 	- `VK_EXT_extended_dynamic_state3` *(Metal does not support `VK_POLYGON_MODE_POINT`)*
 	- `VK_EXT_headless_surface`
 	- `VK_EXT_layer_settings`
-- **MoltenVK** build now hides static _Vulkan_ API symbols by default (build setting `MVK_HIDE_VULKAN_SYMBOLS=1` by default).
 - Add support for format `VK_FORMAT_B4G4R4A4_UNORM_PACK16`.
 - Add support for vertex formats `VK_FORMAT_B10G11R11_UFLOAT_PACK32` & `VK_FORMAT_E5B9G9R9_UFLOAT_PACK32`.
 - Fix regression that broke `VK_POLYGON_MODE_LINE`.
@@ -48,6 +47,7 @@ Released 2024/01/08
 - Reduce disk space consumed after running `fetchDependencies` script by removing intermediate file caches.
 - Deprecate `vkSetMoltenVKConfigurationMVK()`.
 - Deprecate `mvk_config.h` and move content to `mvk_private_api.h` and `mvk_deprecated_api.h`.
+- The _Cube_ demo is now based on _Volk_, with dynamic library linking, and dynamic function pointer calls.
 - Update copyright notices to year 2024.
 - Update dependency libraries to match _Vulkan SDK 1.3.275_.
 - Update to latest SPIRV-Cross:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
 	OUTPUT_FMT_CMD = -quiet
 endif
 
-# Collect all build settings defined on the command-line (eg: MVK_HIDE_VULKAN_SYMBOLS=0, MVK_CONFIG_LOG_LEVEL=3...)
+# Collect all build settings defined on the command-line (eg: MVK_HIDE_VULKAN_SYMBOLS=1, MVK_CONFIG_LOG_LEVEL=3...)
 MAKEARGS := $(strip \
   $(foreach v,$(.VARIABLES),\
     $(if $(filter command\ line,$(origin $(v))),\

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -304,7 +304,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetPhysicalDeviceMemoryProperties(
 	MVKTraceVulkanCallEnd();
 }
 
-MVK_PUBLIC_VULKAN_SYMBOL PFN_vkVoidFunction vkGetInstanceProcAddr(
+MVK_PUBLIC_SYMBOL PFN_vkVoidFunction vkGetInstanceProcAddr(
     VkInstance                                  instance,
     const char*                                 pName) {
 

--- a/README.md
+++ b/README.md
@@ -294,26 +294,25 @@ or
 
 ...etc.
 
+### Hiding Vulkan API Symbols
 
-### Exposing Static Vulkan API Symbols
+You can optionally build **MoltenVK** with the Vulkan API static call symbols (`vk*`) hidden, to avoid 
+library linking conflicts when statically bound to a _Vulkan_ loader that also exports identical symbols.
 
-For default compatability with the _Vulkan SDK_ loader environment, by default, **MoltenVK** hides
-static access to the _Vulkan_ API symbols (`vk*`), in favor of using the standard _Vulkan_ 
-function pointers retrieved using `vkGetInstanceProcAddr()` and `vkGetDeviceProcAddr()`.
-
-If you are not using the _Vulkan_ loader, and wish to statically link to the _Vulkan_ API symbols, 
-you can optionally build **MoltenVK** with the _Vulkan_ API static call symbols exposed.
-
-To do so, when building **MoltenVK**, set the build setting `MVK_HIDE_VULKAN_SYMBOLS=0`.
+To do so, when building **MoltenVK**, set the build setting `MVK_HIDE_VULKAN_SYMBOLS=1`.
 This build setting can be set in the `MoltenVK.xcodeproj` *Xcode* project,
 or it can be included in any of the `make` build commands. For example:
 
-	make MVK_HIDE_VULKAN_SYMBOLS=0
+	make MVK_HIDE_VULKAN_SYMBOLS=1
 or
 
-	make macos MVK_HIDE_VULKAN_SYMBOLS=0
+	make macos MVK_HIDE_VULKAN_SYMBOLS=1
 
 ...etc.
+
+With `MVK_HIDE_VULKAN_SYMBOLS=1`, the _Vulkan_ `vkGetInstanceProcAddr()` call remains
+statically bound, to provide the application with the ability to retrieve the remaining
+_Vulkan_ API calls as function pointers.
 
 
 <a name="demos"></a>


### PR DESCRIPTION
- Statically expose `vkGetInstanceProcAddr()`, even when `MVK_HIDE_VULKAN_SYMBOLS` is enabled.
- To support _Volk_, link _Cube_ demo dynamically to `libMoltenVK.dylib` instead of statically to `MoltenVK.xcframework`.