### PR TITLE
Fix shader argument buffer padding and atomics.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,8 @@ Released 2024/05/07
 - Fix crash when using `VK_EXT_metal_objects` under _ARC_.
 - Fix deadlock when creating a swapchain on a thread other than the main thread.
 - Fix potential memory leak in `vkQueueWaitIdle()`.
+- Fix argument buffer padding on shader conversion.
+- Avoid atomic image usage if native atomics are not supported on the platform.
 - Ensure buffer bindings are actually used to avoid potential overrun on Metal buffer indexes.
 - Update dependency libraries to match _Vulkan SDK 1.3.283_.
 - Update `MVK_PRIVATE_API_VERSION` to `41`.
@@ -40,6 +42,7 @@ Released 2024/05/07
   - MSL: Handle Atomic{S,U}{Min,Max} with mismatched image sign.
   - MSL: Handle missing FP16 trancendental overloads.
   - MSL: Remove pointer wrapper stored in `spvDescriptorArray()` to avoid potential Metal compiler bug. 
+  - MSL: Fix argument buffer padding.
 
 
 

--- a/ExternalRevisions/SPIRV-Cross_repo_revision
+++ b/ExternalRevisions/SPIRV-Cross_repo_revision
@@ -1,1 +1,1 @@
-2ccc81fd826e4dd4a2db2f94b8e6eb738a89f5f1
+84cdc3b68e5ef5a15ecfacda77c61f24a9080cf9

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1081,7 +1081,9 @@ MTLTextureUsage MVKImage::getMTLTextureUsage(MTLPixelFormat mtlPixFmt) {
 		needsReinterpretation = needsReinterpretation || !pixFmts->compatibleAsLinearOrSRGB(mtlPixFmt, viewFmt);
 	}
 
-	MTLTextureUsage mtlUsage = pixFmts->getMTLTextureUsage(getCombinedUsage(), mtlPixFmt, _samples, _isLinear || _isLinearForAtomics, needsReinterpretation, _hasExtendedUsage, _shouldSupportAtomics);
+	MTLTextureUsage mtlUsage = pixFmts->getMTLTextureUsage(getCombinedUsage(), mtlPixFmt, _samples,
+														   _isLinear || _isLinearForAtomics, needsReinterpretation, _hasExtendedUsage,
+														   _shouldSupportAtomics && getPhysicalDevice()->useNativeTextureAtomics());
 
 	// Metal before 3.0 doesn't support 3D compressed textures, so we'll
 	// decompress the texture ourselves, and we need to be able to write to it.


### PR DESCRIPTION
- Pull in SPIRV-Cross fix for argument buffer padding.
- Only use `MTLTextureUsageShaderAtomic` if native atomics are supported on the platform.

Fixes issues #2216 and #2180.