### PR TITLE
Fix potential crash when using multi-planar images.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -13,6 +13,15 @@ Copyright (c) 2015-2024 [The Brenwill Workshop Ltd.](http://www.brenwill.com)
 
 
 
+MoltenVK 1.2.8
+--------------
+
+Released TBD
+
+- Fix potential crash when using multi-planar images.
+
+
+
 MoltenVK 1.2.7
 --------------
 

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -64,7 +64,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 #define MVK_VERSION_MAJOR   1
 #define MVK_VERSION_MINOR   2
-#define MVK_VERSION_PATCH   7
+#define MVK_VERSION_PATCH   8
 
 #define MVK_MAKE_VERSION(major, minor, patch)    (((major) * 10000) + ((minor) * 100) + (patch))
 #define MVK_VERSION     MVK_MAKE_VERSION(MVK_VERSION_MAJOR, MVK_VERSION_MINOR, MVK_VERSION_PATCH)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -345,6 +345,9 @@ protected:
 	bool getIsValidViewFormat(VkFormat viewFormat);
 	VkImageUsageFlags getCombinedUsage() { return _usage | _stencilUsage; }
 	MTLTextureUsage getMTLTextureUsage(MTLPixelFormat mtlPixFmt);
+	uint8_t getMemoryBindingCount() const { return (uint8_t)_memoryBindings.size(); }
+	uint8_t getMemoryBindingIndex(uint8_t planeIndex) const;
+	MVKImageMemoryBinding* getMemoryBinding(uint8_t planeIndex);
 
     MVKSmallVector<MVKImageMemoryBinding*, 3> _memoryBindings;
     MVKSmallVector<MVKImagePlane*, 3> _planes;


### PR DESCRIPTION
- `MVKImage` add functions to consolidate mapping plane indexes to memory bindings to add safety in situation where one memory binding supports all planes.
- Update MoltenVK version to 1.2.8 (unrelated).

This PR fixes an internal design issue uncovered during preliminary testing of PR #2116, the additional functionality of which caused certain CTS tests to crash. This PR fixes those crashes, and potentially other future crashes.

Initially pushing this to a temporary branch, until the current SDK release process is completed.