### PR TITLE
Fixes to enable running on tvOS 13

### DIFF
--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -2561,6 +2561,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_DYLIB_INSTALL_NAME = "@rpath/${PRODUCT_NAME}.framework/${PRODUCT_NAME}";
 				OTHER_LDFLAGS = (
+					"-ld_classic",
 					"-all_load",
 					"-w",
 				);
@@ -2574,6 +2575,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_DYLIB_INSTALL_NAME = "@rpath/${PRODUCT_NAME}.framework/${PRODUCT_NAME}";
 				OTHER_LDFLAGS = (
+					"-ld_classic",
 					"-all_load",
 					"-w",
 				);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
@@ -163,6 +163,7 @@ kernel void cmdResolveColorImage2DFloat(texture2d<float, access::write> dst [[ t
     dst.write(src.read(pos, 0), pos);                                                                           \n\
 }                                                                                                               \n\
                                                                                                                 \n\
+#if __HAVE_TEXTURE_2D_MS_ARRAY__                                                                                \n\
 kernel void cmdResolveColorImage2DFloatArray(texture2d_array<float, access::write> dst [[ texture(0) ]],        \n\
                                              texture2d_ms_array<float, access::read> src [[ texture(1) ]],      \n\
                                              uint2 pos [[thread_position_in_grid]]) {                           \n\
@@ -170,6 +171,7 @@ kernel void cmdResolveColorImage2DFloatArray(texture2d_array<float, access::writ
         dst.write(src.read(pos, i, 0), pos, i);                                                                 \n\
     }                                                                                                           \n\
 }                                                                                                               \n\
+#endif                                                                                                          \n\
                                                                                                                 \n\
 kernel void cmdResolveColorImage2DUInt(texture2d<uint, access::write> dst [[ texture(0) ]],                     \n\
                                        texture2d_ms<uint, access::read> src [[ texture(1) ]],                   \n\
@@ -177,6 +179,7 @@ kernel void cmdResolveColorImage2DUInt(texture2d<uint, access::write> dst [[ tex
     dst.write(src.read(pos, 0), pos);                                                                           \n\
 }                                                                                                               \n\
                                                                                                                 \n\
+#if __HAVE_TEXTURE_2D_MS_ARRAY__                                                                                \n\
 kernel void cmdResolveColorImage2DUIntArray(texture2d_array<uint, access::write> dst [[ texture(0) ]],          \n\
                                             texture2d_ms_array<uint, access::read> src [[ texture(1) ]],        \n\
                                             uint2 pos [[thread_position_in_grid]]) {                            \n\
@@ -184,6 +187,7 @@ kernel void cmdResolveColorImage2DUIntArray(texture2d_array<uint, access::write>
         dst.write(src.read(pos, i, 0), pos, i);                                                                 \n\
     }                                                                                                           \n\
 }                                                                                                               \n\
+#endif                                                                                                          \n\
                                                                                                                 \n\
 kernel void cmdResolveColorImage2DInt(texture2d<int, access::write> dst [[ texture(0) ]],                       \n\
                                       texture2d_ms<int, access::read> src [[ texture(1) ]],                     \n\
@@ -191,6 +195,7 @@ kernel void cmdResolveColorImage2DInt(texture2d<int, access::write> dst [[ textu
     dst.write(src.read(pos, 0), pos);                                                                           \n\
 }                                                                                                               \n\
                                                                                                                 \n\
+#if __HAVE_TEXTURE_2D_MS_ARRAY__                                                                                \n\
 kernel void cmdResolveColorImage2DIntArray(texture2d_array<int, access::write> dst [[ texture(0) ]],            \n\
                                            texture2d_ms_array<int, access::read> src [[ texture(1) ]],          \n\
                                            uint2 pos [[thread_position_in_grid]]) {                             \n\
@@ -198,6 +203,7 @@ kernel void cmdResolveColorImage2DIntArray(texture2d_array<int, access::write> d
         dst.write(src.read(pos, i, 0), pos, i);                                                                 \n\
     }                                                                                                           \n\
 }                                                                                                               \n\
+#endif                                                                                                          \n\
                                                                                                                 \n\
 typedef struct {                                                                                                \n\
     uint32_t srcRowStride;                                                                                      \n\


### PR DESCRIPTION
Two parts:

* SPIRV-Cross uses std::stable_sort, and on tvOS using the new linker, this causes a crash: https://forums.developer.apple.com/forums/thread/742470. A workaround is to use the old linker with the flag `-ld_classic`.
* #2132 causes compilation problems on tvOS 13 because `texture2d_ms_array` is not available.