### PR TITLE
Improve fetchDependencies

### DIFF
--- a/fetchDependencies
+++ b/fetchDependencies
@@ -226,7 +226,7 @@ while (( "$#" )); do
          GLSLANG_ROOT=$2
          shift 2
          ;;
-       -*|--*=)
+       *)
          echo "Error: Unsupported option $1" >&2
          exit 1
          ;;


### PR DESCRIPTION
fetchDependencies can loop forever without any feedback to the user when leading `-` are missing.

Detected when running `./fetchDependencies macos` which is of course incorrect.

This is fixed by widening the wildcard for unsupported options.