### PR TITLE
Support multiplanar images in Metal argument buffers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -28,10 +28,6 @@ class MVKCommandEncoder;
 class MVKResourcesCommandEncoderState;
 
 
-// The size of one Metal3 Argument Buffer slot in bytes.
-static const size_t kMVKMetal3ArgBuffSlotSizeInBytes = sizeof(uint64_t);
-
-
 #pragma mark MVKShaderStageResourceBinding
 
 /** Indicates the Metal resource indexes used by a single shader stage in a descriptor. */
@@ -183,8 +179,8 @@ protected:
 										uint32_t dslIndex);
 	bool validate(MVKSampler* mvkSampler);
 	void encodeImmutableSamplersToMetalArgumentBuffer(MVKDescriptorSet* mvkDescSet);
-	uint32_t getMTLResourceCountPerElement();
-	uint64_t getMetal3ArgumentBufferEncodedSize();
+	uint8_t getMaxPlaneCount();
+	uint32_t getMTLResourceCount();
 	bool needsBuffSizeAuxBuffer();
 	std::string getLogDescription();
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -130,7 +130,7 @@ protected:
 	uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return getBinding(binding)->getDescriptorIndex(elementIndex); }
 	MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
 	const VkDescriptorBindingFlags* getBindingFlags(const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
-	uint32_t getBufferSizeBufferArgBuferIndex() { return _mtlResourceCount; }
+	uint32_t getBufferSizeBufferArgBuferIndex() { return _mtlResourceTotalCount; }
 	std::string getLogDescription();
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
@@ -139,7 +139,7 @@ protected:
 	NSArray<MTLArgumentDescriptor*>* _mtlArgumentEncoderArgs = nil;
 	uint64_t _mtlArgumentBufferEncodedSize = 0;
 	uint32_t _descriptorCount = 0;
-	uint32_t _mtlResourceCount = 0;
+	uint32_t _mtlResourceTotalCount = 0;
 	int32_t _maxBufferIndex = -1;
 	bool _isPushDescriptorLayout = false;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -662,7 +662,7 @@ public:
     VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT; }
     
     /** Returns the number of planes of this ycbcr conversion. */
-    inline uint8_t getPlaneCount() { return _planes; }
+    uint8_t getPlaneCount() { return _planes; }
 
     /** Writes this conversion settings to a MSL constant sampler */
     void updateConstExprSampler(SPIRV_CROSS_NAMESPACE::MSLConstexprSampler& constExprSampler) const;
@@ -700,10 +700,10 @@ public:
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT; }
 
 	/** Returns the Metal sampler state. */
-	inline id<MTLSamplerState> getMTLSamplerState() { return _mtlSamplerState; }
+	id<MTLSamplerState> getMTLSamplerState() { return _mtlSamplerState; }
     
     /** Returns the number of planes if this is a ycbcr conversion or 0 otherwise. */
-    inline uint8_t getPlaneCount() { return (_ycbcrConversion) ? _ycbcrConversion->getPlaneCount() : 0; }
+    uint8_t getPlaneCount() { return (_ycbcrConversion) ? _ycbcrConversion->getPlaneCount() : 0; }
 
 	/**
 	 * If this sampler requires hardcoding in MSL, populates the hardcoded sampler in the resource binding.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -154,10 +154,10 @@ typedef struct MVKVkFormatDesc {
 	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); };
 
 	bool needsSwizzle() const {
-		return componentMapping.r != VK_COMPONENT_SWIZZLE_IDENTITY ||
-			componentMapping.g != VK_COMPONENT_SWIZZLE_IDENTITY ||
-			componentMapping.b != VK_COMPONENT_SWIZZLE_IDENTITY ||
-			componentMapping.a != VK_COMPONENT_SWIZZLE_IDENTITY;
+		return (componentMapping.r != VK_COMPONENT_SWIZZLE_IDENTITY ||
+				componentMapping.g != VK_COMPONENT_SWIZZLE_IDENTITY ||
+				componentMapping.b != VK_COMPONENT_SWIZZLE_IDENTITY ||
+				componentMapping.a != VK_COMPONENT_SWIZZLE_IDENTITY);
 	}
 } MVKVkFormatDesc;
 


### PR DESCRIPTION
- `MVKDescriptorSetLayoutBinding` add `getMaxPlaneCount()` to determine the number of planes for a combined image-sampler, from the immutable samplers.
- When using `MTLArgumentEncoder`, add encoder arguments for each texture plane.
- Don't build `MTLArgumentEncoder` if descriptor count is zero.
- For discrete multi-plane and multiple descriptors per binding, use max plane count to determine a consistent array size for each plane.
- Some minor formatting fixes found along the way.

Although there was some original concern in [this discussion](https://github.com/KhronosGroup/MoltenVK/pull/2260#discussion_r1663613174) that we might need to hold 3 argument buffer slots for all images if `samplerYcbcrConversion` was enabled, it turned out that this feature only permits multiplanar images as combined image-samplers, and only with samplers that are immutable. So we know at descriptor layout binding definition time which descriptors require more than one slot per image.