### PR TITLE
Descriptor set only consumes the variable number of descriptors from the pool.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,6 +25,8 @@ Released TBD
   - Use Metal argument buffers by default when they are available.
   - Revert `MVKConfiguration::useMetalArgumentBuffers` and env var 
     `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS` to a boolean value, and enable it by default.
+  - Support a descriptor pool with less descriptors than the descriptor set layout, 
+    as long as the pool has enough descriptors for the variable descriptor count,     
   - Update max number of bindless buffers and textures per stage to 1M, per Apple Docs.
 - Add option to generate a GPU capture via a temporary named pipe from an external process.
 - Fix shader conversion failure when using native texture atomics.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -692,7 +692,7 @@ void MVKResourcesCommandEncoderState::encodeMetalArgumentBuffer(MVKShaderStage s
 			auto* dslBind = dsLayout->getBindingAt(dslBindIdx);
 			if (dslBind->getApplyToStage(stage) && shaderBindingUsage.getBit(dslBindIdx)) {
 				shouldBindArgBuffToStage = true;
-				uint32_t elemCnt = dslBind->getDescriptorCount(descSet);
+				uint32_t elemCnt = dslBind->getDescriptorCount(descSet->getVariableDescriptorCount());
 				for (uint32_t elemIdx = 0; elemIdx < elemCnt; elemIdx++) {
 					uint32_t descIdx = dslBind->getDescriptorIndex(elemIdx);
 					if (resourceUsageDirtyDescs.getBit(descIdx, true)) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4903,9 +4903,9 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 	}
 #endif
 
-	MVKLogInfoIf(getMVKConfig().debugMode, "Descriptor sets binding resources using %s.",
-				 _physicalDevice->_isUsingMetalArgumentBuffers ? (_physicalDevice->_metalFeatures.needsArgumentBufferEncoders
-																  ? "Metal argument buffers" : "Metal3 argument buffers") : "discrete resource indexes");
+	MVKLogInfo("Descriptor sets binding resources using %s.",
+			   _physicalDevice->_isUsingMetalArgumentBuffers ? (_physicalDevice->_metalFeatures.needsArgumentBufferEncoders
+																? "Metal argument buffers" : "Metal3 argument buffers") : "discrete resource indexes");
 
 	_commandResourceFactory = new MVKCommandResourceFactory(this);
 


### PR DESCRIPTION
Existing implementation allocated enough descriptors to cover the maximum defined by the descriptor layout binding. This used more memory than needed, and caused pool exhaustion when allocating descriptors from a smaller pool, that contains enough descriptors to cover the variable count, but not the maximum count. Descriptors are now allocated from the pool only to cover the variable quantity.

- When creating `MTLArgumentEncoder`, only add the variable number of descriptors, and fix memory leak. 
- Add buffer-sized buffer to the front of the argument buffer, instead of at the end, to give it a fixed slot for access from the shader.
- Set variable count arrays in shader to length `1`.
- `MVKDescriptorSetLayout` don't track fixed descriptor count, resource count, argument buffer encoder descriptors, or argument buffer size. Instead, add `getMetal3ArgumentBufferEncodedLength()` and `getMTLArgumentEncoder()`, and fetch dynamically when finding a descriptor set that fits the variable descriptor count, instead of the maximum.
- Move `MVKDescriptorPool::getVariableDecriptorCounts()` and `MVKDescriptorSetLayout::getBindingFlags()` to constructors, to be consistent with other `pNext` approaches, and to allow future additional `pNext` options.
- Debug log `MVKDescriptorPool` textural description.

This fixes issue #2246, and replaces PR #2199.

For now, this fix could not be applied to variable-count combined image/samplers, multi-plane images, or non-native atomic textures, as they require SPIRV-Cross modifications to define one array of multi-resource structs instead of multiple variable-count arrays of resources, because separate arrays require arrays that are fixed in length at shader compile time (basically, we can have only one variable-count array of resources, not multiple  arrays). This will be fixed soon, but could not be included in time for the upcoming SDK release.