### PR TITLE
MVKQueue: Make sure waitIdle waits for all commands to be encoded before enqueuing its own waitUntilCompleted.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -24,6 +24,7 @@
 #include "MVKSync.h"
 #include "MVKSmallVector.h"
 #include <mutex>
+#include <condition_variable>
 
 #import <Metal/Metal.h>
 
@@ -147,6 +148,9 @@ protected:
 	MVKQueueFamily* _queueFamily;
 	std::string _name;
 	dispatch_queue_t _execQueue;
+	std::mutex _execQueueMutex;
+	std::condition_variable _execQueueConditionVariable;
+	uint32_t _execQueueJobCount = 0;
 	id<MTLCommandQueue> _mtlQueue = nil;
 	NSString* _mtlCmdBuffLabelBeginCommandBuffer = nil;
 	NSString* _mtlCmdBuffLabelQueueSubmit = nil;


### PR DESCRIPTION
That seems to be causing mysterious crashes with asynchronous queue submissions. I've been debugging one where it'd crash the encoding thread because we destroyed the swap chain right after calling `vkQueueWaitIdle`, and it wasn't done encoding the Present.

For what it's worth in my case the bug bisected to f0cb31a12b59f05177f07ab5a46bc9084ba5fbc9.

Ping #2295, possibly others..