### PR TITLE
Disable unsupported Metal Pixel formats for iOS/tvOS Simulator

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2541,6 +2541,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.textureCompressionASTC_LDR = true;
 
 	_features.dualSrcBlend = true;
+	_features.depthClamp = true;
 
     if (supportsMTLGPUFamily(Apple3)) {
         _features.occlusionQueryPrecise = true;
@@ -2548,6 +2549,7 @@ void MVKPhysicalDevice::initFeatures() {
 
 	if (supportsMTLGPUFamily(Apple3)) {
 		_features.tessellationShader = true;
+		_features.shaderTessellationAndGeometryPointSize = true;
 	}
 #endif
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -1595,7 +1595,7 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 	addSurfFmt(RGBA16Float);
 	addSurfFmt(RGB10A2Unorm);
 	addSurfFmt(BGR10A2Unorm);
-#if MVK_APPLE_SILICON
+#if MVK_APPLE_SILICON && !MVK_OS_SIMULATOR
 	addSurfFmt(BGRA10_XR);
 	addSurfFmt(BGRA10_XR_sRGB);
 	addSurfFmt(BGR10_XR);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2146,11 +2146,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	if ( mvkOSVersionIsAtLeast(13.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
 		_metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
-#if MVK_OS_SIMULATOR
-		_metalFeatures.nativeTextureSwizzle = false;
-#else
 		_metalFeatures.nativeTextureSwizzle = true;
-#endif
+
 		if (supportsMTLGPUFamily(Apple3)) {
 			_metalFeatures.native3DCompressedTextures = true;
 		}
@@ -2448,9 +2445,10 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 	}
 
-// iOS and tvOS adjustments necessary when running on the simulator.
+// iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
 	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
+	_metalFeatures.nativeTextureSwizzle = false;
 #endif
 
 	// Argument buffers
@@ -2566,13 +2564,9 @@ void MVKPhysicalDevice::initFeatures() {
 
 	_features.dualSrcBlend = true;
 
-#if MVK_OS_SIMULATOR
-	_features.depthClamp = false;
-#else
 	if (supportsMTLGPUFamily(Apple2)) {
 		_features.depthClamp = true;
 	}
-#endif
 
 	if (supportsMTLGPUFamily(Apple3)) {
 		_features.tessellationShader = true;
@@ -2590,6 +2584,11 @@ void MVKPhysicalDevice::initFeatures() {
 	if (supportsMTLGPUFamily(Apple6)) {
         _features.shaderResourceMinLod = true;
 	}
+#endif
+
+// iOS, tvOS and visionOS adjustments necessary when running on the simulator.
+#if MVK_OS_SIMULATOR
+	_features.depthClamp = false;
 #endif
 
 #if MVK_MACOS

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -126,21 +126,6 @@ using namespace std;
 #       define MTLPixelFormatBC7_RGBAUnorm_sRGB     MTLPixelFormatInvalid
 #   endif
 
-#   if MVK_OS_SIMULATOR
-#       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
-#       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR5A1Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatGBGR422                MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRG422                MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR10_XR               MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR10_XR_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRA10_XR              MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRA10_XR_sRGB         MTLPixelFormatInvalid
-#   endif
-
 #   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth32Float_Stencil8
 #   define MTLPixelFormatDepth24Unorm_Stencil8      MTLPixelFormatInvalid
 #   define MTLPixelFormatX24_Stencil8               MTLPixelFormatInvalid
@@ -167,6 +152,21 @@ using namespace std;
 #       define MTLPixelFormatASTC_10x10_HDR         MTLPixelFormatInvalid
 #       define MTLPixelFormatASTC_12x10_HDR         MTLPixelFormatInvalid
 #       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
+#endif
+
+#if MVK_OS_SIMULATOR
+#   define MTLPixelFormatR8Unorm_sRGB               MTLPixelFormatInvalid
+#   define MTLPixelFormatRG8Unorm_sRGB              MTLPixelFormatInvalid
+#   define MTLPixelFormatB5G6R5Unorm                MTLPixelFormatInvalid
+#   define MTLPixelFormatA1BGR5Unorm                MTLPixelFormatInvalid
+#   define MTLPixelFormatABGR4Unorm                 MTLPixelFormatInvalid
+#   define MTLPixelFormatBGR5A1Unorm                MTLPixelFormatInvalid
+#   define MTLPixelFormatBGR10_XR                   MTLPixelFormatInvalid
+#   define MTLPixelFormatBGR10_XR_sRGB              MTLPixelFormatInvalid
+#   define MTLPixelFormatBGRA10_XR                  MTLPixelFormatInvalid
+#   define MTLPixelFormatBGRA10_XR_sRGB             MTLPixelFormatInvalid
+#   define MTLPixelFormatGBGR422                    MTLPixelFormatInvalid
+#   define MTLPixelFormatBGRG422                    MTLPixelFormatInvalid
 #endif
 
 #if !MVK_XCODE_15
@@ -1194,7 +1194,7 @@ void MVKPixelFormats::addValidatedMTLPixelFormatDesc(MTLPixelFormat mtlPixFmt, M
 
 #define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps, macGPUCaps)  \
 	addValidatedMTLPixelFormatDesc(MTLPixelFormat ##mtlFmt, MTLPixelFormat ##mtlFmtLinear, MVKMTLViewClass:: viewClass,  \
-								   appleGPUCaps, macGPUCaps, gpuCaps, "MTLPixelFormat" #mtlFmt)
+	                               appleGPUCaps, macGPUCaps, gpuCaps, "MTLPixelFormat" #mtlFmt)
 
 #define addMTLPixelFormatDesc(mtlFmt, viewClass, appleGPUCaps, macGPUCaps)  \
 	addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps)
@@ -1202,9 +1202,9 @@ void MVKPixelFormats::addValidatedMTLPixelFormatDesc(MTLPixelFormat mtlPixFmt, M
 #define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, macGPUCaps, mtlFmtLinear)  \
 	/* Cannot write to sRGB textures in the simulator */  \
 	if(MVK_OS_SIMULATOR) { MVKMTLFmtCaps appleFmtCaps = kMVKMTLFmtCaps ##appleGPUCaps;  \
-						   mvkDisableFlags(appleFmtCaps, kMVKMTLFmtCapsWrite);  \
-						   addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps, kMVKMTLFmtCaps ##macGPUCaps); }  \
-	else				 { addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps); }
+	                       mvkDisableFlags(appleFmtCaps, kMVKMTLFmtCapsWrite);  \
+	                       addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps, kMVKMTLFmtCaps ##macGPUCaps); }  \
+	else                 { addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps); }
 
 void MVKPixelFormats::initMTLPixelFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps) {
 	_mtlPixelFormatDescriptions.reserve(KIBI);	// High estimate to future-proof against allocations as elements are added. shrink_to_fit() below will collapse.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -126,6 +126,14 @@ using namespace std;
 #       define MTLPixelFormatBC7_RGBAUnorm_sRGB     MTLPixelFormatInvalid
 #   endif
 
+#   if MVK_OS_SIMULATOR
+#       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
+#       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
+#       define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
+#       define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
+#       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
+#   endif
+
 #   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth32Float_Stencil8
 #   define MTLPixelFormatDepth24Unorm_Stencil8      MTLPixelFormatInvalid
 #   define MTLPixelFormatX24_Stencil8               MTLPixelFormatInvalid

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -132,6 +132,13 @@ using namespace std;
 #       define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
 #       define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
 #       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
+#       define MTLPixelFormatBGR5A1Unorm            MTLPixelFormatInvalid
+#       define MTLPixelFormatGBGR422                MTLPixelFormatInvalid
+#       define MTLPixelFormatBGRG422                MTLPixelFormatInvalid
+#       define MTLPixelFormatBGR10_XR               MTLPixelFormatInvalid
+#       define MTLPixelFormatBGR10_XR_sRGB          MTLPixelFormatInvalid
+#       define MTLPixelFormatBGRA10_XR              MTLPixelFormatInvalid
+#       define MTLPixelFormatBGRA10_XR_sRGB         MTLPixelFormatInvalid
 #   endif
 
 #   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth32Float_Stencil8
@@ -1187,13 +1194,17 @@ void MVKPixelFormats::addValidatedMTLPixelFormatDesc(MTLPixelFormat mtlPixFmt, M
 
 #define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps, macGPUCaps)  \
 	addValidatedMTLPixelFormatDesc(MTLPixelFormat ##mtlFmt, MTLPixelFormat ##mtlFmtLinear, MVKMTLViewClass:: viewClass,  \
-								   kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps, gpuCaps, "MTLPixelFormat" #mtlFmt)
+								   appleGPUCaps, macGPUCaps, gpuCaps, "MTLPixelFormat" #mtlFmt)
 
 #define addMTLPixelFormatDesc(mtlFmt, viewClass, appleGPUCaps, macGPUCaps)  \
-	addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass, appleGPUCaps, macGPUCaps)
+	addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps)
 
 #define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, macGPUCaps, mtlFmtLinear)  \
-	addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps, macGPUCaps)
+	/* Cannot write to sRGB textures in the simulator */  \
+	if(MVK_OS_SIMULATOR) { MVKMTLFmtCaps appleFmtCaps = kMVKMTLFmtCaps ##appleGPUCaps;  \
+						   mvkDisableFlags(appleFmtCaps, kMVKMTLFmtCapsWrite);  \
+						   addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps, kMVKMTLFmtCaps ##macGPUCaps); }  \
+	else				 { addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps); }
 
 void MVKPixelFormats::initMTLPixelFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps) {
 	_mtlPixelFormatDescriptions.reserve(KIBI);	// High estimate to future-proof against allocations as elements are added. shrink_to_fit() below will collapse.
@@ -1515,6 +1526,9 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities
 	// be individually write-enabled during blending on macOS. Disabling blending
 	// on macOS is the least-intrusive way to handle this in a Vulkan-friendly way.
 	disableMTLPixFmtCapsIfGPU( Mac1, RGB9E5Float, Blend);
+
+	// RGB9E5Float cannot be used as a render target on the simulator
+	disableMTLPixFmtCapsIf( MVK_OS_SIMULATOR, RGB9E5Float, ColorAtt );
 
 	setMTLPixFmtCapsIf( iosOnly6, RG32Uint, RWC );
 	setMTLPixFmtCapsIf( iosOnly6, RG32Sint, RWC );


### PR DESCRIPTION
Defines certain unsupported Metal Pixel formats as invalid for the iOS/tvOS Simulator.  Fixes #2353 for MoltenVK 1.2.11.

I have tested this on an x86_64 host using Xcode 15.2 with the iOS Simulator (running iOS 17.2).  I can't test on tvOS so I would appreciate others (@warmenhoven) checking out this scenario.

Also, I am not sure whether the `#ifdef` condition should also contain an Xcode version test.  Perhaps @cdavis5e could weigh in on that aspect.  Thanks.