### PR TITLE
Support Vulkan requirement to allow write or copy beyond descriptor binding size.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,8 @@ Released TBD
 - `vkAllocateDescriptorSets()`: Per Vulkan spec, if any descriptor set allocation 
   fails, populate all descriptor set pointers with `VK_NULL_HANDLE`. In addition, 
   return `VK_ERROR_FRAGMENTED_POOL` if failure was due to pool fragmentation.
+- `vkUpdateDescriptorSets()`: Per Vulkan spec, allow write or copy beyond the 
+  end of a descriptor binding count, including inline uniform block descriptors.
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
 - Ensure all MoltenVK config info set by `VK_EXT_layer_settings` is used.
 - Move primitive-restart-disabled warning from renderpass to pipeline creation, to reduce voluminous log noise.

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -82,7 +82,6 @@ void MVKMTLBufferAllocationPool::returnAllocation(MVKMTLBufferAllocation* ba) {
     }
 }
 
-
 MVKMTLBufferAllocationPool::MVKMTLBufferAllocationPool(MVKDevice* device, NSUInteger allocationLength, bool makeThreadSafe,
 													   bool isDedicated, MTLStorageMode mtlStorageMode) :
 	MVKObjectPool<MVKMTLBufferAllocation>(true),

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -381,18 +381,33 @@ public:
 
 	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstOffset, 	// Inline buffers use this parameter as an offset, not an index
+			   uint32_t dstIdx,
 			   uint32_t srcIdx,
 			   size_t srcStride,
-			   const void* pData) override;
+			   const void* pData) override {}
 
 	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t srcOffset, // For inline buffers we are using this parameter as src offset not as dst descIdx
+			  uint32_t dstIndex,
 			  VkDescriptorImageInfo* pImageInfo,
 			  VkDescriptorBufferInfo* pBufferInfo,
 			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override {}
+
+	uint32_t writeBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+						MVKDescriptorSet* mvkDescSet,
+						uint32_t dstOffset,
+						uint32_t srcOffset,
+						uint32_t byteCount,
+						const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
+
+	uint32_t readBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+					   MVKDescriptorSet* mvkDescSet,
+					   uint32_t dstOffset,
+					   uint32_t srcOffset,
+					   uint32_t byteCount,
+					   const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
+
 
 	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
 							 MVKDescriptorSetLayoutBinding* mvkDSLBind,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -129,7 +129,7 @@ protected:
 	void propagateDebugName() override {}
 	uint32_t getDescriptorCount(uint32_t variableDescriptorCount);
 	uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return getBinding(binding)->getDescriptorIndex(elementIndex); }
-	MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding) { return &_bindings[_bindingToIndex[binding]]; }
+	MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding, uint32_t bindingIndexOffset = 0);
 	uint32_t getBufferSizeBufferArgBuferIndex() { return 0; }
 	id <MTLArgumentEncoder> getMTLArgumentEncoder(uint32_t variableDescriptorCount);
 	uint64_t getMetal3ArgumentBufferEncodedLength(uint32_t variableDescriptorCount);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -350,6 +350,17 @@ uint32_t MVKDescriptorSetLayout::getDescriptorCount(uint32_t variableDescriptorC
 	return descCnt;
 }
 
+MVKDescriptorSetLayoutBinding* MVKDescriptorSetLayout::getBinding(uint32_t binding, uint32_t bindingIndexOffset) {
+	auto itr = _bindingToIndex.find(binding);
+	if (itr != _bindingToIndex.end()) {
+		uint32_t bindIdx = itr->second + bindingIndexOffset;
+		if (bindIdx < _bindings.size()) {
+			return &_bindings[bindIdx];
+		}
+	}
+	return nullptr;
+}
+
 MVKDescriptorSetLayout::MVKDescriptorSetLayout(MVKDevice* device,
                                                const VkDescriptorSetLayoutCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
 
@@ -430,21 +441,32 @@ void MVKDescriptorSet::write(const DescriptorAction* pDescriptorAction,
 							 size_t srcStride,
 							 const void* pData) {
 
-	MVKDescriptorSetLayoutBinding* mvkDSLBind = _layout->getBinding(pDescriptorAction->dstBinding);
-	VkDescriptorType descType = mvkDSLBind->getDescriptorType();
-	if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		// For inline buffers dstArrayElement is a byte offset
-		getDescriptor(pDescriptorAction->dstBinding)->write(mvkDSLBind, this, pDescriptorAction->dstArrayElement, 0, srcStride, pData);
+	auto* mvkDSLBind = _layout->getBinding(pDescriptorAction->dstBinding);
+	if (mvkDSLBind->getDescriptorType() == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+		// For inline buffers, descriptorCount is a byte count and dstArrayElement is a byte offset.
+		// If needed, Vulkan allows updates to extend into subsequent bindings that are of the same type,
+		// so iterate layout bindings and their associated descriptors, until all bytes are updated.
+		const auto* pInlineUniformBlock = (VkWriteDescriptorSetInlineUniformBlockEXT*)pData;
+		uint32_t numBytesToCopy = pDescriptorAction->descriptorCount;
+		uint32_t dstOffset = pDescriptorAction->dstArrayElement;
+		uint32_t srcOffset = 0;
+		while (mvkDSLBind && numBytesToCopy > 0 && srcOffset < pInlineUniformBlock->dataSize) {
+			auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)_descriptors[mvkDSLBind->_descriptorIndex];
+			auto numBytesMoved = mvkDesc->writeBytes(mvkDSLBind, this, dstOffset, srcOffset, numBytesToCopy, pInlineUniformBlock);
+			numBytesToCopy -= numBytesMoved;
+			dstOffset = 0;
+			srcOffset += numBytesMoved;
+			mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(), 1);	// Next binding if needed
+		}
 	} else {
-		uint32_t dslBindDescCnt = mvkDSLBind->getDescriptorCount(_variableDescriptorCount);
+		// We don't test against the descriptor count of the binding, because Vulkan allows
+		// updates to extend into subsequent bindings that are of the same type, if needed.
 		uint32_t srcElemIdx = 0;
 		uint32_t dstElemIdx = pDescriptorAction->dstArrayElement;
-		uint32_t descIdx    = _layout->getDescriptorIndex(pDescriptorAction->dstBinding, dstElemIdx);
-		if (dstElemIdx < dslBindDescCnt) {
-			uint32_t elemCnt = std::min(pDescriptorAction->descriptorCount, dslBindDescCnt - dstElemIdx);
-			while (srcElemIdx < elemCnt) {
-				_descriptors[descIdx++]->write(mvkDSLBind, this, dstElemIdx++, srcElemIdx++, srcStride, pData);
-			}
+		uint32_t descIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding, dstElemIdx);
+		uint32_t descCnt = pDescriptorAction->descriptorCount;
+		while (srcElemIdx < descCnt) {
+			_descriptors[descIdx++]->write(mvkDSLBind, this, dstElemIdx++, srcElemIdx++, srcStride, pData);
 		}
 	}
 }
@@ -458,18 +480,29 @@ void MVKDescriptorSet::read(const VkCopyDescriptorSet* pDescriptorCopy,
 	MVKDescriptorSetLayoutBinding* mvkDSLBind = _layout->getBinding(pDescriptorCopy->srcBinding);
 	VkDescriptorType descType = mvkDSLBind->getDescriptorType();
     if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		// For inline buffers srcArrayElement is a byte offset
-		getDescriptor(pDescriptorCopy->srcBinding)->read(mvkDSLBind, this, pDescriptorCopy->srcArrayElement, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
+		// For inline buffers, descriptorCount is a byte count and dstArrayElement is a byte offset.
+		// If needed, Vulkan allows updates to extend into subsequent bindings that are of the same type,
+		// so iterate layout bindings and their associated descriptors, until all bytes are updated.
+		uint32_t numBytesToCopy = pDescriptorCopy->descriptorCount;
+		uint32_t dstOffset = 0;
+		uint32_t srcOffset = pDescriptorCopy->srcArrayElement;
+		while (mvkDSLBind && numBytesToCopy > 0 && dstOffset < pInlineUniformBlock->dataSize) {
+			auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)_descriptors[mvkDSLBind->_descriptorIndex];
+			auto numBytesMoved = mvkDesc->readBytes(mvkDSLBind, this, dstOffset, srcOffset, numBytesToCopy, pInlineUniformBlock);
+			numBytesToCopy -= numBytesMoved;
+			dstOffset += numBytesMoved;
+			srcOffset = 0;
+			mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(), 1);	// Next binding if needed
+		}
     } else {
-		uint32_t dslBindDescCnt = mvkDSLBind->getDescriptorCount(_variableDescriptorCount);
-		uint32_t dstElemIdx = 0;
+		// We don't test against the descriptor count of the binding, because Vulkan allows
+		// updates to extend into subsequent bindings that are of the same type, if needed.
 		uint32_t srcElemIdx = pDescriptorCopy->srcArrayElement;
-		uint32_t descIdx    = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding, srcElemIdx);
-		if (srcElemIdx < dslBindDescCnt) {
-			uint32_t elemCnt = std::min(pDescriptorCopy->descriptorCount, dslBindDescCnt - srcElemIdx);
-			while (dstElemIdx < elemCnt) {
-				_descriptors[descIdx++]->read(mvkDSLBind, this, dstElemIdx++, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
-			}
+		uint32_t dstElemIdx = 0;
+		uint32_t descIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding, srcElemIdx);
+		uint32_t descCnt = pDescriptorCopy->descriptorCount;
+		while (dstElemIdx < descCnt) {
+			_descriptors[descIdx++]->read(mvkDSLBind, this, dstElemIdx++, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
 		}
     }
 }


### PR DESCRIPTION
- Revert to allowing `vkUpdateDescriptorSets()` to write or copy beyond the end of a descriptor binding count if subsequent descriptors are of the same type. This fixes a regression caused by 7fe7423 in PR #2293, that added a guard against writing or copying past a descriptor binding size.

- Add `MVKInlineUniformBlockDescriptor::writeBytes()` & `readBytes()` to support updating byte contents, and allow `vkUpdateDescriptorSets()` to break a write or copy of a large byte range into multiple inline uniform block descriptors of smaller size.