### PR TITLE
Add MTLStoreAction mapping for VK_ATTACHMENT_STORE_OP_NONE.

### DIFF
--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -608,8 +608,13 @@ MVK_PUBLIC_SYMBOL MTLStoreAction mvkMTLStoreActionFromVkAttachmentStoreOp(VkAtta
 // If we need to resolve, but the format doesn't support it, we must store the attachment so we can run a post-renderpass compute shader to perform the resolve.
 MTLStoreAction mvkMTLStoreActionFromVkAttachmentStoreOpInObj(VkAttachmentStoreOp vkStoreOp, bool hasResolveAttachment, bool canResolveFormat, MVKBaseObject* mvkObj) {
 	switch (vkStoreOp) {
-		case VK_ATTACHMENT_STORE_OP_STORE:		return hasResolveAttachment && canResolveFormat ? MTLStoreActionStoreAndMultisampleResolve : MTLStoreActionStore;
-		case VK_ATTACHMENT_STORE_OP_DONT_CARE:	return hasResolveAttachment ? (canResolveFormat ? MTLStoreActionMultisampleResolve : MTLStoreActionStore) : MTLStoreActionDontCare;
+		// Metal does not support VK_ATTACHMENT_STORE_OP_NONE. Next best option is store.
+		case VK_ATTACHMENT_STORE_OP_NONE:
+		case VK_ATTACHMENT_STORE_OP_STORE:
+			return hasResolveAttachment && canResolveFormat ? MTLStoreActionStoreAndMultisampleResolve : MTLStoreActionStore;
+
+		case VK_ATTACHMENT_STORE_OP_DONT_CARE:
+			return hasResolveAttachment ? (canResolveFormat ? MTLStoreActionMultisampleResolve : MTLStoreActionStore) : MTLStoreActionDontCare;
 
 		default:
 			MVKBaseObject::reportError(mvkObj, VK_ERROR_FORMAT_NOT_SUPPORTED, "VkAttachmentStoreOp value %d is not supported.", vkStoreOp);


### PR DESCRIPTION
As per https://github.com/KhronosGroup/MoltenVK/issues/1930#issuecomment-2089164911, adds a mapping for `VK_ATTACHMENT_STORE_OP_NONE` to `MTLStoreActionStore`, since it is required by `VK_KHR_dynamic_rendering` and storing is the closest equivalent in behavior provided by Metal. This will help silence log spam from the default case in applications that use this store op.

I assumed that it should mirror the behavior of `VK_ATTACHMENT_STORE_OP_STORE` with regards to multisampling and assigned it the same switch case. Let me know if that's not the case and I'll adjust it.