### PR TITLE
Return MoltenVK log level string in pMessageIdName field of debug utils callback data

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -227,7 +227,7 @@ void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, MVKConfigLog
 			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT,
 			.pNext = nullptr,
 			.flags = 0,
-			.pMessageIdName = nullptr,
+			.pMessageIdName = mvkGetReportingLevelString(logLevel),
 			.messageIdNumber = 0,
 			.pMessage = pMessage,
 			.queueLabelCount = 0,

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -225,10 +225,8 @@ static inline const MVKConfiguration& mvkGetMVKConfig(MVKBaseObject* mvkObj) {
 	return mvkObj ? mvkObj->getMVKConfig() : getGlobalMVKConfig();
 }
 
-/**
- * Returns the reporting level string associated with the specified MoltenVK log level.
- */
-static inline const char* mvkGetReportingLevelString(MVKConfigLogLevel logLevel) {
+/** Returns the reporting level string associated with the specified MoltenVK log level. */
+static constexpr char* mvkGetReportingLevelString(MVKConfigLogLevel logLevel) {
 	switch (logLevel) {
 		case MVK_CONFIG_LOG_LEVEL_ERROR:    return "mvk-error";
 		case MVK_CONFIG_LOG_LEVEL_WARNING:  return "mvk-warn";

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.h
@@ -224,3 +224,16 @@ protected:
 static inline const MVKConfiguration& mvkGetMVKConfig(MVKBaseObject* mvkObj) {
 	return mvkObj ? mvkObj->getMVKConfig() : getGlobalMVKConfig();
 }
+
+/**
+ * Returns the reporting level string associated with the specified MoltenVK log level.
+ */
+static inline const char* mvkGetReportingLevelString(MVKConfigLogLevel logLevel) {
+	switch (logLevel) {
+		case MVK_CONFIG_LOG_LEVEL_ERROR:    return "mvk-error";
+		case MVK_CONFIG_LOG_LEVEL_WARNING:  return "mvk-warn";
+		case MVK_CONFIG_LOG_LEVEL_INFO:     return "mvk-info";
+		case MVK_CONFIG_LOG_LEVEL_DEBUG:    return "mvk-debug";
+		default:                            return "mvk-unknown";
+	}
+}

--- a/MoltenVK/MoltenVK/Utility/MVKBaseObject.mm
+++ b/MoltenVK/MoltenVK/Utility/MVKBaseObject.mm
@@ -29,16 +29,6 @@ using namespace std;
 #pragma mark -
 #pragma mark MVKBaseObject
 
-static const char* getReportingLevelString(MVKConfigLogLevel logLevel) {
-	switch (logLevel) {
-		case MVK_CONFIG_LOG_LEVEL_ERROR:    return "mvk-error";
-		case MVK_CONFIG_LOG_LEVEL_WARNING:  return "mvk-warn";
-		case MVK_CONFIG_LOG_LEVEL_INFO:     return "mvk-info";
-		case MVK_CONFIG_LOG_LEVEL_DEBUG:    return "mvk-debug";
-		default:                            return "mvk-unknown";
-	}
-}
-
 string MVKBaseObject::getClassName() { return mvk::getTypeName(this); }
 
 const MVKConfiguration& MVKBaseObject::getMVKConfig() {
@@ -95,7 +85,7 @@ void MVKBaseObject::reportMessage(MVKBaseObject* mvkObj, MVKConfigLogLevel logLe
 	va_end(origArgs);
 
 	// Log the message to the standard error stream
-	if (shouldLog) { fprintf(stderr, "[%s] %s\n", getReportingLevelString(logLevel), pMessage); }
+	if (shouldLog) { fprintf(stderr, "[%s] %s\n", mvkGetReportingLevelString(logLevel), pMessage); }
 
 	// Broadcast the message to any Vulkan debug report callbacks
 	if (hasDebugCallbacks) { mvkInst->debugReportMessage(mvkAPIObj, logLevel, pMessage); }


### PR DESCRIPTION
Fixes #2219.

Previously the `pMessageIdName` field of debug utils callback data was set to **nullptr**, i.e. no messageId name.  To provide more context and information to the user, we now fill this field with the MoltenVK log level string.  This, combined with the `pMessage` string, shows the severity of the message in textual form, and indicates that it comes from MoltenVK.

Note I have changed the `mvkGetReportingLevelString()` function declaration to **inline** - I hope this is appropriate.

Also, after making this change I wonder whether it should also be applied to the debug report callback code, i.e. replace `_debugReportCallbackLayerPrefix` with `mvkGetReportingLevelString()` for consistency?  I don't want to break anything re automated testing scripts, etc. so I didn't make this change yet.  However, I think it's a question worth asking.