### PR TITLE
Refactor public MVKDevice content into MVKDeviceTrackingMixin functions.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -97,7 +97,7 @@ VkResult MVKCmdDraw::setContent(MVKCommandBuffer* cmdBuff,
 	_firstInstance = firstInstance;
 
     // Validate
-    if ((_firstInstance != 0) && !(cmdBuff->getDevice()->_pMetalFeatures->baseVertexInstanceDrawing)) {
+    if ((_firstInstance != 0) && !(cmdBuff->getMetalFeatures().baseVertexInstanceDrawing)) {
         return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDraw(): The current device does not support drawing with a non-zero base instance.");
     }
 
@@ -149,6 +149,8 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->restartMetalRenderPassIfNeeded();
 
 	auto* pipeline = cmdEncoder->getGraphicsPipeline();
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
+	auto& dvcLimits = cmdEncoder->getDeviceProperties().limits;
 
 	// Metal doesn't support triangle fans, so encode it as triangles via an indexed indirect triangles command instead.
 	if (pipeline->getVkPrimitiveTopology() == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN) {
@@ -187,7 +189,7 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
             case kMVKGraphicsStageVertex: {
                 mtlTessCtlEncoder = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
                 if (pipeline->needsVertexOutputBuffer()) {
-                    vtxOutBuff = cmdEncoder->getTempMTLBuffer(_vertexCount * _instanceCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxVertexOutputComponents, true);
+                    vtxOutBuff = cmdEncoder->getTempMTLBuffer(_vertexCount * _instanceCount * 4 * dvcLimits.maxVertexOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: vtxOutBuff->_mtlBuffer
                                           offset: vtxOutBuff->_offset
                                          atIndex: pipeline->getOutputBufferIndex().stages[kMVKShaderStageVertex]];
@@ -197,7 +199,7 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 				// _firstInstance * stride, since that is the expected behaviour for a divisor of 0.
                 cmdEncoder->_graphicsResourcesState.offsetZeroDivisorVertexBuffers(stage, pipeline, _firstInstance);
 				id<MTLComputePipelineState> vtxState = pipeline->getTessVertexStageState();
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(_vertexCount, _instanceCount, 1)
                                  threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
@@ -217,13 +219,13 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
             case kMVKGraphicsStageTessControl: {
                 mtlTessCtlEncoder = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
                 if (pipeline->needsTessCtlOutputBuffer()) {
-                    tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * tessParams.patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerVertexOutputComponents, true);
+                    tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * tessParams.patchCount * 4 * dvcLimits.maxTessellationControlPerVertexOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: tcOutBuff->_mtlBuffer
                                           offset: tcOutBuff->_offset
                                          atIndex: pipeline->getOutputBufferIndex().stages[kMVKShaderStageTessCtl]];
                 }
                 if (pipeline->needsTessCtlPatchOutputBuffer()) {
-                    tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(tessParams.patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerPatchOutputComponents, true);
+                    tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(tessParams.patchCount * 4 * dvcLimits.maxTessellationControlPerPatchOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: tcPatchOutBuff->_mtlBuffer
                                           offset: tcPatchOutBuff->_offset
                                          atIndex: pipeline->getTessCtlPatchOutputBufferIndex()];
@@ -244,11 +246,11 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 				
 				NSUInteger sgSize = pipeline->getTessControlStageState().threadExecutionWidth;
 				NSUInteger wgSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
-				while (wgSize > cmdEncoder->getDevice()->_pProperties->limits.maxComputeWorkGroupSize[0]) {
+				while (wgSize > dvcLimits.maxComputeWorkGroupSize[0]) {
 					sgSize >>= 1;
 					wgSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
 				}
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(tessParams.patchCount * outControlPointCount, 1, 1)
 								 threadsPerThreadgroup: MTLSizeMake(wgSize, 1, 1)];
@@ -297,7 +299,7 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
                     uint32_t viewCount = subpass->isMultiview() ? subpass->getViewCountInMetalPass(cmdEncoder->getMultiviewPassIndex()) : 1;
                     uint32_t instanceCount = _instanceCount * viewCount;
                     cmdEncoder->_graphicsResourcesState.offsetZeroDivisorVertexBuffers(stage, pipeline, _firstInstance);
-                    if (cmdEncoder->_pDeviceMetalFeatures->baseVertexInstanceDrawing) {
+                    if (mtlFeats.baseVertexInstanceDrawing) {
                         [cmdEncoder->_mtlRenderEncoder drawPrimitives: cmdEncoder->_renderingState.getPrimitiveType()
                                                           vertexStart: _firstVertex
                                                           vertexCount: _vertexCount
@@ -332,11 +334,11 @@ VkResult MVKCmdDrawIndexed::setContent(MVKCommandBuffer* cmdBuff,
 	_firstInstance = firstInstance;
 
     // Validate
-	MVKDevice* mvkDvc = cmdBuff->getDevice();
-    if ((_firstInstance != 0) && !(mvkDvc->_pMetalFeatures->baseVertexInstanceDrawing)) {
+	auto& mtlFeats = cmdBuff->getMetalFeatures();
+    if ((_firstInstance != 0) && !(mtlFeats.baseVertexInstanceDrawing)) {
         return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndexed(): The current device does not support drawing with a non-zero base instance.");
     }
-    if ((_vertexOffset != 0) && !(mvkDvc->_pMetalFeatures->baseVertexInstanceDrawing)) {
+    if ((_vertexOffset != 0) && !(mtlFeats.baseVertexInstanceDrawing)) {
         return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndexed(): The current device does not support drawing with a non-zero base vertex.");
     }
 
@@ -373,6 +375,8 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->restartMetalRenderPassIfNeeded();
 
 	auto* pipeline = cmdEncoder->getGraphicsPipeline();
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
+	auto& dvcLimits = cmdEncoder->getDeviceProperties().limits;
 
 	// Metal doesn't support triangle fans, so encode it as triangles via an indexed indirect triangles command instead.
 	if (pipeline->getVkPrimitiveTopology() == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN) {
@@ -414,7 +418,7 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
             case kMVKGraphicsStageVertex: {
                 mtlTessCtlEncoder = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
                 if (pipeline->needsVertexOutputBuffer()) {
-                    vtxOutBuff = cmdEncoder->getTempMTLBuffer(_indexCount * _instanceCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxVertexOutputComponents, true);
+                    vtxOutBuff = cmdEncoder->getTempMTLBuffer(_indexCount * _instanceCount * 4 * dvcLimits.maxVertexOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: vtxOutBuff->_mtlBuffer
                                           offset: vtxOutBuff->_offset
                                          atIndex: pipeline->getOutputBufferIndex().stages[kMVKShaderStageVertex]];
@@ -427,7 +431,7 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 				// _firstInstance * stride, since that is the expected behaviour for a divisor of 0.
                 cmdEncoder->_graphicsResourcesState.offsetZeroDivisorVertexBuffers(stage, pipeline, _firstInstance);
 				id<MTLComputePipelineState> vtxState = ibb.mtlIndexType == MTLIndexTypeUInt16 ? pipeline->getTessVertexStageIndex16State() : pipeline->getTessVertexStageIndex32State();
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(_indexCount, _instanceCount, 1)
                                  threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
@@ -447,13 +451,13 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
             case kMVKGraphicsStageTessControl: {
                 mtlTessCtlEncoder = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
                 if (pipeline->needsTessCtlOutputBuffer()) {
-                    tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * tessParams.patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerVertexOutputComponents, true);
+                    tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * tessParams.patchCount * 4 * dvcLimits.maxTessellationControlPerVertexOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: tcOutBuff->_mtlBuffer
                                           offset: tcOutBuff->_offset
                                          atIndex: pipeline->getOutputBufferIndex().stages[kMVKShaderStageTessCtl]];
                 }
                 if (pipeline->needsTessCtlPatchOutputBuffer()) {
-                    tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(tessParams.patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerPatchOutputComponents, true);
+                    tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(tessParams.patchCount * 4 * dvcLimits.maxTessellationControlPerPatchOutputComponents, true);
                     [mtlTessCtlEncoder setBuffer: tcPatchOutBuff->_mtlBuffer
                                           offset: tcPatchOutBuff->_offset
                                          atIndex: pipeline->getTessCtlPatchOutputBufferIndex()];
@@ -475,11 +479,11 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 				// an index buffer here.
 				NSUInteger sgSize = pipeline->getTessControlStageState().threadExecutionWidth;
 				NSUInteger wgSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
-				while (wgSize > cmdEncoder->getDevice()->_pProperties->limits.maxComputeWorkGroupSize[0]) {
+				while (wgSize > dvcLimits.maxComputeWorkGroupSize[0]) {
 					sgSize >>= 1;
 					wgSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
 				}
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(tessParams.patchCount * outControlPointCount, 1, 1)
 								 threadsPerThreadgroup: MTLSizeMake(wgSize, 1, 1)];
@@ -530,7 +534,7 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
                     uint32_t viewCount = subpass->isMultiview() ? subpass->getViewCountInMetalPass(cmdEncoder->getMultiviewPassIndex()) : 1;
                     uint32_t instanceCount = _instanceCount * viewCount;
                     cmdEncoder->_graphicsResourcesState.offsetZeroDivisorVertexBuffers(stage, pipeline, _firstInstance);
-                    if (cmdEncoder->_pDeviceMetalFeatures->baseVertexInstanceDrawing) {
+                    if (mtlFeats.baseVertexInstanceDrawing) {
                         [cmdEncoder->_mtlRenderEncoder drawIndexedPrimitives: cmdEncoder->_renderingState.getPrimitiveType()
                                                                   indexCount: _indexCount
                                                                    indexType: (MTLIndexType)ibb.mtlIndexType
@@ -575,11 +579,11 @@ VkResult MVKCmdDrawIndirect::setContent(MVKCommandBuffer* cmdBuff,
 	_drawCount = drawCount;
 
     // Validate
-	MVKDevice* mvkDvc = cmdBuff->getDevice();
-    if ( !mvkDvc->_pMetalFeatures->indirectDrawing ) {
+	auto& mtlFeats = cmdBuff->getMetalFeatures();
+    if ( !mtlFeats.indirectDrawing ) {
         return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndirect(): The current device does not support indirect drawing.");
     }
-	if (cmdBuff->_lastTessellationPipeline && !mvkDvc->_pMetalFeatures->indirectTessellationDrawing) {
+	if (cmdBuff->_lastTessellationPipeline && !mtlFeats.indirectTessellationDrawing) {
 		return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndirect(): The current device does not support indirect tessellated drawing.");
 	}
 
@@ -623,7 +627,7 @@ void MVKCmdDrawIndirect::encodeIndexedIndirect(MVKCommandEncoder* cmdEncoder) {
 	[mtlConvertEncoder setBuffer: ibb.mtlBuffer
 						  offset: ibb.offset
 						 atIndex: 4];
-	if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+	if (cmdEncoder->getMetalFeatures().nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 		[mtlConvertEncoder dispatchThreads: MTLSizeMake(_drawCount, 1, 1)
 					 threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
@@ -650,6 +654,8 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 	cmdEncoder->restartMetalRenderPassIfNeeded();
 
 	auto* pipeline = cmdEncoder->getGraphicsPipeline();
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
+	auto& dvcLimits = cmdEncoder->getDeviceProperties().limits;
 
 	// Metal doesn't support triangle fans, so encode it as indexed indirect triangles instead.
 	if (pipeline->getVkPrimitiveTopology() == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN) {
@@ -691,10 +697,10 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
         vertexCount = kMVKMaxDrawIndirectVertexCount;
         patchCount = mvkCeilingDivide(vertexCount, inControlPointCount);
         VkDeviceSize indirectSize = (2 * sizeof(MTLDispatchThreadgroupsIndirectArguments) + sizeof(MTLDrawPatchIndirectArguments)) * _drawCount;
-        if (cmdEncoder->_pDeviceMetalFeatures->mslVersion >= 20100) {
+        if (mtlFeats.mslVersion >= 20100) {
             indirectSize += sizeof(MTLStageInRegionIndirectArguments) * _drawCount;
         }
-		paramsIncr = std::max((size_t)cmdEncoder->getDevice()->_pProperties->limits.minUniformBufferOffsetAlignment, sizeof(uint32_t) * 2);
+		paramsIncr = std::max((size_t)dvcLimits.minUniformBufferOffsetAlignment, sizeof(uint32_t) * 2);
 		VkDeviceSize paramsSize = paramsIncr * _drawCount;
         tempIndirectBuff = cmdEncoder->getTempMTLBuffer(indirectSize, true);
         mtlIndBuff = tempIndirectBuff->_mtlBuffer;
@@ -702,20 +708,20 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
 		tcParamsBuff = cmdEncoder->getTempMTLBuffer(paramsSize, true);
         mtlParmBuffOfst = tcParamsBuff->_offset;
         if (pipeline->needsVertexOutputBuffer()) {
-            vtxOutBuff = cmdEncoder->getTempMTLBuffer(vertexCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxVertexOutputComponents, true);
+            vtxOutBuff = cmdEncoder->getTempMTLBuffer(vertexCount * 4 * dvcLimits.maxVertexOutputComponents, true);
         }
         if (pipeline->needsTessCtlOutputBuffer()) {
-            tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerVertexOutputComponents, true);
+            tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * patchCount * 4 * dvcLimits.maxTessellationControlPerVertexOutputComponents, true);
         }
         if (pipeline->needsTessCtlPatchOutputBuffer()) {
-            tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerPatchOutputComponents, true);
+            tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(patchCount * 4 * dvcLimits.maxTessellationControlPerPatchOutputComponents, true);
         }
         tcLevelBuff = cmdEncoder->getTempMTLBuffer(patchCount * sizeof(MTLQuadTessellationFactorsHalf), true);
 
         vtxThreadExecWidth = pipeline->getTessVertexStageState().threadExecutionWidth;
         NSUInteger sgSize = pipeline->getTessControlStageState().threadExecutionWidth;
         tcWorkgroupSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
-        while (tcWorkgroupSize > cmdEncoder->getDevice()->_pProperties->limits.maxComputeWorkGroupSize[0]) {
+        while (tcWorkgroupSize > dvcLimits.maxComputeWorkGroupSize[0]) {
             sgSize >>= 1;
             tcWorkgroupSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
         }
@@ -776,7 +782,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                                             &tcWorkgroupSize,
                                             sizeof(tcWorkgroupSize),
                                             8);
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(_drawCount, 1, 1)
 								 threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
@@ -818,7 +824,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                                             &viewCount,
                                             sizeof(viewCount),
                                             4);
-                if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+                if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
                     [mtlConvertEncoder dispatchThreads: MTLSizeMake(_drawCount, 1, 1)
                                  threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
@@ -895,7 +901,7 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {
-						if (cmdEncoder->getDevice()->_pMetalFeatures->indirectTessellationDrawing) {
+						if (mtlFeats.indirectTessellationDrawing) {
 							if (pipeline->needsTessCtlOutputBuffer()) {
 								[cmdEncoder->_mtlRenderEncoder setVertexBuffer: tcOutBuff->_mtlBuffer
 																		offset: tcOutBuff->_offset
@@ -978,11 +984,11 @@ VkResult MVKCmdDrawIndexedIndirect::setContent(MVKCommandBuffer* cmdBuff,
 	_directCmdFirstInstance = directCmdFirstInstance;
 
 	// Validate
-	MVKDevice* mvkDvc = cmdBuff->getDevice();
-	if ( !mvkDvc->_pMetalFeatures->indirectDrawing ) {
+	auto& mtlFeats = cmdBuff->getMetalFeatures();
+	if ( !mtlFeats.indirectDrawing ) {
 		return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndexedIndirect(): The current device does not support indirect drawing.");
 	}
-	if (cmdBuff->_lastTessellationPipeline && !mvkDvc->_pMetalFeatures->indirectTessellationDrawing) {
+	if (cmdBuff->_lastTessellationPipeline && !mtlFeats.indirectTessellationDrawing) {
 		return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdDrawIndexedIndirect(): The current device does not support indirect tessellated drawing.");
 	}
 
@@ -1001,6 +1007,8 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
     MVKIndexMTLBufferBinding ibb = ibbOrig;
 	MVKIndexMTLBufferBinding ibbTriFan = ibb;
     auto* pipeline = cmdEncoder->getGraphicsPipeline();
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
+	auto& dvcLimits = cmdEncoder->getDeviceProperties().limits;
 
 	MVKVertexAdjustments vtxAdjmts;
 	vtxAdjmts.mtlIndexType = ibb.mtlIndexType;
@@ -1040,10 +1048,10 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
         vertexCount = kMVKMaxDrawIndirectVertexCount;
         patchCount = mvkCeilingDivide(vertexCount, inControlPointCount);
         VkDeviceSize indirectSize = (sizeof(MTLDispatchThreadgroupsIndirectArguments) + sizeof(MTLDrawPatchIndirectArguments)) * _drawCount;
-        if (cmdEncoder->_pDeviceMetalFeatures->mslVersion >= 20100) {
+        if (mtlFeats.mslVersion >= 20100) {
             indirectSize += sizeof(MTLStageInRegionIndirectArguments) * _drawCount;
         }
-		paramsIncr = std::max((size_t)cmdEncoder->getDevice()->_pProperties->limits.minUniformBufferOffsetAlignment, sizeof(uint32_t) * 2);
+		paramsIncr = std::max((size_t)dvcLimits.minUniformBufferOffsetAlignment, sizeof(uint32_t) * 2);
 		VkDeviceSize paramsSize = paramsIncr * _drawCount;
         tempIndirectBuff = cmdEncoder->getTempMTLBuffer(indirectSize, true);
         mtlIndBuff = tempIndirectBuff->_mtlBuffer;
@@ -1051,13 +1059,13 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
         tcParamsBuff = cmdEncoder->getTempMTLBuffer(paramsSize, true);
         mtlParmBuffOfst = tcParamsBuff->_offset;
         if (pipeline->needsVertexOutputBuffer()) {
-            vtxOutBuff = cmdEncoder->getTempMTLBuffer(vertexCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxVertexOutputComponents, true);
+            vtxOutBuff = cmdEncoder->getTempMTLBuffer(vertexCount * 4 * dvcLimits.maxVertexOutputComponents, true);
         }
         if (pipeline->needsTessCtlOutputBuffer()) {
-            tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerVertexOutputComponents, true);
+            tcOutBuff = cmdEncoder->getTempMTLBuffer(outControlPointCount * patchCount * 4 * dvcLimits.maxTessellationControlPerVertexOutputComponents, true);
         }
         if (pipeline->needsTessCtlPatchOutputBuffer()) {
-            tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(patchCount * 4 * cmdEncoder->_pDeviceProperties->limits.maxTessellationControlPerPatchOutputComponents, true);
+            tcPatchOutBuff = cmdEncoder->getTempMTLBuffer(patchCount * 4 * dvcLimits.maxTessellationControlPerPatchOutputComponents, true);
         }
         tcLevelBuff = cmdEncoder->getTempMTLBuffer(patchCount * sizeof(MTLQuadTessellationFactorsHalf), true);
         vtxIndexBuff = cmdEncoder->getTempMTLBuffer(ibb.mtlBuffer.length, true);
@@ -1068,7 +1076,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
 
         NSUInteger sgSize = pipeline->getTessControlStageState().threadExecutionWidth;
         tcWorkgroupSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
-        while (tcWorkgroupSize > cmdEncoder->getDevice()->_pProperties->limits.maxComputeWorkGroupSize[0]) {
+        while (tcWorkgroupSize > dvcLimits.maxComputeWorkGroupSize[0]) {
             sgSize >>= 1;
             tcWorkgroupSize = mvkLeastCommonMultiple(outControlPointCount, sgSize);
         }
@@ -1200,7 +1208,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
 				[mtlConvertEncoder setBuffer: ibbTriFan.mtlBuffer
 									  offset: ibbTriFan.offset
 									 atIndex: 7];
-				if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+				if (mtlFeats.nonUniformThreadgroups) {
 #if MVK_MACOS_OR_IOS
 					[mtlConvertEncoder dispatchThreads: MTLSizeMake(_drawCount, 1, 1)
 								 threadsPerThreadgroup: MTLSizeMake(mtlConvertState.threadExecutionWidth, 1, 1)];
@@ -1282,7 +1290,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
                     break;
                 case kMVKGraphicsStageRasterization:
                     if (pipeline->isTessellationPipeline()) {
-						if (cmdEncoder->getDevice()->_pMetalFeatures->indirectTessellationDrawing) {
+						if (mtlFeats.indirectTessellationDrawing) {
 							if (pipeline->needsTessCtlOutputBuffer()) {
 								[cmdEncoder->_mtlRenderEncoder setVertexBuffer: tcOutBuff->_mtlBuffer
 																		offset: tcOutBuff->_offset

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -319,7 +319,7 @@ VkResult MVKCmdBlitImage<N>::setContent(MVKCommandBuffer* cmdBuff,
 
 	_filter = filter;
 
-	bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getDevice()->_pMetalFeatures->renderLinearTextures && _dstImage->getIsLinear();
+	bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getMetalFeatures().renderLinearTextures && _dstImage->getIsLinear();
 
 	_vkImageBlits.clear();		// Clear for reuse
 	for (uint32_t rIdx = 0; rIdx < regionCount; rIdx++) {
@@ -350,7 +350,7 @@ VkResult MVKCmdBlitImage<N>::setContent(MVKCommandBuffer* cmdBuff,
 
     _filter = pBlitImageInfo->filter;
 
-    bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getDevice()->_pMetalFeatures->renderLinearTextures && _dstImage->getIsLinear();
+    bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getMetalFeatures().renderLinearTextures && _dstImage->getIsLinear();
 
     _vkImageBlits.clear();        // Clear for reuse
     _vkImageBlits.reserve(pBlitImageInfo->regionCount);
@@ -457,6 +457,7 @@ void MVKCmdBlitImage<N>::populateVertices(MVKVertexPosTex* vertices, const VkIma
 template <size_t N>
 void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse commandUse) {
 
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
 	size_t vkIBCnt = _vkImageBlits.size();
 	VkImageCopy vkImageCopies[vkIBCnt];
 	MVKImageBlitRender mvkBlitRenders[vkIBCnt];
@@ -507,7 +508,7 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
         id<MTLTexture> srcMTLTex = _srcImage->getMTLTexture(srcPlaneIndex);
         id<MTLTexture> dstMTLTex = _dstImage->getMTLTexture(dstPlaneIndex);
         if (blitCnt && srcMTLTex && dstMTLTex) {
-			if (cmdEncoder->getDevice()->_pMetalFeatures->nativeTextureSwizzle &&
+			if (mtlFeats.nativeTextureSwizzle &&
 				_srcImage->needsSwizzle()) {
 				// Use a view that has a swizzle on it.
 				srcMTLTex = [srcMTLTex newTextureViewWithPixelFormat:srcMTLTex.pixelFormat
@@ -564,7 +565,7 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
             blitKey.srcFilter = mvkMTLSamplerMinMagFilterFromVkFilter(_filter);
             blitKey.srcAspect = mvkIBR.region.srcSubresource.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
             blitKey.dstSampleCount = mvkSampleCountFromVkSampleCountFlagBits(_dstImage->getSampleCount());
-			if (!cmdEncoder->getDevice()->_pMetalFeatures->nativeTextureSwizzle &&
+			if (!mtlFeats.nativeTextureSwizzle &&
 				_srcImage->needsSwizzle()) {
 				VkComponentMapping vkMapping = _srcImage->getPixelFormats()->getVkComponentMapping(_srcImage->getVkFormat());
 				blitKey.srcSwizzleR = vkMapping.r;
@@ -581,7 +582,7 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
             mtlDepthAttDesc.level = mvkIBR.region.dstSubresource.mipLevel;
             mtlStencilAttDesc.level = mvkIBR.region.dstSubresource.mipLevel;
 
-            bool isLayeredBlit = blitKey.dstSampleCount > 1 ? cmdEncoder->getDevice()->_pMetalFeatures->multisampleLayeredRendering : cmdEncoder->getDevice()->_pMetalFeatures->layeredRendering;
+            bool isLayeredBlit = blitKey.dstSampleCount > 1 ? mtlFeats.multisampleLayeredRendering : mtlFeats.layeredRendering;
             
             uint32_t layCnt = mvkIBR.region.srcSubresource.layerCount;
             if (_dstImage->getMTLTextureType() == MTLTextureType3D) {
@@ -761,13 +762,14 @@ inline VkResult MVKCmdResolveImage<N>::validate(MVKCommandBuffer* cmdBuff, const
 template <size_t N>
 void MVKCmdResolveImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
 
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
 	size_t vkIRCnt = _vkImageResolves.size();
 	VkImageBlit expansionRegions[vkIRCnt];
 	VkImageCopy copyRegions[vkIRCnt];
 
 	// If we can do layered rendering to a multisample texture, I can resolve all the layers at once.
 	uint32_t layerCnt = 0;
-	if (cmdEncoder->getDevice()->_pMetalFeatures->multisampleLayeredRendering) {
+	if (mtlFeats.multisampleLayeredRendering) {
 		layerCnt = (uint32_t)_vkImageResolves.size();
 	} else {
 		for (VkImageResolve2& vkIR : _vkImageResolves) { layerCnt += vkIR.dstSubresource.layerCount; }
@@ -820,7 +822,7 @@ void MVKCmdResolveImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		// direct resolve, but that of the DESTINATION if we need a temporary transfer image.
 		mtlResolveSlices[sliceCnt].dstSubresource = vkIR.dstSubresource;
 		mtlResolveSlices[sliceCnt].srcSubresource = needXfrImage ? vkIR.dstSubresource : vkIR.srcSubresource;
-		if (cmdEncoder->getDevice()->_pMetalFeatures->multisampleLayeredRendering) {
+		if (mtlFeats.multisampleLayeredRendering) {
 			sliceCnt++;
 		} else {
 			uint32_t layCnt = vkIR.dstSubresource.layerCount;
@@ -961,7 +963,7 @@ void MVKCmdCopyBuffer<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	id<MTLBuffer> dstMTLBuff = _dstBuffer->getMTLBuffer();
 	NSUInteger dstMTLBuffOffset = _dstBuffer->getMTLBufferOffset();
 
-	VkDeviceSize buffAlign = cmdEncoder->getDevice()->_pMetalFeatures->mtlCopyBufferAlignment;
+	VkDeviceSize buffAlign = cmdEncoder->getMetalFeatures().mtlCopyBufferAlignment;
 
 	for (const auto& cpyRgn : _bufferCopyRegions) {
 		const bool useComputeCopy = buffAlign > 1 && (cpyRgn.srcOffset % buffAlign != 0 ||
@@ -1149,7 +1151,7 @@ void MVKCmdBufferImageCopy<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		// If we're copying to mip level 0, we can skip the copy and just decode
 		// directly into the image. Otherwise, we need to use an intermediate buffer.
         if (_toImage && _image->getIsCompressed() && mtlTexture.textureType == MTLTextureType3D &&
-            !cmdEncoder->getDevice()->_pMetalFeatures->native3DCompressedTextures) {
+            !cmdEncoder->getMetalFeatures().native3DCompressedTextures) {
 
             MVKCmdCopyBufferToImageInfo info;
             info.srcRowStride = bytesPerRow & 0xffffffff;
@@ -1496,7 +1498,7 @@ void MVKCmdClearAttachments<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	// Apple GPUs do not support rendering/writing to an attachment and then reading from
 	// that attachment within a single Metal renderpass. So, if any of the attachments just
 	// cleared is an input attachment, we need to restart into separate Metal renderpasses.
-	if (cmdEncoder->getDevice()->_pMetalFeatures->tileBasedDeferredRendering) {
+	if (cmdEncoder->getMetalFeatures().tileBasedDeferredRendering) {
 		bool needsRenderpassRestart = false;
 		for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
 			if (_rpsKey.isAttachmentEnabled(caIdx) && subpass->isColorAttachmentAlsoInputAttachment(caIdx)) {
@@ -1562,7 +1564,7 @@ VkResult MVKCmdClearImage<N>::setContent(MVKCommandBuffer* cmdBuff,
 
         // Validate
         MVKMTLFmtCaps mtlFmtCaps = cmdBuff->getPixelFormats()->getCapabilities(_image->getMTLPixelFormat(planeIndex));
-		bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getDevice()->_pMetalFeatures->renderLinearTextures && _image->getIsLinear();
+		bool isDestUnwritableLinear = MVK_MACOS && !cmdBuff->getMetalFeatures().renderLinearTextures && _image->getIsLinear();
 		uint32_t reqCap = isDS ? kMVKMTLFmtCapsDSAtt : (isDestUnwritableLinear ? kMVKMTLFmtCapsWrite : kMVKMTLFmtCapsColorAtt);
         if (!mvkAreAllFlagsEnabled(mtlFmtCaps, reqCap)) {
             return cmdBuff->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdClear%sImage(): Format %s cannot be cleared on this device.", (isDS ? "DepthStencil" : "Color"), cmdBuff->getPixelFormats()->getName(_image->getVkFormat()));
@@ -1588,6 +1590,7 @@ void MVKCmdClearImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
 
 	cmdEncoder->endCurrentMetalEncoding();
 
+	auto& mtlFeats = cmdEncoder->getMetalFeatures();
 	MVKPixelFormats* pixFmts = cmdEncoder->getPixelFormats();
 	for (auto& srRange : _subresourceRanges) {
 		uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(srRange.aspectMask);
@@ -1595,7 +1598,7 @@ void MVKCmdClearImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
         if ( !imgMTLTex ) { continue; }
 
 #if MVK_MACOS
-        if ( _image->getIsLinear() && !cmdEncoder->getDevice()->_pMetalFeatures->renderLinearTextures ) {
+        if (_image->getIsLinear() && !mtlFeats.renderLinearTextures) {
             // These images cannot be rendered. Instead, use a compute shader.
             // Luckily for us, linear images only have one mip and one array layer under Metal.
             assert( !isDS );
@@ -1608,7 +1611,7 @@ void MVKCmdClearImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
             cmdEncoder->setComputeBytes(mtlComputeEnc, &_clearValue, sizeof(_clearValue), 0);
             MTLSize gridSize = mvkMTLSizeFromVkExtent3D(_image->getExtent3D());
             MTLSize tgSize = MTLSizeMake(mtlClearState.threadExecutionWidth, 1, 1);
-            if (cmdEncoder->getDevice()->_pMetalFeatures->nonUniformThreadgroups) {
+            if (mtlFeats.nonUniformThreadgroups) {
                 [mtlComputeEnc dispatchThreads: gridSize threadsPerThreadgroup: tgSize];
             } else {
                 MTLSize tgCount = MTLSizeMake(gridSize.width / tgSize.width, gridSize.height, gridSize.depth);
@@ -1681,8 +1684,7 @@ void MVKCmdClearImage<N>::encode(MVKCommandEncoder* cmdEncoder) {
 			}
 
             // If we can do layered rendering, I can clear all the layers at once.
-            if (cmdEncoder->getDevice()->_pMetalFeatures->layeredRendering &&
-                (_image->getSampleCount() == VK_SAMPLE_COUNT_1_BIT || cmdEncoder->getDevice()->_pMetalFeatures->multisampleLayeredRendering)) {
+            if (mtlFeats.layeredRendering && (mtlFeats.multisampleLayeredRendering || _image->getSampleCount() == VK_SAMPLE_COUNT_1_BIT)) {
                 if (is3D) {
                     mtlRPCADesc.depthPlane = layerStart;
                     mtlRPDADesc.depthPlane = layerStart;

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -421,18 +421,6 @@ public:
 	/** Context for tracking information across multiple encodings. */
 	MVKCommandEncodingContext* _pEncodingContext;
 
-    /** A reference to the Metal features supported by the device. */
-    const MVKPhysicalDeviceMetalFeatures* _pDeviceMetalFeatures;
-
-    /** A reference to the Vulkan features supported by the device. */
-    const VkPhysicalDeviceFeatures* _pDeviceFeatures;
-
-    /** Pointer to the properties of the device. */
-    const VkPhysicalDeviceProperties* _pDeviceProperties;
-
-    /** Pointer to the memory properties of the device. */
-    const VkPhysicalDeviceMemoryProperties* _pDeviceMemoryProperties;
-
 	/** The command buffer whose commands are being encoded. */
 	MVKCommandBuffer* _cmdBuffer;
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
@@ -174,9 +174,9 @@ void MVKCommandEncodingPool::clear() {
 #pragma mark Construction
 
 MVKCommandEncodingPool::MVKCommandEncodingPool(MVKCommandPool* commandPool) : _commandPool(commandPool),
-    _mtlBufferAllocator(commandPool->getDevice(), commandPool->getDevice()->_pMetalFeatures->maxMTLBufferSize, true),
-    _privateMtlBufferAllocator(commandPool->getDevice(), commandPool->getDevice()->_pMetalFeatures->maxMTLBufferSize, true, false, MTLStorageModePrivate),
-    _dedicatedMtlBufferAllocator(commandPool->getDevice(), commandPool->getDevice()->_pMetalFeatures->maxQueryBufferSize, true, true, MTLStorageModePrivate) {
+    _mtlBufferAllocator(commandPool->getDevice(), commandPool->getMetalFeatures().maxMTLBufferSize, true),
+    _privateMtlBufferAllocator(commandPool->getDevice(), commandPool->getMetalFeatures().maxMTLBufferSize, true, false, MTLStorageModePrivate),
+    _dedicatedMtlBufferAllocator(commandPool->getDevice(), commandPool->getMetalFeatures().maxQueryBufferSize, true, true, MTLStorageModePrivate) {
 }
 
 MVKCommandEncodingPool::~MVKCommandEncodingPool() {

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -45,7 +45,7 @@ MVKMTLBufferAllocation* MVKMTLBufferAllocationPool::newObject() {
 // Adds a new MTLBuffer to the buffer pool and resets the next offset to the start of it
 void MVKMTLBufferAllocationPool::addMTLBuffer() {
     MTLResourceOptions mbOpts = (_mtlStorageMode << MTLResourceStorageModeShift) | MTLResourceCPUCacheModeDefaultCache;
-    _mtlBuffers.push_back({ [_device->getMTLDevice() newBufferWithLength: _mtlBufferLength options: mbOpts], 0 });
+    _mtlBuffers.push_back({ [getMTLDevice() newBufferWithLength: _mtlBufferLength options: mbOpts], 0 });
     _nextOffset = 0;
 }
 
@@ -120,7 +120,7 @@ MVKMTLBufferAllocation* MVKMTLBufferAllocator::acquireMTLBufferRegion(NSUInteger
 	MVKAssert(length <= _maxAllocationLength, "This MVKMTLBufferAllocator has been configured to dispense MVKMTLBufferRegions no larger than %lu bytes.", (unsigned long)_maxAllocationLength);
 
 	// Can't allocate a segment smaller than the minimum MTLBuffer alignment.
-	length = std::max<NSUInteger>(length, _device->_pMetalFeatures->mtlBufferAlignment);
+	length = std::max<NSUInteger>(length, getMetalFeatures().mtlBufferAlignment);
 
     // Convert max length to the next power-of-two exponent to use as a lookup
     NSUInteger p2Exp = mvkPowerOfTwoExponent(length);
@@ -128,7 +128,7 @@ MVKMTLBufferAllocation* MVKMTLBufferAllocator::acquireMTLBufferRegion(NSUInteger
 }
 
 MVKMTLBufferAllocator::MVKMTLBufferAllocator(MVKDevice* device, NSUInteger maxRegionLength, bool makeThreadSafe, bool isDedicated, MTLStorageMode mtlStorageMode) : MVKBaseDeviceObject(device) {
-	_maxAllocationLength = std::max<NSUInteger>(maxRegionLength, _device->_pMetalFeatures->mtlBufferAlignment);
+	_maxAllocationLength = std::max<NSUInteger>(maxRegionLength, getMetalFeatures().mtlBufferAlignment);
 	_isThreadSafe = makeThreadSafe;
 
     // Convert max length to the next power-of-two exponent

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -619,6 +619,7 @@ void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescri
 		}																					\
 	} while(false)
 
+	auto& mtlFeats = getMetalFeatures();
 	MVKShaderStageResourceBinding& bindIdxs = _mtlResourceIndexOffsets.stages[stage];
 	MVKShaderStageResourceBinding& dslCnts = _layout->_mtlResourceCounts.stages[stage];
 
@@ -627,7 +628,7 @@ void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescri
         case VK_DESCRIPTOR_TYPE_SAMPLER:
 			setResourceIndexOffset(samplerIndex);
 
-			if (pBinding->descriptorCount > 1 && !_device->_pMetalFeatures->arrayOfSamplers) {
+			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfSamplers) {
 				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of samplers.", _device->getName()));
 			}
             break;
@@ -637,10 +638,10 @@ void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescri
 			setResourceIndexOffset(samplerIndex);
 
 			if (pBinding->descriptorCount > 1) {
-				if ( !_device->_pMetalFeatures->arrayOfTextures ) {
+				if ( !mtlFeats.arrayOfTextures ) {
 					_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
 				}
-				if ( !_device->_pMetalFeatures->arrayOfSamplers ) {
+				if ( !mtlFeats.arrayOfSamplers ) {
 					_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of samplers.", _device->getName()));
 				}
 			}
@@ -660,7 +661,7 @@ void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescri
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
 			setResourceIndexOffset(textureIndex);
 
-			if (pBinding->descriptorCount > 1 && !_device->_pMetalFeatures->arrayOfTextures) {
+			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
 				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
 			}
             break;
@@ -670,7 +671,7 @@ void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescri
 			setResourceIndexOffset(textureIndex);
 			if (!getPhysicalDevice()->useNativeTextureAtomics()) setResourceIndexOffset(bufferIndex);
 
-			if (pBinding->descriptorCount > 1 && !_device->_pMetalFeatures->arrayOfTextures) {
+			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
 				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
 			}
 			break;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -474,16 +474,10 @@ public:
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT; }
 
 	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _physicalDevice->getInstance(); }
-
-	/** Returns the physical device underlying this logical device. */
-	MVKPhysicalDevice* getPhysicalDevice() { return _physicalDevice; }
-
-	/** Returns info about the pixel format supported by the physical device. */
-	MVKPixelFormats* getPixelFormats() { return &_physicalDevice->_pixelFormats; }
+	MVKInstance* getInstance() override { return _physicalDevice->_mvkInstance; }
 
 	/** Returns the name of this device. */
-	const char* getName() { return _pProperties->deviceName; }
+	const char* getName() { return _physicalDevice->_properties.deviceName; }
 
     /** Returns the common resource factory for creating command resources. */
     MVKCommandResourceFactory* getCommandResourceFactory() { return _commandResourceFactory; }
@@ -698,44 +692,6 @@ public:
 							MVKCommandEncoder* cmdEncoder,
 							MVKCommandUse cmdUse);
 
-    /**
-	 * If performance is being tracked, returns a monotonic timestamp value for use performance timestamping.
-	 * The returned value corresponds to the number of CPU "ticks" since the app was initialized.
-	 *
-	 * Call this function twice, then use the functions mvkGetElapsedNanoseconds() or mvkGetElapsedMilliseconds()
-	 * to determine the number of nanoseconds or milliseconds between the two calls.
-     */
-    uint64_t getPerformanceTimestamp() { return _isPerformanceTracking ? mvkGetTimestamp() : 0; }
-
-    /**
-     * If performance is being tracked, adds the performance for an activity with a duration interval
-	 * between the start and end times, measured in milliseconds, to the given performance statistics.
-     *
-     * If endTime is zero or not supplied, the current time is used.
-     */
-	void addPerformanceInterval(MVKPerformanceTracker& perfTracker,
-								uint64_t startTime, uint64_t endTime = 0) {
-		if (_isPerformanceTracking) {
-			updateActivityPerformance(perfTracker, mvkGetElapsedMilliseconds(startTime, endTime));
-		}
-	};
-
-	/**
-	 * If performance is being tracked, adds the performance for an activity
-	 * with a kilobyte count, to the given performance statistics.
-	 */
-	void addPerformanceByteCount(MVKPerformanceTracker& perfTracker, uint64_t byteCount) {
-		if (_isPerformanceTracking) {
-			updateActivityPerformance(perfTracker, double(byteCount / KIBI));
-		}
-	};
-
-	/** Updates the given performance statistic. */
-	void updateActivityPerformance(MVKPerformanceTracker& activity, double currentValue);
-
-    /** Populates the specified statistics structure from the current activity performance statistics. */
-    void getPerformanceStatistics(MVKPerformanceStatistics* pPerf);
-
 	/** Invalidates the memory regions. */
 	VkResult invalidateMappedMemoryRanges(uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
 
@@ -748,14 +704,14 @@ public:
 	/** Returns the number of views to be rendered in the given multiview pass. */
 	uint32_t getViewCountInMetalPass(uint32_t viewMask, uint32_t passIdx) const;
 
+	/** Populates the specified statistics structure from the current activity performance statistics. */
+	void getPerformanceStatistics(MVKPerformanceStatistics* pPerf);
+
 	/** Log all performance statistics. */
 	void logPerformanceSummary();
 
 
 #pragma mark Metal
-
-	/** Returns the underlying Metal device. */
-	id<MTLDevice> getMTLDevice() { return _physicalDevice->getMTLDevice(); }
 
 	/** Returns whether this device is using Metal argument buffers. */
 	bool isUsingMetalArgumentBuffers() { return _isUsingMetalArgumentBuffers; };
@@ -837,37 +793,6 @@ public:
 	void getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);
 
 
-#pragma mark Properties directly accessible
-
-	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
-	MVKExtensionList _enabledExtensions;
-
-	/** Device features available and enabled. */
-	VkPhysicalDeviceFeatures _enabledFeatures;
-
-	// List of extended device feature enabling structures, as public member variables.
-#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
-	VkPhysicalDevice##structName##Features _enabled##structName##Features;
-#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
-	VkPhysicalDevice##structName##Features##extnSfx _enabled##structName##Features;
-#include "MVKDeviceFeatureStructs.def"
-
-	/** VkPhysicalDeviceVulkan12Features entries that did not originate in a prior extension available and enabled. */
-	MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
-
-	/** Pointer to the Metal-specific features of the underlying physical device. */
-	const MVKPhysicalDeviceMetalFeatures* _pMetalFeatures;
-
-	/** Pointer to the properties of the underlying physical device. */
-	const VkPhysicalDeviceProperties* _pProperties;
-
-	/** Pointer to the memory properties of the underlying physical device. */
-	const VkPhysicalDeviceMemoryProperties* _pMemoryProperties;
-
-    /** Performance statistics. */
-    MVKPerformanceStatistics _performanceStatistics;
-
-
 #pragma mark Construction
 
 	/** Constructs an instance on the specified physical device. */
@@ -905,6 +830,7 @@ protected:
 	template<typename S> void enableFeatures(S* pEnabled, const S* pRequested, const S* pAvailable, uint32_t count);
 	template<typename S> void enableFeatures(S* pRequested, VkBool32* pEnabledBools, const VkBool32* pRequestedBools, const VkBool32* pAvailableBools, uint32_t count);
 	void enableExtensions(const VkDeviceCreateInfo* pCreateInfo);
+	void updateActivityPerformance(MVKPerformanceTracker& activity, double currentValue);
     const char* getActivityPerformanceDescription(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
 	MVKActivityPerformanceValueType getActivityPerformanceValueType(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
 	void logActivityInline(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
@@ -915,6 +841,18 @@ protected:
 														   VkDescriptorSetVariableDescriptorCountLayoutSupport* pVarDescSetCountSupport);
 
 	MVKPhysicalDevice* _physicalDevice = nullptr;
+	MVKExtensionList _enabledExtensions;
+	VkPhysicalDeviceFeatures _enabledFeatures;
+	MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
+
+	// List of extended device feature enabling structures, as member variables.
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
+	VkPhysicalDevice##structName##Features _enabled##structName##Features;
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
+	VkPhysicalDevice##structName##Features##extnSfx _enabled##structName##Features;
+#include "MVKDeviceFeatureStructs.def"
+
+	MVKPerformanceStatistics _performanceStats;
     MVKCommandResourceFactory* _commandResourceFactory = nullptr;
 	MVKSmallVector<MVKSmallVector<MVKQueue*, kMVKQueueCountPerQueueFamily>, kMVKQueueFamilyCount> _queuesByQueueFamilyIndex;
 	MVKSmallVector<MVKResource*> _resources;
@@ -956,28 +894,75 @@ public:
 	MVKDevice* getDevice() { return _device; }
 
 	/** Returns the physical device underlying this logical device. */
-	MVKPhysicalDevice* getPhysicalDevice() { return _device->getPhysicalDevice(); }
+	MVKPhysicalDevice* getPhysicalDevice() { return _device->_physicalDevice; }
 
 	/** Returns the underlying Metal device. */
-	id<MTLDevice> getMTLDevice() { return _device->getMTLDevice(); }
+	id<MTLDevice> getMTLDevice() { return _device->_physicalDevice->_mtlDevice; }
 
 	/** Returns whether the GPU is a unified memory device. */
-	bool isUnifiedMemoryGPU() { return getPhysicalDevice()->_hasUnifiedMemory; }
+	bool isUnifiedMemoryGPU() { return _device->_physicalDevice->_hasUnifiedMemory; }
 
 	/** Returns whether the GPU is Apple Silicon. */
-	bool isAppleGPU() { return getPhysicalDevice()->_isAppleGPU; }
+	bool isAppleGPU() { return _device->_physicalDevice->_isAppleGPU; }
 
 	/** Returns info about the pixel format supported by the physical device. */
-	MVKPixelFormats* getPixelFormats() { return _device->getPixelFormats(); }
+	MVKPixelFormats* getPixelFormats() { return &_device->_physicalDevice->_pixelFormats; }
 
 	/** Returns whether this device is using Metal argument buffers. */
-	bool isUsingMetalArgumentBuffers() { return _device->isUsingMetalArgumentBuffers(); };
+	bool isUsingMetalArgumentBuffers() { return _device->_isUsingMetalArgumentBuffers; };
 
 	/** Returns whether this device is using one Metal argument buffer for each descriptor set, on multiple pipeline and pipeline stages. */
-	bool isUsingDescriptorSetMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && _device->_pMetalFeatures->descriptorSetArgumentBuffers; };
+	bool isUsingDescriptorSetMetalArgumentBuffers() { return _device->_isUsingMetalArgumentBuffers && getMetalFeatures().descriptorSetArgumentBuffers; };
 
 	/** Returns whether this device is using one Metal argument buffer for each descriptor set-pipeline-stage combination. */
-	bool isUsingPipelineStageMetalArgumentBuffers() { return isUsingMetalArgumentBuffers() && !_device->_pMetalFeatures->descriptorSetArgumentBuffers; };
+	bool isUsingPipelineStageMetalArgumentBuffers() { return _device->_isUsingMetalArgumentBuffers && !getMetalFeatures().descriptorSetArgumentBuffers; };
+
+	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
+	MVKExtensionList& getEnabledExtensions() { return _device->_enabledExtensions; }
+
+	/** Device features available and enabled. */
+	VkPhysicalDeviceFeatures& getEnabledFeatures() { return _device->_enabledFeatures; }
+
+	// List of extended device feature enabling structures, as getEnabledXXXFeatures() functions.
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
+	VkPhysicalDevice##structName##Features& getEnabled##structName##Features() { return _device->_enabled##structName##Features; }
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
+	VkPhysicalDevice##structName##Features##extnSfx& getEnabled##structName##Features() { return _device->_enabled##structName##Features; }
+#include "MVKDeviceFeatureStructs.def"
+
+	/** Pointer to the Metal-specific features of the underlying physical device. */
+	const MVKPhysicalDeviceMetalFeatures& getMetalFeatures() { return _device->_physicalDevice->_metalFeatures; }
+
+	/** Pointer to the properties of the underlying physical device. */
+	const VkPhysicalDeviceProperties& getDeviceProperties() { return _device->_physicalDevice->_properties; }
+
+	/** Pointer to the memory properties of the underlying physical device. */
+	const VkPhysicalDeviceMemoryProperties& getDeviceMemoryProperties() { return _device->_physicalDevice->_memoryProperties; }
+
+	/** Performance statistics. */
+	MVKPerformanceStatistics& getPerformanceStats() { return _device->_performanceStats; }
+
+	/**
+	 * If performance is being tracked, returns a monotonic timestamp value for use performance timestamping.
+	 * The returned value corresponds to the number of CPU "ticks" since the app was initialized.
+	 *
+	 * Call this function twice, then use the functions mvkGetElapsedNanoseconds() or mvkGetElapsedMilliseconds()
+	 * to determine the number of nanoseconds or milliseconds between the two calls.
+	 */
+	uint64_t getPerformanceTimestamp() { return _device->_isPerformanceTracking ? mvkGetTimestamp() : 0; }
+
+	/**
+	 * If performance is being tracked, adds the performance for an activity with a duration interval
+	 * between the start and end times, measured in milliseconds, to the given performance statistics.
+	 *
+	 * If endTime is zero or not supplied, the current time is used.
+	 * If addAlways is true, the duration is tracked even if performance tracking is disabled.
+	 */
+	void addPerformanceInterval(MVKPerformanceTracker& perfTracker, uint64_t startTime, uint64_t endTime = 0, bool addAlways = false) {
+		if (_device->_isPerformanceTracking || addAlways) {
+			_device->updateActivityPerformance(perfTracker, mvkGetElapsedMilliseconds(startTime, endTime));
+		}
+	};
 
 	/** Constructs an instance for the specified device. */
 	MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) { assert(_device); }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
@@ -37,7 +37,7 @@ id<MTLTexture> MVKFramebuffer::getDummyAttachmentMTLTexture(MVKRenderSubpass* su
 	MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: MTLPixelFormatR8Unorm width: fbExtent.width height: fbExtent.height mipmapped: NO];
 	if (subpass->isMultiview()) {
 #if MVK_MACOS_OR_IOS
-		if (sampleCount > 1 && getDevice()->_pMetalFeatures->multisampleLayeredRendering) {
+		if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
 			mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
 			mtlTexDesc.sampleCount = sampleCount;
 		} else {
@@ -49,7 +49,7 @@ id<MTLTexture> MVKFramebuffer::getDummyAttachmentMTLTexture(MVKRenderSubpass* su
 		mtlTexDesc.arrayLength = subpass->getViewCountInMetalPass(passIdx);
 	} else if (fbLayerCount > 1) {
 #if MVK_MACOS
-		if (sampleCount > 1 && getDevice()->_pMetalFeatures->multisampleLayeredRendering) {
+		if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
 			mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
 			mtlTexDesc.sampleCount = sampleCount;
 		} else {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -159,9 +159,6 @@ public:
 	/** Returns whether debug callbacks are being used. */
 	bool hasDebugCallbacks() { return _hasDebugReportCallbacks || _hasDebugUtilsMessengers; }
 
-	/** The list of Vulkan extensions, indicating whether each has been enabled by the app. */
-	const MVKExtensionList _enabledExtensions;
-
 
 #pragma mark Object Creation
 
@@ -198,6 +195,7 @@ protected:
     void logVersions();
 	VkResult verifyLayers(uint32_t count, const char* const* names);
 
+	MVKExtensionList _enabledExtensions;
 	MVKConfiguration _mvkConfig;
 	VkApplicationInfo _appInfo;
 	MVKSmallVector<MVKPhysicalDevice*, 2> _physicalDevices;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -164,7 +164,7 @@ public:
 
 	/** Returns whether the pipeline creation fail if a pipeline compile is required. */
 	bool shouldFailOnPipelineCompileRequired() {
-		return (_device->_enabledPipelineCreationCacheControlFeatures.pipelineCreationCacheControl &&
+		return (getEnabledPipelineCreationCacheControlFeatures().pipelineCreationCacheControl &&
 				mvkIsAnyFlagEnabled(_flags, VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT));
 	}
 
@@ -590,7 +590,7 @@ public:
 
 	MVKRenderPipelineCompiler(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
 		_compilerType = "Render pipeline";
-		_pPerformanceTracker = &_owner->getDevice()->_performanceStatistics.shaderCompilation.pipelineCompile;
+		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.pipelineCompile;
 	}
 
 	~MVKRenderPipelineCompiler() override;
@@ -635,7 +635,7 @@ public:
 
 	MVKComputePipelineCompiler(MVKVulkanAPIDeviceObject* owner, const char* compilerType = nullptr) : MVKMetalCompiler(owner) {
 		_compilerType = compilerType ? compilerType : "Compute pipeline";
-		_pPerformanceTracker = &_owner->getDevice()->_performanceStatistics.shaderCompilation.pipelineCompile;
+		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.pipelineCompile;
 	}
 
 	~MVKComputePipelineCompiler() override;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -184,7 +184,7 @@ public:
 } MVKSemaphoreSubmitInfo;
 
 /** This is an abstract class for an operation that can be submitted to an MVKQueue. */
-class MVKQueueSubmission : public MVKBaseObject, public MVKConfigurableMixin {
+class MVKQueueSubmission : public MVKBaseDeviceObject, public MVKConfigurableMixin {
 
 public:
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -60,7 +60,7 @@ private:
 const MVKMTLFunction MVKMTLFunctionNull(nil, SPIRVToMSLConversionResultInfo(), MTLSizeMake(1, 1, 1));
 
 /** Wraps a single MTLLibrary. */
-class MVKShaderLibrary : public MVKBaseObject {
+class MVKShaderLibrary : public MVKBaseDeviceObject {
 
 public:
 
@@ -128,7 +128,7 @@ protected:
 #pragma mark MVKShaderLibraryCache
 
 /** Represents a cache of shader libraries for one shader module. */
-class MVKShaderLibraryCache : public MVKBaseObject {
+class MVKShaderLibraryCache : public MVKBaseDeviceObject {
 
 public:
 
@@ -149,7 +149,7 @@ public:
 									   bool* pWasAdded, VkPipelineCreationFeedback* pShaderFeedback,
 									   uint64_t startTime = 0);
 
-	MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner) : _owner(owner) {};
+	MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner) : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {};
 
 	~MVKShaderLibraryCache() override;
 
@@ -273,7 +273,7 @@ public:
 
 	MVKShaderLibraryCompiler(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
 		_compilerType = "Shader library";
-		_pPerformanceTracker = &_owner->getDevice()->_performanceStatistics.shaderCompilation.mslCompile;
+		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.mslCompile;
 	}
 
 	~MVKShaderLibraryCompiler() override;
@@ -311,7 +311,7 @@ public:
 
 	MVKFunctionSpecializer(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
 		_compilerType = "Function specialization";
-		_pPerformanceTracker = &_owner->getDevice()->_performanceStatistics.shaderCompilation.functionSpecialization;
+		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.functionSpecialization;
 	}
 
 	~MVKFunctionSpecializer() override;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -171,7 +171,7 @@ void MVKSwapchain::markFrameInterval() {
 
 	if (prevFrameTime == 0) { return; }		// First frame starts at first presentation
 
-	_device->updateActivityPerformance(_device->_performanceStatistics.queue.frameInterval, mvkGetElapsedMilliseconds(prevFrameTime, _lastFrameTime));
+	addPerformanceInterval(getPerformanceStats().queue.frameInterval, prevFrameTime, _lastFrameTime, true);
 
 	auto& mvkCfg = getMVKConfig();
 	bool shouldLogOnFrames = mvkCfg.performanceTracking && mvkCfg.activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT;
@@ -179,7 +179,7 @@ void MVKSwapchain::markFrameInterval() {
 		_currentPerfLogFrameCount = 0;
 		MVKLogInfo("Performance statistics reporting every: %d frames, avg FPS: %.2f, elapsed time: %.3f seconds:",
 				   mvkCfg.performanceLoggingFrameCount,
-				   (1000.0 / _device->_performanceStatistics.queue.frameInterval.average),
+				   (1000.0 / getPerformanceStats().queue.frameInterval.average),
 				   mvkGetElapsedMilliseconds() / 1000.0);
 		if (getMVKConfig().activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT) {
 			_device->logPerformanceSummary();
@@ -419,9 +419,10 @@ MVKSwapchain::MVKSwapchain(MVKDevice* device, const VkSwapchainCreateInfoKHR* pC
 		}
 	}
 
+	auto& mtlFeats = getMetalFeatures();
 	uint32_t imgCnt = mvkClamp(pCreateInfo->minImageCount,
-							   _device->_pMetalFeatures->minSwapchainImageCount,
-							   _device->_pMetalFeatures->maxSwapchainImageCount);
+							   mtlFeats.minSwapchainImageCount,
+							   mtlFeats.maxSwapchainImageCount);
 	initCAMetalLayer(pCreateInfo, pScalingInfo, imgCnt);
     initSurfaceImages(pCreateInfo, imgCnt);		// After initCAMetalLayer()
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
@@ -605,7 +605,7 @@ VkResult mvkWaitSemaphores(MVKDevice* device,
  *
  * Instances of this class are one-shot, and can only be used for a single compilation.
  */
-class MVKMetalCompiler : public MVKBaseObject {
+class MVKMetalCompiler : public MVKBaseDeviceObject {
 
 public:
 
@@ -618,7 +618,7 @@ public:
 
 #pragma mark Construction
 
-	MVKMetalCompiler(MVKVulkanAPIDeviceObject* owner) : _owner(owner) {}
+	MVKMetalCompiler(MVKVulkanAPIDeviceObject* owner) : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {}
 
 	~MVKMetalCompiler() override;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
@@ -141,10 +141,10 @@ MVKSemaphoreMTLEvent::MVKSemaphoreMTLEvent(MVKDevice* device,
 		_mtlEvent = [pImportInfo->mtlSharedEvent retain];		// retained
 		_mtlEventValue = pImportInfo->mtlSharedEvent.signaledValue + 1;
 	} else if (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) {
-		_mtlEvent = [device->getMTLDevice() newSharedEvent];	//retained
+		_mtlEvent = [getMTLDevice() newSharedEvent];	//retained
 		_mtlEventValue = ((id<MTLSharedEvent>)_mtlEvent).signaledValue + 1;
 	} else {
-		_mtlEvent = [device->getMTLDevice() newEvent];			//retained
+		_mtlEvent = [getMTLDevice() newEvent];			//retained
 		_mtlEventValue = 1;
 	}
 }
@@ -241,7 +241,7 @@ MVKTimelineSemaphoreMTLEvent::MVKTimelineSemaphoreMTLEvent(MVKDevice* device,
 	// Import or create a Metal event
 	_mtlEvent = (pImportInfo && pImportInfo->mtlSharedEvent
 				 ? [pImportInfo->mtlSharedEvent retain]
-				 : [device->getMTLDevice() newSharedEvent]);	//retained
+				 : [getMTLDevice() newSharedEvent]);	//retained
 
 	if (pTypeCreateInfo) {
 		_mtlEvent.signaledValue = pTypeCreateInfo->initialValue;
@@ -423,7 +423,7 @@ MVKEventNative::MVKEventNative(MVKDevice* device,
 	// Import or create a Metal event
 	_mtlEvent = (pImportInfo
 				 ? [pImportInfo->mtlSharedEvent retain]
-				 : [device->getMTLDevice() newSharedEvent]);	//retained
+				 : [getMTLDevice() newSharedEvent]);	//retained
 }
 
 MVKEventNative::~MVKEventNative() {
@@ -570,8 +570,7 @@ VkResult mvkWaitSemaphores(MVKDevice* device,
 void MVKMetalCompiler::compile(unique_lock<mutex>& lock, dispatch_block_t block) {
 	MVKAssert( _startTime == 0, "%s compile occurred already in this instance. Instances of %s should only be used for a single compile activity.", _compilerType.c_str(), getClassName().c_str());
 
-	MVKDevice* mvkDev = _owner->getDevice();
-	_startTime = mvkDev->getPerformanceTimestamp();
+	_startTime = getPerformanceTimestamp();
 
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{ @autoreleasepool { block(); } });
 
@@ -588,7 +587,7 @@ void MVKMetalCompiler::compile(unique_lock<mutex>& lock, dispatch_block_t block)
 
 	if (_compileError) { handleError(); }
 
-	mvkDev->addPerformanceInterval(*_pPerformanceTracker, _startTime);
+	addPerformanceInterval(*_pPerformanceTracker, _startTime);
 }
 
 void MVKMetalCompiler::handleError() {


### PR DESCRIPTION
This is a non-functional code-maintenance change.

Previously, `MVKDevice` contained a significant amount of publicly exposed internal content. This patch adds functions to `MVKDeviceTrackingMixin` to better encapsulate, consolidate & streamline access to this content.

- Make `MVKDeviceTrackingMixin` a friend of `MVKDevice` & `MVKPhysicalDevice`.
- Hide public `MVKDevice` content behind `MVKDeviceTrackingMixin` functions.
- Remove similar `MVKDevice` content pointers from `MVKCommandEncoder`.
- `MVKDevice` remove `getPhysicalDevice()`, `getPixelFormats()` & `getMTLDevice()`, to focus access through `MVKDeviceTrackingMixin`.
- Move performance tracking functions to `MVKDeviceTrackingMixin` to remove need to reference `MVKDevice` multiple times when marking performance values.
- Subclass `MVKQueueSubmission`, `MVKMetalCompiler`, `MVKShaderLibrary`, and `MVKShaderLibraryCache` from `MVKBaseDeviceObject` to make use of these changes.

Note to reviewers:
- This is a non-functional change and passes the same CTS tests as previously.
- The primary design changes of interest are in the declarations of `MVKDeviceTrackingMixin` and `MVKDevice` in `MVKDevice.h`, and to `MVKCommandEncoder` in `MVKCommandBuffer.h`.
- The remaining changes are simple find-and-replace syntax changes to delegate to `MVKDeviceTrackingMixin` instead of reaching into `MVKDevice`.