### PR TITLE
On macOS Apple Silicon, avoid managed-memory textures, and resource syncs.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -482,9 +482,6 @@ static inline VkExtent3D mvkVkExtent3DFromMTLSize(MTLSize mtlSize) {
 /** Macro indicating the Vulkan memory type bits corresponding to Metal memoryless memory (not host visible and lazily allocated). */
 #define MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS	(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
 
-/** Returns the Metal storage mode corresponding to the specified Vulkan memory flags. */
-MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
-
 /** Returns the Metal CPU cache mode corresponding to the specified Vulkan memory flags. */
 MTLCPUCacheMode mvkMTLCPUCacheModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -331,9 +331,6 @@ public:
 	 */
 	uint32_t getLazilyAllocatedMemoryTypes() { return _lazilyAllocatedMemoryTypes; }
 
-	/** Returns whether this is a unified memory device. */
-	bool getHasUnifiedMemory();
-
 	/** Returns the external memory properties supported for buffers for the handle type. */
 	VkExternalMemoryProperties& getExternalBufferProperties(VkExternalMemoryHandleTypeFlagBits handleType);
 
@@ -363,6 +360,9 @@ public:
 	/** Returns whether native texture atomics are supported and should be used. */
 	bool useNativeTextureAtomics() { return _metalFeatures.nativeTextureAtomics; }
 
+	/** Returns the MTLStorageMode that matches the Vulkan memory property flags. */
+	MTLStorageMode getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
+
 
 #pragma mark Construction
 
@@ -388,6 +388,7 @@ public:
 
 protected:
 	friend class MVKDevice;
+	friend class MVKDeviceTrackingMixin;
 
 	void propagateDebugName() override {}
 	MTLFeatureSet getMaximalMTLFeatureSet();
@@ -443,6 +444,8 @@ protected:
 	uint32_t _hostCoherentMemoryTypes;
 	uint32_t _privateMemoryTypes;
 	uint32_t _lazilyAllocatedMemoryTypes;
+	bool _hasUnifiedMemory = true;
+	bool _isAppleGPU = true;
 };
 
 
@@ -887,6 +890,8 @@ public:
     }
 
 protected:
+	friend class MVKDeviceTrackingMixin;
+
 	void propagateDebugName() override  {}
 	MVKBuffer* addBuffer(MVKBuffer* mvkBuff);
 	MVKBuffer* removeBuffer(MVKBuffer* mvkBuff);
@@ -955,6 +960,12 @@ public:
 
 	/** Returns the underlying Metal device. */
 	id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
+
+	/** Returns whether the GPU is a unified memory device. */
+	bool isUnifiedMemoryGPU() { return getPhysicalDevice()->_hasUnifiedMemory; }
+
+	/** Returns whether the GPU is Apple Silicon. */
+	bool isAppleGPU() { return getPhysicalDevice()->_isAppleGPU; }
 
 	/** Returns info about the pixel format supported by the physical device. */
 	MVKPixelFormats* getPixelFormats() { return _device->getPixelFormats(); }

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -882,31 +882,6 @@ MVK_PUBLIC_SYMBOL CGRect mvkCGRectFromVkRectLayerKHR(VkRectLayerKHR vkRect) {
 #pragma mark -
 #pragma mark Memory options
 
-MVK_PUBLIC_SYMBOL MTLStorageMode mvkMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags) {
-
-	// If not visible to the host, use Private, or Memoryless if available and lazily allocated.
-	if ( !mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ) {
-#if MVK_APPLE_SILICON
-		if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
-			return MTLStorageModeMemoryless;
-		}
-#endif
-		return MTLStorageModePrivate;
-	}
-
-	// If visible to the host and coherent: Shared
-	if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-		return MTLStorageModeShared;
-	}
-
-	// If visible to the host, and not coherent: Managed on macOS, Shared on iOS
-#if MVK_MACOS
-	return MTLStorageModeManaged;
-#else
-	return MTLStorageModeShared;
-#endif
-}
-
 MVK_PUBLIC_SYMBOL MTLCPUCacheMode mvkMTLCPUCacheModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags) {
 	return MTLCPUCacheModeDefaultCache;
 }


### PR DESCRIPTION
Like their iOS/tvOS counterparts, macOS Apple Silicon GPUs support using Shared memory for textures, and do not require resource synchronization, even with Managed memory. This change treats macOS Apple Silicon the same as iOS & tvOS.

- `MVKPhysicalDevice` add `_hasUnifiedMemory` & `_isAppleGPU` flags.
- `MVKDeviceTrackingMixin` add `isUnifiedMemoryGPU()` & `isAppleGPU()`.
- Do not advertise host-visible-but-not-host-coherent Vulkan memory type on macOS Apple Silicon.
- Replace `mvkMTLStorageModeFromVkMemoryPropertyFlags()` with `MVKPhysicalDevice::getMTLStorageModeFromVkMemoryPropertyFlags()`, and return Shared instead of Managed for Apple Silicon, even if coherency is not requested.
- On unified memory devices, avoid needless calls to `didModifyRange:`, `synchronizeResource:`, and `synchronizeTexture:slice:level:`.
