### PR TITLE
Fix shader conversion failure when using storage images

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -28,15 +28,16 @@ Released 2024-09-24
 - Update `VkFormat` capabilities based on latest Metal docs.
 - Ensure all MoltenVK config info set by `VK_EXT_layer_settings` is used.
 - Support storage images in Metal argument buffers on _iOS_.
+- `vkUpdateDescriptorSets()`: Support writing beyond descriptor binding size if subsequent bindings are of same type.
 - Fix rendering issue with render pass that immediately follows a kernel dispatch.
 - Fix race condition when `VkImage` destroyed while used by descriptor.
 - Fix crash in `vkCmdPushDescriptorSetWithTemplateKHR()` when entries in 
   `VkDescriptorUpdateTemplateCreateInfo` are not sorted by offset.
 - Fix issue where `vkQueueWaitIdle()` and `vkDeviceWaitIdle()` were not 
   waiting for all commands to be enqueued before enqueuing wait operation.
+- Fix shader conversion failure when using storage images on _iOS_ & _tvOS_ with Tier 1 argument buffer support.
 - Fix memory leak in debug utils messenger.
 - Fix build failure on _VisionOS 2.0_ platform.
-- `vkUpdateDescriptorSets()`: Support writing beyond descriptor binding size if subsequent bindings are of same type.
 - Support `VK_FORMAT_A2B10G10R10_UNORM_PACK32` and `VK_FORMAT_A2R10G10B10_UNORM_PACK32` formats as surface formats on all platforms.
 - Add `MTLStoreAction` mapping for `VK_ATTACHMENT_STORE_OP_NONE`.
 - Add estimate of `presentMargin` in returned data from `vkGetPastPresentationTimingGOOGLE()`.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -724,13 +724,6 @@ if (isUsingMtlArgBuff) {									\
 			setResourceIndexOffset(textureIndex, 1);
 			if (!getMetalFeatures().nativeTextureAtomics) { setResourceIndexOffset(bufferIndex, 1); }
 
-#if MVK_IOS_OR_TVOS
-			// iOS Tier 1 argument buffers do not support writable images.
-			if (getMetalFeatures().argumentBuffersTier < MTLArgumentBuffersTier2) {
-				_layout->_canUseMetalArgumentBuffer = false;
-			}
-#endif
-
 			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
 				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
 			}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -133,6 +133,7 @@ protected:
 	uint32_t getBufferSizeBufferArgBuferIndex() { return 0; }
 	id <MTLArgumentEncoder> getMTLArgumentEncoder(uint32_t variableDescriptorCount);
 	uint64_t getMetal3ArgumentBufferEncodedLength(uint32_t variableDescriptorCount);
+	bool checkCanUseArgumentBuffers(const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 	std::string getLogDescription();
 
 	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;


### PR DESCRIPTION
- `MVKDescriptorSetLayout`: Test for iOS & tvOS Tier 1 storage images in any binding before construction of `MVKDescriptorSetLayoutBindings`.


Fixes issue #2329.