### PR TITLE
Allow vertex buffer binding when they are used disregarding implicit buffer index

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -431,7 +431,7 @@ protected:
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
 	static constexpr uint32_t kMVKMaxVertexInputBindingBufferCount = 31u; // Taken from Metal Feature Set Table. Highest value out of all present GPUs
-	bool _isVertexInputBindingUsed[_maxVertexInputBindingBufferCount] = { false };
+	bool _isVertexInputBindingUsed[kMVKMaxVertexInputBindingBufferCount] = { false };
 	bool _primitiveRestartEnable = true;
 	bool _hasRasterInfo = false;
 	bool _needsVertexSwizzleBuffer = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -430,6 +430,8 @@ protected:
 	uint32_t _tessCtlPatchOutputBufferIndex = 0;
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
+	static constexpr uint32_t _maxVertexInputBindingBufferCount = 31u; // Taken from Metal Feature Set Table. Highest value out of all present GPUs
+	bool _isVertexInputBindingUsed[_maxVertexInputBindingBufferCount] = { false };
 	bool _primitiveRestartEnable = true;
 	bool _hasRasterInfo = false;
 	bool _needsVertexSwizzleBuffer = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -430,7 +430,7 @@ protected:
 	uint32_t _tessCtlPatchOutputBufferIndex = 0;
 	uint32_t _tessCtlLevelBufferIndex = 0;
 
-	static constexpr uint32_t _maxVertexInputBindingBufferCount = 31u; // Taken from Metal Feature Set Table. Highest value out of all present GPUs
+	static constexpr uint32_t kMVKMaxVertexInputBindingBufferCount = 31u; // Taken from Metal Feature Set Table. Highest value out of all present GPUs
 	bool _isVertexInputBindingUsed[_maxVertexInputBindingBufferCount] = { false };
 	bool _primitiveRestartEnable = true;
 	bool _hasRasterInfo = false;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1414,6 +1414,7 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
 
 			maxBinding = max(pVKVB->binding, maxBinding);
 			uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
+			_isVertexInputBindingUsed[vbIdx] = true;
 			auto vbDesc = inputDesc.layouts[vbIdx];
 			if (isVtxStrideStatic && pVKVB->stride == 0) {
 				// Stride can't be 0, it will be set later to attributes' maximum offset + size
@@ -1840,7 +1841,7 @@ void MVKGraphicsPipeline::initReservedVertexAttributeBufferCount(const VkGraphic
 }
 
 bool MVKGraphicsPipeline::isValidVertexBufferIndex(MVKShaderStage stage, uint32_t mtlBufferIndex) {
-	return mtlBufferIndex < _descriptorBufferCounts.stages[stage] || mtlBufferIndex > getImplicitBufferIndex(stage, 0);
+	return _isVertexInputBindingUsed[mtlBufferIndex] || mtlBufferIndex < _descriptorBufferCounts.stages[stage] || mtlBufferIndex > getImplicitBufferIndex(stage, 0);
 }
 
 // Initializes the vertex attributes in a shader conversion configuration.


### PR DESCRIPTION
Fixes #1609 

Due to how MoltenVK decides when a buffer can be bound based on its requirements for the implicit buffer, if the application uses all bindings, implicit buffer index will be uint max. This lead to used buffers not being bound.

I did not test with the application mentioned in #1592 so if someone with the set up ready to test could, it would be great.

Although this change fixes the issue, it's a partial fix. I will create a new issue to discuss some concerns about the whole vertex input attachment architecture, since I do believe we would benefit from a rework of the system (I may be wrong tho). Haven't created a PR with a proof of concept since it'll require a considerable time investment I cannot afford currently.