### PR TITLE
Simplify repetitive copy-paste declarations of single-value Vulkan commands.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDebug.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDebug.h
@@ -42,7 +42,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerBegin
 
-/** Vulkan command to begin a marker region into the command buffer. */
 class MVKCmdDebugMarkerBegin : public MVKCmdDebugMarker {
 
 public:
@@ -57,7 +56,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerEnd
 
-/** Vulkan command to end an open marker region in the command buffer. */
 class MVKCmdDebugMarkerEnd : public MVKCommand {
 
 public:
@@ -74,7 +72,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDebugMarkerInsert
 
-/** Vulkan command to insert a debug marker into the command encoder. */
 class MVKCmdDebugMarkerInsert : public MVKCmdDebugMarker {
 
 public:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.h
@@ -26,7 +26,6 @@
 #pragma mark -
 #pragma mark MVKCmdDispatch
 
-/** Vulkan command to dispatch compute threadgroups. */
 class MVKCmdDispatch : public MVKCommand {
 
 public:
@@ -51,7 +50,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDispatchIndirect
 
-/** Vulkan command to dispatch compute threadgroups. */
 class MVKCmdDispatchIndirect : public MVKCommand {
 
 public:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
@@ -61,7 +61,6 @@ typedef MVKCmdBindVertexBuffers<8> MVKCmdBindVertexBuffersMulti;
 #pragma mark -
 #pragma mark MVKCmdBindIndexBuffer
 
-/** Vulkan command to bind a vertex index buffer. */
 class MVKCmdBindIndexBuffer : public MVKCommand {
 
 public:
@@ -82,7 +81,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDraw
 
-/** Vulkan command to draw vertices. */
 class MVKCmdDraw : public MVKCommand {
 
 public:
@@ -108,7 +106,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDrawIndexed
 
-/** Vulkan command to draw indexed vertices. */
 class MVKCmdDrawIndexed : public MVKCommand {
 
 public:
@@ -136,7 +133,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDrawIndirect
 
-/** Vulkan command to draw vertices indirectly. */
 class MVKCmdDrawIndirect : public MVKCommand {
 
 public:
@@ -162,7 +158,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdDrawIndexedIndirect
 
-/** Vulkan command to draw indexed vertices indirectly. */
 class MVKCmdDrawIndexedIndirect : public MVKCommand {
 
 public:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -119,7 +119,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdBindGraphicsPipeline
 
-/** Vulkan command to bind a graphics pipeline. */
 class MVKCmdBindGraphicsPipeline : public MVKCmdBindPipeline {
 
 public:
@@ -136,7 +135,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdBindComputePipeline
 
-/** Vulkan command to bind a compute pipeline. */
 class MVKCmdBindComputePipeline : public MVKCmdBindPipeline {
 
 public:
@@ -256,7 +254,6 @@ typedef MVKCmdPushConstants<512> MVKCmdPushConstantsMulti;
 #pragma mark -
 #pragma mark MVKCmdPushDescriptorSet
 
-/** Vulkan command to update a descriptor set. */
 class MVKCmdPushDescriptorSet : public MVKCommand {
 
 public:
@@ -285,7 +282,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdPushDescriptorSetWithTemplate
 
-/** Vulkan command to update a descriptor set from a template. */
 class MVKCmdPushDescriptorSetWithTemplate : public MVKCommand {
 
 public:
@@ -312,7 +308,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetEvent
 
-/** Vulkan command to set an event. */
 class MVKCmdSetEvent : public MVKCommand {
 
 public:
@@ -336,7 +331,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdResetEvent
 
-/** Vulkan command to reset an event. */
 class MVKCmdResetEvent : public MVKCommand {
 
 public:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdQueries.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdQueries.h
@@ -44,7 +44,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdBeginQuery
 
-/** Vulkan command to begin a query. */
 class MVKCmdBeginQuery : public MVKCmdQuery {
 
 public:
@@ -65,7 +64,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdEndQuery
 
-/** Vulkan command to end a query. */
 class MVKCmdEndQuery : public MVKCmdQuery {
 
 public:
@@ -80,7 +78,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdWriteTimestamp
 
-/** Vulkan command to write a timestamp. */
 class MVKCmdWriteTimestamp : public MVKCmdQuery {
 
 public:
@@ -101,7 +98,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdResetQueryPool
 
-/** Vulkan command to reset the results in a query pool. */
 class MVKCmdResetQueryPool : public MVKCmdQuery {
 
 public:
@@ -122,7 +118,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdCopyQueryPoolResults
 
-/** Vulkan command to reset the results in a query pool. */
 class MVKCmdCopyQueryPoolResults : public MVKCmdQuery {
 
 public:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRendering.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRendering.h
@@ -99,7 +99,6 @@ typedef MVKCmdBeginRenderPass<9, 9> MVKCmdBeginRenderPassMultiMulti;
 #pragma mark -
 #pragma mark MVKCmdNextSubpass
 
-/** Vulkan command to begin a render pass. */
 class MVKCmdNextSubpass : public MVKCommand {
 
 public:
@@ -121,7 +120,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdEndRenderPass
 
-/** Vulkan command to end the current render pass. */
 class MVKCmdEndRenderPass : public MVKCommand {
 
 public:
@@ -173,7 +171,6 @@ typedef MVKCmdBeginRendering<8> MVKCmdBeginRenderingMulti;
 #pragma mark -
 #pragma mark MVKCmdEndRendering
 
-/** Vulkan command to end the current dynamic rendering. */
 class MVKCmdEndRendering : public MVKCommand {
 
 public:
@@ -190,7 +187,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetSampleLocations
 
-/** Vulkan command to dynamically set custom sample locations. */
 class MVKCmdSetSampleLocations : public MVKCommand {
 
 public:
@@ -209,19 +205,13 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetSampleLocationsEnable
 
-/** Vulkan command to dynamically enable custom sample locations. */
-class MVKCmdSetSampleLocationsEnable : public MVKCommand {
+class MVKCmdSetSampleLocationsEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 sampleLocationsEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _sampleLocationsEnable;
 };
 
 
@@ -288,7 +278,6 @@ typedef MVKCmdSetScissor<kMVKMaxViewportScissorCount> MVKCmdSetScissorMulti;
 #pragma mark -
 #pragma mark MVKCmdSetDepthBias
 
-/** Vulkan command to set the depth bias. */
 class MVKCmdSetDepthBias : public MVKCommand {
 
 public:
@@ -311,140 +300,97 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetDepthBiasEnable
 
-/** Vulkan command to dynamically enable or disable depth bias. */
-class MVKCmdSetDepthBiasEnable : public MVKCommand {
+class MVKCmdSetDepthBiasEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 depthBiasEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _depthBiasEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetBlendConstants
 
-/** Vulkan command to set the blend constants. */
-class MVKCmdSetBlendConstants : public MVKCommand {
+class MVKCmdSetBlendConstants : public MVKSingleValueCommand<MVKColor32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						const float blendConst[4]);
-
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	float _blendConstants[4] = {};
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthTestEnable
 
-/** Vulkan command to dynamically enable depth testing. */
-class MVKCmdSetDepthTestEnable : public MVKCommand {
+class MVKCmdSetDepthTestEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 depthTestEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _depthTestEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthWriteEnable
 
-/** Vulkan command to dynamically enable depth writing. */
-class MVKCmdSetDepthWriteEnable : public MVKCommand {
+class MVKCmdSetDepthWriteEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 depthWriteEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _depthWriteEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthClipEnable
 
-/** Vulkan command to dynamically enable depth clip. */
-class MVKCmdSetDepthClipEnable : public MVKCommand {
+class MVKCmdSetDepthClipEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 depthClipEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _depthClipEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthCompareOp
 
-/** Vulkan command to dynamically set the depth compare operation. */
-class MVKCmdSetDepthCompareOp : public MVKCommand {
+class MVKCmdSetDepthCompareOp : public MVKSingleValueCommand<VkCompareOp> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkCompareOp depthCompareOp);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkCompareOp _depthCompareOp;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetStencilTestEnable
 
-/** Vulkan command to dynamically enable stencil testing. */
-class MVKCmdSetStencilTestEnable : public MVKCommand {
+class MVKCmdSetStencilTestEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 stencilTestEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _stencilTestEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetStencilOp
 
-/** Vulkan command to dynamically set the stencil operations. */
 class MVKCmdSetStencilOp : public MVKCommand {
 
 public:
@@ -471,7 +417,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetStencilCompareMask
 
-/** Vulkan command to set the stencil compare mask. */
 class MVKCmdSetStencilCompareMask : public MVKCommand {
 
 public:
@@ -492,7 +437,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetStencilWriteMask
 
-/** Vulkan command to set the stencil write mask. */
 class MVKCmdSetStencilWriteMask : public MVKCommand {
 
 public:
@@ -513,7 +457,6 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetStencilReference
 
-/** Vulkan command to set the stencil reference value. */
 class MVKCmdSetStencilReference : public MVKCommand {
 
 public:
@@ -534,151 +477,103 @@ protected:
 #pragma mark -
 #pragma mark MVKCmdSetCullMode
 
-/** Vulkan command to dynamically set the cull mode. */
-class MVKCmdSetCullMode : public MVKCommand {
+class MVKCmdSetCullMode : public MVKSingleValueCommand<VkCullModeFlags> {
 
 public:
-    VkResult setContent(MVKCommandBuffer* cmdBuff,
-                        VkCullModeFlags cullMode);
-
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
     MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkCullModeFlags _cullMode;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetFrontFace
 
-/** Vulkan command to dynamically set the front facing winding order. */
-class MVKCmdSetFrontFace : public MVKCommand {
+class MVKCmdSetFrontFace : public MVKSingleValueCommand<VkFrontFace> {
 
 public:
-    VkResult setContent(MVKCommandBuffer* cmdBuff,
-                        VkFrontFace frontFace);
-
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
     MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkFrontFace _frontFace;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPatchControlPoints
 
-/** Vulkan command to dynamically set the number of patch control points. */
-class MVKCmdSetPatchControlPoints : public MVKCommand {
+class MVKCmdSetPatchControlPoints : public MVKSingleValueCommand<uint32_t> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						uint32_t patchControlPoints);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	uint32_t _patchControlPoints;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPolygonMode
 
-/** Vulkan command to dynamically set the polygon mode. */
-class MVKCmdSetPolygonMode : public MVKCommand {
+class MVKCmdSetPolygonMode : public MVKSingleValueCommand<VkPolygonMode> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkPolygonMode polygonMode);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkPolygonMode _polygonMode;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetLineWidth
 
-/** Vulkan command to dynamically set the line width. */
-class MVKCmdSetLineWidth : public MVKCommand {
+class MVKCmdSetLineWidth : public MVKSingleValueCommand<float> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						float lineWidth);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	float _lineWidth;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPrimitiveTopology
 
-/** Vulkan command to dynamically set the primitive topology. */
-class MVKCmdSetPrimitiveTopology : public MVKCommand {
+class MVKCmdSetPrimitiveTopology : public MVKSingleValueCommand<VkPrimitiveTopology> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkPrimitiveTopology primitiveTopology);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkPrimitiveTopology _primitiveTopology;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPrimitiveRestartEnable
 
-/** Vulkan command to dynamically enable or disable primitive restart functionality. */
-class MVKCmdSetPrimitiveRestartEnable : public MVKCommand {
+class MVKCmdSetPrimitiveRestartEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 primitiveRestartEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _primitiveRestartEnable;
 };
 
 
 #pragma mark -
 #pragma mark MVKCmdSetRasterizerDiscardEnable
 
-/** Vulkan command to dynamically enable or disable rasterization. */
-class MVKCmdSetRasterizerDiscardEnable : public MVKCommand {
+class MVKCmdSetRasterizerDiscardEnable : public MVKSingleValueCommand<VkBool32> {
 
 public:
-	VkResult setContent(MVKCommandBuffer* cmdBuff,
-						VkBool32 rasterizerDiscardEnable);
-
 	void encode(MVKCommandEncoder* cmdEncoder) override;
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
-
-	VkBool32 _rasterizerDiscardEnable;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdRendering.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdRendering.mm
@@ -199,14 +199,8 @@ void MVKCmdSetSampleLocations::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetSampleLocationsEnable
 
-VkResult MVKCmdSetSampleLocationsEnable::setContent(MVKCommandBuffer* cmdBuff,
-													VkBool32 sampleLocationsEnable) {
-	_sampleLocationsEnable = sampleLocationsEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetSampleLocationsEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setSampleLocationsEnable(_sampleLocationsEnable, true);
+	cmdEncoder->_renderingState.setSampleLocationsEnable(_value, true);
 }
 
 
@@ -288,98 +282,56 @@ void MVKCmdSetDepthBias::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetDepthBiasEnable
 
-VkResult MVKCmdSetDepthBiasEnable::setContent(MVKCommandBuffer* cmdBuff,
-											  VkBool32 depthBiasEnable) {
-	_depthBiasEnable = depthBiasEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetDepthBiasEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setDepthBiasEnable(_depthBiasEnable);
+	cmdEncoder->_renderingState.setDepthBiasEnable(_value);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetBlendConstants
 
-VkResult MVKCmdSetBlendConstants::setContent(MVKCommandBuffer* cmdBuff,
-											 const float blendConst[4]) {
-	mvkCopy(_blendConstants, blendConst, 4);
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetBlendConstants::encode(MVKCommandEncoder* cmdEncoder) {
-    cmdEncoder->_renderingState.setBlendConstants(_blendConstants, true);
+    cmdEncoder->_renderingState.setBlendConstants(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthTestEnable
 
-VkResult MVKCmdSetDepthTestEnable::setContent(MVKCommandBuffer* cmdBuff,
-											  VkBool32 depthTestEnable) {
-	_depthTestEnable = depthTestEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetDepthTestEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_depthStencilState.setDepthTestEnable(_depthTestEnable);
+	cmdEncoder->_depthStencilState.setDepthTestEnable(_value);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthWriteEnable
 
-VkResult MVKCmdSetDepthWriteEnable::setContent(MVKCommandBuffer* cmdBuff,
-											   VkBool32 depthWriteEnable) {
-	_depthWriteEnable = depthWriteEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetDepthWriteEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_depthStencilState.setDepthWriteEnable(_depthWriteEnable);
+	cmdEncoder->_depthStencilState.setDepthWriteEnable(_value);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthClipEnable
 
-VkResult MVKCmdSetDepthClipEnable::setContent(MVKCommandBuffer* cmdBuff,
-											  VkBool32 depthClipEnable) {
-	_depthClipEnable = depthClipEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetDepthClipEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setDepthClipEnable(_depthClipEnable, true);
+	cmdEncoder->_renderingState.setDepthClipEnable(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetDepthCompareOp
 
-VkResult MVKCmdSetDepthCompareOp::setContent(MVKCommandBuffer* cmdBuff,
-											 VkCompareOp depthCompareOp) {
-	_depthCompareOp = depthCompareOp;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetDepthCompareOp::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_depthStencilState.setDepthCompareOp(_depthCompareOp);
+	cmdEncoder->_depthStencilState.setDepthCompareOp(_value);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetStencilTestEnable
 
-VkResult MVKCmdSetStencilTestEnable::setContent(MVKCommandBuffer* cmdBuff,
-											  VkBool32 stencilTestEnable) {
-	_stencilTestEnable = stencilTestEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetStencilTestEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_depthStencilState.setStencilTestEnable(_stencilTestEnable);
+	cmdEncoder->_depthStencilState.setStencilTestEnable(_value);
 }
 
 
@@ -459,110 +411,62 @@ void MVKCmdSetStencilReference::encode(MVKCommandEncoder* cmdEncoder) {
 #pragma mark -
 #pragma mark MVKCmdSetCullMode
 
-VkResult MVKCmdSetCullMode::setContent(MVKCommandBuffer* cmdBuff,
-                                       VkCullModeFlags cullMode) {
-	_cullMode = cullMode;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetCullMode::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setCullMode(_cullMode, true);
+	cmdEncoder->_renderingState.setCullMode(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetFrontFace
 
-VkResult MVKCmdSetFrontFace::setContent(MVKCommandBuffer* cmdBuff,
-                                       VkFrontFace frontFace) {
-	_frontFace = frontFace;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetFrontFace::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setFrontFace(_frontFace, true);
+	cmdEncoder->_renderingState.setFrontFace(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPatchControlPoints
 
-VkResult MVKCmdSetPatchControlPoints::setContent(MVKCommandBuffer* cmdBuff,
-												 uint32_t patchControlPoints) {
-	_patchControlPoints = patchControlPoints;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetPatchControlPoints::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setPatchControlPoints(_patchControlPoints, true);
+	cmdEncoder->_renderingState.setPatchControlPoints(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPolygonMode
 
-VkResult MVKCmdSetPolygonMode::setContent(MVKCommandBuffer* cmdBuff,
-										  VkPolygonMode polygonMode) {
-	_polygonMode = polygonMode;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetPolygonMode::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setPolygonMode(_polygonMode, true);
+	cmdEncoder->_renderingState.setPolygonMode(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetLineWidth
 
-VkResult MVKCmdSetLineWidth::setContent(MVKCommandBuffer* cmdBuff,
-										float lineWidth) {
-	_lineWidth = lineWidth;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetLineWidth::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setLineWidth(_lineWidth, true);
+	cmdEncoder->_renderingState.setLineWidth(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPrimitiveTopology
 
-VkResult MVKCmdSetPrimitiveTopology::setContent(MVKCommandBuffer* cmdBuff,
-												VkPrimitiveTopology primitiveTopology) {
-	_primitiveTopology = primitiveTopology;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetPrimitiveTopology::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setPrimitiveTopology(_primitiveTopology, true);
+	cmdEncoder->_renderingState.setPrimitiveTopology(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetPrimitiveRestartEnable
 
-VkResult MVKCmdSetPrimitiveRestartEnable::setContent(MVKCommandBuffer* cmdBuff,
-													 VkBool32 primitiveRestartEnable) {
-	_primitiveRestartEnable = primitiveRestartEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetPrimitiveRestartEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setPrimitiveRestartEnable(_primitiveRestartEnable, true);
+	cmdEncoder->_renderingState.setPrimitiveRestartEnable(_value, true);
 }
 
 
 #pragma mark -
 #pragma mark MVKCmdSetRasterizerDiscardEnable
 
-VkResult MVKCmdSetRasterizerDiscardEnable::setContent(MVKCommandBuffer* cmdBuff,
-													  VkBool32 rasterizerDiscardEnable) {
-	_rasterizerDiscardEnable = rasterizerDiscardEnable;
-	return VK_SUCCESS;
-}
-
 void MVKCmdSetRasterizerDiscardEnable::encode(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setRasterizerDiscardEnable(_rasterizerDiscardEnable, true);
+	cmdEncoder->_renderingState.setRasterizerDiscardEnable(_value, true);
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommand.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommand.h
@@ -76,3 +76,21 @@ protected:
 	virtual MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) = 0;
 };
 
+
+#pragma mark -
+#pragma mark MVKSingleValueCommand
+
+/** Abstract class of a simple Vulkan command that simply holds a single value to encode. */
+template <typename Tv>
+class MVKSingleValueCommand : public MVKCommand {
+
+public:
+	VkResult setContent(MVKCommandBuffer* cmdBuff, Tv value) {
+		_value = value;
+		return VK_SUCCESS;
+	}
+
+protected:
+	Tv _value;
+};
+

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -265,7 +265,7 @@ public:
 
 	void setLineWidth(float lineWidth, bool isDynamic);
 
-	void setBlendConstants(float blendConstants[4], bool isDynamic);
+	void setBlendConstants(MVKColor32 blendConstants, bool isDynamic);
 
 	void setDepthBias(const VkPipelineRasterizationStateCreateInfo& vkRasterInfo);
 	void setDepthBias(float depthBiasConstantFactor, float depthBiasSlopeFactor, float depthBiasClamp);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -327,9 +327,8 @@ void MVKRenderingCommandEncoderState::setLineWidth(float lineWidth, bool isDynam
 	setMTLContent(LineWidth);
 }
 
-void MVKRenderingCommandEncoderState::setBlendConstants(float blendConstants[4], bool isDynamic) {
-	MVKColor32 mtlBlendConstants;
-	mvkCopy(mtlBlendConstants.float32, blendConstants, 4);
+void MVKRenderingCommandEncoderState::setBlendConstants(MVKColor32 blendConstants, bool isDynamic) {
+	MVKColor32 mtlBlendConstants = blendConstants;
 	setMTLContent(BlendConstants);
 }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2341,7 +2341,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.depthBiasClamp = true;
     _features.fillModeNonSolid = true;
     _features.largePoints = true;
-	_features.wideLines = bool(MVK_USE_METAL_PRIVATE_API);
+	_features.wideLines = static_cast<bool>(MVK_USE_METAL_PRIVATE_API);
     _features.alphaToOne = true;
     _features.samplerAnisotropy = true;
     _features.shaderImageGatherExtended = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -421,7 +421,7 @@ protected:
 	id<MTLComputePipelineState> _mtlTessControlStageState = nil;
 	id<MTLRenderPipelineState> _mtlPipelineState = nil;
 
-	float _blendConstants[4] = {};
+	MVKColor32 _blendConstants = { 0.0, 0.0, 0.0, 1.0 };
 	MVKShaderImplicitRezBinding _reservedVertexAttributeBufferCount;
 	MVKShaderImplicitRezBinding _viewRangeBufferIndex;
 	MVKShaderImplicitRezBinding _outputBufferIndex;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -505,10 +505,7 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 
 	// Blending - must ignore allowed bad pColorBlendState pointer if rasterization disabled or no color attachments
 	if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
-		mvkCopy(_blendConstants, pCreateInfo->pColorBlendState->blendConstants, 4);
-	} else {
-		static float defaultBlendConstants[4] = { 0, 0.0, 0.0, 1.0 };
-		mvkCopy(_blendConstants, defaultBlendConstants, 4);
+		mvkCopy(_blendConstants.float32, pCreateInfo->pColorBlendState->blendConstants, 4);
 	}
 
 	// Topology

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -1486,7 +1486,9 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdSetBlendConstants(
 	const float                                 blendConst[4]) {
 
 	MVKTraceVulkanCallStart();
-    MVKAddCmd(SetBlendConstants, commandBuffer, blendConst);
+	MVKColor32 blendConstants;
+	mvkCopy(blendConstants.float32, blendConst, 4);
+    MVKAddCmd(SetBlendConstants, commandBuffer, blendConstants);
 	MVKTraceVulkanCallEnd();
 }
 


### PR DESCRIPTION
There are many `MVKCommand` subclasses that simply encode a single value, resulting in loads of repetitive copy-pasted code.
- Add abstract template superclass `MVKSingleValueCommand` for these concrete command classes.
- Modify `MVKCmdSetBlendConstants` to hold an `MVKColor32` so it can subclass from `MVKSingleValueCommand`, and modify `MVKGraphicsPipeline` and `MVKRenderingCommandEncoderState` to use `MVKColor32`.
- Remove trivial comments for simple concrete Vulkan command classes.

@cdavis5e This has interactions with your PR #2142, particularly your new `MVKCmdSetDepthBounds` and `MVKCmdSetDepthBoundsTestEnable` classes, which should both become subclasses of `MVKSingleValueCommand ` (for `MVKCmdSetDepthBounds`, by passing & tracking an `MVKDepthBounds`, similar to how `MVKCmdSetBlendConstants` passes and tracks a `MVKColor32`).

So we'll need to merge these two PRs in order. We can either merge this PR first, and you modify PR #2142, or merge #2142 first, once we've resolved the discussion there, and then I'll add `MVKCmdSetDepthBounds` and `MVKCmdSetDepthBoundsTestEnable` to this PR.