### PR TITLE
MVKSmallVector: Make iterator const correct.

### DIFF
--- a/MoltenVK/MoltenVK/Utility/MVKSmallVector.h
+++ b/MoltenVK/MoltenVK/Utility/MVKSmallVector.h
@@ -86,9 +86,9 @@ public:
       return *this;
     }
 
-    Type *operator->() { return &vector->alc.ptr[index]; }
-    Type &operator*()  { return  vector->alc.ptr[index]; }
-    operator Type*()   { return &vector->alc.ptr[index]; }
+    Type *operator->() const { return &vector->alc.ptr[index]; }
+    Type &operator*()  const { return  vector->alc.ptr[index]; }
+    operator Type*()   const { return &vector->alc.ptr[index]; }
 
     bool operator==( const iterator &it ) const { return vector == it.vector && index == it.index; }
     bool operator!=( const iterator &it ) const { return vector != it.vector || index != it.index; }
@@ -98,20 +98,19 @@ public:
     iterator& operator--()      {                 --index; return *this; }
     iterator  operator--( int ) { auto t = *this; --index; return t; }
 
-    iterator operator+ (const diff_type n)   { return iterator( index + n, *vector ); }
-    iterator& operator+= (const diff_type n) { index += n; return *this; }
-    iterator operator- (const diff_type n)   { return iterator( index - n, *vector ); }
-    iterator& operator-= (const diff_type n) { index -= n; return *this; }
+    iterator operator+ (const diff_type n)   const { return iterator( index + n, *vector ); }
+    iterator& operator+= (const diff_type n)       { index += n; return *this; }
+    iterator operator- (const diff_type n)   const { return iterator( index - n, *vector ); }
+    iterator& operator-= (const diff_type n)       { index -= n; return *this; }
 
-    diff_type operator- (const iterator& it) { return index - it.index; }
+    diff_type operator- (const iterator& it) const { return index - it.index; }
 
-    bool operator< (const iterator& it)  { return index < it.index; }
-    bool operator<= (const iterator& it) { return index <= it.index; }
-    bool operator> (const iterator& it)  { return index > it.index; }
-    bool operator>= (const iterator& it) { return index >= it.index; }
+    bool operator< (const iterator& it)  const { return index < it.index; }
+    bool operator<= (const iterator& it) const { return index <= it.index; }
+    bool operator> (const iterator& it)  const { return index > it.index; }
+    bool operator>= (const iterator& it) const { return index >= it.index; }
 
-    const Type &operator[]( const diff_type i ) const { return vector->alc.ptr[index + i]; }
-    Type &operator[]( const diff_type i )             { return vector->alc.ptr[index + i]; }
+    Type &operator[]( const diff_type i ) const { return vector->alc.ptr[index + i]; }
 
     bool   is_valid()     const { return index < vector->alc.size(); }
     size_t get_position() const { return index; }


### PR DESCRIPTION
Or the newest libc++ in Xcode 15.3 won't build.

Fixes #2156.