### PR TITLE
Fix Random Crashes when Using Pool with Freeable Descriptor Sets

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -761,7 +761,6 @@ VkResult MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL
 			// on a reset pool), set the offset and update the next available offset value.
 			if ( !mtlArgBuffOffset && (dsIdx || !_nextMetalArgumentBufferOffset)) {
 				mtlArgBuffOffset = _nextMetalArgumentBufferOffset;
-				_nextMetalArgumentBufferOffset += mtlArgBuffEncAlignedSize;
 			}
 
 			// Get the offset of the next desc set, if one exists and
@@ -780,6 +779,11 @@ VkResult MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL
 			} else {
 				_descriptorSetAvailablility.disableBit(dsIdx);
 				_maxAllocDescSetCount = std::max(_maxAllocDescSetCount, dsIdx + 1);
+				if ((dsIdx + 1) == _maxAllocDescSetCount)
+				{
+					// if this is the highest index set, update the next free arg buffer offset
+					_nextMetalArgumentBufferOffset = mtlArgBuffOffset + mtlArgBuffEncAlignedSize;
+				}
 				*pVKDS = (VkDescriptorSet)mvkDS;
 			}
 			return false;

--- a/MoltenVK/MoltenVK/Utility/MVKBitArray.h
+++ b/MoltenVK/MoltenVK/Utility/MVKBitArray.h
@@ -124,7 +124,7 @@ public:
 		for (size_t bitIdx = getIndexOfFirstEnabledBit();
 			 bitIdx < _bitCount;
 			 bitIdx = getIndexOfFirstEnabledBit(++bitIdx)) {
-
+			if ( !getBit(bitIdx)) { continue; }
 			if ( !func(bitIdx) ) { return false; }
 		}
 		return true;


### PR DESCRIPTION
Some small changes to fix crashes and random descriptor set issues I was running into when using a pool with `FREE_DESCRIPTOR_SET` enabled

First issue was caused by `_nextMetalArgumentBufferOffset` in the pool becoming out-of-date if the allocated set in the highest index is freed and re-used. Argument buffers of any size would be allowed to use that slot, but the offset wasn't adjusted, resulting in some argument buffer ranges overlapping

Eventually crashing with the error: `[mvk-error] VK_ERROR_OUT_OF_DEVICE_MEMORY: Lost VkDevice after MTLCommandBuffer "vkQueueSubmit MTLCommandBuffer on Queue 0-0 (0x406e75600)" execution failed (code 3): Caused GPU Address Fault Error (0000000b:kIOGPUCommandBufferCallbackErrorPageFault)`

Second issue is caused by a bug in `enumerateEnabledBits()` where it is enumerating bits that were disabled.
Specifically, in the case where `startIndex` is higher than the first enabled bit, but the next enabled bit is in a different section than `startIndex`, it looks like it just return the first index in the next section, instead of the next enabled bit.

I just added a quick fix so that the enumerate func checks whether the returned bit is enabled before calling the functor. More changes to the MVKBitArray functions might be called for, but I hope this is helpful 😄 