### PR TITLE
Fix crash when VkDescriptorSetLayout is destroyed while descriptor set is in use.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -204,6 +204,8 @@ public:
 
 	MVKDescriptorSet(MVKDescriptorPool* pool);
 
+	~MVKDescriptorSet() override;
+
 protected:
 	friend class MVKDescriptorSetLayoutBinding;
 	friend class MVKDescriptorPool;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -538,6 +538,7 @@ VkResult MVKDescriptorSet::allocate(MVKDescriptorSetLayout* layout,
 									NSUInteger mtlArgBufferOffset,
 									id<MTLArgumentEncoder> mtlArgEnc) {
 	_layout = layout;
+	_layout->retain();
 	_variableDescriptorCount = variableDescriptorCount;
 	_argumentBuffer.setArgumentBuffer(_pool->_metalArgumentBuffer, mtlArgBufferOffset, mtlArgEnc);
 
@@ -574,6 +575,7 @@ VkResult MVKDescriptorSet::allocate(MVKDescriptorSetLayout* layout,
 }
 
 void MVKDescriptorSet::free(bool isPoolReset) {
+	if(_layout) { _layout->release(); }
 	_layout = nullptr;
 	_dynamicOffsetDescriptorCount = 0;
 	_variableDescriptorCount = 0;
@@ -611,6 +613,10 @@ void MVKDescriptorSet::encodeAuxBufferUsage(MVKResourcesCommandEncoderState* rez
 
 MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorPool* pool) : MVKVulkanAPIDeviceObject(pool->_device), _pool(pool) {
 	free(true);
+}
+
+MVKDescriptorSet::~MVKDescriptorSet() {
+	if(_layout) { _layout->release(); }
 }
 
 


### PR DESCRIPTION
Vulkan permits `VkDescriptorSetLayout` to be destroyed while descriptor set is in use, as long as `vkUpdateDescriptorSets()` is not called.

- `MVKDescriptorSet` retain() layout on allocation, and release() it on free.

Fixes #2356.