### PR TITLE
Add support for RGB10A2Unorm and BGR10A2Unorm formats on ios/tvos

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1593,10 +1593,8 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 	addSurfFmt(BGRA8Unorm);
 	addSurfFmt(BGRA8Unorm_sRGB);
 	addSurfFmt(RGBA16Float);
-#if MVK_MACOS
 	addSurfFmt(RGB10A2Unorm);
 	addSurfFmt(BGR10A2Unorm);
-#endif
 #if MVK_APPLE_SILICON
 	addSurfFmt(BGRA10_XR);
 	addSurfFmt(BGRA10_XR_sRGB);


### PR DESCRIPTION
The Apple documentation is ambiguous on exactly when these formats were added to iOS and tvOS, but it was sometime around tvOS 11. They are definitely available in iOS/tvOS 13+.