### PR TITLE
Fix crash when using VK_EXT_metal_objects under ARC.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -20,6 +20,7 @@ Released TBD
 
 - To support legacy apps, restore `MoltenVK/dylib` directory via symlink to `MoltenVK/dynamic/dylib`.
 - Add `MVKPerformanceTracker::previous` to track latest-but-one performance measurements.
+- Fix crash when using `VK_EXT_metal_objects` under _ARC_.
 
 
 MoltenVK 1.2.8

--- a/Templates/Vulkan-Headers/VK_EXT_metal_objects-unret.gitdiff
+++ b/Templates/Vulkan-Headers/VK_EXT_metal_objects-unret.gitdiff
@@ -1,0 +1,46 @@
+diff --git a/include/vulkan/vulkan_metal.h b/include/vulkan/vulkan_metal.h
+index e6f7bf7..c6bccf5 100644
+--- a/include/vulkan/vulkan_metal.h
++++ b/include/vulkan/vulkan_metal.h
+@@ -52,28 +52,28 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(
+ #define VK_EXT_metal_objects 1
+ #ifdef __OBJC__
+ @protocol MTLDevice;
+-typedef id<MTLDevice> MTLDevice_id;
++typedef __unsafe_unretained id<MTLDevice> MTLDevice_id;
+ #else
+ typedef void* MTLDevice_id;
+ #endif
+ 
+ #ifdef __OBJC__
+ @protocol MTLCommandQueue;
+-typedef id<MTLCommandQueue> MTLCommandQueue_id;
++typedef __unsafe_unretained id<MTLCommandQueue> MTLCommandQueue_id;
+ #else
+ typedef void* MTLCommandQueue_id;
+ #endif
+ 
+ #ifdef __OBJC__
+ @protocol MTLBuffer;
+-typedef id<MTLBuffer> MTLBuffer_id;
++typedef __unsafe_unretained id<MTLBuffer> MTLBuffer_id;
+ #else
+ typedef void* MTLBuffer_id;
+ #endif
+ 
+ #ifdef __OBJC__
+ @protocol MTLTexture;
+-typedef id<MTLTexture> MTLTexture_id;
++typedef __unsafe_unretained id<MTLTexture> MTLTexture_id;
+ #else
+ typedef void* MTLTexture_id;
+ #endif
+@@ -81,7 +81,7 @@ typedef void* MTLTexture_id;
+ typedef struct __IOSurface* IOSurfaceRef;
+ #ifdef __OBJC__
+ @protocol MTLSharedEvent;
+-typedef id<MTLSharedEvent> MTLSharedEvent_id;
++typedef __unsafe_unretained id<MTLSharedEvent> MTLSharedEvent_id;
+ #else
+ typedef void* MTLSharedEvent_id;
+ #endif

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -320,6 +320,14 @@ else
 	update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 fi
 
+# Apply a Git diff file to add an __unsafe_unretained ownership
+# qualifier to the Metal object declarations in vulkan_metal.h.
+# This should be a temporary patch until the VK_EXT_metal_objects extension can be properly modified.
+echo "Adding __unsafe_unretained ownership qualifier to the Metal objects in vulkan_metal.h."
+cd ${REPO_NAME}
+git apply ../../Templates/${REPO_NAME}/VK_EXT_metal_objects-unret.gitdiff
+cd -  > /dev/null
+
 
 # ----------------- SPIRV-Cross -------------------
 


### PR DESCRIPTION
Apple's Automatic Reference Counting automatically releases the Metal objects returned by `VK_EXT_metal_objects`.

The `fetchDependencies` script now applies
`Templates/Vulkan-Headers/VK_EXT_metal_objects-unret.gitdiff` to add an `__unsafe_unretained` ownership qualifier to the Metal object declarations in `vulkan_metal.h`.

This should be a temporary patch until the `VK_EXT_metal_objects` extension can be properly modified.

Fixes #2151.
Replaces #2179.

@MennoVink Please review.