### PR TITLE
Move primitive-restart-disabled warning from renderpass to pipeline creation, to reduce voluminous log noise.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -25,7 +25,7 @@ Released TBD
   return `VK_ERROR_FRAGMENTED_POOL` if failure was due to pool fragmentation.
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
 - Ensure all MoltenVK config info set by `VK_EXT_layer_settings` is used.
-
+- Move primitive-restart-disabled warning from renderpass to pipeline creation, to reduce voluminous log noise.
 
 
 MoltenVK 1.2.10

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -591,17 +591,6 @@ void MVKRenderingCommandEncoderState::encodeImpl(uint32_t stage) {
 		[rendEnc setStencilFrontReferenceValue: sr.frontFaceValue backReferenceValue: sr.backFaceValue];
 	}
 
-	// Validate
-	// In Metal, primitive restart cannot be disabled.
-	// Just issue warning here, as it is very likely the app is not actually expecting
-	// to use primitive restart at all, and is just setting this as a "just-in-case",
-	// and forcing an error here would be unexpected to the app (including CTS).
-	auto mtlPrimType = getPrimitiveType();
-	if (isDirty(PrimitiveRestartEnable) && !getMTLContent(PrimitiveRestartEnable) &&
-		(mtlPrimType == MTLPrimitiveTypeTriangleStrip || mtlPrimType == MTLPrimitiveTypeLineStrip)) {
-		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Metal does not support disabling primitive restart.");
-	}
-
 	if (isDirty(Viewports)) {
 		auto& mtlViewports = getMTLContent(Viewports);
 		if (enabledFeats.multiViewport) {


### PR DESCRIPTION
Fixes issue #2279.