### PR TITLE
Fix SPIRV-Cross namespace build error on some alternate build environments.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,7 +18,8 @@ MoltenVK 1.2.12
 
 Released TBD
 
-
+- Fix _SPIRV-Cross_ namespace build error on some alternate build environments.
+- Fix recent failure of `CI.yml` to upload release build artifacts to GitHub.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -263,7 +263,7 @@ void MVKDescriptorSetLayout::populateShaderConversionConfig(mvk::SPIRVToMSLConve
 		MVKShaderStageResourceBinding buffBinding;
 		buffBinding.bufferIndex = getBufferSizeBufferArgBuferIndex();
 		populateAuxBuffer(shaderConfig, buffBinding, descSetIndex,
-						  MVK_spirv_cross::kBufferSizeBufferBinding,
+						  SPIRV_CROSS_NAMESPACE::kBufferSizeBufferBinding,
 						  getMetalFeatures().nativeTextureAtomics);
 	}
 


### PR DESCRIPTION
- Replace hardcoded reference to `MVK_spirv_cross` with `SPIRV_CROSS_NAMESPACE`.

Fixes #2365.