### PR TITLE
Support libMoltenVK.dylib for iOS Simulator architecture.

### DIFF
--- a/Demos/Cube/Cube.xcodeproj/project.pbxproj
+++ b/Demos/Cube/Cube.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -269,6 +269,7 @@
 				A9B53B2E1C3AC15200ABC6F6 /* Resources */,
 				A9B53B331C3AC15200ABC6F6 /* Sources */,
 				A90998A12B4EFA78002CEF67 /* Copy MoltenVK Library */,
+				A90998AE2B602480002CEF67 /* Copy MoltenVK Simulator Library */,
 				A9B53B371C3AC15200ABC6F6 /* Frameworks */,
 			);
 			buildRules = (
@@ -351,6 +352,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		A90998AE2B602480002CEF67 /* Copy MoltenVK Simulator Library */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy MoltenVK Simulator Library";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/bash\n\n# If running on the simulator, we need to overwrite the \n# iOS build of MoltenVK with the iOS Simulator build.\n# We can't use this script to copy the iOS build itself, \n# because it needs to be signed to run on an actual device.\n# The simulator build does not need to be signed.\nif [[ \"${PLATFORM_NAME}\" == \"iphonesimulator\" ]]; then \n\tmvk_lib_file=\"libMoltenVK.dylib\"\n\tmvk_lib_dir=\"${PROJECT_DIR}/../../MoltenVK/dylib/iOS-simulator\"\n\tapp_fwk_dir=\"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Frameworks\"\n\tcp -af \"${mvk_lib_dir}/${mvk_lib_file}\" \"${app_fwk_dir}/${mvk_lib_file}\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A93DBF4024A2A4D500079F64 /* Sources */ = {

--- a/Demos/README.md
+++ b/Demos/README.md
@@ -34,7 +34,8 @@ The demo can be found in the `Cube` folder, and in the `Cube` group in the
 *Xcode Project Navigator* in the `Demos.xcworkspace` *Xcode* workspace.
 
 To run this demo, run the `Cube-macOS`, `Cube-iOS`, or `Cube-tvOS` *Scheme* from within *Xcode*.
-In addition to devices, this demo will also run on the `iOS Simulator` or `tvOS Simulator` destinations.
+In addition to devices, this demo will also run on an `iOS Simulator` destination.
+This demo is not supported on a `tvOS Simulator` destination.
 
 The `Cube` demo is a simple example of installing **MoltenVK** as a `libMoltenVK.dylib` library that 
 is dynamically linked to the application, and the _Vulkan_ calls all use _Volk_ to dynamically access 

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,7 +20,8 @@ Released TBD
 
 - Fix potential crash when using multi-planar images.
 - Ensure buffers available for buffer addresses in push constants.
-
+- Support `libMoltenVK.dylib` for _iOS Simulator_ architecture.
+- Restore support for _iOS Simulator_ destination in recent update to _Cube_ demo that uses dynamic-linking.
 
 
 MoltenVK 1.2.7

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -2027,7 +2027,6 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MVK_SKIP_DYLIB = "";
 				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
-				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
 				PRODUCT_NAME = MoltenVK;
 				SKIP_INSTALL = YES;
@@ -2098,7 +2097,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MVK_SKIP_DYLIB = "";
 				"MVK_SKIP_DYLIB[sdk=appletvsimulator*]" = YES;
-				"MVK_SKIP_DYLIB[sdk=iphonesimulator*]" = YES;
 				PRELINK_LIBS = "${CONFIGURATION_BUILD_DIR}/libMoltenVKShaderConverter.a";
 				PRODUCT_NAME = MoltenVK;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
- Xcode now supports building `dylib` for iOS Simulator (but unfortunately not yet tvOS Simulator).
- Restore support for iOS Simulator destination in recent update to Cube demo that uses dynamic-linking, by using script build phase to overwrite the iOS build of MoltenVK with the iOS Simulator build.

Fix #2134.