### PR TITLE
When logging a pipeline layout, log contained descriptor set layouts.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -158,7 +158,7 @@ public:
 	bool getApplyToStage(MVKShaderStage stage) { return _applyToStage[stage]; }
 
 	/** Returns a text description of this binding. */
-	std::string getLogDescription();
+	std::string getLogDescription(std::string indent = "");
 
 	MVKDescriptorSetLayoutBinding(MVKDevice* device,
 								  MVKDescriptorSetLayout* layout,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -587,7 +587,7 @@ MTLRenderStages MVKDescriptorSetLayoutBinding::getMTLRenderStages() {
 	return mtlStages;
 }
 
-std::string MVKDescriptorSetLayoutBinding::getLogDescription() {
+std::string MVKDescriptorSetLayoutBinding::getLogDescription(std::string indent) {
 	uint32_t elemCnt = getDescriptorCount();
 	std::stringstream descStr;
 	descStr << getDescriptorIndex() << ": ";

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -118,7 +118,7 @@ public:
 	bool needsBufferSizeAuxBuffer() { return _maxBufferIndex >= 0; }
 
 	/** Returns a text description of this layout. */
-	std::string getLogDescription();
+	std::string getLogDescription(std::string indent = "");
 
 	MVKDescriptorSetLayout(MVKDevice* device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 
@@ -285,7 +285,7 @@ public:
 	VkResult reset(VkDescriptorPoolResetFlags flags);
 
 	/** Returns a text description of this pool. */
-	std::string getLogDescription();
+	std::string getLogDescription(std::string indent = "");
 
 	MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -415,11 +415,12 @@ MVKDescriptorSetLayout::MVKDescriptorSetLayout(MVKDevice* device,
 	MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n", getLogDescription().c_str());
 }
 
-std::string MVKDescriptorSetLayout::getLogDescription() {
+std::string MVKDescriptorSetLayout::getLogDescription(std::string indent) {
 	std::stringstream descStr;
-	descStr << "VkDescriptorSetLayout " << this << " with " << _bindings.size() << " bindings:";
+	descStr << "VkDescriptorSetLayout with " << _bindings.size() << " bindings:";
+	auto bindIndent = indent + "\t";
 	for (auto& dlb : _bindings) {
-		descStr << "\n\t" << dlb.getLogDescription();
+		descStr << "\n" << bindIndent << dlb.getLogDescription(bindIndent);
 	}
 	return descStr.str();
 }
@@ -959,18 +960,19 @@ size_t MVKDescriptorPool::getPoolSize(const VkDescriptorPoolCreateInfo* pCreateI
 	return descCnt;
 }
 
-std::string MVKDescriptorPool::getLogDescription() {
+std::string MVKDescriptorPool::getLogDescription(std::string indent) {
 #define STR(name) #name
 #define printDescCnt(descType, spacing, descPool)  \
 	if (_##descPool##Descriptors.size()) {  \
-		descStr << "\n\t" STR(VK_DESCRIPTOR_TYPE_##descType) ": " spacing << _##descPool##Descriptors.size()  \
+		descStr << "\n" << descCntIndent << STR(VK_DESCRIPTOR_TYPE_##descType) ": " spacing << _##descPool##Descriptors.size()  \
 		<< "  (" << _##descPool##Descriptors.getRemainingDescriptorCount() << " remaining)"; }
 
 	std::stringstream descStr;
-	descStr << "VkDescriptorPool " << this;
-	descStr << " with " << _descriptorSetAvailablility.size() << " descriptor sets";
+	descStr << "VkDescriptorPool with " << _descriptorSetAvailablility.size() << " descriptor sets";
 	descStr << " (reset " << (mvkIsAnyFlagEnabled(_flags, VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT) ? "or free" : "only") << ")";
 	descStr << ", and pooled descriptors:";
+
+	auto descCntIndent = indent + "\t";
 	printDescCnt(UNIFORM_BUFFER, "          ", uniformBuffer);
 	printDescCnt(STORAGE_BUFFER, "          ", storageBuffer);
 	printDescCnt(UNIFORM_BUFFER_DYNAMIC, "  ", uniformBufferDynamic);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -80,7 +80,7 @@ public:
 	MVKDescriptorSetLayout* getDescriptorSetLayout(uint32_t descSetIndex) { return _descriptorSetLayouts[descSetIndex]; }
 
 	/** Returns a text description of this layout. */
-	std::string getLogDescription();
+	std::string getLogDescription(std::string indent = "");
 
 	/** Constructs an instance for the specified device. */
 	MVKPipelineLayout(MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -129,12 +129,13 @@ bool MVKPipelineLayout::stageUsesPushConstants(MVKShaderStage mvkStage) {
 	return false;
 }
 
-std::string MVKPipelineLayout::getLogDescription() {
+std::string MVKPipelineLayout::getLogDescription(std::string indent) {
 	std::stringstream descStr;
 	size_t dslCnt = _descriptorSetLayouts.size();
-	descStr << "VkPipelineLayout " << this << " with " << dslCnt << " descriptor set layouts:";
+	descStr << "VkPipelineLayout with " << dslCnt << " descriptor set layouts:";
+	auto descLayoutIndent = indent + "\t";
 	for (uint32_t dslIdx = 0; dslIdx < dslCnt; dslIdx++) {
-		descStr << "\n\t" << dslIdx << ": " << _descriptorSetLayouts[dslIdx];
+		descStr << "\n" << descLayoutIndent << dslIdx << ": " << _descriptorSetLayouts[dslIdx]->getLogDescription(descLayoutIndent);
 	}
 	return descStr.str();
 }


### PR DESCRIPTION
- Add support for passing an indent value to `getLogDescription()`.
- `MVKPipelineLayout::getLogDescription()` log descriptions of descriptor set layouts.