### PR TITLE
WIP: Calculate argument buffer allocation size taking variable counts into account.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDispatch.mm
@@ -43,6 +43,9 @@ VkResult MVKCmdDispatch::setContent(MVKCommandBuffer* cmdBuff,
 }
 
 void MVKCmdDispatch::encode(MVKCommandEncoder* cmdEncoder) {
+	if (_groupCountX == 0 || _groupCountY == 0 || _groupCountZ == 0)
+		return;
+
 	MTLRegion mtlThreadgroupCount = MTLRegionMake3D(_baseGroupX, _baseGroupY, _baseGroupZ, _groupCountX, _groupCountY, _groupCountZ);
 	cmdEncoder->finalizeDispatchState();	// Ensure all updated state has been submitted to Metal
 	id<MTLComputeCommandEncoder> mtlEncoder = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -687,7 +687,7 @@ void MVKResourcesCommandEncoderState::encodeMetalArgumentBuffer(MVKShaderStage s
 
 		// The Metal arg encoder can only write to one arg buffer at a time (it holds the arg buffer),
 		// so we need to lock out other access to it while we are writing to it.
-		auto& mvkArgEnc = useDescSetArgBuff ? dsLayout->getMTLArgumentEncoder() : pipeline->getMTLArgumentEncoder(dsIdx, stage);
+		auto& mvkArgEnc = useDescSetArgBuff ? dsLayout->getMTLArgumentEncoder(descSet) : pipeline->getMTLArgumentEncoder(dsIdx, stage);
 		lock_guard<mutex> lock(mvkArgEnc.mtlArgumentEncodingLock);
 
 		id<MTLBuffer> mtlArgBuffer = nil;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -105,7 +105,7 @@ public:
 	 * count provided to that descriptor set is returned. Otherwise returns the value
 	 * defined in VkDescriptorSetLayoutBinding::descriptorCount.
 	 */
-	uint32_t getDescriptorCount(MVKDescriptorSet* descSet = nullptr) const;
+	uint32_t getDescriptorCount(MVKDescriptorSet* descSet = nullptr, uint32_t variableDescriptorCount = std::numeric_limits<uint32_t>::max()) const;
 
 	/** Returns the descriptor type of this layout. */
 	inline VkDescriptorType getDescriptorType() { return _info.descriptorType; }
@@ -170,11 +170,12 @@ protected:
     friend class MVKInlineUniformBlockDescriptor;
 	
 	void initMetalResourceIndexOffsets(const VkDescriptorSetLayoutBinding* pBinding, uint32_t stage);
-	void addMTLArgumentDescriptors(NSMutableArray<MTLArgumentDescriptor*>* args);
+	void addMTLArgumentDescriptors(NSMutableArray<MTLArgumentDescriptor*>* args, uint32_t variableDescriptorCount = 0);
 	void addMTLArgumentDescriptor(NSMutableArray<MTLArgumentDescriptor*>* args,
 								  uint32_t argIndex,
 								  MTLDataType dataType,
-								  MTLArgumentAccess access);
+								  MTLArgumentAccess access,
+								  uint32_t variableDescriptorCount);
 	bool isUsingMetalArgumentBuffer();
 	void populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
 										MVKShaderResourceBinding& dslMTLRezIdxOffsets,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -501,10 +501,10 @@ void MVKDescriptorSetLayoutBinding::populateShaderConversionConfig(mvk::SPIRVToM
     // Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
     MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
 
-	uint32_t descCnt = getDescriptorCount();
+	uint32_t descCnt = getDescriptorCount(nullptr, 0);
 	bool isUsingMtlArgBuff = isUsingMetalArgumentBuffer();
 	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-        if ((_applyToStage[stage] || isUsingMtlArgBuff) && descCnt > 0) {
+        if ((_applyToStage[stage] || isUsingMtlArgBuff) && (descCnt > 0 || hasVariableDescriptorCount())) {
             mvkPopulateShaderConversionConfig(shaderConfig,
                                               mtlIdxs.stages[stage],
                                               MVKShaderStage(stage),

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -122,6 +122,9 @@ public:
 	/** Returns the MTLArgumentEncoder for the descriptor set. */
 	MVKMTLArgumentEncoder& getMTLArgumentEncoder() { return _mtlArgumentEncoder; }
 
+	/** Calculates the length of encoded argument buffer. */
+	size_t getEncodedArgumentBufferLength(uint32_t variableDescriptorCount = 0);
+
 	MVKDescriptorSetLayout(MVKDevice* device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 
 protected:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -120,7 +120,7 @@ public:
 	bool isUsingMetalArgumentBuffer()  { return isUsingMetalArgumentBuffers() && !isPushDescriptorLayout(); };
 
 	/** Returns the MTLArgumentEncoder for the descriptor set. */
-	MVKMTLArgumentEncoder& getMTLArgumentEncoder() { return _mtlArgumentEncoder; }
+	MVKMTLArgumentEncoder& getMTLArgumentEncoder(MVKDescriptorSet *dsSet);
 
 	/** Calculates the length of encoded argument buffer. */
 	size_t getEncodedArgumentBufferLength(uint32_t variableDescriptorCount = 0);
@@ -138,7 +138,8 @@ protected:
 	uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return getBinding(binding)->getDescriptorIndex(elementIndex); }
 	MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
 	const VkDescriptorBindingFlags* getBindingFlags(const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
-	void initMTLArgumentEncoder();
+	void initMTLArgumentEncoder(MVKMTLArgumentEncoder &encoder, MVKDescriptorSet *dsSet = nullptr);
+	bool needsDedicatedArgumentEncoder(MVKDescriptorSet *dsSet);
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
 	std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
@@ -206,6 +207,9 @@ public:
 	/** Returns the number of descriptors in this descriptor set that use dynamic offsets. */
 	uint32_t getDynamicOffsetDescriptorCount() { return _dynamicOffsetDescriptorCount; }
 
+	/** Returns the MTLArgumentEncoder for the descriptor set. */
+	MVKMTLArgumentEncoder& getMTLArgumentEncoder() { return _mtlArgumentEncoder; }
+
 	MVKDescriptorSet(MVKDescriptorPool* pool);
 
 protected:
@@ -226,6 +230,7 @@ protected:
 	NSUInteger _metalArgumentBufferOffset;
 	uint32_t _dynamicOffsetDescriptorCount;
 	uint32_t _variableDescriptorCount;
+	MVKMTLArgumentEncoder _mtlArgumentEncoder;
 };
 
 

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
@@ -317,6 +317,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverter::convert(SPIRVToMSLConversionConfigur
 		for (auto& rb : shaderConfig.resourceBindings) {
 			auto& rbb = rb.resourceBinding;
 			pMSLCompiler->add_msl_resource_binding(rbb);
+			if (rbb.count == 0) pMSLCompiler->set_argument_buffer_device_address_space(rbb.desc_set, true);
 
 			if (rb.requiresConstExprSampler) {
 				pMSLCompiler->remap_constexpr_sampler_by_binding(rbb.desc_set, rbb.binding, rb.constExprSampler);


### PR DESCRIPTION
When allocating descriptors from the pool, we should only request as much as needed for the variable number of descriptors, if applicable.

It looks slightly dicey to use the fixed size argument encoder when encoding variable sized bindings. Since here we're creating the encoder to calculate the size, maybe we could use it for encoding too..