### PR TITLE
Xc16 temp

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -106,30 +106,36 @@ extern "C" {
 #	define MVK_MACOS_APPLE_SILICON	(MVK_MACOS && MVK_APPLE_SILICON)
 #endif
 
-/** Building with Xcode versions. iOS version also covers tvOS. */
+/** Building with Xcode versions. */
 #ifndef MVK_XCODE_16
-#define MVK_XCODE_16			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
-                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 180000))
+#   define MVK_XCODE_16             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
+                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 180000))
 #endif
 #ifndef MVK_XCODE_15
 #   define MVK_XCODE_15             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) || \
-                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000))
+                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 170000))
 #endif
 #ifndef MVK_XCODE_14_3
 #	define MVK_XCODE_14_3			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130300) || \
-									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160400))
+									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160400) || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 160400))
 #endif
 #ifndef MVK_XCODE_14
 #	define MVK_XCODE_14				((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130000) || \
-									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160000))
+									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160000) || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 160000))
 #endif
 #ifndef MVK_XCODE_13
 #	define MVK_XCODE_13 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || \
-									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 150000))
+									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 150000)))
 #endif
 #ifndef MVK_XCODE_12
 #	define MVK_XCODE_12 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 110000) || \
-									 (__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000))
+									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 140000)))
 #endif
 
 /**

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,17 +19,18 @@ MoltenVK 1.2.10
 Released TBD
 
 - Improvements to bindless resources and descriptor indexing:
-  - Add support for Metal3 argument buffers.
-  - Support argument buffers on all platforms, when Metal 3 is available.
-  - Support argument buffers on macOS when Metal3 is not available.
+  - Add support for _Metal 3_ argument buffers.
+  - Support argument buffers on all platforms, when _Metal 3_ is available.
+  - Support argument buffers on _macOS_ when _Metal 3_ is not available.
   - Use Metal argument buffers by default when they are available.
-  - Revert MVKConfiguration::useMetalArgumentBuffers and env var 
+  - Revert `MVKConfiguration::useMetalArgumentBuffers` and env var 
     `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS` to a boolean value, and enable it by default.
   - Update max number of bindless buffers and textures per stage to 1M, per Apple Docs.
 - Add option to generate a GPU capture via a temporary named pipe from an external process.
 - Fix shader conversion failure when using native texture atomics.
 - MSL shader conversion, only pass resource bindings that apply to current shader stage.
 - Update documentation for minimum runtime OS requirements to indicate _macOS 10.15_, _iOS 13_, or _tvOS 13_.
+- Add support for _Xcode 16_, _macOS 15 SDK_, _iOS 18 SDK_, and _MSL 3.2_.
 - Update `MVK_PRIVATE_API_VERSION` to version `42`.
 - Update to latest SPIRV-Cross:
   - MSL: Add option to force depth write in fragment shaders

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2016,8 +2016,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 #if MVK_XCODE_16
 	if ( mvkOSVersionIsAtLeast(18.0) ) {
-		// We don't explicitly support Metal 3.2 yet
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
 	}
 #endif
 
@@ -2145,8 +2144,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 #if MVK_XCODE_16
 	if ( mvkOSVersionIsAtLeast(18.0) ) {
-		// We don't explicitly support Metal 3.2 yet
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
 	}
 #endif
 
@@ -2240,9 +2238,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
     }
 #endif
 #if MVK_XCODE_16
-	if ( mvkOSVersionIsAtLeast(18.0) ) {
-		// We don't explicitly support Metal 3.2 yet
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	if ( mvkOSVersionIsAtLeast(15.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
 	}
 #endif
 
@@ -2362,8 +2359,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	switch (_metalFeatures.mslVersionEnum) {
 #if MVK_XCODE_16
 		case MTLLanguageVersion3_2:
-			// We don't explicitly support Metal 3.2 yet
-			setMSLVersion(3, 1);
+			setMSLVersion(3, 2);
 			break;
 #endif
 #if MVK_XCODE_15

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -73,7 +73,7 @@ bool mvk::compile(const string& mslSourceCode,
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
 #if MVK_XCODE_16
 	if (mslVer(3, 2, 0)) {
-		mslVerEnum = MTLLanguageVersion3_1;
+		mslVerEnum = MTLLanguageVersion3_2;
 	} else
 		#endif
 #if MVK_XCODE_15


### PR DESCRIPTION
- Add `MVK_XCODE_16` macro definition.
- Include tvOS version in `MVK_XCODE_NN` definitions, as Xcode 16 seems not to define iOS version in tvOS SDK. Might be an early Xcode beta bug, but it doesn't hurt to include this test anyway.
- Support macOS 15 SDK, iOS 18 SDK, and MSL 3.2.

This includes a merger of previous work by another author.