### PR TITLE
Update .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,12 @@
-# MoltenVK specific
-Package/
+# MoltenVK runtime build
+/Package
 
-# MoltenVK Dependencies
-External/cereal
-External/glslang
-External/SPIRV-Cross
-External/Volk
-External/Vulkan-Headers
-External/Vulkan-Tools
+# MoltenVK dependencies
+/External
 
 # Vulkan CTS testing artifacts
-Scripts/TestResults.qpa
-Scripts/shadercache.bin
+/Scripts/TestResults.qpa
+/Scripts/shadercache.bin
 
 # Mac OS X Finder
 .DS_Store


### PR DESCRIPTION
- `.gitignore` exclude all directories under `External`, to allow temp directories to be created during dependency developments.
- `.gitignore` specify MoltenVK exclusions are relative to root directory.