### PR TITLE
[ios18 support] add new case for Metal Version 3.2 that is on ios 18 -- reroutes MoltenMK to use version 3.1

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -107,6 +107,10 @@ extern "C" {
 #endif
 
 /** Building with Xcode versions. iOS version also covers tvOS. */
+#ifndef MVK_XCODE_16
+#define MVK_XCODE_16			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
+                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 180000))
+#endif
 #ifndef MVK_XCODE_15
 #   define MVK_XCODE_15             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) || \
                                     (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000))

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2014,6 +2014,13 @@ void MVKPhysicalDevice::initMetalFeatures() {
     }
 #endif
 
+#if MVK_XCODE_16
+	if ( mvkOSVersionIsAtLeast(18.0) ) {
+		// We don't explicitly support Metal 3.2 yet
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
+#endif
+
 #endif
 
 #if MVK_IOS
@@ -2136,6 +2143,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
     }
 #endif
+#if MVK_XCODE_16
+	if ( mvkOSVersionIsAtLeast(18.0) ) {
+		// We don't explicitly support Metal 3.2 yet
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
+#endif
 
 #endif
 
@@ -2225,6 +2238,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
     if ( mvkOSVersionIsAtLeast(14.0) ) {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
     }
+#endif
+#if MVK_XCODE_16
+	if ( mvkOSVersionIsAtLeast(18.0) ) {
+		// We don't explicitly support Metal 3.2 yet
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
 #endif
 
 	// This is an Apple GPU--treat it accordingly.
@@ -2341,6 +2360,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj, min);
 
 	switch (_metalFeatures.mslVersionEnum) {
+#if MVK_XCODE_16
+		case MTLLanguageVersion3_2:
+			// We don't explicitly support Metal 3.2 yet
+			setMSLVersion(3, 1);
+			break;
+#endif
 #if MVK_XCODE_15
         case MTLLanguageVersion3_1:
             setMSLVersion(3, 1);

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -71,6 +71,11 @@ bool mvk::compile(const string& mslSourceCode,
 #define mslVer(MJ, MN, PT)	mslVersionMajor == MJ && mslVersionMinor == MN && mslVersionPoint == PT
 
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
+#if MVK_XCODE_16
+	if (mslVer(3, 2, 0)) {
+		mslVerEnum = MTLLanguageVersion3_1;
+	} else
+		#endif
 #if MVK_XCODE_15
     if (mslVer(3, 1, 0)) {
         mslVerEnum = MTLLanguageVersion3_1;


### PR DESCRIPTION
This adds a new preprocessor macro for xcode16 / ios18 sdk and reroutes the version to 3.1 (additions to MVKDevice are iline with as what we did for other xcode versions in the past)