### PR TITLE
Fix shader conversion failure when using native texture atomics.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,7 @@ MoltenVK 1.2.10
 
 Released TBD
 
+- Fix shader conversion failure when using native texture atomics.
 - MSL shader conversion, only pass resource bindings that apply to current shader stage.
 - Update documentation for minimum runtime OS requirements to indicate _macOS 10.15_, _iOS 13_, or _tvOS 13_.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -296,7 +296,7 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
         if ( mvkIsAnyFlagEnabled(_buffer->getUsage(), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) ) {
 			usage |= MTLTextureUsageShaderWrite;
 #if MVK_XCODE_15
-			if (getPhysicalDevice()->useNativeTextureAtomics() && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint || _mtlPixelFormat == MTLPixelFormatRG32Uint))
+			if (getMetalFeatures().nativeTextureAtomics && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint || _mtlPixelFormat == MTLPixelFormatRG32Uint))
 				usage |= MTLTextureUsageShaderAtomic;
 #endif
         }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -75,7 +75,8 @@ void mvkPopulateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& s
 									   uint32_t bindingIndex,
 									   uint32_t count,
 									   VkDescriptorType descType,
-									   MVKSampler* immutableSampler);
+									   MVKSampler* immutableSampler,
+									   bool usingNativeTextureAtomics);
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -764,7 +764,7 @@ void MVKDescriptorPool::initMetalArgumentBuffer(const VkDescriptorPoolCreateInfo
 				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
 				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
 					mtlTexCnt += poolSize.descriptorCount;
-					if (!getPhysicalDevice()->useNativeTextureAtomics())
+					if (!getMetalFeatures().nativeTextureAtomics)
 						mtlBuffCnt += poolSize.descriptorCount;
 					break;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -357,9 +357,6 @@ public:
 		return _metalFeatures.argumentBuffers && getMVKConfig().useMetalArgumentBuffers != MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS_NEVER;
 	};
 
-	/** Returns whether native texture atomics are supported and should be used. */
-	bool useNativeTextureAtomics() { return _metalFeatures.nativeTextureAtomics; }
-
 	/** Returns the MTLStorageMode that matches the Vulkan memory property flags. */
 	MTLStorageMode getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3764,7 +3764,7 @@ void MVKDevice::getDescriptorVariableDescriptorCountLayoutSupport(const VkDescri
 				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
 				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
 					mtlTexCnt += pBind->descriptorCount;
-					if (_physicalDevice->useNativeTextureAtomics()) {
+					if (_physicalDevice->_metalFeatures.nativeTextureAtomics) {
 						mtlBuffCnt += pBind->descriptorCount;
 					}
 					maxVarDescCount = min(mtlFeats.maxPerStageTextureCount - mtlTexCnt,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1083,7 +1083,7 @@ MTLTextureUsage MVKImage::getMTLTextureUsage(MTLPixelFormat mtlPixFmt) {
 
 	MTLTextureUsage mtlUsage = pixFmts->getMTLTextureUsage(getCombinedUsage(), mtlPixFmt, _samples,
 														   _isLinear || _isLinearForAtomics, needsReinterpretation, _hasExtendedUsage,
-														   _shouldSupportAtomics && getPhysicalDevice()->useNativeTextureAtomics());
+														   _shouldSupportAtomics && getMetalFeatures().nativeTextureAtomics);
 
 	// Metal before 3.0 doesn't support 3D compressed textures, so we'll
 	// decompress the texture ourselves, and we need to be able to write to it.
@@ -1162,7 +1162,7 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
 				((_vkFormat == VK_FORMAT_R32_UINT || _vkFormat == VK_FORMAT_R32_SINT) ||
 					(_hasMutableFormat && pixFmts->getViewClass(_vkFormat) == MVKMTLViewClass::Color32 && (getIsValidViewFormat(VK_FORMAT_R32_UINT) || getIsValidViewFormat(VK_FORMAT_R32_SINT))));
 
-	_isLinearForAtomics = _shouldSupportAtomics && !getPhysicalDevice()->useNativeTextureAtomics() && _arrayLayers == 1 && getImageType() == VK_IMAGE_TYPE_2D;
+	_isLinearForAtomics = _shouldSupportAtomics && !getMetalFeatures().nativeTextureAtomics && _arrayLayers == 1 && getImageType() == VK_IMAGE_TYPE_2D;
 
 	_is3DCompressed = (getImageType() == VK_IMAGE_TYPE_3D) && (pixFmts->getFormatType(pCreateInfo->format) == kMVKFormatCompressed) && !mtlFeats.native3DCompressedTextures;
 	_isDepthStencilAttachment = (mvkAreAllFlagsEnabled(pCreateInfo->usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ||

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -104,7 +104,8 @@ void MVKPipelineLayout::populateShaderConversionConfig(SPIRVToMSLConversionConfi
 											  kPushConstBinding,
 											  1,
 											  VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT,
-											  nullptr);
+											  nullptr,
+											  getMetalFeatures().nativeTextureAtomics);
 		}
 	}
 


### PR DESCRIPTION
- `mvkPopulateShaderConversionConfig()` `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE` and `VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER`, don't add buffer resource binding if native texture atomics are supported.
- Remove `MVKPhysicalDevice::useNativeTextureAtomics()` and update all occurrences of `getPhysicalDevice()->useNativeTextureAtomics()` to `getMetalFeatures().nativeTextureAtomics`.

Fixes issue #2180.