### PR TITLE
Fixed crashes when using VK_EXT_metal_objects from ARC enabled apps

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4699,18 +4699,21 @@ void MVKDevice::getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) 
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT: {
 				auto* pDvcInfo = (VkExportMetalDeviceInfoEXT*)next;
 				pDvcInfo->mtlDevice = getMTLDevice();
+				[pDvcInfo->mtlDevice retain];
 				break;
 			}
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT: {
 				auto* pQInfo = (VkExportMetalCommandQueueInfoEXT*)next;
 				MVKQueue* mvkQ = MVKQueue::getMVKQueue(pQInfo->queue);
 				pQInfo->mtlCommandQueue = mvkQ->getMTLCommandQueue();
+				[pQInfo->mtlCommandQueue retain];
 				break;
 			}
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
 				auto* pBuffInfo = (VkExportMetalBufferInfoEXT*)next;
 				auto* mvkDevMem = (MVKDeviceMemory*)pBuffInfo->memory;
 				pBuffInfo->mtlBuffer = mvkDevMem->getMTLBuffer();
+				[pBuffInfo->mtlBuffer retain];
 				break;
 			}
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
@@ -4726,12 +4729,14 @@ void MVKDevice::getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) 
 				} else {
 					pImgInfo->mtlTexture = mvkBuffView->getMTLTexture();
 				}
+				[pImgInfo->mtlTexture retain];
 				break;
 			}
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
 				auto* pIOSurfInfo = (VkExportMetalIOSurfaceInfoEXT*)next;
 				auto* mvkImg = (MVKImage*)pIOSurfInfo->image;
 				pIOSurfInfo->ioSurface = mvkImg->getIOSurface();
+				CFRetain(pIOSurfInfo->ioSurface);
 				break;
 			}
 			case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
@@ -4743,6 +4748,7 @@ void MVKDevice::getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) 
 				} else if (mvkEvt) {
 					pShEvtInfo->mtlSharedEvent = mvkEvt->getMTLSharedEvent();
 				}
+				[pShEvtInfo->mtlSharedEvent retain];
 				break;
 			}
 			default:


### PR DESCRIPTION
Fixing https://github.com/KhronosGroup/MoltenVK/issues/2151

While this fixes ARC enabled apps, it will require non-ARC apps to manually release. I think that is to be expected, how else can the pointers be usable for an app-determined amount of time. Should i add some documentation for this somewhere?

Could you review if there need to be checks for making sure there is any output? For example:
```
auto* pBuffInfo = (VkExportMetalBufferInfoEXT*)next;
auto* mvkDevMem = (MVKDeviceMemory*)pBuffInfo->memory;
pBuffInfo->mtlBuffer = mvkDevMem->getMTLBuffer();
[pBuffInfo->mtlBuffer retain];
```
It's not checking if `mvkDevMem` is even valid before calling `getMTLBuffer` on it. Consequently i didn't check if `getMTLBuffer`'s result is valid before calling retain on it. I'm assuming this is part of Vulkan's VU specs.