### PR TITLE
Add present handler only if VkPresentTimesInfoGOOGLE struct available in VkPresentInfoKHR

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -448,7 +448,7 @@ typedef struct  {
 	uint64_t desiredPresentTime;  	// VK_GOOGLE_display_timing desired presentation time in nanoseconds
 	uint32_t presentID;           	// VK_GOOGLE_display_timing presentID
 	VkPresentModeKHR presentMode;	// VK_EXT_swapchain_maintenance1 present mode specialization
-	bool hasPresentTime;      		// Keep track of whether presentation included VK_GOOGLE_display_timing
+	bool hasPresentTimesInfo;      	// Keep track of whether presentation included VK_GOOGLE_display_timing
 } MVKImagePresentInfo;
 
 /** Tracks a semaphore and fence for later signaling. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1552,13 +1552,13 @@ VkResult MVKPresentableSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffe
 	id<CAMetalDrawable> mtlDrwbl = getCAMetalDrawable();
 	MVKSwapchainSignaler signaler = getPresentationSignaler();
 	[mtlCmdBuff addScheduledHandler: ^(id<MTLCommandBuffer> mcb) {
-
-		addPresentedHandler(mtlDrwbl, presentInfo, signaler);
-
 		// Try to do any present mode transitions as late as possible in an attempt
 		// to avoid visual disruptions on any presents already on the queue.
 		if (presentInfo.presentMode != VK_PRESENT_MODE_MAX_ENUM_KHR) {
 			mtlDrwbl.layer.displaySyncEnabledMVK = (presentInfo.presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
+		}
+		if (presentInfo.hasPresentTimesInfo) {
+			addPresentedHandler(mtlDrwbl, presentInfo, signaler);
 		}
 		if (presentInfo.desiredPresentTime) {
 			[mtlDrwbl presentAtTime: (double)presentInfo.desiredPresentTime * 1.0e-9];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -799,10 +799,12 @@ MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKQueue* que
 		presentInfo.presentableImage = mvkSC->getPresentableImage(pPresentInfo->pImageIndices[scIdx]);
 		presentInfo.presentMode = pPresentModes ? pPresentModes[scIdx] : VK_PRESENT_MODE_MAX_ENUM_KHR;
 		presentInfo.fence = pFences ? (MVKFence*)pFences[scIdx] : nullptr;
-		if (pPresentTimes) {
-			presentInfo.hasPresentTime = true;
-			presentInfo.presentID = pPresentTimes[scIdx].presentID;
-			presentInfo.desiredPresentTime = pPresentTimes[scIdx].desiredPresentTime;
+		if (pPresentTimesInfo) {
+			presentInfo.hasPresentTimesInfo = true;
+			if (pPresentTimes) {
+				presentInfo.presentID = pPresentTimes[scIdx].presentID;
+				presentInfo.desiredPresentTime = pPresentTimes[scIdx].desiredPresentTime;
+			}
 		}
 		mvkSC->setLayerNeedsDisplay(pRegions ? &pRegions[scIdx] : nullptr);
 		_presentInfo.push_back(presentInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -771,7 +771,7 @@ MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKQueue* que
 	// Populate the array of swapchain images, testing each one for status
 	uint32_t scCnt = pPresentInfo->swapchainCount;
 	const VkPresentTimeGOOGLE* pPresentTimes = nullptr;
-	if (pPresentTimesInfo && pPresentTimesInfo->pTimes) {
+	if (pPresentTimesInfo) {
 		pPresentTimes = pPresentTimesInfo->pTimes;
 		MVKAssert(pPresentTimesInfo->swapchainCount == scCnt, "VkPresentTimesInfoGOOGLE swapchainCount must match VkPresentInfo swapchainCount.");
 	}


### PR DESCRIPTION
This PR solves issue #2284.

A presentation handler only needs to be activated if the `VK_GOOGLE_display_timing` extension is enabled and the `VkPresentTimesInfoGOOGLE` struct is included in the pNext chain of the `VkPresentInfoKHR` struct during calls to `vkQueuePresentKHR()`.  Previously the presentation handler would always be added.  This could lead to system-level diagnostic messages when used with `SDL_PollEvent()` as described in the issue noted above.

This change also permits `presentInfo.actualPresentTime` info to be recorded whether `VkPresentTimeGOOGLE* pPresentTimes` is defined or not.  This more closely follows the Vulkan spec which permits `pPresentTimes = NULL`.

I have tested this change against my Optick profiler integration with RBDoom3-BFG and correct `actualPresentTime` and `presentID` information is returned.  No regressions observed running on macOS Ventura 13.6.6 on x86_64.