### PR TITLE
Fix some random crashes when using metal argument buffers

### DIFF
--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -155,7 +155,7 @@ public:
 	bool enumerateEnabledBits(bool shouldClear, std::function<bool(size_t bitIndex)> func) {
 		for (size_t bitIdx = getIndexOfFirstSetBit(shouldClear);
 			 bitIdx < _bitCount;
-			 getIndexOfFirstSetBit(++bitIdx, shouldClear)) {
+			 bitIdx = getIndexOfFirstSetBit(++bitIdx, shouldClear)) {
 
 			if ( !func(bitIdx) ) { return false; }
 		}


### PR DESCRIPTION
Commit should fix a bug with the loop iteration in `enumerateEnabledBits()`. It would jump to the first set bit, then iterate over EVERY subsequent bit, instead of only iterating over bits that were set

Discovered this after a lot of time debugging random crashes in MoltenVK 1.2.11, that would only happen with `MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS` enabled

What seemed to be happening was:`MVKDescriptorPool::allocateDescriptorSet()` would iterate over `_descriptorSetAvailablility` to find an empty set, but it would check sets that weren't freed yet. 
If one of those got picked, the new set is initialized on top of an existing one, essentially corrupting it. Odd behavior would happen after that, and the app would eventually crash trying to use the corrupted set

These crashes could only happen when using Metal Argument buffers, and using a pool with `VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT`

This is a pretty simple change, so hopefully it doesn't break anything :smiley: