### PR TITLE
MVKGraphicsPipeline: Don't use _tessInfo to decide if pipeline is a tessellation pipeline.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -288,7 +288,7 @@ public:
 	bool isDynamicState(MVKRenderStateType state) { return _dynamicState.isEnabled(state); }
 
     /** Returns whether this pipeline has tessellation shaders. */
-    bool isTessellationPipeline() { return _tessInfo.patchControlPoints > 0; }
+    bool isTessellationPipeline() { return _isTessellationPipeline; }
 
     /** Returns the number of output tessellation patch control points. */
     uint32_t getOutputControlPointCount() { return _outputControlPointCount; }
@@ -455,6 +455,7 @@ protected:
 	bool _isRasterizing = false;
 	bool _isRasterizingColor = false;
 	bool _sampleLocationsEnable = false;
+	bool _isTessellationPipeline = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -489,6 +489,8 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 	SPIRVTessReflectionData reflectData;
 	std::string reflectErrorLog;
 	if (pTessCtlSS && pTessEvalSS) {
+		_isTessellationPipeline = true;
+
 		if (!getTessReflectionData(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(), pTessCtlSS->pName, ((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(), pTessEvalSS->pName, reflectData, reflectErrorLog) ) {
 			setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to reflect tessellation shaders: %s", reflectErrorLog.c_str()));
 			return;
@@ -502,7 +504,7 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 
 	// Tessellation - must ignore allowed bad pTessellationState pointer if not tess pipeline
 	_outputControlPointCount = reflectData.numControlPoints;
-	mvkSetOrClear(&_tessInfo, (pTessCtlSS && pTessEvalSS) ? pCreateInfo->pTessellationState : nullptr);
+	mvkSetOrClear(&_tessInfo, _isTessellationPipeline ? pCreateInfo->pTessellationState : nullptr);
 
 	// Render pipeline state. Do this as early as possible, to fail fast if pipeline requires a fail on cache-miss.
 	initMTLRenderPipelineState(pCreateInfo, reflectData, pPipelineFB, pVertexSS, pVertexFB, pTessCtlSS, pTessCtlFB, pTessEvalSS, pTessEvalFB, pFragmentSS, pFragmentFB);


### PR DESCRIPTION
With dynamic patch control points enabled, the pipeline does not need to be created with tessellation info included in the create info. Store a separate boolean flag to treat all pipelines that have tessellation shaders properly.