### PR TITLE
Add option to dump shaders

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -676,3 +676,14 @@ features that are difficult to support otherwise.
 Unlike `MVK_USE_METAL_PRIVATE_API`, this setting may be overridden at run time.
 
 This option is not available unless MoltenVK were built with `MVK_USE_METAL_PRIVATE_API` set to `1`.
+
+---------------------------------------
+#### MVK_CONFIG_SHADER_DUMP_DIR
+
+##### Type: String
+##### Default: `""`
+
+_(The default value is an empty string)._
+
+If not empty, MoltenVK will dump all SPIRV shaders, compiled MSL shaders, and pipeline shader lists to the given directory.
+The directory will be non-recursively created if it doesn't already exist.

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -244,6 +244,7 @@ typedef struct {
 	VkBool32 shouldMaximizeConcurrentCompilation;                              /**< MVK_CONFIG_SHOULD_MAXIMIZE_CONCURRENT_COMPILATION */
 	float timestampPeriodLowPassAlpha;                                         /**< MVK_CONFIG_TIMESTAMP_PERIOD_LOWPASS_ALPHA */
 	VkBool32 useMetalPrivateAPI;                                               /**< MVK_CONFIG_USE_METAL_PRIVATE_API */
+	const char* shaderDumpDir;                                                 /**< MVK_CONFIG_SHADER_DUMP_DIR */
 } MVKConfiguration;
 
 // Legacy support for renamed struct elements.

--- a/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
+++ b/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
@@ -83,6 +83,7 @@ MVK_CONFIG_MEMBER(shaderSourceCompressionAlgorithm,       MVKConfigCompressionAl
 MVK_CONFIG_MEMBER(shouldMaximizeConcurrentCompilation,    VkBool32,                                 SHOULD_MAXIMIZE_CONCURRENT_COMPILATION)
 MVK_CONFIG_MEMBER(timestampPeriodLowPassAlpha,            float,                                    TIMESTAMP_PERIOD_LOWPASS_ALPHA)
 MVK_CONFIG_MEMBER(useMetalPrivateAPI,                     VkBool32,                                 USE_METAL_PRIVATE_API)
+MVK_CONFIG_MEMBER_STRING(shaderDumpDir,                   char*,                                    SHADER_DUMP_DIR)
 
 #undef MVK_CONFIG_MEMBER
 #undef MVK_CONFIG_MEMBER_STRING

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -362,5 +362,3 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #   define MVK_CONFIG_SHADER_DUMP_DIR ""
 #endif
 
-#undef MVK_CONFIG__UNUSED_STRUCT_PADDING
-#define MVK_CONFIG__UNUSED_STRUCT_PADDING 0

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -357,9 +357,7 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #	define MVK_CONFIG_USE_METAL_PRIVATE_API MVK_USE_METAL_PRIVATE_API
 #endif
 
-/**
- * If set, MVK will dump spirv input, translated msl, and pipelines into the given directory.
- */
+/** If set, MVK will dump spirv input, translated msl, and pipelines into the given directory. */
 #ifndef MVK_CONFIG_SHADER_DUMP_DIR
 #   define MVK_CONFIG_SHADER_DUMP_DIR ""
 #endif

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -86,7 +86,7 @@
 #ifdef __cplusplus
 
 /** The number of members of MVKConfiguration that are strings. */
-static constexpr uint32_t kMVKConfigurationStringCount = 1;
+static constexpr uint32_t kMVKConfigurationStringCount = 2;
 
 /** Global function to access MoltenVK configuration info. */
 const MVKConfiguration& getGlobalMVKConfig();
@@ -355,6 +355,13 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
  */
 #ifndef MVK_CONFIG_USE_METAL_PRIVATE_API
 #	define MVK_CONFIG_USE_METAL_PRIVATE_API MVK_USE_METAL_PRIVATE_API
+#endif
+
+/**
+ * If set, MVK will dump spirv input, translated msl, and pipelines into the given directory.
+ */
+#ifndef MVK_CONFIG_SHADER_DUMP_DIR
+#   define MVK_CONFIG_SHADER_DUMP_DIR ""
 #endif
 
 #undef MVK_CONFIG__UNUSED_STRUCT_PADDING


### PR DESCRIPTION
Adds an option to dump shaders and pipelines to a directory

When enabled, it writes the spirv and resulting msl for every shader compiled to a file named by the spirv hash

Usually a bit easier to search through than trying to look through an MVK_DEBUG=1 log, especially for pipeline link failures