### PR TITLE
Fixes to vkCmdPushDescriptorSetWithTemplateKHR().

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,6 +28,8 @@ Released TBD
 - Update `VkFormat` capabilities based on latest Metal docs.
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
 - Fix race condition when `VkImage` destroyed while used by descriptor.
+- Fix crash in `vkCmdPushDescriptorSetWithTemplateKHR()` when entries in 
+  `VkDescriptorUpdateTemplateCreateInfo` are not sorted by offset.
 - Ensure all MoltenVK config info set by `VK_EXT_layer_settings` is used.
 - Move primitive-restart-disabled warning from renderpass to pipeline creation, to reduce voluminous log noise.
 - iOS: Support storage images in _Metal_ argument buffers.

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.h
@@ -298,10 +298,11 @@ public:
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
-	MVKDescriptorUpdateTemplate* _descUpdateTemplate;
+	MVKDescriptorUpdateTemplate* _descUpdateTemplate = nullptr;
 	MVKPipelineLayout* _pipelineLayout = nullptr;
 	void* _pData = nullptr;
-	uint32_t _set;
+	size_t _dataSize = 0;
+	uint32_t _set = 0;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -339,6 +339,9 @@ public:
 	/** Get the total number of entries. */
 	uint32_t getNumberOfEntries() const;
 
+	/** Get the total number of bytes of data requried by this template. */
+	size_t getSize() const { return _size; }
+
 	/** Get the type of this template. */
 	VkDescriptorUpdateTemplateType getType() const;
 
@@ -354,9 +357,10 @@ public:
 protected:
 	void propagateDebugName() override {}
 
+	MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
+	size_t _size = 0;
 	VkPipelineBindPoint _pipelineBindPoint;
 	VkDescriptorUpdateTemplateType _type;
-	MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
 };
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Utility/MVKFoundation.h
+++ b/MoltenVK/MoltenVK/Utility/MVKFoundation.h
@@ -571,13 +571,22 @@ static void mvkClear(const T* pVal, size_t count = 1) { mvkClear((T*)pVal, count
 /**
  * If pSrc and pDst are both not null, copies the contents of the source value to the
  * destination value. The optional count allows copying of multiple elements in an array.
+ * Supports void pointers, and copies single values via direct assignment.
  */
 template<typename T>
 static void mvkCopy(T* pDst, const T* pSrc, size_t count = 1) {
-	if ( !pDst || !pSrc ) { return; }			// Bad pointers
-	if (pDst == pSrc) { return; }				// Same object
-	if constexpr(std::is_arithmetic_v<T>) { if (count == 1) { *pDst = *pSrc; } }  // Fast copy of a single primitive
-	memcpy(pDst, pSrc, sizeof(T) * count);		// Memory copy of complex content or array
+	if ( !pDst || !pSrc ) { return; }				// Bad pointers
+	if (pDst == pSrc) { return; }					// Same object
+
+	if constexpr(std::is_void_v<T>) {
+		memcpy(pDst, pSrc, count);					// Copy as bytes
+	} else {
+		if (count == 1) {
+			*pDst = *pSrc;  						// Fast copy of a single value
+		} else {
+			memcpy(pDst, pSrc, sizeof(T) * count);	// Memory copy of value array
+		}
+	}
 }
 
 /**

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -3121,7 +3121,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetKHR(
 
 MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
     VkCommandBuffer                            commandBuffer,
-    VkDescriptorUpdateTemplate              descriptorUpdateTemplate,
+    VkDescriptorUpdateTemplate                 descriptorUpdateTemplate,
     VkPipelineLayout                           layout,
     uint32_t                                   set,
     const void*                                pData) {


### PR DESCRIPTION
- Fix crash when entries in `VkDescriptorUpdateTemplateCreateInfo` are not sorted by offset.
- `MVKCmdPushDescriptorSetWithTemplate` allocate new data memory only if existing memory allocation is too small.
- `mvkCopy()` support void pointers, and copy a single value directly.

Fixes issue #2323.