### PR TITLE
Add support for final version of VK_KHR_portability_subset extension.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -136,6 +136,9 @@ public:
 	/** Populates the specified structure with the features of this device. */
 	void getFeatures(VkPhysicalDeviceFeatures2* features);
 
+	/** Populates a list of Vulkan features that are NOT supported by this device. */
+	VkResult getMissingFeatures(uint32_t* pMissingFeatureCount, VkPortabilitySubsetMissingFeatureKHR* pMissingFeatures);
+
 	/** Populates the specified structure with the properties of this device. */
 	void getProperties(VkPhysicalDeviceProperties* properties);
 

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -3100,6 +3100,22 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkUnmapMemory2KHR(
 
 
 #pragma mark -
+#pragma mark VK_KHR_portability_subset extension
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkGetPhysicalDevicePortabilitySubsetMissingFeaturesKHR(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pMissingFeatureCount,
+    VkPortabilitySubsetMissingFeatureKHR*       pMissingFeatures) {
+
+	MVKTraceVulkanCallStart();
+	MVKPhysicalDevice* mvkPD = MVKPhysicalDevice::getMVKPhysicalDevice(physicalDevice);
+	VkResult rslt = mvkPD->getMissingFeatures(pMissingFeatureCount, pMissingFeatures);
+	MVKTraceVulkanCallEnd();
+	return rslt;
+}
+
+
+#pragma mark -
 #pragma mark VK_KHR_push_descriptor extension
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetKHR(

--- a/fetchDependencies
+++ b/fetchDependencies
@@ -320,6 +320,18 @@ else
 	update_repo ${REPO_NAME} ${REPO_URL} ${REPO_REV}
 fi
 
+	# Temporary patch to fetch dev versions of header files that support
+	# VK_KHR_portability_subset_metal header and copy them to Vulkan-Headers repo.
+	# This requires password access to private Khronos member dev repos.
+	REPO_URL="https://gitlab.khronos.org/vulkan/vulkan.git"
+	REPO_REV="78b1dc7cb54714f8f7ce639b336277a861c6f059"
+	update_repo "vulkan" ${REPO_URL} ${REPO_REV}
+	cd "vulkan/xml"
+	make clean install
+	cd -  > /dev/null
+	cp -a "vulkan/gen/include/vulkan/vulkan_core.h" "${REPO_NAME}/include/vulkan/"
+	cp -a "vulkan/gen/include/vulkan/vulkan_beta.h" "${REPO_NAME}/include/vulkan/"
+
 
 # ----------------- SPIRV-Cross -------------------
 


### PR DESCRIPTION
- Add `vkGetPhysicalDevicePortabilitySubsetMissingFeaturesKHR()`.
- Log missing features when creating a physical device.