### PR TITLE
Development support for future VK_KHR_portability_subset_metal extension.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -375,6 +375,19 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				portabilityFeatures->vertexAttributeAccessBeyondStride = true;	// Costs additional buffers. Should make configuration switch.
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_METAL_FEATURES_KHR: {
+				auto* portabilityFeaturesMetal = (VkPhysicalDevicePortabilitySubsetMetalFeaturesKHR*)next;
+				portabilityFeaturesMetal->imageView2DOn3DImage = false;
+				portabilityFeaturesMetal->rasterizationDynamicPolygonModePoints = false;
+				portabilityFeaturesMetal->samplerMipLodBias = getMVKConfig().useMetalPrivateAPI;
+				portabilityFeaturesMetal->shaderAtomicOrderingStrong = false;
+				portabilityFeaturesMetal->shaderImageGatherExtendedConstOffsets = false;
+				portabilityFeaturesMetal->shaderNonUniformMemoryBarriers = false;
+				portabilityFeaturesMetal->shaderSampleRateInterpolationFunctions = _metalFeatures.pullModelInterpolation;
+				portabilityFeaturesMetal->shaderTessellationIsolines = false;
+				portabilityFeaturesMetal->shaderTessellationPointMode = false;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: {
 				auto* shaderIntDotFeatures = (VkPhysicalDeviceShaderIntegerDotProductFeatures*)next;
 				shaderIntDotFeatures->shaderIntegerDotProduct = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -64,6 +64,7 @@ MVK_DEVICE_FEATURE(VariablePointer,                   VARIABLE_POINTER,         
 MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,                    3)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
+MVK_DEVICE_FEATURE_EXTN(PortabilitySubsetMetal,       PORTABILITY_SUBSET_METAL,        KHR,   9)
 MVK_DEVICE_FEATURE_EXTN(4444Formats,                  4444_FORMATS,                    EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState,         EXTENDED_DYNAMIC_STATE,          EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState2,        EXTENDED_DYNAMIC_STATE_2,        EXT,   3)

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -77,6 +77,7 @@ MVK_EXTENSION(KHR_maintenance3,                       KHR_MAINTENANCE3,         
 MVK_EXTENSION(KHR_map_memory2,                        KHR_MAP_MEMORY_2,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_multiview,                          KHR_MULTIVIEW,                          DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_portability_subset,                 KHR_PORTABILITY_SUBSET,                 DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_portability_subset_metal,           KHR_PORTABILITY_SUBSET_METAL,           DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_push_descriptor,                    KHR_PUSH_DESCRIPTOR,                    DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_relaxed_block_layout,               KHR_RELAXED_BLOCK_LAYOUT,               DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_sampler_mirror_clamp_to_edge,       KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE,       DEVICE,   10.11, 14.0,  1.0)

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -320,6 +320,18 @@ else
 	update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 fi
 
+	# Temporary patch to fetch dev versions of header files that support
+	# VK_KHR_portability_subset_metal header and copy them to Vulkan-Headers repo.
+	# This requires password access to private Khronos member dev repos.
+	REPO_URL="https://gitlab.khronos.org/vulkan/vulkan.git"
+	REPO_REV="8708d625bc4ef31d34686aac82f640682d73dbdf"
+	update_repo "vulkan" ${REPO_URL} ${REPO_REV}
+	cd "vulkan/xml"
+	make clean install
+	cd -  > /dev/null
+	cp -a "vulkan/gen/include/vulkan/vulkan_metal.h" "${REPO_NAME}/include/vulkan/"
+	cp -a "vulkan/gen/include/vulkan/vulkan_core.h" "${REPO_NAME}/include/vulkan/"
+
 
 # ----------------- SPIRV-Cross -------------------
 


### PR DESCRIPTION
- `fetchDependencies` script pulls `VK_KHR_portability_subset_metal` content from private Khronos repo.
- Add `VK_KHR_portability_subset_metal` extension.
- Include `VkPhysicalDevicePortabilitySubsetMetalFeaturesKHR` in `pNext` of `VkPhysicalDeviceFeatures2`.