### PR TITLE
Don't update currentExtent of headless surface when swapchain attached.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,8 @@ Released TBD
 - Ensure buffers available for buffer addresses in push constants.
 - Support `libMoltenVK.dylib` for _iOS Simulator_ architecture.
 - Restore support for _iOS Simulator_ destination in recent update to _Cube_ demo that uses dynamic-linking.
+- Don't update `currentExtent` of headless surface when swapchain attached.
+
 
 
 MoltenVK 1.2.7

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
@@ -87,6 +87,5 @@ protected:
 	CAMetalLayer* _mtlCAMetalLayer = nil;
 	MVKBlockObserver* _layerObserver = nil;
 	MVKSwapchain* _activeSwapchain = nullptr;
-	VkExtent2D _headlessExtent = {0xFFFFFFFF, 0xFFFFFFFF};
 };
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
@@ -41,6 +41,11 @@
 #define STR_PLATFORM(NAME) #NAME
 #define STR(NAME) STR_PLATFORM(NAME)
 
+// As defined in the Vulkan spec, represents an undefined extent.
+// Spec is currently somewhat ambiguous about whether an undefined surface extent should be updated
+// once a swapchain is attached, but consensus amoung the spec authors is that it should not.
+static constexpr VkExtent2D kMVKUndefinedExtent = {0xFFFFFFFF, 0xFFFFFFFF};
+
 
 #pragma mark MVKSurface
 
@@ -50,17 +55,15 @@ CAMetalLayer* MVKSurface::getCAMetalLayer() {
 }
 
 VkExtent2D MVKSurface::getExtent() {
-	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.drawableSize) : _headlessExtent;
+	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.drawableSize) : kMVKUndefinedExtent;
 }
 
 VkExtent2D MVKSurface::getNaturalExtent() {
-	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.naturalDrawableSizeMVK) : _headlessExtent;
+	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.naturalDrawableSizeMVK) : kMVKUndefinedExtent;
 }
 
-// Per spec, headless surface extent is set from the swapchain.
 void MVKSurface::setActiveSwapchain(MVKSwapchain* swapchain) {
 	_activeSwapchain = swapchain;
-	_headlessExtent = swapchain->getImageExtent();
 }
 
 MVKSurface::MVKSurface(MVKInstance* mvkInstance,


### PR DESCRIPTION
Fixes #2129.