### PR TITLE
To support legacy apps, restore MoltenVK/dylib directory.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,7 +18,8 @@ MoltenVK 1.2.9
 
 Released TBD
 
-
+- To support legacy apps, restore `MoltenVK/dylib` directory via symlink to `MoltenVK/dynamic/dylib`.
+- Add `MVKPerformanceTracker::previous` to track latest-but-one performance measurements.
 
 
 MoltenVK 1.2.8

--- a/Scripts/package_dylibs.sh
+++ b/Scripts/package_dylibs.sh
@@ -45,3 +45,7 @@ copy_dylib "" "macOS"
 #copy_dylib "-appletvsimulator" "tvOS-simulator"
 #copy_dylib "-xrvos" "xrOS"
 #copy_dylib "-xrsimulator" "xrOS-simulator"
+
+# For legacy support, symlink old dylib location to new location
+ln -sfn "dynamic/dylib" "${mvk_pkg_prod_path}/dylib"
+


### PR DESCRIPTION
- Create symlink from `MoltenVK/dylib` to `MoltenVK/dynamic/dylib`.

Fixes issue #2191.