### PR TITLE
Support dynamically allocating descriptors when pool is exhausted.

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -325,19 +325,6 @@ You can also use the `MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE` and
 
 
 ---------------------------------------
-#### MVK_CONFIG_PREALLOCATE_DESCRIPTORS
-
-##### Type: Boolean
-##### Default: `1`
-
-Controls whether **MoltenVK** should preallocate memory in each `VkDescriptorPool` according
-to the values of the `VkDescriptorPoolSize` parameters. Doing so may improve descriptor set
-allocation performance and memory stability at a cost of preallocated application memory.
-If this setting is disabled, the descriptors required for a descriptor set will be individually
-dynamically allocated in application memory when the descriptor set itself is allocated.
-
-
----------------------------------------
 #### MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS
 
 ##### Type: Enumeration

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,6 +18,11 @@ MoltenVK 1.2.11
 
 Released TBD
 
+- Support dynamically allocating descriptors when pool is exhausted.
+- Deprecate `MVKConfiguration::preallocateDescriptors` and `MVK_CONFIG_PREALLOCATE_DESCRIPTORS` environment variable.
+- `vkAllocateDescriptorSets()`: Per Vulkan spec, if any descriptor set allocation 
+  fails, populate all descriptor set pointers with `VK_NULL_HANDLE`. In addition, 
+  return `VK_ERROR_FRAGMENTED_POOL` if failure was due to pool fragmentation.
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
 
 

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -225,7 +225,7 @@ typedef struct {
 	MVKConfigAutoGPUCaptureScope autoGPUCaptureScope;                          /**< MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE */
 	const char* autoGPUCaptureOutputFilepath;                                  /**< MVK_CONFIG_AUTO_GPU_CAPTURE_OUTPUT_FILE */
 	VkBool32 texture1DAs2D;                                                    /**< MVK_CONFIG_TEXTURE_1D_AS_2D */
-	VkBool32 preallocateDescriptors;                                           /**< MVK_CONFIG_PREALLOCATE_DESCRIPTORS */
+	VkBool32 preallocateDescriptors;                                           /**< Obsolete, deprecated, and ignored. */
 	VkBool32 useCommandPooling;                                                /**< MVK_CONFIG_USE_COMMAND_POOLING */
 	VkBool32 useMTLHeap;                                                       /**< MVK_CONFIG_USE_MTLHEAP */
 	MVKConfigActivityPerformanceLoggingStyle activityPerformanceLoggingStyle;  /**< MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -217,12 +217,13 @@ protected:
 	void setBufferSize(uint32_t descIdx, uint32_t value);
 
 	MVKDescriptorPool* _pool;
-	MVKDescriptorSetLayout* _layout;
+	MVKDescriptorSetLayout* _layout = nullptr;
+	MVKMTLBufferAllocation* _bufferSizesBuffer = nullptr;
 	MVKSmallVector<MVKDescriptor*> _descriptors;
 	MVKMetalArgumentBuffer _argumentBuffer;
-	MVKMTLBufferAllocation* _bufferSizesBuffer = nullptr;
-	uint32_t _dynamicOffsetDescriptorCount;
-	uint32_t _variableDescriptorCount;
+	uint32_t _dynamicOffsetDescriptorCount = 0;
+	uint32_t _variableDescriptorCount = 0;
+	bool _allDescriptorsAreFromPool = true;
 };
 
 
@@ -242,9 +243,11 @@ public:
 protected:
 	friend class MVKDescriptorPool;
 
-	VkResult allocateDescriptor(MVKDescriptor** pMVKDesc, MVKDescriptorPool* pool);
+	VkResult allocateDescriptor(VkDescriptorType descType, MVKDescriptor** pMVKDesc, bool& dynamicAllocation, MVKDescriptorPool* pool);
 	void freeDescriptor(MVKDescriptor* mvkDesc, MVKDescriptorPool* pool);
 	void reset();
+	size_t size() { return _availability.size(); }
+	size_t getRemainingDescriptorCount();
 
 	MVKSmallVector<DescriptorClass> _descriptors;
 	MVKBitArray _availability;
@@ -286,7 +289,7 @@ protected:
 	void propagateDebugName() override {}
 	VkResult allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL, uint32_t variableDescriptorCount, VkDescriptorSet* pVKDS);
 	void freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset);
-	VkResult allocateDescriptor(VkDescriptorType descriptorType, MVKDescriptor** pMVKDesc);
+	VkResult allocateDescriptor(VkDescriptorType descriptorType, MVKDescriptor** pMVKDesc, bool& dynamicAllocation);
 	void freeDescriptor(MVKDescriptor* mvkDesc);
 	void initMetalArgumentBuffer(const VkDescriptorPoolCreateInfo* pCreateInfo);
 	NSUInteger getMetalArgumentBufferEncodedResourceStorageSize(NSUInteger bufferCount, NSUInteger textureCount, NSUInteger samplerCount);
@@ -294,7 +297,6 @@ protected:
 	size_t getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo, VkDescriptorType descriptorType);
 	std::string getLogDescription();
 
-    bool _hasPooledDescriptors;
 	MVKSmallVector<MVKDescriptorSet> _descriptorSets;
 	MVKBitArray _descriptorSetAvailablility;
 	id<MTLBuffer> _metalArgumentBuffer;

--- a/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
+++ b/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
@@ -72,7 +72,7 @@ MVK_CONFIG_MEMBER(semaphoreSupportStyle,                  MVKVkSemaphoreSupportS
 MVK_CONFIG_MEMBER(autoGPUCaptureScope,                    MVKConfigAutoGPUCaptureScope,             AUTO_GPU_CAPTURE_SCOPE)
 MVK_CONFIG_MEMBER_STRING(autoGPUCaptureOutputFilepath,    const char*,                              AUTO_GPU_CAPTURE_OUTPUT_FILE)
 MVK_CONFIG_MEMBER(texture1DAs2D,                          VkBool32,                                 TEXTURE_1D_AS_2D)
-MVK_CONFIG_MEMBER(preallocateDescriptors,                 VkBool32,                                 PREALLOCATE_DESCRIPTORS)
+MVK_CONFIG_MEMBER(preallocateDescriptors,                 VkBool32,                                 PREALLOCATE_DESCRIPTORS)			// Deprecated legacy
 MVK_CONFIG_MEMBER(useCommandPooling,                      VkBool32,                                 USE_COMMAND_POOLING)
 MVK_CONFIG_MEMBER(useMTLHeap,                             VkBool32,                                 USE_MTLHEAP)
 MVK_CONFIG_MEMBER(apiVersionToAdvertise,                  uint32_t,                                 API_VERSION_TO_ADVERTISE)

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -293,7 +293,7 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #   define MVK_CONFIG_TEXTURE_1D_AS_2D    1
 #endif
 
-/** Preallocate descriptors when creating VkDescriptorPool. Enabled by default. */
+/** Obsolete, deprecated, and ignored. */
 #ifndef MVK_CONFIG_PREALLOCATE_DESCRIPTORS
 #   define MVK_CONFIG_PREALLOCATE_DESCRIPTORS    1
 #endif


### PR DESCRIPTION
- `MVKDescriptorTypePool` if the pool is exhausted, report a warning, allocate a new descriptor instance, and when it is freed, destroy it.
- Deprecate `MVKConfiguration::preallocateDescriptors` and `MVK_CONFIG_PREALLOCATE_DESCRIPTORS`, as both preallocation and dynamic allocation of descriptors are now supported.
- `vkAllocateDescriptorSets()`: Per Vulkan spec, if any descriptor set allocation fails, free any successful allocations, and populate all descriptor set pointers with `VK_NULL_HANDLE`. In addition, return `VK_ERROR_FRAGMENTED_POOL` if failure was due to Metal argument buffer fragmentation.
- `vkUpdateDescriptorSets()` accepts null `VkDescriptorSet`s as no-ops.
- `MVKDescriptorPool::getLogDescription()` include count of remaining descriptors in the pool, for diagnostic logging during debugging.

Fix #2282.