### PR TITLE
Fix a crash when searching the first enabled bit in a completely disabled bit array

### DIFF
--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "MVKFoundation.h"
+#include <functional>
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -105,6 +105,10 @@ public:
 			secIdx = _fullyDisabledSectionCount;
 			startIndex = 0;
 		}
+		/* If all bits are disabled and the number of bits is precisely a multiple of SectionBitCount,
+		 * then we'd be trying to access a section that doesn't exist, so we must bail out immediately. */
+		if (secIdx >= getSectionCount())
+			return _bitCount;
 		return std::min((secIdx * SectionBitCount) + getIndexOfFirstEnabledBitInSection(getSection(secIdx), getBitIndexInSection(startIndex)), _bitCount);
 	}
 

--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "MVKFoundation.h"
-#include <functional>
 
 
 #pragma mark -
@@ -105,10 +104,7 @@ public:
 			secIdx = _fullyDisabledSectionCount;
 			startIndex = 0;
 		}
-		/* If all bits are disabled and the number of bits is precisely a multiple of SectionBitCount,
-		 * then we'd be trying to access a section that doesn't exist, so we must bail out immediately. */
-		if (secIdx >= getSectionCount())
-			return _bitCount;
+		if (secIdx >= getSectionCount()) { return _bitCount; }
 		return std::min((secIdx * SectionBitCount) + getIndexOfFirstEnabledBitInSection(getSection(secIdx), getBitIndexInSection(startIndex)), _bitCount);
 	}
 


### PR DESCRIPTION
In some conditions the bit array ends up fetching a section that doesn't exist, one past the end of the array.