### PR TITLE
Support disabling logging GLSL shader code during shader conversion logging.

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -426,6 +426,28 @@ the viewport, in which case this parameter can be disabled.
 
 
 ---------------------------------------
+#### MVK_CONFIG_SHADER_DUMP_DIR
+
+##### Type: String
+##### Default: `""`
+
+_(The default value is an empty string)._
+
+If not empty, **MoltenVK** will dump all SPIR-V shaders, compiled MSL shaders, and pipeline shader lists to the given directory.
+The directory will be non-recursively created if it doesn't already exist.
+
+
+---------------------------------------
+#### MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL
+
+##### Type: Boolean
+##### Default: `0`
+
+If the `MVK_CONFIG_DEBUG` parameter is enabled, and this parameter is enabled, when 
+SPIR-V code is converted to MSL, an estimate of the equivalent GLSL shader will be logged.
+
+
+---------------------------------------
 #### MVK_CONFIG_SHOULD_MAXIMIZE_CONCURRENT_COMPILATION
 
 ##### Type: Boolean
@@ -613,6 +635,20 @@ cases improves performance.
 
 
 ---------------------------------------
+#### MVK_CONFIG_USE_METAL_PRIVATE_API
+
+##### Type: Boolean
+##### Default: Value of `MVK_USE_METAL_PRIVATE_API`
+
+If enabled, **MoltenVK** will _use_ private interfaces exposed by _Metal_ to implement _Vulkan_
+features that are difficult to support otherwise.
+
+Unlike `MVK_USE_METAL_PRIVATE_API`, this setting may be overridden at run time.
+
+This option is not available unless **MoltenVK** was built with `MVK_USE_METAL_PRIVATE_API` set to `1`.
+
+
+---------------------------------------
 #### MVK_CONFIG_USE_MTLHEAP
 
 ##### Type: Boolean
@@ -648,29 +684,3 @@ Determines the style used to implement _Vulkan_ semaphore (`VkSemaphore`) functi
 
 In the special case of `VK_SEMAPHORE_TYPE_TIMELINE` semaphores, **MoltenVK** will always use
 `MTLSharedEvent` if it is available on the platform, regardless of the value of this parameter.
-
-
----------------------------------------
-#### MVK_CONFIG_USE_METAL_PRIVATE_API
-
-##### Type: Boolean
-##### Default: Value of `MVK_USE_METAL_PRIVATE_API`
-
-If enabled, **MoltenVK** will _use_ private interfaces exposed by _Metal_ to implement _Vulkan_
-features that are difficult to support otherwise.
-
-Unlike `MVK_USE_METAL_PRIVATE_API`, this setting may be overridden at run time.
-
-This option is not available unless **MoltenVK** was built with `MVK_USE_METAL_PRIVATE_API` set to `1`.
-
-
----------------------------------------
-#### MVK_CONFIG_SHADER_DUMP_DIR
-
-##### Type: String
-##### Default: `""`
-
-_(The default value is an empty string)._
-
-If not empty, **MoltenVK** will dump all SPIR-V shaders, compiled MSL shaders, and pipeline shader lists to the given directory.
-The directory will be non-recursively created if it doesn't already exist.

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -45,7 +45,10 @@ Released 2024-09-24
 - Only add present handler if `VK_GOOGLE_display_timing` info is available during presentation.
 - Move primitive-restart-disabled warning from renderpass to pipeline creation, to reduce voluminous log noise.
 - iOS: Support storage images in _Metal_ argument buffers.
+- Add `MVKConfiguration::shaderLogEstimatedGLSL`, and environment variable `MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL`, 
+  to enable or disable the logging of estimated _GLSL_ code, and disable it by default
 - Update dependency libraries to match _Vulkan SDK 1.3.295_.
+- Update `MVK_PRIVATE_API_VERSION` to version `43`.
 
 
 

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -44,7 +44,7 @@ typedef unsigned long MTLArgumentBuffersTier;
  */
 
 
-#define MVK_PRIVATE_API_VERSION   42
+#define MVK_PRIVATE_API_VERSION   43
 
 
 #pragma mark -
@@ -238,6 +238,7 @@ typedef struct {
 	float timestampPeriodLowPassAlpha;                                         /**< MVK_CONFIG_TIMESTAMP_PERIOD_LOWPASS_ALPHA */
 	VkBool32 useMetalPrivateAPI;                                               /**< MVK_CONFIG_USE_METAL_PRIVATE_API */
 	const char* shaderDumpDir;                                                 /**< MVK_CONFIG_SHADER_DUMP_DIR */
+	VkBool32 shaderLogEstimatedGLSL;                                           /**< MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL */
 } MVKConfiguration;
 
 // Legacy support for renamed struct elements.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -361,8 +361,9 @@ MVKMTLFunction MVKShaderModule::getMTLFunction(SPIRVToMSLConversionConfiguration
 
 bool MVKShaderModule::convert(SPIRVToMSLConversionConfiguration* pShaderConfig,
 							  SPIRVToMSLConversionResult& conversionResult) {
-	bool shouldLogCode = getMVKConfig().debugMode;
-	bool shouldLogEstimatedGLSL = shouldLogCode;
+	const auto& mvkCfg = getMVKConfig();
+	bool shouldLogCode = mvkCfg.debugMode;
+	bool shouldLogEstimatedGLSL = shouldLogCode && mvkCfg.shaderLogEstimatedGLSL;
 
 	// If the SPIR-V converter does not have any code, but the GLSL converter does,
 	// convert the GLSL code to SPIR-V and set it into the SPIR-V conveter.

--- a/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
+++ b/MoltenVK/MoltenVK/Utility/MVKConfigMembers.def
@@ -84,6 +84,7 @@ MVK_CONFIG_MEMBER(shouldMaximizeConcurrentCompilation,    VkBool32,             
 MVK_CONFIG_MEMBER(timestampPeriodLowPassAlpha,            float,                                    TIMESTAMP_PERIOD_LOWPASS_ALPHA)
 MVK_CONFIG_MEMBER(useMetalPrivateAPI,                     VkBool32,                                 USE_METAL_PRIVATE_API)
 MVK_CONFIG_MEMBER_STRING(shaderDumpDir,                   char*,                                    SHADER_DUMP_DIR)
+MVK_CONFIG_MEMBER(shaderLogEstimatedGLSL,                 VkBool32,                                 SHADER_LOG_ESTIMATED_GLSL)
 
 #undef MVK_CONFIG_MEMBER
 #undef MVK_CONFIG_MEMBER_STRING
@@ -99,5 +100,5 @@ MVK_CONFIG_MEMBER_STRING(shaderDumpDir,                   char*,                
  * Once  MVKConfiguration and the list above are in agreement, it may be necessary to modify
  * this value if the internal padding has changed as a result of new MVKConfiguration members.
  */
-#define kMVKConfigurationInternalPaddingByteCount  4
+#define kMVKConfigurationInternalPaddingByteCount  8
 

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -362,3 +362,11 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #   define MVK_CONFIG_SHADER_DUMP_DIR ""
 #endif
 
+/**
+ * Enable logging estimated GLSL code during shader conversion.
+ * Disabled by default.
+ */
+#ifndef MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL
+#	define MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL		0
+#endif
+


### PR DESCRIPTION
Logging estimated GLSL shader code by default clutters the log with info that is not necessarily helpful, and it can occasionally result in a crash during the generation of GLSL, even though the MSL is correctly generated.

- Add `MVKConfiguration::shaderLogEstimatedGLSL`, and environment variable `MVK_CONFIG_SHADER_LOG_ESTIMATED_GLSL`, to enable or disable the logging of estimated GLSL code, and disable it by default.
- Clean up alphabetic order of `MoltenVK_Configuration_Parameters.md` doc.