### PR TITLE
Fix translation of fully remapped multi vertex attribute bindings

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -206,6 +206,7 @@ struct MVKTranslatedVertexBinding {
 	uint16_t binding;
 	uint16_t translationBinding;
 	uint32_t translationOffset;
+	uint32_t mappedAttributeCount;
 };
 
 /** Describes a vertex buffer binding whose divisor is zero. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1491,7 +1491,7 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
 					vbXltdDesc.stride = vbDesc.stride;
 					vbXltdDesc.stepFunction = vbDesc.stepFunction;
 					vbXltdDesc.stepRate = vbDesc.stepRate;
-					xldtVACnt++;
+					xldtVACnt += xltdBind.mappedAttributeCount;
 				}
 			}
 
@@ -1533,13 +1533,14 @@ uint32_t MVKGraphicsPipeline::getTranslatedVertexBinding(uint32_t binding, uint3
 	// See if a translated binding already exists (for example if more than one VA needs the same translation).
 	for (auto& xltdBind : _translatedVertexBindings) {
 		if (xltdBind.binding == binding && xltdBind.translationOffset == translationOffset) {
+			xltdBind.mappedAttributeCount++;
 			return xltdBind.translationBinding;
 		}
 	}
 
 	// Get next available binding point and add a translation binding description for it
 	uint16_t xltdBindPt = (uint16_t)(maxBinding + _translatedVertexBindings.size() + 1);
-	_translatedVertexBindings.push_back( {.binding = (uint16_t)binding, .translationBinding = xltdBindPt, .translationOffset = translationOffset} );
+	_translatedVertexBindings.push_back( {.binding = (uint16_t)binding, .translationBinding = xltdBindPt, .translationOffset = translationOffset, .mappedAttributeCount = 1u} );
 
 	return xltdBindPt;
 }


### PR DESCRIPTION
Fix crash on CTS test:
dEQP-VK.robustness.robustness1_vertex_access.out_of_bounds_stride_30_middle_of_buffer

Bindings with multiple vertex attributes would not correctly detect if the whole binding was remapped to new location/s. This meant original binding's stride was never set to 0 which would report an error and in some cases crash.