### PR TITLE
Ensure all MoltenVK config info set by VK_EXT_layer_settings is used.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.2.11
 Released TBD
 
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
+- Ensure all MoltenVK config info set by `VK_EXT_layer_settings` is used.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -438,7 +438,7 @@ protected:
 	uint32_t _lazilyAllocatedMemoryTypes;
 	bool _hasUnifiedMemory = true;
 	bool _isAppleGPU = true;
-	bool _isUsingMetalArgumentBuffers = false;
+	bool _isUsingMetalArgumentBuffers = true;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -281,21 +281,27 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 	initDebugCallbacks(pCreateInfo);	// Do before any creation activities
 
 	mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
-    
     if (_appInfo.apiVersion == 0) {
         _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
     }
     else if (MVK_VULKAN_API_VERSION_CONFORM(_appInfo.apiVersion) > MVK_VULKAN_API_VERSION_CONFORM(MVK_VULKAN_API_VERSION)) {
         _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
     }
-    
-	initProcAddrs();		// Init function pointers
 
-	logVersions();	// Log the MoltenVK and Vulkan versions
+	// Enable extensions before setting config.
+	setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames));
+	MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_enabledExtensions;
+	setConfigurationResult(pWritableExtns->enable(pCreateInfo->enabledExtensionCount,
+												  pCreateInfo->ppEnabledExtensionNames,
+												  getDriverLayer()->getSupportedInstanceExtensions()));
+
+	initMVKConfig(pCreateInfo);		// After extensions enabled.
+	initProcAddrs();				// Init function pointers
+	logVersions();					// Log the MoltenVK and Vulkan versions. After config.
 
 	// Populate the array of physical GPU devices.
-	// This effort creates a number of autoreleased instances of Metal
-	// and other Obj-C classes, so wrap it all in an autorelease pool.
+	// This must be performed after extensions and config are established.
+	// This effort creates a number of autoreleased Metal objects, so wrap it all in an autorelease pool.
 	@autoreleasepool {
 		NSArray<id<MTLDevice>>* mtlDevices = mvkGetAvailableMTLDevicesArray(this);
 		_physicalDevices.reserve(mtlDevices.count);
@@ -311,14 +317,6 @@ MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExte
 	if (MVK_MACCAT && !mvkOSVersionIsAtLeast(11.0)) {
 		setConfigurationResult(reportError(VK_ERROR_INCOMPATIBLE_DRIVER, "To support Mac Catalyst, MoltenVK requires macOS 11.0 or above."));
 	}
-
-	// Enable extensions after logging the system and GPU info, for any logging done during extension enablement.
-	setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames));
-	MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_enabledExtensions;
-	setConfigurationResult(pWritableExtns->enable(pCreateInfo->enabledExtensionCount,
-												  pCreateInfo->ppEnabledExtensionNames,
-												  getDriverLayer()->getSupportedInstanceExtensions()));
-	initMVKConfig(pCreateInfo);
 
 	MVKLogInfo("Created VkInstance for Vulkan version %s, as requested by app, with the following %d Vulkan extensions enabled:%s",
 			   mvkGetVulkanVersionString(_appInfo.apiVersion).c_str(),


### PR DESCRIPTION
Some `VK_EXT_layer_settings` info was being read too late to have effect.

- `MVKInstance` enable extensions and set config info from `VkLayerSettingsCreateInfoEXT` before creating `MVKPhysicalDevice` instances, and before any logging.