### PR TITLE
Apply SPIRV-Cross workarounds for Metal bugs

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -456,6 +456,7 @@ protected:
 	bool _isRasterizingColor = false;
 	bool _sampleLocationsEnable = false;
 	bool _isTessellationPipeline = false;
+	bool _inputAttachmentIsDSAttachment = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -67,10 +67,10 @@ public:
 	bool isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx);
 
 	/** Returns whether or not the depth attachment is being used. */
-	bool isDepthAttachmentUsed() { return _depthAttachment.attachment != VK_ATTACHMENT_UNUSED; }
+	bool isDepthAttachmentUsed() const { return _depthAttachment.attachment != VK_ATTACHMENT_UNUSED; }
 
 	/** Returns whether or not the stencil attachment is being used. */
-	bool isStencilAttachmentUsed() { return _stencilAttachment.attachment != VK_ATTACHMENT_UNUSED; }
+	bool isStencilAttachmentUsed() const { return _stencilAttachment.attachment != VK_ATTACHMENT_UNUSED; }
 
 	/** Return the depth attachment format. */
 	VkFormat getDepthFormat();
@@ -89,6 +89,9 @@ public:
 
 	/** Returns whether or not this is a multiview subpass. */
 	bool isMultiview() const { return _pipelineRenderingCreateInfo.viewMask != 0; }
+
+	/** Returns whether or not the depth stencil is being used as input attachment */
+	bool isInputAttachmentDepthStencilAttachment() const { return _isInputAttachmentDepthStencilAttachment; }
 
 	/** Returns the multiview view mask. */
 	uint32_t getViewMask() const { return _pipelineRenderingCreateInfo.viewMask; }
@@ -177,6 +180,7 @@ protected:
 	VkResolveModeFlagBits _stencilResolveMode = VK_RESOLVE_MODE_NONE;
 	VkSampleCountFlagBits _defaultSampleCount = VK_SAMPLE_COUNT_1_BIT;
 	uint32_t _subpassIndex;
+	bool _isInputAttachmentDepthStencilAttachment = false;
 };
 
 


### PR DESCRIPTION
2 workarounds introduced:
 - Fragments with side effects will now execute following Vulkan
 - Depth/Stencil write postponed to post fragment execution when input attachment and depth/stencil attachment reference the same resource

Fixes #2232
Fixes #2233