### PR TITLE
Clang-format proposal

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,49 @@
+# Indentation
+IndentWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+
+# Braces
+BreakBeforeBraces: Attach  # Braces attach to control statements (if, while, for)
+
+# Spacing
+SpaceBeforeParens: ControlStatements
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeAssignmentOperators: true
+
+# Line Breaking
+ColumnLimit: 80  # Larger column limit to prevent premature breaks
+PenaltyBreakBeforeFirstCallParameter: 1000  # Prevent breaking at the first call parameter
+PenaltyBreakString: 1000  # Prevent breaking strings
+PenaltyBreakComment: 1000  # Prevent breaking comments
+
+# Allow Short If-Statements, Loops, and Functions on a Single Line
+AllowShortIfStatementsOnASingleLine: true  # Keep short if-statements on a single line
+AllowShortLoopsOnASingleLine: true  # Keep short loops on a single line
+AllowShortFunctionsOnASingleLine: All  # Keep short functions on a single line
+
+# Comments
+AlignTrailingComments: true
+
+# Includes
+SortIncludes: false 
+
+# Objective-C
+ObjCSpaceBeforeProtocolList: true
+
+# Space in Parentheses
+SpacesInParens: Custom
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InConditionalStatements: false
+  Other: false
+
+# Pointer alignment
+PointerAlignment: Left
+
+# Prevent line break for very short blocks
+MaxEmptyLinesToKeep: 1  # Don't break up short blocks with many empty lines
+
+# Function formatting
+AlwaysBreakAfterReturnType: None  # Avoid breaking the return type of functions

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,108 +23,121 @@
 
 class MVKCommandEncoder;
 
-
 #pragma mark MVKBuffer
 
 /** Represents a Vulkan buffer. */
 class MVKBuffer : public MVKResource {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_BUFFER; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_BUFFER; }
-
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;
+    }
 
 #pragma mark Resource memory
 
-	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements);
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
+    VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements);
 
-	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
+    VkResult getMemoryRequirements(const void* pInfo,
+                                   VkMemoryRequirements2* pMemoryRequirements);
 
-	/** Binds this resource to the specified offset within the specified memory allocation. */
-	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                              VkDeviceSize memOffset) override;
 
-	/** Binds this resource to the specified offset within the specified memory allocation. */
-	VkResult bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo);
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    VkResult bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo);
 
-	/** Applies the specified global memory barrier. */
-	void applyMemoryBarrier(MVKPipelineBarrier& barrier,
-							MVKCommandEncoder* cmdEncoder,
-							MVKCommandUse cmdUse) override;
+    /** Applies the specified global memory barrier. */
+    void applyMemoryBarrier(MVKPipelineBarrier& barrier,
+                            MVKCommandEncoder* cmdEncoder,
+                            MVKCommandUse cmdUse) override;
 
-	/** Applies the specified buffer memory barrier. */
-	void applyBufferMemoryBarrier(MVKPipelineBarrier& barrier,
-								  MVKCommandEncoder* cmdEncoder,
-								  MVKCommandUse cmdUse);
+    /** Applies the specified buffer memory barrier. */
+    void applyBufferMemoryBarrier(MVKPipelineBarrier& barrier,
+                                  MVKCommandEncoder* cmdEncoder,
+                                  MVKCommandUse cmdUse);
 
     /** Returns the intended usage of this buffer. */
     VkBufferUsageFlags getUsage() const { return _usage; }
 
-
 #pragma mark Metal
 
-	/** Returns the Metal buffer underlying this memory allocation. */
+    /** Returns the Metal buffer underlying this memory allocation. */
     id<MTLBuffer> getMTLBuffer();
 
-	/** Returns the offset at which the contents of this instance starts within the underlying Metal buffer. */
-	inline NSUInteger getMTLBufferOffset() { return !_deviceMemory || _deviceMemory->getMTLHeap() ? 0 : _deviceMemoryOffset; }
+    /** Returns the offset at which the contents of this instance starts within
+     * the underlying Metal buffer. */
+    inline NSUInteger getMTLBufferOffset() {
+        return !_deviceMemory || _deviceMemory->getMTLHeap()
+                   ? 0
+                   : _deviceMemoryOffset;
+    }
 
-    /** Returns the Metal buffer used as a cache for host-coherent texel buffers. */
+    /** Returns the Metal buffer used as a cache for host-coherent texel
+     * buffers. */
     id<MTLBuffer> getMTLBufferCache();
-    
-	/** Returns the GPU address for this MTLBuffer, respecting its offset. */
-	uint64_t getMTLBufferGPUAddress();
+
+    /** Returns the GPU address for this MTLBuffer, respecting its offset. */
+    uint64_t getMTLBufferGPUAddress();
 
 #pragma mark Construction
-	
-	MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo);
 
-	~MVKBuffer() override;
+    MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo);
 
-	void destroy() override;
+    ~MVKBuffer() override;
 
-protected:
-	friend class MVKDeviceMemory;
+    void destroy() override;
 
-	void propagateDebugName() override;
-	bool needsHostReadSync(MVKPipelineBarrier& barrier);
-    bool overlaps(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize &overlapOffset, VkDeviceSize &overlapSize);
-	bool shouldFlushHostMemory();
-	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
-	VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);
-	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
-	void detachMemory();
+  protected:
+    friend class MVKDeviceMemory;
 
-	VkBufferUsageFlags _usage;
-	bool _isHostCoherentTexelBuffer = false;
+    void propagateDebugName() override;
+    bool needsHostReadSync(MVKPipelineBarrier& barrier);
+    bool overlaps(VkDeviceSize offset, VkDeviceSize size,
+                  VkDeviceSize& overlapOffset, VkDeviceSize& overlapSize);
+    bool shouldFlushHostMemory();
+    VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
+    VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size);
+    void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
+    void detachMemory();
+
+    VkBufferUsageFlags _usage;
+    bool _isHostCoherentTexelBuffer = false;
     id<MTLBuffer> _mtlBufferCache = nil;
-	id<MTLBuffer> _mtlBuffer = nil;
+    id<MTLBuffer> _mtlBuffer = nil;
     std::mutex _lock;
 };
-
 
 #pragma mark MVKBufferView
 
 /** Represents a Vulkan buffer view. */
 class MVKBufferView : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_BUFFER_VIEW;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_BUFFER_VIEW; }
-
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT;
+    }
 
 #pragma mark Metal
 
     /** Returns a Metal texture that overlays this buffer view. */
     id<MTLTexture> getMTLTexture();
-
 
 #pragma mark Construction
 
@@ -132,18 +145,17 @@ public:
 
     ~MVKBufferView() override;
 
-	void destroy() override;
+    void destroy() override;
 
-protected:
-	void propagateDebugName() override;
-	void detachMemory();
+  protected:
+    void propagateDebugName() override;
+    void detachMemory();
 
     MVKBuffer* _buffer;
     NSUInteger _offset;
-	id<MTLTexture> _mtlTexture;
-	MTLPixelFormat _mtlPixelFormat;
-	NSUInteger _mtlBytesPerRow;
+    id<MTLTexture> _mtlTexture;
+    MTLPixelFormat _mtlPixelFormat;
+    NSUInteger _mtlBytesPerRow;
     VkExtent2D _textureSize;
-	std::mutex _lock;
+    std::mutex _lock;
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,89 +23,104 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKBuffer
 
 void MVKBuffer::propagateDebugName() {
-	if (!_debugName) { return; }
-	if (_deviceMemory &&
-		_deviceMemory->isDedicatedAllocation() &&
-		_deviceMemory->_debugName.length == 0) {
+    if (!_debugName) {
+        return;
+    }
+    if (_deviceMemory && _deviceMemory->isDedicatedAllocation() &&
+        _deviceMemory->_debugName.length == 0) {
 
-		_deviceMemory->setDebugName(_debugName.UTF8String);
-	}
-	setMetalObjectLabel(_mtlBuffer, _debugName);
+        _deviceMemory->setDebugName(_debugName.UTF8String);
+    }
+    setMetalObjectLabel(_mtlBuffer, _debugName);
 }
-
 
 #pragma mark Resource memory
 
-VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements) {
-	if (getMetalFeatures().placementHeaps) {
-		MTLSizeAndAlign sizeAndAlign = [getMTLDevice() heapBufferSizeAndAlignWithLength: getByteCount() 
-																				options: MTLResourceStorageModePrivate];
-		pMemoryRequirements->size = sizeAndAlign.size;
-		pMemoryRequirements->alignment = sizeAndAlign.align;
-	} else {
-		pMemoryRequirements->size = getByteCount();
-		pMemoryRequirements->alignment = _byteAlignment;
-	}
-	pMemoryRequirements->memoryTypeBits = getPhysicalDevice()->getAllMemoryTypes();
-	// Memoryless storage is not allowed for buffers
-	mvkDisableFlags(pMemoryRequirements->memoryTypeBits, getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
-	return VK_SUCCESS;
+VkResult
+MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements) {
+    if (getMetalFeatures().placementHeaps) {
+        MTLSizeAndAlign sizeAndAlign = [getMTLDevice()
+            heapBufferSizeAndAlignWithLength:getByteCount()
+                                     options:MTLResourceStorageModePrivate];
+        pMemoryRequirements->size = sizeAndAlign.size;
+        pMemoryRequirements->alignment = sizeAndAlign.align;
+    } else {
+        pMemoryRequirements->size = getByteCount();
+        pMemoryRequirements->alignment = _byteAlignment;
+    }
+    pMemoryRequirements->memoryTypeBits =
+        getPhysicalDevice()->getAllMemoryTypes();
+    // Memoryless storage is not allowed for buffers
+    mvkDisableFlags(pMemoryRequirements->memoryTypeBits,
+                    getPhysicalDevice()->getLazilyAllocatedMemoryTypes());
+    return VK_SUCCESS;
 }
 
-VkResult MVKBuffer::getMemoryRequirements(const void*, VkMemoryRequirements2* pMemoryRequirements) {
-	pMemoryRequirements->sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
-	getMemoryRequirements(&pMemoryRequirements->memoryRequirements);
-	for (auto* next = (VkBaseOutStructure*)pMemoryRequirements->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-		case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
-			auto* dedicatedReqs = (VkMemoryDedicatedRequirements*)next;
-			dedicatedReqs->requiresDedicatedAllocation = _requiresDedicatedMemoryAllocation;
-			dedicatedReqs->prefersDedicatedAllocation = dedicatedReqs->requiresDedicatedAllocation;
-			break;
-		}
-		default:
-			break;
-		}
-	}
-	return VK_SUCCESS;
+VkResult
+MVKBuffer::getMemoryRequirements(const void*,
+                                 VkMemoryRequirements2* pMemoryRequirements) {
+    pMemoryRequirements->sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
+    getMemoryRequirements(&pMemoryRequirements->memoryRequirements);
+    for (auto* next = (VkBaseOutStructure*)pMemoryRequirements->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
+            auto* dedicatedReqs = (VkMemoryDedicatedRequirements*)next;
+            dedicatedReqs->requiresDedicatedAllocation =
+                _requiresDedicatedMemoryAllocation;
+            dedicatedReqs->prefersDedicatedAllocation =
+                dedicatedReqs->requiresDedicatedAllocation;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return VK_SUCCESS;
 }
 
-VkResult MVKBuffer::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) {
-	if (_deviceMemory) { _deviceMemory->removeBuffer(this); }
+VkResult MVKBuffer::bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                     VkDeviceSize memOffset) {
+    if (_deviceMemory) {
+        _deviceMemory->removeBuffer(this);
+    }
 
-	MVKResource::bindDeviceMemory(mvkMem, memOffset);
+    MVKResource::bindDeviceMemory(mvkMem, memOffset);
 
 #if MVK_MACOS
-	if (_deviceMemory) {
-		_isHostCoherentTexelBuffer = (!isUnifiedMemoryGPU() &&
-									  !getMetalFeatures().sharedLinearTextures &&
-									  _deviceMemory->isMemoryHostCoherent() &&
-									  mvkIsAnyFlagEnabled(_usage, (VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT |
-																   VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)));
-	}
+    if (_deviceMemory) {
+        _isHostCoherentTexelBuffer =
+            (!isUnifiedMemoryGPU() &&
+             !getMetalFeatures().sharedLinearTextures &&
+             _deviceMemory->isMemoryHostCoherent() &&
+             mvkIsAnyFlagEnabled(_usage,
+                                 (VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT |
+                                  VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)));
+    }
 #endif
 
-	propagateDebugName();
+    propagateDebugName();
 
-	return _deviceMemory ? _deviceMemory->addBuffer(this) : VK_SUCCESS;
+    return _deviceMemory ? _deviceMemory->addBuffer(this) : VK_SUCCESS;
 }
 
 VkResult MVKBuffer::bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo) {
-	return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset);
+    return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory,
+                            pBindInfo->memoryOffset);
 }
 
 void MVKBuffer::applyMemoryBarrier(MVKPipelineBarrier& barrier,
                                    MVKCommandEncoder* cmdEncoder,
                                    MVKCommandUse cmdUse) {
 #if MVK_MACOS
-	if ( needsHostReadSync(barrier) ) {
-		[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeResource: getMTLBuffer()];
-	}
+    if (needsHostReadSync(barrier)) {
+        [cmdEncoder->getMTLBlitEncoder(cmdUse)
+            synchronizeResource:getMTLBuffer()];
+    }
 #endif
 }
 
@@ -113,26 +128,33 @@ void MVKBuffer::applyBufferMemoryBarrier(MVKPipelineBarrier& barrier,
                                          MVKCommandEncoder* cmdEncoder,
                                          MVKCommandUse cmdUse) {
 #if MVK_MACOS
-	if ( needsHostReadSync(barrier) ) {
-		[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeResource: getMTLBuffer()];
-	}
+    if (needsHostReadSync(barrier)) {
+        [cmdEncoder->getMTLBlitEncoder(cmdUse)
+            synchronizeResource:getMTLBuffer()];
+    }
 #endif
 }
 
-// Returns whether the specified buffer memory barrier requires a sync between this
-// buffer and host memory for the purpose of the host reading texture memory.
+// Returns whether the specified buffer memory barrier requires a sync between
+// this buffer and host memory for the purpose of the host reading texture
+// memory.
 bool MVKBuffer::needsHostReadSync(MVKPipelineBarrier& barrier) {
 #if MVK_MACOS
-	return (!isUnifiedMemoryGPU() &&
-			mvkIsAnyFlagEnabled(barrier.dstStageMask, (VK_PIPELINE_STAGE_HOST_BIT)) &&
-			mvkIsAnyFlagEnabled(barrier.dstAccessMask, (VK_ACCESS_HOST_READ_BIT)) &&
-			isMemoryHostAccessible() && (!isMemoryHostCoherent() || _isHostCoherentTexelBuffer));
+    return (
+        !isUnifiedMemoryGPU() &&
+        mvkIsAnyFlagEnabled(barrier.dstStageMask,
+                            (VK_PIPELINE_STAGE_HOST_BIT)) &&
+        mvkIsAnyFlagEnabled(barrier.dstAccessMask, (VK_ACCESS_HOST_READ_BIT)) &&
+        isMemoryHostAccessible() &&
+        (!isMemoryHostCoherent() || _isHostCoherentTexelBuffer));
 #else
-	return false;
+    return false;
 #endif
 }
 
-bool MVKBuffer::overlaps(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize &overlapOffset, VkDeviceSize &overlapSize) {
+bool MVKBuffer::overlaps(VkDeviceSize offset, VkDeviceSize size,
+                         VkDeviceSize& overlapOffset,
+                         VkDeviceSize& overlapSize) {
     VkDeviceSize end = offset + size;
     VkDeviceSize bufferEnd = _deviceMemoryOffset + _byteCount;
     if (offset < bufferEnd && end > _deviceMemoryOffset) {
@@ -144,64 +166,83 @@ bool MVKBuffer::overlaps(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize &o
     return false;
 }
 
-bool MVKBuffer::shouldFlushHostMemory() { return !isUnifiedMemoryGPU() && _isHostCoherentTexelBuffer; }
+bool MVKBuffer::shouldFlushHostMemory() {
+    return !isUnifiedMemoryGPU() && _isHostCoherentTexelBuffer;
+}
 
 // Flushes the device memory at the specified memory range into the MTLBuffer.
 VkResult MVKBuffer::flushToDevice(VkDeviceSize offset, VkDeviceSize size) {
 #if MVK_MACOS
     VkDeviceSize flushOffset, flushSize;
-	if (shouldFlushHostMemory() && _mtlBufferCache && overlaps(offset, size, flushOffset, flushSize)) {
-		memcpy(reinterpret_cast<char *>(_mtlBufferCache.contents) + flushOffset - _deviceMemoryOffset,
-		       reinterpret_cast<const char *>(_deviceMemory->getHostMemoryAddress()) + flushOffset,
-		       flushSize);
-		[_mtlBufferCache didModifyRange: NSMakeRange(flushOffset - _deviceMemoryOffset, flushSize)];
-	}
+    if (shouldFlushHostMemory() && _mtlBufferCache &&
+        overlaps(offset, size, flushOffset, flushSize)) {
+        memcpy(reinterpret_cast<char*>(_mtlBufferCache.contents) + flushOffset -
+                   _deviceMemoryOffset,
+               reinterpret_cast<const char*>(
+                   _deviceMemory->getHostMemoryAddress()) +
+                   flushOffset,
+               flushSize);
+        [_mtlBufferCache
+            didModifyRange:NSMakeRange(flushOffset - _deviceMemoryOffset,
+                                       flushSize)];
+    }
 #endif
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-// Pulls content from the MTLBuffer into the device memory at the specified memory range.
+// Pulls content from the MTLBuffer into the device memory at the specified
+// memory range.
 VkResult MVKBuffer::pullFromDevice(VkDeviceSize offset, VkDeviceSize size) {
 #if MVK_MACOS
     VkDeviceSize pullOffset, pullSize;
-	if (shouldFlushHostMemory() && _mtlBufferCache && overlaps(offset, size, pullOffset, pullSize)) {
-		memcpy(reinterpret_cast<char *>(_deviceMemory->getHostMemoryAddress()) + pullOffset,
-		       reinterpret_cast<const char *>(_mtlBufferCache.contents) + pullOffset - _deviceMemoryOffset,
-		       pullSize);
-	}
+    if (shouldFlushHostMemory() && _mtlBufferCache &&
+        overlaps(offset, size, pullOffset, pullSize)) {
+        memcpy(reinterpret_cast<char*>(_deviceMemory->getHostMemoryAddress()) +
+                   pullOffset,
+               reinterpret_cast<const char*>(_mtlBufferCache.contents) +
+                   pullOffset - _deviceMemoryOffset,
+               pullSize);
+    }
 #endif
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
-
 
 #pragma mark Metal
 
 id<MTLBuffer> MVKBuffer::getMTLBuffer() {
-	if (_mtlBuffer) { return _mtlBuffer; }
-	if (_deviceMemory) {
-		if (_deviceMemory->getMTLHeap()) {
+    if (_mtlBuffer) {
+        return _mtlBuffer;
+    }
+    if (_deviceMemory) {
+        if (_deviceMemory->getMTLHeap()) {
             lock_guard<mutex> lock(_lock);
-            if (_mtlBuffer) { return _mtlBuffer; }
-			_mtlBuffer = [_deviceMemory->getMTLHeap() newBufferWithLength: getByteCount()
-																  options: _deviceMemory->getMTLResourceOptions()
-																   offset: _deviceMemoryOffset];	// retained
-			propagateDebugName();
-			return _mtlBuffer;
-		} else {
-			return _deviceMemory->getMTLBuffer();
-		}
-	}
-	return nil;
+            if (_mtlBuffer) {
+                return _mtlBuffer;
+            }
+            _mtlBuffer = [_deviceMemory->getMTLHeap()
+                newBufferWithLength:getByteCount()
+                            options:_deviceMemory->getMTLResourceOptions()
+                             offset:_deviceMemoryOffset]; // retained
+            propagateDebugName();
+            return _mtlBuffer;
+        } else {
+            return _deviceMemory->getMTLBuffer();
+        }
+    }
+    return nil;
 }
 
 id<MTLBuffer> MVKBuffer::getMTLBufferCache() {
 #if MVK_MACOS
     if (_isHostCoherentTexelBuffer && !_mtlBufferCache) {
         lock_guard<mutex> lock(_lock);
-        if (_mtlBufferCache) { return _mtlBufferCache; }
+        if (_mtlBufferCache) {
+            return _mtlBufferCache;
+        }
 
-		_mtlBufferCache = [getMTLDevice() newBufferWithLength: getByteCount()
-													  options: MTLResourceStorageModeManaged];    // retained
+        _mtlBufferCache = [getMTLDevice()
+            newBufferWithLength:getByteCount()
+                        options:MTLResourceStorageModeManaged]; // retained
         flushToDevice(_deviceMemoryOffset, _byteCount);
     }
 #endif
@@ -210,99 +251,120 @@ id<MTLBuffer> MVKBuffer::getMTLBufferCache() {
 
 uint64_t MVKBuffer::getMTLBufferGPUAddress() {
 #if MVK_XCODE_14
-	return [getMTLBuffer() gpuAddress] + getMTLBufferOffset();
+    return [getMTLBuffer() gpuAddress] + getMTLBufferOffset();
 #endif
-	return 0;
+    return 0;
 }
 
 #pragma mark Construction
 
-MVKBuffer::MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo) : MVKResource(device), _usage(pCreateInfo->usage) {
+MVKBuffer::MVKBuffer(MVKDevice* device, const VkBufferCreateInfo* pCreateInfo)
+    : MVKResource(device), _usage(pCreateInfo->usage) {
     _byteAlignment = getMetalFeatures().mtlBufferAlignment;
     _byteCount = pCreateInfo->size;
 
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO: {
-				auto* pExtMemInfo = (const VkExternalMemoryBufferCreateInfo*)next;
-				initExternalMemory(pExtMemInfo->handleTypes);
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO: {
+            auto* pExtMemInfo = (const VkExternalMemoryBufferCreateInfo*)next;
+            initExternalMemory(pExtMemInfo->handleTypes);
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
-void MVKBuffer::initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes) {
-	if ( !handleTypes ) { return; }
-	if (mvkIsOnlyAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
-		_externalMemoryHandleTypes = handleTypes;
-		auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
-		_requiresDedicatedMemoryAllocation = _requiresDedicatedMemoryAllocation || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
-	} else {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateBuffer(): Only external memory handle type VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR is supported."));
-	}
+void MVKBuffer::initExternalMemory(
+    VkExternalMemoryHandleTypeFlags handleTypes) {
+    if (!handleTypes) {
+        return;
+    }
+    if (mvkIsOnlyAnyFlagEnabled(
+            handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
+        _externalMemoryHandleTypes = handleTypes;
+        auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
+        _requiresDedicatedMemoryAllocation =
+            _requiresDedicatedMemoryAllocation ||
+            mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures,
+                                VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+    } else {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateBuffer(): Only external memory handle type "
+                        "VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR is "
+                        "supported."));
+    }
 }
 
 // Memory detached in destructor too, as a fail-safe.
-MVKBuffer::~MVKBuffer() {
-	detachMemory();
-}
+MVKBuffer::~MVKBuffer() { detachMemory(); }
 
-// Overridden to detach from the resource memory when the app destroys this object.
-// This object can be retained in a descriptor after the app destroys it, even
-// though the descriptor can't use it. But doing so retains usuable resource memory.
-// In addition, a potential race condition exists if the app updates the descriptor
-// on one thread at the same time it is destroying the buffer and freeing the device
-// memory on another thread. The race condition occurs when the device memory calls
-// back to this buffer to unbind from it. By detaching from the device memory here,
-// (when the app destroys the buffer), even if this buffer is retained by a descriptor,
-// when the device memory is freed by the app, it won't try to call back here to unbind.
+// Overridden to detach from the resource memory when the app destroys this
+// object. This object can be retained in a descriptor after the app destroys
+// it, even though the descriptor can't use it. But doing so retains usuable
+// resource memory. In addition, a potential race condition exists if the app
+// updates the descriptor on one thread at the same time it is destroying the
+// buffer and freeing the device memory on another thread. The race condition
+// occurs when the device memory calls back to this buffer to unbind from it. By
+// detaching from the device memory here, (when the app destroys the buffer),
+// even if this buffer is retained by a descriptor, when the device memory is
+// freed by the app, it won't try to call back here to unbind.
 void MVKBuffer::destroy() {
-	detachMemory();
-	MVKResource::destroy();
+    detachMemory();
+    MVKResource::destroy();
 }
 
-// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
+// Potentially called twice, from destroy() and destructor, so ensure everything
+// is nulled out.
 void MVKBuffer::detachMemory() {
-	if (_deviceMemory) { _deviceMemory->removeBuffer(this); }
-	_deviceMemory = nullptr;
-	[_mtlBuffer release];
-	_mtlBuffer = nil;
-	[_mtlBufferCache release];
-	_mtlBufferCache = nil;
+    if (_deviceMemory) {
+        _deviceMemory->removeBuffer(this);
+    }
+    _deviceMemory = nullptr;
+    [_mtlBuffer release];
+    _mtlBuffer = nil;
+    [_mtlBufferCache release];
+    _mtlBufferCache = nil;
 }
-
 
 #pragma mark -
 #pragma mark MVKBufferView
 
 void MVKBufferView::propagateDebugName() {
-	setMetalObjectLabel(_mtlTexture, _debugName);
+    setMetalObjectLabel(_mtlTexture, _debugName);
 }
 
 #pragma mark Metal
 
 id<MTLTexture> MVKBufferView::getMTLTexture() {
-	auto& mtlFeats = getMetalFeatures();
-    if ( !_mtlTexture && _mtlPixelFormat && mtlFeats.texelBuffers) {
+    auto& mtlFeats = getMetalFeatures();
+    if (!_mtlTexture && _mtlPixelFormat && mtlFeats.texelBuffers) {
 
-		// Lock and check again in case another thread has created the texture.
-		lock_guard<mutex> lock(_lock);
-		if (_mtlTexture) { return _mtlTexture; }
+        // Lock and check again in case another thread has created the texture.
+        lock_guard<mutex> lock(_lock);
+        if (_mtlTexture) {
+            return _mtlTexture;
+        }
 
         MTLTextureUsage usage = MTLTextureUsageShaderRead;
-        if ( mvkIsAnyFlagEnabled(_buffer->getUsage(), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) ) {
-			usage |= MTLTextureUsageShaderWrite;
+        if (mvkIsAnyFlagEnabled(_buffer->getUsage(),
+                                VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)) {
+            usage |= MTLTextureUsageShaderWrite;
 #if MVK_XCODE_15
-			if (getMetalFeatures().nativeTextureAtomics && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint || _mtlPixelFormat == MTLPixelFormatRG32Uint))
-				usage |= MTLTextureUsageShaderAtomic;
+            if (getMetalFeatures().nativeTextureAtomics &&
+                (_mtlPixelFormat == MTLPixelFormatR32Sint ||
+                 _mtlPixelFormat == MTLPixelFormatR32Uint ||
+                 _mtlPixelFormat == MTLPixelFormatRG32Uint))
+                usage |= MTLTextureUsageShaderAtomic;
 #endif
         }
         id<MTLBuffer> mtlBuff;
         VkDeviceSize mtlBuffOffset;
-        if ( !mtlFeats.sharedLinearTextures && _buffer->isMemoryHostCoherent() ) {
+        if (!mtlFeats.sharedLinearTextures && _buffer->isMemoryHostCoherent()) {
             mtlBuff = _buffer->getMTLBufferCache();
             mtlBuffOffset = _offset;
         } else {
@@ -310,86 +372,110 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
             mtlBuffOffset = _buffer->getMTLBufferOffset() + _offset;
         }
         MTLTextureDescriptor* mtlTexDesc;
-        if ( mtlFeats.textureBuffers ) {
-            mtlTexDesc = [MTLTextureDescriptor textureBufferDescriptorWithPixelFormat: _mtlPixelFormat
-                                                                                width: _textureSize.width
-                                                                      resourceOptions: (mtlBuff.cpuCacheMode << MTLResourceCPUCacheModeShift) | (mtlBuff.storageMode << MTLResourceStorageModeShift)
-                                                                                usage: usage];
+        if (mtlFeats.textureBuffers) {
+            mtlTexDesc = [MTLTextureDescriptor
+                textureBufferDescriptorWithPixelFormat:_mtlPixelFormat
+                                                 width:_textureSize.width
+                                       resourceOptions:
+                                           (mtlBuff.cpuCacheMode
+                                            << MTLResourceCPUCacheModeShift) |
+                                           (mtlBuff.storageMode
+                                            << MTLResourceStorageModeShift)
+                                                 usage:usage];
         } else {
-            mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: _mtlPixelFormat
-                                                                            width: _textureSize.width
-                                                                           height: _textureSize.height
-                                                                        mipmapped: NO];
+            mtlTexDesc = [MTLTextureDescriptor
+                texture2DDescriptorWithPixelFormat:_mtlPixelFormat
+                                             width:_textureSize.width
+                                            height:_textureSize.height
+                                         mipmapped:NO];
             mtlTexDesc.storageMode = mtlBuff.storageMode;
             mtlTexDesc.cpuCacheMode = mtlBuff.cpuCacheMode;
             mtlTexDesc.usage = usage;
         }
-		_mtlTexture = [mtlBuff newTextureWithDescriptor: mtlTexDesc
-												 offset: mtlBuffOffset
-											bytesPerRow: _mtlBytesPerRow];
-		propagateDebugName();
+        _mtlTexture = [mtlBuff newTextureWithDescriptor:mtlTexDesc
+                                                 offset:mtlBuffOffset
+                                            bytesPerRow:_mtlBytesPerRow];
+        propagateDebugName();
     }
     return _mtlTexture;
 }
 
-
 #pragma mark Construction
 
-MVKBufferView::MVKBufferView(MVKDevice* device, const VkBufferViewCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	MVKPixelFormats* pixFmts = getPixelFormats();
+MVKBufferView::MVKBufferView(MVKDevice* device,
+                             const VkBufferViewCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    MVKPixelFormats* pixFmts = getPixelFormats();
     _buffer = (MVKBuffer*)pCreateInfo->buffer;
     _offset = pCreateInfo->offset;
     _mtlPixelFormat = pixFmts->getMTLPixelFormat(pCreateInfo->format);
-    VkExtent2D fmtBlockSize = pixFmts->getBlockTexelSize(pCreateInfo->format);  // Pixel size of format
+    VkExtent2D fmtBlockSize =
+        pixFmts->getBlockTexelSize(pCreateInfo->format); // Pixel size of format
     size_t bytesPerBlock = pixFmts->getBytesPerBlock(pCreateInfo->format);
-	_mtlTexture = nil;
+    _mtlTexture = nil;
 
-    // Layout texture as a 1D array of texel blocks (which are texels for non-compressed textures) that covers the bytes
+    // Layout texture as a 1D array of texel blocks (which are texels for
+    // non-compressed textures) that covers the bytes
     VkDeviceSize byteCount = pCreateInfo->range;
-    if (byteCount == VK_WHOLE_SIZE) { byteCount = _buffer->getByteCount() - pCreateInfo->offset; }    // Remaining bytes in buffer
+    if (byteCount == VK_WHOLE_SIZE) {
+        byteCount = _buffer->getByteCount() - pCreateInfo->offset;
+    } // Remaining bytes in buffer
     size_t blockCount = byteCount / bytesPerBlock;
 
-	auto& mtlFeats = getMetalFeatures();
-	if ( !mtlFeats.textureBuffers ) {
-		// But Metal requires the texture to be a 2D texture. Determine the number of 2D rows we need and their width.
-		// Multiple rows will automatically align with PoT max texture dimension, but need to align upwards if less than full single row.
-		size_t maxBlocksPerRow = mtlFeats.maxTextureDimension / fmtBlockSize.width;
-		size_t blocksPerRow = min(blockCount, maxBlocksPerRow);
-		_mtlBytesPerRow = mvkAlignByteCount(blocksPerRow * bytesPerBlock, _device->getVkFormatTexelBufferAlignment(pCreateInfo->format, this));
+    auto& mtlFeats = getMetalFeatures();
+    if (!mtlFeats.textureBuffers) {
+        // But Metal requires the texture to be a 2D texture. Determine the
+        // number of 2D rows we need and their width. Multiple rows will
+        // automatically align with PoT max texture dimension, but need to align
+        // upwards if less than full single row.
+        size_t maxBlocksPerRow =
+            mtlFeats.maxTextureDimension / fmtBlockSize.width;
+        size_t blocksPerRow = min(blockCount, maxBlocksPerRow);
+        _mtlBytesPerRow =
+            mvkAlignByteCount(blocksPerRow * bytesPerBlock,
+                              _device->getVkFormatTexelBufferAlignment(
+                                  pCreateInfo->format, this));
 
-		size_t rowCount = blockCount / blocksPerRow;
-		if (blockCount % blocksPerRow) { rowCount++; }
+        size_t rowCount = blockCount / blocksPerRow;
+        if (blockCount % blocksPerRow) {
+            rowCount++;
+        }
 
-		_textureSize.width = uint32_t(blocksPerRow * fmtBlockSize.width);
-		_textureSize.height = uint32_t(rowCount * fmtBlockSize.height);
-	} else {
-		// With native texture buffers we don't need to bother with any of that.
-		// We can just use a simple 1D texel array.
-		_textureSize.width = uint32_t(blockCount * fmtBlockSize.width);
-		_textureSize.height = 1;
-		_mtlBytesPerRow = mvkAlignByteCount(byteCount, _device->getVkFormatTexelBufferAlignment(pCreateInfo->format, this));
-	}
+        _textureSize.width = uint32_t(blocksPerRow * fmtBlockSize.width);
+        _textureSize.height = uint32_t(rowCount * fmtBlockSize.height);
+    } else {
+        // With native texture buffers we don't need to bother with any of that.
+        // We can just use a simple 1D texel array.
+        _textureSize.width = uint32_t(blockCount * fmtBlockSize.width);
+        _textureSize.height = 1;
+        _mtlBytesPerRow =
+            mvkAlignByteCount(byteCount,
+                              _device->getVkFormatTexelBufferAlignment(
+                                  pCreateInfo->format, this));
+    }
 
-    if ( !mtlFeats.texelBuffers ) {
-        setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Texel buffers are not supported on this device."));
+    if (!mtlFeats.texelBuffers) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "Texel buffers are not supported on this device."));
     }
 }
 
 // Memory detached in destructor too, as a fail-safe.
-MVKBufferView::~MVKBufferView() {
-	detachMemory();
-}
+MVKBufferView::~MVKBufferView() { detachMemory(); }
 
-// Overridden to detach from the resource memory when the app destroys this object.
-// This object can be retained in a descriptor after the app destroys it, even
-// though the descriptor can't use it. But doing so retains usuable resource memory.
+// Overridden to detach from the resource memory when the app destroys this
+// object. This object can be retained in a descriptor after the app destroys
+// it, even though the descriptor can't use it. But doing so retains usuable
+// resource memory.
 void MVKBufferView::destroy() {
-	detachMemory();
-	MVKVulkanAPIDeviceObject::destroy();
+    detachMemory();
+    MVKVulkanAPIDeviceObject::destroy();
 }
 
-// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
+// Potentially called twice, from destroy() and destructor, so ensure everything
+// is nulled out.
 void MVKBufferView::detachMemory() {
-	[_mtlTexture release];
-	_mtlTexture = nil;
+    [_mtlTexture release];
+    _mtlTexture = nil;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,59 +27,62 @@ class MVKDescriptorSetLayout;
 class MVKCommandEncoder;
 class MVKResourcesCommandEncoderState;
 
-
-/** Magic number to indicate the variable descriptor count is currently unknown. */
-static uint32_t kMVKVariableDescriptorCountUnknown = std::numeric_limits<uint32_t>::max();
-
+/** Magic number to indicate the variable descriptor count is currently unknown.
+ */
+static uint32_t kMVKVariableDescriptorCountUnknown =
+    std::numeric_limits<uint32_t>::max();
 
 #pragma mark MVKShaderStageResourceBinding
 
-/** Indicates the Metal resource indexes used by a single shader stage in a descriptor. */
+/** Indicates the Metal resource indexes used by a single shader stage in a
+ * descriptor. */
 typedef struct MVKShaderStageResourceBinding {
-	uint32_t bufferIndex = 0;
-	uint32_t textureIndex = 0;
-	uint32_t samplerIndex = 0;
-	uint32_t dynamicOffsetBufferIndex = 0;
+    uint32_t bufferIndex = 0;
+    uint32_t textureIndex = 0;
+    uint32_t samplerIndex = 0;
+    uint32_t dynamicOffsetBufferIndex = 0;
 
-	MVKShaderStageResourceBinding operator+ (const MVKShaderStageResourceBinding& rhs);
-	MVKShaderStageResourceBinding& operator+= (const MVKShaderStageResourceBinding& rhs);
-	void clearArgumentBufferResources();
+    MVKShaderStageResourceBinding
+    operator+(const MVKShaderStageResourceBinding& rhs);
+    MVKShaderStageResourceBinding&
+    operator+=(const MVKShaderStageResourceBinding& rhs);
+    void clearArgumentBufferResources();
 
 } MVKShaderStageResourceBinding;
 
-
 #pragma mark MVKShaderResourceBinding
 
-/** Indicates the Metal resource indexes used by each shader stage in a descriptor. */
+/** Indicates the Metal resource indexes used by each shader stage in a
+ * descriptor. */
 typedef struct MVKShaderResourceBinding {
-	MVKShaderStageResourceBinding stages[kMVKShaderStageCount];
+    MVKShaderStageResourceBinding stages[kMVKShaderStageCount];
 
-	uint32_t getMaxBufferIndex();
-	uint32_t getMaxTextureIndex();
-	uint32_t getMaxSamplerIndex();
+    uint32_t getMaxBufferIndex();
+    uint32_t getMaxTextureIndex();
+    uint32_t getMaxSamplerIndex();
 
-	MVKShaderResourceBinding operator+ (const MVKShaderResourceBinding& rhs);
-	MVKShaderResourceBinding& operator+= (const MVKShaderResourceBinding& rhs);
-	MVKShaderStageResourceBinding& getMetalResourceIndexes(MVKShaderStage stage = kMVKShaderStageVertex) { return stages[stage]; }
-	void clearArgumentBufferResources();
-	void addArgumentBuffers(uint32_t count);
+    MVKShaderResourceBinding operator+(const MVKShaderResourceBinding& rhs);
+    MVKShaderResourceBinding& operator+=(const MVKShaderResourceBinding& rhs);
+    MVKShaderStageResourceBinding&
+    getMetalResourceIndexes(MVKShaderStage stage = kMVKShaderStageVertex) {
+        return stages[stage];
+    }
+    void clearArgumentBufferResources();
+    void addArgumentBuffers(uint32_t count);
 
 } MVKShaderResourceBinding;
 
 /**
- * If the shader stage binding has a binding defined for the specified stage, populates
- * the context at the descriptor set binding from the shader stage resource binding.
+ * If the shader stage binding has a binding defined for the specified stage,
+ * populates the context at the descriptor set binding from the shader stage
+ * resource binding.
  */
-void mvkPopulateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-									   MVKShaderStageResourceBinding& ssRB,
-									   MVKShaderStage stage,
-									   uint32_t descriptorSetIndex,
-									   uint32_t bindingIndex,
-									   uint32_t count,
-									   VkDescriptorType descType,
-									   MVKSampler* immutableSampler,
-									   bool usingNativeTextureAtomics);
-
+void mvkPopulateShaderConversionConfig(
+    mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+    MVKShaderStageResourceBinding& ssRB, MVKShaderStage stage,
+    uint32_t descriptorSetIndex, uint32_t bindingIndex, uint32_t count,
+    VkDescriptorType descType, MVKSampler* immutableSampler,
+    bool usingNativeTextureAtomics);
 
 #pragma mark -
 #pragma mark MVKDescriptorSetLayoutBinding
@@ -87,122 +90,126 @@ void mvkPopulateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& s
 /** Represents a Vulkan descriptor set layout binding. */
 class MVKDescriptorSetLayoutBinding : public MVKBaseDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
+    /** Returns the binding number of this layout. */
+    uint32_t getBinding() { return _info.binding; }
 
-	/** Returns the binding number of this layout. */
-	uint32_t getBinding() { return _info.binding; }
+    /** Returns whether this binding has a variable descriptor count. */
+    bool hasVariableDescriptorCount() const {
+        return mvkIsAnyFlagEnabled(
+            _flags, VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT);
+    }
 
-	/** Returns whether this binding has a variable descriptor count. */
-	bool hasVariableDescriptorCount() const {
-		return mvkIsAnyFlagEnabled(_flags, VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT);
-	}
+    /**
+     * Returns the number of descriptors in this layout.
+     *
+     * If this is an inline block data descriptor, always returns 1. If this
+     * descriptor has a variable descriptor count, and it is provided here, it
+     * is returned. Otherwise returns the value defined in
+     * VkDescriptorSetLayoutBinding::descriptorCount.
+     */
+    uint32_t getDescriptorCount(uint32_t variableDescriptorCount =
+                                    kMVKVariableDescriptorCountUnknown) const;
 
-	/**
-	 * Returns the number of descriptors in this layout.
-	 *
-	 * If this is an inline block data descriptor, always returns 1. If this descriptor
-	 * has a variable descriptor count, and it is provided here, it is returned.
-	 * Otherwise returns the value defined in VkDescriptorSetLayoutBinding::descriptorCount.
-	 */
-	uint32_t getDescriptorCount(uint32_t variableDescriptorCount = kMVKVariableDescriptorCountUnknown) const;
+    /** Returns the descriptor type of this layout. */
+    VkDescriptorType getDescriptorType() { return _info.descriptorType; }
 
-	/** Returns the descriptor type of this layout. */
-	VkDescriptorType getDescriptorType() { return _info.descriptorType; }
+    /** Returns whether this binding uses immutable samplers. */
+    bool usesImmutableSamplers() { return !_immutableSamplers.empty(); }
 
-	/** Returns whether this binding uses immutable samplers. */
-	bool usesImmutableSamplers() { return !_immutableSamplers.empty(); }
+    /** Returns the immutable sampler at the index, or nullptr if immutable
+     * samplers are not used. */
+    MVKSampler* getImmutableSampler(uint32_t index) {
+        return (index < _immutableSamplers.size()) ? _immutableSamplers[index]
+                                                   : nullptr;
+    }
 
-	/** Returns the immutable sampler at the index, or nullptr if immutable samplers are not used. */
-	MVKSampler* getImmutableSampler(uint32_t index) {
-		return (index < _immutableSamplers.size()) ? _immutableSamplers[index] : nullptr;
-	}
+    /** Encodes the descriptors in the descriptor set that are specified by this
+     * layout, */
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint, MVKDescriptorSet* descSet,
+              MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex);
 
-	/** Encodes the descriptors in the descriptor set that are specified by this layout, */
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSet* descSet,
-			  MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex);
-
-    /** Encodes this binding layout and the specified descriptor on the specified command encoder immediately. */
+    /** Encodes this binding layout and the specified descriptor on the
+     * specified command encoder immediately. */
     void push(MVKCommandEncoder* cmdEncoder,
-              VkPipelineBindPoint pipelineBindPoint,
-              uint32_t& dstArrayElement,
-              uint32_t& descriptorCount,
-              uint32_t& descriptorsPushed,
-              VkDescriptorType descriptorType,
-              size_t stride,
-              const void* pData,
+              VkPipelineBindPoint pipelineBindPoint, uint32_t& dstArrayElement,
+              uint32_t& descriptorCount, uint32_t& descriptorsPushed,
+              VkDescriptorType descriptorType, size_t stride, const void* pData,
               MVKShaderResourceBinding& dslMTLRezIdxOffsets);
 
-	/** Returns the index of the descriptor within the descriptor set of the element at the index within this descriptor layout. */
-	uint32_t getDescriptorIndex(uint32_t elementIndex = 0) const { return _descriptorIndex + elementIndex; }
+    /** Returns the index of the descriptor within the descriptor set of the
+     * element at the index within this descriptor layout. */
+    uint32_t getDescriptorIndex(uint32_t elementIndex = 0) const {
+        return _descriptorIndex + elementIndex;
+    }
 
-	/**
-	 * Returns the indexes into the resources, relative to the descriptor set.
-	 * When using Metal argument buffers, all stages have the same values, and
-	 * in that case the stage can be withheld and a default stage will be used.
-	 */
-	MVKShaderStageResourceBinding& getMetalResourceIndexOffsets(MVKShaderStage stage = kMVKShaderStageVertex) {
-		return _mtlResourceIndexOffsets.getMetalResourceIndexes(stage);
-	}
+    /**
+     * Returns the indexes into the resources, relative to the descriptor set.
+     * When using Metal argument buffers, all stages have the same values, and
+     * in that case the stage can be withheld and a default stage will be used.
+     */
+    MVKShaderStageResourceBinding&
+    getMetalResourceIndexOffsets(MVKShaderStage stage = kMVKShaderStageVertex) {
+        return _mtlResourceIndexOffsets.getMetalResourceIndexes(stage);
+    }
 
-	/** Returns a bitwise OR of Metal render stages. */
-	MTLRenderStages getMTLRenderStages();
+    /** Returns a bitwise OR of Metal render stages. */
+    MTLRenderStages getMTLRenderStages();
 
-	/** Returns whether this binding should be applied to the shader stage. */
-	bool getApplyToStage(MVKShaderStage stage) { return _applyToStage[stage]; }
+    /** Returns whether this binding should be applied to the shader stage. */
+    bool getApplyToStage(MVKShaderStage stage) { return _applyToStage[stage]; }
 
-	/** Returns a text description of this binding. */
-	std::string getLogDescription(std::string indent = "");
+    /** Returns a text description of this binding. */
+    std::string getLogDescription(std::string indent = "");
 
-	MVKDescriptorSetLayoutBinding(MVKDevice* device,
-								  MVKDescriptorSetLayout* layout,
-								  const VkDescriptorSetLayoutBinding* pBinding,
-								  VkDescriptorBindingFlagsEXT bindingFlags,
-								  uint32_t& dslDescCnt,
-								  uint32_t& dslMTLRezCnt);
+    MVKDescriptorSetLayoutBinding(MVKDevice* device,
+                                  MVKDescriptorSetLayout* layout,
+                                  const VkDescriptorSetLayoutBinding* pBinding,
+                                  VkDescriptorBindingFlagsEXT bindingFlags,
+                                  uint32_t& dslDescCnt, uint32_t& dslMTLRezCnt);
 
-	MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding);
+    MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding);
 
-	~MVKDescriptorSetLayoutBinding() override;
+    ~MVKDescriptorSetLayoutBinding() override;
 
-protected:
-	friend class MVKDescriptorSetLayout;
-	friend class MVKDescriptorSet;
+  protected:
+    friend class MVKDescriptorSetLayout;
+    friend class MVKDescriptorSet;
     friend class MVKInlineUniformBlockDescriptor;
-	
-	void initMetalResourceIndexOffsets(const VkDescriptorSetLayoutBinding* pBinding,
-									   uint32_t stage,
-									   uint32_t dslMTLRezCnt);
-	void addMTLArgumentDescriptors(NSMutableArray<MTLArgumentDescriptor*>* args,
-								   uint32_t variableDescriptorCount);
-	void addMTLArgumentDescriptor(NSMutableArray<MTLArgumentDescriptor*>* args,
-								  uint32_t variableDescriptorCount,
-								  uint32_t argIndex,
-								  MTLDataType dataType,
-								  MTLArgumentAccess access);
-	void populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-										MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-										uint32_t dslIndex);
-	bool validate(MVKSampler* mvkSampler);
-	void encodeImmutableSamplersToMetalArgumentBuffer(MVKDescriptorSet* mvkDescSet);
-	uint8_t getMaxPlaneCount();
-	uint32_t getMTLResourceCount(uint32_t variableDescriptorCount = kMVKVariableDescriptorCountUnknown);
 
-	MVKDescriptorSetLayout* _layout;
-	VkDescriptorSetLayoutBinding _info;
-	VkDescriptorBindingFlagsEXT _flags;
-	MVKSmallVector<MVKSampler*> _immutableSamplers;
-	MVKShaderResourceBinding _mtlResourceIndexOffsets;
-	uint32_t _descriptorIndex;
-	bool _applyToStage[kMVKShaderStageCount];
+    void
+    initMetalResourceIndexOffsets(const VkDescriptorSetLayoutBinding* pBinding,
+                                  uint32_t stage, uint32_t dslMTLRezCnt);
+    void addMTLArgumentDescriptors(NSMutableArray<MTLArgumentDescriptor*>* args,
+                                   uint32_t variableDescriptorCount);
+    void addMTLArgumentDescriptor(NSMutableArray<MTLArgumentDescriptor*>* args,
+                                  uint32_t variableDescriptorCount,
+                                  uint32_t argIndex, MTLDataType dataType,
+                                  MTLArgumentAccess access);
+    void populateShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        MVKShaderResourceBinding& dslMTLRezIdxOffsets, uint32_t dslIndex);
+    bool validate(MVKSampler* mvkSampler);
+    void
+    encodeImmutableSamplersToMetalArgumentBuffer(MVKDescriptorSet* mvkDescSet);
+    uint8_t getMaxPlaneCount();
+    uint32_t getMTLResourceCount(
+        uint32_t variableDescriptorCount = kMVKVariableDescriptorCountUnknown);
+
+    MVKDescriptorSetLayout* _layout;
+    VkDescriptorSetLayoutBinding _info;
+    VkDescriptorBindingFlagsEXT _flags;
+    MVKSmallVector<MVKSampler*> _immutableSamplers;
+    MVKShaderResourceBinding _mtlResourceIndexOffsets;
+    uint32_t _descriptorIndex;
+    bool _applyToStage[kMVKShaderStageCount];
 };
-
 
 #pragma mark -
 #pragma mark MVKDescriptor
@@ -210,72 +217,69 @@ protected:
 /** Represents a Vulkan descriptor. */
 class MVKDescriptor : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
+    virtual VkDescriptorType getDescriptorType() = 0;
 
-	virtual VkDescriptorType getDescriptorType() = 0;
+    /** Returns whether this descriptor type uses dynamic buffer offsets. */
+    virtual bool usesDynamicBufferOffsets() { return false; }
 
-	/** Returns whether this descriptor type uses dynamic buffer offsets. */
-	virtual bool usesDynamicBufferOffsets() { return false; }
+    /** Encodes this descriptor (based on its layout binding index) on the the
+     * command encoder. */
+    virtual void bind(MVKCommandEncoder* cmdEncoder,
+                      VkPipelineBindPoint pipelineBindPoint,
+                      MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                      uint32_t elementIndex, bool stages[],
+                      MVKShaderResourceBinding& mtlIndexes,
+                      MVKArrayRef<uint32_t> dynamicOffsets,
+                      uint32_t& dynamicOffsetIndex) = 0;
 
-	/** Encodes this descriptor (based on its layout binding index) on the the command encoder. */
-	virtual void bind(MVKCommandEncoder* cmdEncoder,
-					  VkPipelineBindPoint pipelineBindPoint,
-					  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-					  uint32_t elementIndex,
-					  bool stages[],
-					  MVKShaderResourceBinding& mtlIndexes,
-					  MVKArrayRef<uint32_t> dynamicOffsets,
-					  uint32_t& dynamicOffsetIndex) = 0;
+    /**
+     * Updates the internal binding from the specified content. The format of
+     * the content depends on the descriptor type, and is extracted from pData
+     * at the location given by index * stride. MVKInlineUniformBlockDescriptor
+     * uses the index as byte offset to write to.
+     */
+    virtual void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                       MVKDescriptorSet* mvkDescSet, uint32_t dstIdx,
+                       uint32_t srcIdx, size_t srcStride,
+                       const void* pData) = 0;
 
-	/**
-	 * Updates the internal binding from the specified content. The format of the content depends
-	 * on the descriptor type, and is extracted from pData at the location given by index * stride.
-	 * MVKInlineUniformBlockDescriptor uses the index as byte offset to write to.
-	 */
-	virtual void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-					   MVKDescriptorSet* mvkDescSet,
-					   uint32_t dstIdx,
-					   uint32_t srcIdx,
-					   size_t srcStride,
-					   const void* pData) = 0;
+    /**
+     * Updates the specified content arrays from the internal binding.
+     *
+     * Depending on the descriptor type, the binding content is placed into one
+     * of the specified pImageInfo, pBufferInfo, or pTexelBufferView arrays, and
+     * the other arrays are ignored (and may be a null pointer).
+     *
+     * The index parameter indicates the index of the initial descriptor element
+     * at which to start writing.
+     * MVKInlineUniformBlockDescriptor uses the index as byte offset to read
+     * from.
+     */
+    virtual void
+    read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+         MVKDescriptorSet* mvkDescSet, uint32_t index,
+         VkDescriptorImageInfo* pImageInfo, VkDescriptorBufferInfo* pBufferInfo,
+         VkBufferView* pTexelBufferView,
+         VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) = 0;
 
-	/**
-	 * Updates the specified content arrays from the internal binding.
-	 *
-	 * Depending on the descriptor type, the binding content is placed into one of the
-	 * specified pImageInfo, pBufferInfo, or pTexelBufferView arrays, and the other
-	 * arrays are ignored (and may be a null pointer).
-	 *
-	 * The index parameter indicates the index of the initial descriptor element
-	 * at which to start writing.
-	 * MVKInlineUniformBlockDescriptor uses the index as byte offset to read from.
-	 */
-	virtual void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-					  MVKDescriptorSet* mvkDescSet,
-					  uint32_t index,
-					  VkDescriptorImageInfo* pImageInfo,
-					  VkDescriptorBufferInfo* pBufferInfo,
-					  VkBufferView* pTexelBufferView,
-					  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) = 0;
+    /** Encodes the usage of this resource to the Metal command encoder. */
+    virtual void
+    encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                        MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                        MVKShaderStage stage) = 0;
 
-	/** Encodes the usage of this resource to the Metal command encoder. */
-	virtual void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-									 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									 MVKShaderStage stage) = 0;
+    /** Resets any internal content. */
+    virtual void reset() {}
 
-	/** Resets any internal content. */
-	virtual void reset() {}
+    ~MVKDescriptor() { reset(); }
 
-	~MVKDescriptor() { reset(); }
-
-protected:
-	MTLResourceUsage getMTLResourceUsage();
-
+  protected:
+    MTLResourceUsage getMTLResourceUsage();
 };
-
 
 #pragma mark -
 #pragma mark MVKBufferDescriptor
@@ -283,85 +287,81 @@ protected:
 /** Represents a Vulkan descriptor tracking a buffer. */
 class MVKBufferDescriptor : public MVKDescriptor {
 
-public:
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+  public:
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override;
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override;
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    void read(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+        VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+        VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override;
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override;
 
-	void reset() override;
+    void reset() override;
 
-	~MVKBufferDescriptor() { reset(); }
+    ~MVKBufferDescriptor() { reset(); }
 
-protected:
-	uint32_t getBufferSize(VkDeviceSize dynamicOffset = 0);
+  protected:
+    uint32_t getBufferSize(VkDeviceSize dynamicOffset = 0);
 
-	MVKBuffer* _mvkBuffer = nullptr;
-	VkDeviceSize _buffOffset = 0;
-	VkDeviceSize _buffRange = 0;
+    MVKBuffer* _mvkBuffer = nullptr;
+    VkDeviceSize _buffOffset = 0;
+    VkDeviceSize _buffRange = 0;
 };
-
 
 #pragma mark -
 #pragma mark MVKUniformBufferDescriptor
 
 class MVKUniformBufferDescriptor : public MVKBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKUniformBufferDynamicDescriptor
 
 class MVKUniformBufferDynamicDescriptor : public MVKBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC; }
-	bool usesDynamicBufferOffsets() override { return true; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+    }
+    bool usesDynamicBufferOffsets() override { return true; }
 };
-
 
 #pragma mark -
 #pragma mark MVKStorageBufferDescriptor
 
 class MVKStorageBufferDescriptor : public MVKBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKStorageBufferDynamicDescriptor
 
 class MVKStorageBufferDynamicDescriptor : public MVKBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC; }
-	bool usesDynamicBufferOffsets() override { return true; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
+    }
+    bool usesDynamicBufferOffsets() override { return true; }
 };
-
 
 #pragma mark -
 #pragma mark MVKInlineUniformBlockDescriptor
@@ -369,62 +369,57 @@ public:
 /** Represents a Vulkan descriptor tracking an inline block of uniform data. */
 class MVKInlineUniformBlockDescriptor : public MVKDescriptor {
 
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
+    }
 
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override {}
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override {}
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override {}
+    void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+              MVKDescriptorSet* mvkDescSet, uint32_t dstIndex,
+              VkDescriptorImageInfo* pImageInfo,
+              VkDescriptorBufferInfo* pBufferInfo,
+              VkBufferView* pTexelBufferView,
+              VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock)
+        override {}
 
-	uint32_t writeBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-						MVKDescriptorSet* mvkDescSet,
-						uint32_t dstOffset,
-						uint32_t srcOffset,
-						uint32_t byteCount,
-						const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
+    uint32_t writeBytes(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstOffset, uint32_t srcOffset, uint32_t byteCount,
+        const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
 
-	uint32_t readBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-					   MVKDescriptorSet* mvkDescSet,
-					   uint32_t dstOffset,
-					   uint32_t srcOffset,
-					   uint32_t byteCount,
-					   const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
+    uint32_t readBytes(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstOffset, uint32_t srcOffset, uint32_t byteCount,
+        const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
 
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override;
+    void reset() override;
 
-	void reset() override;
+    ~MVKInlineUniformBlockDescriptor() { reset(); }
 
-	~MVKInlineUniformBlockDescriptor() { reset(); }
+  protected:
+    uint8_t* getData() {
+        return _mvkMTLBufferAllocation
+                   ? (uint8_t*)_mvkMTLBufferAllocation->getContents()
+                   : nullptr;
+    }
 
-protected:
-	uint8_t* getData() { return _mvkMTLBufferAllocation ? (uint8_t*)_mvkMTLBufferAllocation->getContents() : nullptr; }
-
-	MVKMTLBufferAllocation* _mvkMTLBufferAllocation = nullptr;
+    MVKMTLBufferAllocation* _mvkMTLBufferAllocation = nullptr;
 };
-
 
 #pragma mark -
 #pragma mark MVKImageDescriptor
@@ -432,70 +427,65 @@ protected:
 /** Represents a Vulkan descriptor tracking an image. */
 class MVKImageDescriptor : public MVKDescriptor {
 
-public:
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+  public:
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override;
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override;
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    void read(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+        VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+        VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override;
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override;
 
-	void reset() override;
+    void reset() override;
 
-	~MVKImageDescriptor() { reset(); }
+    ~MVKImageDescriptor() { reset(); }
 
-protected:
-	MVKImageView* _mvkImageView = nullptr;
+  protected:
+    MVKImageView* _mvkImageView = nullptr;
 };
-
 
 #pragma mark -
 #pragma mark MVKSampledImageDescriptor
 
 class MVKSampledImageDescriptor : public MVKImageDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKStorageImageDescriptor
 
 class MVKStorageImageDescriptor : public MVKImageDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKInputAttachmentDescriptor
 
 class MVKInputAttachmentDescriptor : public MVKImageDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKSamplerDescriptorMixin
@@ -503,136 +493,118 @@ public:
 /**
  * This mixin class adds the ability for a descriptor to track a sampler.
  *
- * As a mixin, this class should only be used as a component of multiple inheritance.
- * Any class that inherits from this class should also inherit from MVKDescriptor.
- * This requirement is to avoid the diamond problem of multiple inheritance.
+ * As a mixin, this class should only be used as a component of multiple
+ * inheritance. Any class that inherits from this class should also inherit from
+ * MVKDescriptor. This requirement is to avoid the diamond problem of multiple
+ * inheritance.
  */
 class MVKSamplerDescriptorMixin {
 
-protected:
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex);
+  protected:
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex);
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData);
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData);
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock);
+    void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+              MVKDescriptorSet* mvkDescSet, uint32_t dstIndex,
+              VkDescriptorImageInfo* pImageInfo,
+              VkDescriptorBufferInfo* pBufferInfo,
+              VkBufferView* pTexelBufferView,
+              VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock);
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) {}
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) {}
 
-	void reset();
+    void reset();
 
-	~MVKSamplerDescriptorMixin() { reset(); }
+    ~MVKSamplerDescriptorMixin() { reset(); }
 
-	MVKSampler* _mvkSampler = nullptr;
+    MVKSampler* _mvkSampler = nullptr;
 };
-
 
 #pragma mark -
 #pragma mark MVKSamplerDescriptor
 
 /** Represents a Vulkan descriptor tracking a sampler. */
-class MVKSamplerDescriptor : public MVKDescriptor, public MVKSamplerDescriptorMixin {
+class MVKSamplerDescriptor : public MVKDescriptor,
+                             public MVKSamplerDescriptorMixin {
 
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_SAMPLER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_SAMPLER;
+    }
 
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override;
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override;
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    void read(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+        VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+        VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override {}
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override {}
 
-	void reset() override;
+    void reset() override;
 
-	~MVKSamplerDescriptor() { reset(); }
-
+    ~MVKSamplerDescriptor() { reset(); }
 };
-
 
 #pragma mark -
 #pragma mark MVKCombinedImageSamplerDescriptor
 
 /** Represents a Vulkan descriptor tracking a combined image and sampler. */
-class MVKCombinedImageSamplerDescriptor : public MVKImageDescriptor, public MVKSamplerDescriptorMixin {
+class MVKCombinedImageSamplerDescriptor : public MVKImageDescriptor,
+                                          public MVKSamplerDescriptorMixin {
 
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    }
 
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override;
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override;
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    void read(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+        VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+        VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override;
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override;
 
-	void reset() override;
+    void reset() override;
 
-	~MVKCombinedImageSamplerDescriptor() { reset(); }
-
+    ~MVKCombinedImageSamplerDescriptor() { reset(); }
 };
-
 
 #pragma mark -
 #pragma mark MVKTexelBufferDescriptor
@@ -640,69 +612,63 @@ public:
 /** Represents a Vulkan descriptor tracking a texel buffer. */
 class MVKTexelBufferDescriptor : public MVKDescriptor {
 
-public:
-	void bind(MVKCommandEncoder* cmdEncoder,
-			  VkPipelineBindPoint pipelineBindPoint,
-			  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  uint32_t elementIndex,
-			  bool stages[],
-			  MVKShaderResourceBinding& mtlIndexes,
-			  MVKArrayRef<uint32_t> dynamicOffsets,
-			  uint32_t& dynamicOffsetIndex) override;
+  public:
+    void bind(MVKCommandEncoder* cmdEncoder,
+              VkPipelineBindPoint pipelineBindPoint,
+              MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+              bool stages[], MVKShaderResourceBinding& mtlIndexes,
+              MVKArrayRef<uint32_t> dynamicOffsets,
+              uint32_t& dynamicOffsetIndex) override;
 
-	void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			   MVKDescriptorSet* mvkDescSet,
-			   uint32_t dstIdx,
-			   uint32_t srcIdx,
-			   size_t srcStride,
-			   const void* pData) override;
+    void write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx, uint32_t srcIdx,
+               size_t srcStride, const void* pData) override;
 
-	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-			  MVKDescriptorSet* mvkDescSet,
-			  uint32_t dstIndex,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
+    void read(
+        MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+        uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+        VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+        VkWriteDescriptorSetInlineUniformBlockEXT* inlineUniformBlock) override;
 
-	void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-							 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							 MVKShaderStage stage) override;
+    void encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
+                             MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                             MVKShaderStage stage) override;
 
-	void reset() override;
+    void reset() override;
 
-	~MVKTexelBufferDescriptor() { reset(); }
+    ~MVKTexelBufferDescriptor() { reset(); }
 
-protected:
-	MVKBufferView* _mvkBufferView = nullptr;
+  protected:
+    MVKBufferView* _mvkBufferView = nullptr;
 };
-
 
 #pragma mark -
 #pragma mark MVKUniformTexelBufferDescriptor
 
 class MVKUniformTexelBufferDescriptor : public MVKTexelBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    }
 };
-
 
 #pragma mark -
 #pragma mark MVKStorageTexelBufferDescriptor
 
 class MVKStorageTexelBufferDescriptor : public MVKTexelBufferDescriptor {
-public:
-	VkDescriptorType getDescriptorType() override { return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER; }
+  public:
+    VkDescriptorType getDescriptorType() override {
+        return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+    }
 };
-
 
 #pragma mark -
 #pragma mark Support functions
 
-/** 
+/**
  * If the binding defines a buffer type, returns whether there are buffers, and
- * therefore an auxilliary buffer is required to hold the lengths of those buffers.
- * Returns false if the binding does not define a buffer type.
+ * therefore an auxilliary buffer is required to hold the lengths of those
+ * buffers. Returns false if the binding does not define a buffer type.
  */
 bool mvkNeedsBuffSizeAuxBuffer(const VkDescriptorSetLayoutBinding* pBinding);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,220 +22,238 @@
 #include <sstream>
 #include <iomanip>
 
-
-#define BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bind, pipelineBindPoint, stage, ...) \
-	do { \
-		if ((stage) == kMVKShaderStageCompute) { \
-			if ((cmdEncoder) && (pipelineBindPoint) == VK_PIPELINE_BIND_POINT_COMPUTE) \
-				(cmdEncoder)->_computeResourcesState.bind(__VA_ARGS__); \
-		} else { \
-			if ((cmdEncoder) && (pipelineBindPoint) == VK_PIPELINE_BIND_POINT_GRAPHICS) \
-				(cmdEncoder)->_graphicsResourcesState.bind(static_cast<MVKShaderStage>(stage), __VA_ARGS__); \
-		} \
-	} while (0)
+#define BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bind, pipelineBindPoint, stage,   \
+                                 ...)                                          \
+    do {                                                                       \
+        if ((stage) == kMVKShaderStageCompute) {                               \
+            if ((cmdEncoder) &&                                                \
+                (pipelineBindPoint) == VK_PIPELINE_BIND_POINT_COMPUTE)         \
+                (cmdEncoder)->_computeResourcesState.bind(__VA_ARGS__);        \
+        } else {                                                               \
+            if ((cmdEncoder) &&                                                \
+                (pipelineBindPoint) == VK_PIPELINE_BIND_POINT_GRAPHICS)        \
+                (cmdEncoder)                                                   \
+                    ->_graphicsResourcesState                                  \
+                    .bind(static_cast<MVKShaderStage>(stage), __VA_ARGS__);    \
+        }                                                                      \
+    } while (0)
 
 #pragma mark MVKShaderStageResourceBinding
 
-MVKShaderStageResourceBinding MVKShaderStageResourceBinding::operator+ (const MVKShaderStageResourceBinding& rhs) {
-	MVKShaderStageResourceBinding rslt;
-	rslt.bufferIndex = this->bufferIndex + rhs.bufferIndex;
-	rslt.textureIndex = this->textureIndex + rhs.textureIndex;
-	rslt.samplerIndex = this->samplerIndex + rhs.samplerIndex;
-	rslt.dynamicOffsetBufferIndex = this->dynamicOffsetBufferIndex + rhs.dynamicOffsetBufferIndex;
-	return rslt;
+MVKShaderStageResourceBinding MVKShaderStageResourceBinding::operator+(
+    const MVKShaderStageResourceBinding& rhs) {
+    MVKShaderStageResourceBinding rslt;
+    rslt.bufferIndex = this->bufferIndex + rhs.bufferIndex;
+    rslt.textureIndex = this->textureIndex + rhs.textureIndex;
+    rslt.samplerIndex = this->samplerIndex + rhs.samplerIndex;
+    rslt.dynamicOffsetBufferIndex =
+        this->dynamicOffsetBufferIndex + rhs.dynamicOffsetBufferIndex;
+    return rslt;
 }
 
-MVKShaderStageResourceBinding& MVKShaderStageResourceBinding::operator+= (const MVKShaderStageResourceBinding& rhs) {
-	this->bufferIndex += rhs.bufferIndex;
-	this->textureIndex += rhs.textureIndex;
-	this->samplerIndex += rhs.samplerIndex;
-	this->dynamicOffsetBufferIndex += rhs.dynamicOffsetBufferIndex;
-	return *this;
+MVKShaderStageResourceBinding& MVKShaderStageResourceBinding::operator+=(
+    const MVKShaderStageResourceBinding& rhs) {
+    this->bufferIndex += rhs.bufferIndex;
+    this->textureIndex += rhs.textureIndex;
+    this->samplerIndex += rhs.samplerIndex;
+    this->dynamicOffsetBufferIndex += rhs.dynamicOffsetBufferIndex;
+    return *this;
 }
 
 void MVKShaderStageResourceBinding::clearArgumentBufferResources() {
-	bufferIndex = 0;
-	textureIndex = 0;
-	samplerIndex = 0;
+    bufferIndex = 0;
+    textureIndex = 0;
+    samplerIndex = 0;
 }
-
 
 #pragma mark MVKShaderResourceBinding
 
 uint32_t MVKShaderResourceBinding::getMaxBufferIndex() {
-	return std::max({stages[kMVKShaderStageVertex].bufferIndex, stages[kMVKShaderStageTessCtl].bufferIndex, stages[kMVKShaderStageTessEval].bufferIndex, stages[kMVKShaderStageFragment].bufferIndex, stages[kMVKShaderStageCompute].bufferIndex});
+    return std::max({stages[kMVKShaderStageVertex].bufferIndex,
+                     stages[kMVKShaderStageTessCtl].bufferIndex,
+                     stages[kMVKShaderStageTessEval].bufferIndex,
+                     stages[kMVKShaderStageFragment].bufferIndex,
+                     stages[kMVKShaderStageCompute].bufferIndex});
 }
 
 uint32_t MVKShaderResourceBinding::getMaxTextureIndex() {
-	return std::max({stages[kMVKShaderStageVertex].textureIndex, stages[kMVKShaderStageTessCtl].textureIndex, stages[kMVKShaderStageTessEval].textureIndex, stages[kMVKShaderStageFragment].textureIndex, stages[kMVKShaderStageCompute].textureIndex});
+    return std::max({stages[kMVKShaderStageVertex].textureIndex,
+                     stages[kMVKShaderStageTessCtl].textureIndex,
+                     stages[kMVKShaderStageTessEval].textureIndex,
+                     stages[kMVKShaderStageFragment].textureIndex,
+                     stages[kMVKShaderStageCompute].textureIndex});
 }
 
 uint32_t MVKShaderResourceBinding::getMaxSamplerIndex() {
-	return std::max({stages[kMVKShaderStageVertex].samplerIndex, stages[kMVKShaderStageTessCtl].samplerIndex, stages[kMVKShaderStageTessEval].samplerIndex, stages[kMVKShaderStageFragment].samplerIndex, stages[kMVKShaderStageCompute].samplerIndex});
+    return std::max({stages[kMVKShaderStageVertex].samplerIndex,
+                     stages[kMVKShaderStageTessCtl].samplerIndex,
+                     stages[kMVKShaderStageTessEval].samplerIndex,
+                     stages[kMVKShaderStageFragment].samplerIndex,
+                     stages[kMVKShaderStageCompute].samplerIndex});
 }
 
-MVKShaderResourceBinding MVKShaderResourceBinding::operator+ (const MVKShaderResourceBinding& rhs) {
-	MVKShaderResourceBinding rslt;
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		rslt.stages[i] = this->stages[i] + rhs.stages[i];
-	}
-	return rslt;
+MVKShaderResourceBinding
+MVKShaderResourceBinding::operator+(const MVKShaderResourceBinding& rhs) {
+    MVKShaderResourceBinding rslt;
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        rslt.stages[i] = this->stages[i] + rhs.stages[i];
+    }
+    return rslt;
 }
 
-MVKShaderResourceBinding& MVKShaderResourceBinding::operator+= (const MVKShaderResourceBinding& rhs) {
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		this->stages[i] += rhs.stages[i];
-	}
-	return *this;
+MVKShaderResourceBinding&
+MVKShaderResourceBinding::operator+=(const MVKShaderResourceBinding& rhs) {
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        this->stages[i] += rhs.stages[i];
+    }
+    return *this;
 }
 
 void MVKShaderResourceBinding::clearArgumentBufferResources() {
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		stages[i].clearArgumentBufferResources();
-	}
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        stages[i].clearArgumentBufferResources();
+    }
 }
 
 void MVKShaderResourceBinding::addArgumentBuffers(uint32_t count) {
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		stages[i].bufferIndex += count;
-	}
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        stages[i].bufferIndex += count;
+    }
 }
 
-void mvkPopulateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-									   MVKShaderStageResourceBinding& ssRB,
-									   MVKShaderStage stage,
-									   uint32_t descriptorSetIndex,
-									   uint32_t bindingIndex,
-									   uint32_t count,
-									   VkDescriptorType descType,
-									   MVKSampler* immutableSampler,
-									   bool usingNativeTextureAtomics) {
-	if (count == 0) { return; }
+void mvkPopulateShaderConversionConfig(
+    mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+    MVKShaderStageResourceBinding& ssRB, MVKShaderStage stage,
+    uint32_t descriptorSetIndex, uint32_t bindingIndex, uint32_t count,
+    VkDescriptorType descType, MVKSampler* immutableSampler,
+    bool usingNativeTextureAtomics) {
+    if (count == 0) {
+        return;
+    }
 
-#define addResourceBinding(spvRezType)												\
-	do {																			\
-		mvk::MSLResourceBinding rb;													\
-		auto& rbb = rb.resourceBinding;												\
-		rbb.stage = spvExecModels[stage];											\
-		rbb.basetype = SPIRV_CROSS_NAMESPACE::SPIRType::spvRezType;					\
-		rbb.desc_set = descriptorSetIndex;											\
-		rbb.binding = bindingIndex;													\
-		rbb.count = count;															\
-		rbb.msl_buffer = ssRB.bufferIndex;											\
-		rbb.msl_texture = ssRB.textureIndex;										\
-		rbb.msl_sampler = ssRB.samplerIndex;										\
-		if (immutableSampler) { immutableSampler->getConstexprSampler(rb); }		\
-		shaderConfig.resourceBindings.push_back(rb);								\
-	} while(false)
+#define addResourceBinding(spvRezType)                                         \
+    do {                                                                       \
+        mvk::MSLResourceBinding rb;                                            \
+        auto& rbb = rb.resourceBinding;                                        \
+        rbb.stage = spvExecModels[stage];                                      \
+        rbb.basetype = SPIRV_CROSS_NAMESPACE::SPIRType::spvRezType;            \
+        rbb.desc_set = descriptorSetIndex;                                     \
+        rbb.binding = bindingIndex;                                            \
+        rbb.count = count;                                                     \
+        rbb.msl_buffer = ssRB.bufferIndex;                                     \
+        rbb.msl_texture = ssRB.textureIndex;                                   \
+        rbb.msl_sampler = ssRB.samplerIndex;                                   \
+        if (immutableSampler) {                                                \
+            immutableSampler->getConstexprSampler(rb);                         \
+        }                                                                      \
+        shaderConfig.resourceBindings.push_back(rb);                           \
+    } while (false)
 
-	static const spv::ExecutionModel spvExecModels[] = {
-		spv::ExecutionModelVertex,
-		spv::ExecutionModelTessellationControl,
-		spv::ExecutionModelTessellationEvaluation,
-		spv::ExecutionModelFragment,
-		spv::ExecutionModelGLCompute
-	};
+    static const spv::ExecutionModel spvExecModels[] =
+        {spv::ExecutionModelVertex, spv::ExecutionModelTessellationControl,
+         spv::ExecutionModelTessellationEvaluation, spv::ExecutionModelFragment,
+         spv::ExecutionModelGLCompute};
 
-	switch (descType) {
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			addResourceBinding(Void);
-			break;
+    switch (descType) {
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        addResourceBinding(Void);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
-			addResourceBinding(Float);
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
+        addResourceBinding(Float);
 
-			mvk::DescriptorBinding db;
-			db.stage = spvExecModels[stage];
-			db.descriptorSet = descriptorSetIndex;
-			db.binding = bindingIndex;
-			db.index = ssRB.dynamicOffsetBufferIndex;
-			shaderConfig.dynamicBufferDescriptors.push_back(db);
-			break;
-		}
+        mvk::DescriptorBinding db;
+        db.stage = spvExecModels[stage];
+        db.descriptorSet = descriptorSetIndex;
+        db.binding = bindingIndex;
+        db.index = ssRB.dynamicOffsetBufferIndex;
+        shaderConfig.dynamicBufferDescriptors.push_back(db);
+        break;
+    }
 
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-		case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-			addResourceBinding(Image);
-			break;
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        addResourceBinding(Image);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			addResourceBinding(Image);
-			if ( !usingNativeTextureAtomics ) {
-				addResourceBinding(Void);
-			}
-			break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        addResourceBinding(Image);
+        if (!usingNativeTextureAtomics) {
+            addResourceBinding(Void);
+        }
+        break;
 
-		case VK_DESCRIPTOR_TYPE_SAMPLER:
-			addResourceBinding(Sampler);
-			break;
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+        addResourceBinding(Sampler);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			addResourceBinding(SampledImage);
-			break;
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        addResourceBinding(SampledImage);
+        break;
 
-		default:
-			addResourceBinding(Unknown);
-			break;
-	}
+    default:
+        addResourceBinding(Unknown);
+        break;
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKDescriptorSetLayoutBinding
 
-MVKVulkanAPIObject* MVKDescriptorSetLayoutBinding::getVulkanAPIObject() { return _layout; };
+MVKVulkanAPIObject* MVKDescriptorSetLayoutBinding::getVulkanAPIObject() {
+    return _layout;
+};
 
-uint32_t MVKDescriptorSetLayoutBinding::getDescriptorCount(uint32_t variableDescriptorCount) const {
-	if (_info.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		return 1;
-	}
-	if (hasVariableDescriptorCount()) {
-		return std::min(variableDescriptorCount, _info.descriptorCount);
-	}
-	return _info.descriptorCount;
+uint32_t MVKDescriptorSetLayoutBinding::getDescriptorCount(
+    uint32_t variableDescriptorCount) const {
+    if (_info.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        return 1;
+    }
+    if (hasVariableDescriptorCount()) {
+        return std::min(variableDescriptorCount, _info.descriptorCount);
+    }
+    return _info.descriptorCount;
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKDescriptorSetLayoutBinding::bind(MVKCommandEncoder* cmdEncoder,
-										 VkPipelineBindPoint pipelineBindPoint,
-										 MVKDescriptorSet* descSet,
-										 MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-										 MVKArrayRef<uint32_t> dynamicOffsets,
-										 uint32_t& dynamicOffsetIndex) {
+void MVKDescriptorSetLayoutBinding::bind(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKDescriptorSet* descSet, MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+    MVKArrayRef<uint32_t> dynamicOffsets, uint32_t& dynamicOffsetIndex) {
 
-	// Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
-    MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
+    // Establish the resource indices to use, by combining the offsets of the
+    // DSL and this DSL binding.
+    MVKShaderResourceBinding mtlIdxs =
+        _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
 
-	VkDescriptorType descType = getDescriptorType();
-	uint32_t descCnt = getDescriptorCount(descSet->_variableDescriptorCount);
+    VkDescriptorType descType = getDescriptorType();
+    uint32_t descCnt = getDescriptorCount(descSet->_variableDescriptorCount);
     for (uint32_t descIdx = 0; descIdx < descCnt; descIdx++) {
-		MVKDescriptor* mvkDesc = descSet->getDescriptor(getBinding(), descIdx);
-		if (mvkDesc->getDescriptorType() == descType) {
-			mvkDesc->bind(cmdEncoder, pipelineBindPoint, this, descIdx, _applyToStage, mtlIdxs, dynamicOffsets, dynamicOffsetIndex);
-		}
+        MVKDescriptor* mvkDesc = descSet->getDescriptor(getBinding(), descIdx);
+        if (mvkDesc->getDescriptorType() == descType) {
+            mvkDesc->bind(cmdEncoder, pipelineBindPoint, this, descIdx,
+                          _applyToStage, mtlIdxs, dynamicOffsets,
+                          dynamicOffsetIndex);
+        }
     }
 }
 
-template<typename T>
+template <typename T>
 static const T& get(const void* pData, size_t stride, uint32_t index) {
     return *(T*)((const char*)pData + stride * index);
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
-                                         VkPipelineBindPoint pipelineBindPoint,
-                                         uint32_t& dstArrayElement,
-                                         uint32_t& descriptorCount,
-                                         uint32_t& descriptorsPushed,
-                                         VkDescriptorType descriptorType,
-                                         size_t stride,
-                                         const void* pData,
-                                         MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
+void MVKDescriptorSetLayoutBinding::push(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    uint32_t& dstArrayElement, uint32_t& descriptorCount,
+    uint32_t& descriptorsPushed, VkDescriptorType descriptorType, size_t stride,
+    const void* pData, MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
     MVKMTLBufferBinding bb;
     MVKMTLTextureBinding tb;
     MVKMTLSamplerStateBinding sb;
@@ -256,151 +274,196 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
         return;
     }
 
-    // Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
-    MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
+    // Establish the resource indices to use, by combining the offsets of the
+    // DSL and this DSL binding.
+    MVKShaderResourceBinding mtlIdxs =
+        _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
 
     for (uint32_t rezIdx = dstArrayElement;
-         rezIdx < _info.descriptorCount && rezIdx - dstArrayElement < descriptorCount;
+         rezIdx < _info.descriptorCount &&
+         rezIdx - dstArrayElement < descriptorCount;
          rezIdx++) {
         switch (_info.descriptorType) {
 
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: {
-                const auto& bufferInfo = get<VkDescriptorBufferInfo>(pData, stride, rezIdx - dstArrayElement);
-                MVKBuffer* buffer = (MVKBuffer*)bufferInfo.buffer;
-                bb.mtlBuffer = buffer->getMTLBuffer();
-                bb.offset = buffer->getMTLBufferOffset() + bufferInfo.offset;
-                if (bufferInfo.range == VK_WHOLE_SIZE)
-                    bb.size = (uint32_t)(buffer->getByteCount() - bb.offset);
-                else
-                    bb.size = (uint32_t)bufferInfo.range;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: {
+            const auto& bufferInfo =
+                get<VkDescriptorBufferInfo>(pData, stride,
+                                            rezIdx - dstArrayElement);
+            MVKBuffer* buffer = (MVKBuffer*)bufferInfo.buffer;
+            bb.mtlBuffer = buffer->getMTLBuffer();
+            bb.offset = buffer->getMTLBufferOffset() + bufferInfo.offset;
+            if (bufferInfo.range == VK_WHOLE_SIZE)
+                bb.size = (uint32_t)(buffer->getByteCount() - bb.offset);
+            else
+                bb.size = (uint32_t)bufferInfo.range;
 
-                for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-                    if (_applyToStage[i]) {
-                        bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
-                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-                    }
+            for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount;
+                 i++) {
+                if (_applyToStage[i]) {
+                    bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
+                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                             pipelineBindPoint, i, bb);
                 }
-                break;
             }
+            break;
+        }
 
-            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT: {
-                const auto& inlineUniformBlock = *(VkWriteDescriptorSetInlineUniformBlockEXT*)pData;
-                bb.mtlBytes = inlineUniformBlock.pData;
-                bb.size = inlineUniformBlock.dataSize;
-                bb.isInline = true;
-                for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-                    if (_applyToStage[i]) {
-                        bb.index = mtlIdxs.stages[i].bufferIndex;
-                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-                    }
+        case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT: {
+            const auto& inlineUniformBlock =
+                *(VkWriteDescriptorSetInlineUniformBlockEXT*)pData;
+            bb.mtlBytes = inlineUniformBlock.pData;
+            bb.size = inlineUniformBlock.dataSize;
+            bb.isInline = true;
+            for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount;
+                 i++) {
+                if (_applyToStage[i]) {
+                    bb.index = mtlIdxs.stages[i].bufferIndex;
+                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                             pipelineBindPoint, i, bb);
                 }
-                break;
             }
+            break;
+        }
 
-            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
-                const auto& imageInfo = get<VkDescriptorImageInfo>(pData, stride, rezIdx - dstArrayElement);
-                MVKImageView* imageView = (MVKImageView*)imageInfo.imageView;
-                uint8_t planeCount = (imageView) ? imageView->getPlaneCount() : 1;
-                for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
-                    tb.mtlTexture = imageView->getMTLTexture(planeIndex);
-                    tb.swizzle = (_info.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ? imageView->getPackedSwizzle() : 0;
-                    if (_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-                        id<MTLTexture> mtlTex = tb.mtlTexture;
-                        if (mtlTex.parentTexture) { mtlTex = mtlTex.parentTexture; }
-                        bb.mtlBuffer = mtlTex.buffer;
-                        bb.offset = mtlTex.bufferOffset;
-                        bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
-                    }
-                    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-                        if (_applyToStage[i]) {
-                            tb.index = mtlIdxs.stages[i].textureIndex + rezIdx + planeIndex;
-                            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint, i, tb);
-                            if (_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !getMetalFeatures().nativeTextureAtomics) {
-                                bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
-                                BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-                            }
-                        }
-                    }
-                }
-                break;
-            }
-
-            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-                auto* bufferView = get<MVKBufferView*>(pData, stride, rezIdx - dstArrayElement);
-                tb.mtlTexture = bufferView->getMTLTexture();
-                tb.swizzle = 0;
-                if (_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
+            const auto& imageInfo =
+                get<VkDescriptorImageInfo>(pData, stride,
+                                           rezIdx - dstArrayElement);
+            MVKImageView* imageView = (MVKImageView*)imageInfo.imageView;
+            uint8_t planeCount = (imageView) ? imageView->getPlaneCount() : 1;
+            for (uint8_t planeIndex = 0; planeIndex < planeCount;
+                 planeIndex++) {
+                tb.mtlTexture = imageView->getMTLTexture(planeIndex);
+                tb.swizzle =
+                    (_info.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)
+                        ? imageView->getPackedSwizzle()
+                        : 0;
+                if (_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
                     id<MTLTexture> mtlTex = tb.mtlTexture;
+                    if (mtlTex.parentTexture) {
+                        mtlTex = mtlTex.parentTexture;
+                    }
                     bb.mtlBuffer = mtlTex.buffer;
                     bb.offset = mtlTex.bufferOffset;
-                    bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
+                    bb.size =
+                        (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
                 }
-                for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+                for (uint32_t i = kMVKShaderStageVertex;
+                     i < kMVKShaderStageCount; i++) {
                     if (_applyToStage[i]) {
-                        tb.index = mtlIdxs.stages[i].textureIndex + rezIdx;
-                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint, i, tb);
-                        if (_info.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER && !getMetalFeatures().nativeTextureAtomics) {
+                        tb.index = mtlIdxs.stages[i].textureIndex + rezIdx +
+                                   planeIndex;
+                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture,
+                                                 pipelineBindPoint, i, tb);
+                        if (_info.descriptorType ==
+                                VK_DESCRIPTOR_TYPE_STORAGE_IMAGE &&
+                            !getMetalFeatures().nativeTextureAtomics) {
                             bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
-                            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
+                            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                                     pipelineBindPoint, i, bb);
                         }
                     }
                 }
-                break;
             }
+            break;
+        }
 
-            case VK_DESCRIPTOR_TYPE_SAMPLER: {
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
+            auto* bufferView =
+                get<MVKBufferView*>(pData, stride, rezIdx - dstArrayElement);
+            tb.mtlTexture = bufferView->getMTLTexture();
+            tb.swizzle = 0;
+            if (_info.descriptorType ==
+                VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
+                id<MTLTexture> mtlTex = tb.mtlTexture;
+                bb.mtlBuffer = mtlTex.buffer;
+                bb.offset = mtlTex.bufferOffset;
+                bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
+            }
+            for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount;
+                 i++) {
+                if (_applyToStage[i]) {
+                    tb.index = mtlIdxs.stages[i].textureIndex + rezIdx;
+                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture,
+                                             pipelineBindPoint, i, tb);
+                    if (_info.descriptorType ==
+                            VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER &&
+                        !getMetalFeatures().nativeTextureAtomics) {
+                        bb.index = mtlIdxs.stages[i].bufferIndex + rezIdx;
+                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                                 pipelineBindPoint, i, bb);
+                    }
+                }
+            }
+            break;
+        }
+
+        case VK_DESCRIPTOR_TYPE_SAMPLER: {
+            MVKSampler* sampler;
+            if (_immutableSamplers.empty()) {
+                sampler =
+                    (MVKSampler*)get<VkDescriptorImageInfo>(pData, stride,
+                                                            rezIdx -
+                                                                dstArrayElement)
+                        .sampler;
+                validate(sampler);
+            } else {
+                sampler = _immutableSamplers[rezIdx];
+            }
+            sb.mtlSamplerState = sampler->getMTLSamplerState();
+            for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount;
+                 i++) {
+                if (_applyToStage[i]) {
+                    sb.index = mtlIdxs.stages[i].samplerIndex + rezIdx;
+                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState,
+                                             pipelineBindPoint, i, sb);
+                }
+            }
+            break;
+        }
+
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
+            const auto& imageInfo =
+                get<VkDescriptorImageInfo>(pData, stride,
+                                           rezIdx - dstArrayElement);
+            MVKImageView* imageView = (MVKImageView*)imageInfo.imageView;
+            uint8_t planeCount = (imageView) ? imageView->getPlaneCount() : 1;
+            for (uint8_t planeIndex = 0; planeIndex < planeCount;
+                 planeIndex++) {
+                tb.mtlTexture = imageView->getMTLTexture(planeIndex);
+                tb.swizzle = (imageView) ? imageView->getPackedSwizzle() : 0;
                 MVKSampler* sampler;
-				if (_immutableSamplers.empty()) {
-                    sampler = (MVKSampler*)get<VkDescriptorImageInfo>(pData, stride, rezIdx - dstArrayElement).sampler;
-					validate(sampler);
-				} else {
+                if (_immutableSamplers.empty()) {
+                    sampler = (MVKSampler*)imageInfo.sampler;
+                    validate(sampler);
+                } else {
                     sampler = _immutableSamplers[rezIdx];
-				}
+                }
                 sb.mtlSamplerState = sampler->getMTLSamplerState();
-                for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+                for (uint32_t i = kMVKShaderStageVertex;
+                     i < kMVKShaderStageCount; i++) {
                     if (_applyToStage[i]) {
+                        tb.index = mtlIdxs.stages[i].textureIndex + rezIdx +
+                                   planeIndex;
                         sb.index = mtlIdxs.stages[i].samplerIndex + rezIdx;
-                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState, pipelineBindPoint, i, sb);
+                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture,
+                                                 pipelineBindPoint, i, tb);
+                        BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState,
+                                                 pipelineBindPoint, i, sb);
                     }
                 }
-                break;
             }
+            break;
+        }
 
-            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
-                const auto& imageInfo = get<VkDescriptorImageInfo>(pData, stride, rezIdx - dstArrayElement);
-                MVKImageView* imageView = (MVKImageView*)imageInfo.imageView;
-                uint8_t planeCount = (imageView) ? imageView->getPlaneCount() : 1;
-                for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
-                    tb.mtlTexture = imageView->getMTLTexture(planeIndex);
-                    tb.swizzle = (imageView) ? imageView->getPackedSwizzle() : 0;
-                    MVKSampler* sampler;
-                    if (_immutableSamplers.empty()) {
-                        sampler = (MVKSampler*)imageInfo.sampler;
-                        validate(sampler);
-                    } else {
-                        sampler = _immutableSamplers[rezIdx];
-                    }
-                    sb.mtlSamplerState = sampler->getMTLSamplerState();
-                    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-                        if (_applyToStage[i]) {
-                            tb.index = mtlIdxs.stages[i].textureIndex + rezIdx + planeIndex;
-                            sb.index = mtlIdxs.stages[i].samplerIndex + rezIdx;
-                            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint, i, tb);
-                            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState, pipelineBindPoint, i, sb);
-                        }
-                    }
-                }
-                break;
-            }
-
-            default:
-                break;
+        default:
+            break;
         }
     }
 
@@ -413,592 +476,702 @@ void MVKDescriptorSetLayoutBinding::push(MVKCommandEncoder* cmdEncoder,
     }
 }
 
-// Adds MTLArgumentDescriptors to the array, and updates resource indexes consumed.
-void MVKDescriptorSetLayoutBinding::addMTLArgumentDescriptors(NSMutableArray<MTLArgumentDescriptor*>* args,
-															  uint32_t variableDescriptorCount) {
-	switch (getDescriptorType()) {
+// Adds MTLArgumentDescriptors to the array, and updates resource indexes
+// consumed.
+void MVKDescriptorSetLayoutBinding::addMTLArgumentDescriptors(
+    NSMutableArray<MTLArgumentDescriptor*>* args,
+    uint32_t variableDescriptorCount) {
+    switch (getDescriptorType()) {
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().bufferIndex, MTLDataTypePointer, MTLArgumentAccessReadOnly);
-			break;
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().bufferIndex,
+                                 MTLDataTypePointer, MTLArgumentAccessReadOnly);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().bufferIndex, MTLDataTypePointer, MTLArgumentAccessReadWrite);
-			break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().bufferIndex,
+                                 MTLDataTypePointer,
+                                 MTLArgumentAccessReadWrite);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-		case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().textureIndex, MTLDataTypeTexture, MTLArgumentAccessReadOnly);
-			break;
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().textureIndex,
+                                 MTLDataTypeTexture, MTLArgumentAccessReadOnly);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().textureIndex, MTLDataTypeTexture, MTLArgumentAccessReadWrite);
-			if (!getMetalFeatures().nativeTextureAtomics) { // Needed for emulated atomic operations
-				addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().bufferIndex, MTLDataTypePointer, MTLArgumentAccessReadWrite);
-			}
-			break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().textureIndex,
+                                 MTLDataTypeTexture,
+                                 MTLArgumentAccessReadWrite);
+        if (!getMetalFeatures().nativeTextureAtomics) { // Needed for emulated
+                                                        // atomic operations
+            addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                     getMetalResourceIndexOffsets().bufferIndex,
+                                     MTLDataTypePointer,
+                                     MTLArgumentAccessReadWrite);
+        }
+        break;
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().textureIndex, MTLDataTypeTexture, MTLArgumentAccessReadOnly);
-			break;
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().textureIndex,
+                                 MTLDataTypeTexture, MTLArgumentAccessReadOnly);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().textureIndex, MTLDataTypeTexture, MTLArgumentAccessReadWrite);
-			if (!getMetalFeatures().nativeTextureAtomics) { // Needed for emulated atomic operations
-				addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().bufferIndex, MTLDataTypePointer, MTLArgumentAccessReadWrite);
-			}
-			break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().textureIndex,
+                                 MTLDataTypeTexture,
+                                 MTLArgumentAccessReadWrite);
+        if (!getMetalFeatures().nativeTextureAtomics) { // Needed for emulated
+                                                        // atomic operations
+            addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                     getMetalResourceIndexOffsets().bufferIndex,
+                                     MTLDataTypePointer,
+                                     MTLArgumentAccessReadWrite);
+        }
+        break;
 
-		case VK_DESCRIPTOR_TYPE_SAMPLER:
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().samplerIndex, MTLDataTypeSampler, MTLArgumentAccessReadOnly);
-			break;
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().samplerIndex,
+                                 MTLDataTypeSampler, MTLArgumentAccessReadOnly);
+        break;
 
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
-			uint8_t maxPlaneCnt = getMaxPlaneCount();
-			for (uint8_t planeIdx = 0; planeIdx < maxPlaneCnt; planeIdx++) {
-				addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().textureIndex + planeIdx, MTLDataTypeTexture, MTLArgumentAccessReadOnly);
-			}
-			addMTLArgumentDescriptor(args, variableDescriptorCount, getMetalResourceIndexOffsets().samplerIndex, MTLDataTypeSampler, MTLArgumentAccessReadOnly);
-			break;
-		}
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
+        uint8_t maxPlaneCnt = getMaxPlaneCount();
+        for (uint8_t planeIdx = 0; planeIdx < maxPlaneCnt; planeIdx++) {
+            addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                     getMetalResourceIndexOffsets()
+                                             .textureIndex +
+                                         planeIdx,
+                                     MTLDataTypeTexture,
+                                     MTLArgumentAccessReadOnly);
+        }
+        addMTLArgumentDescriptor(args, variableDescriptorCount,
+                                 getMetalResourceIndexOffsets().samplerIndex,
+                                 MTLDataTypeSampler, MTLArgumentAccessReadOnly);
+        break;
+    }
 
-		default:
-			break;
-	}
+    default:
+        break;
+    }
 }
 
-void MVKDescriptorSetLayoutBinding::addMTLArgumentDescriptor(NSMutableArray<MTLArgumentDescriptor*>* args,
-															 uint32_t variableDescriptorCount,
-															 uint32_t argIndex,
-															 MTLDataType dataType,
-															 MTLArgumentAccess access) {
-	uint32_t descCnt = getDescriptorCount(variableDescriptorCount);
-	if (descCnt == 0) { return; }
-	
-	auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
-	argDesc.dataType = dataType;
-	argDesc.access = access;
-	argDesc.index = argIndex;
-	argDesc.arrayLength = descCnt;
-	argDesc.textureType = MTLTextureType2D;
+void MVKDescriptorSetLayoutBinding::addMTLArgumentDescriptor(
+    NSMutableArray<MTLArgumentDescriptor*>* args,
+    uint32_t variableDescriptorCount, uint32_t argIndex, MTLDataType dataType,
+    MTLArgumentAccess access) {
+    uint32_t descCnt = getDescriptorCount(variableDescriptorCount);
+    if (descCnt == 0) {
+        return;
+    }
 
-	[args addObject: argDesc];
+    auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
+    argDesc.dataType = dataType;
+    argDesc.access = access;
+    argDesc.index = argIndex;
+    argDesc.arrayLength = descCnt;
+    argDesc.textureType = MTLTextureType2D;
+
+    [args addObject:argDesc];
 }
 
 uint8_t MVKDescriptorSetLayoutBinding::getMaxPlaneCount() {
-	uint8_t maxPlaneCnt = 1;
-	for (auto* mvkSamp : _immutableSamplers) {
-		maxPlaneCnt = std::max(maxPlaneCnt, mvkSamp->getPlaneCount());
-	}
-	return maxPlaneCnt;
+    uint8_t maxPlaneCnt = 1;
+    for (auto* mvkSamp : _immutableSamplers) {
+        maxPlaneCnt = std::max(maxPlaneCnt, mvkSamp->getPlaneCount());
+    }
+    return maxPlaneCnt;
 }
 
-uint32_t MVKDescriptorSetLayoutBinding::getMTLResourceCount(uint32_t variableDescriptorCount) {
-	uint32_t rezCntPerElem = 1;
-	switch (_info.descriptorType) {
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			rezCntPerElem = getMaxPlaneCount() + 1;
-			break;
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			rezCntPerElem = getMetalFeatures().nativeTextureAtomics ? 1 : 2;
-			break;
-		default:
-			break;
-	}
-	return rezCntPerElem * getDescriptorCount(variableDescriptorCount);
+uint32_t MVKDescriptorSetLayoutBinding::getMTLResourceCount(
+    uint32_t variableDescriptorCount) {
+    uint32_t rezCntPerElem = 1;
+    switch (_info.descriptorType) {
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        rezCntPerElem = getMaxPlaneCount() + 1;
+        break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        rezCntPerElem = getMetalFeatures().nativeTextureAtomics ? 1 : 2;
+        break;
+    default:
+        break;
+    }
+    return rezCntPerElem * getDescriptorCount(variableDescriptorCount);
 }
 
 // Encodes an immutable sampler to the Metal argument buffer.
-void MVKDescriptorSetLayoutBinding::encodeImmutableSamplersToMetalArgumentBuffer(MVKDescriptorSet* mvkDescSet) {
-	if ( !mvkDescSet->hasMetalArgumentBuffer() ) { return; }
+void MVKDescriptorSetLayoutBinding::
+    encodeImmutableSamplersToMetalArgumentBuffer(MVKDescriptorSet* mvkDescSet) {
+    if (!mvkDescSet->hasMetalArgumentBuffer()) {
+        return;
+    }
 
-	auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-	size_t sCnt = _immutableSamplers.size();
-	for (uint32_t sIdx = 0; sIdx < sCnt; sIdx++) {
-		MVKSampler* mvkSamp = _immutableSamplers[sIdx];
-		id<MTLSamplerState> mtlSamp = (mvkSamp
-									   ? mvkSamp->getMTLSamplerState()
-									   : getDevice()->getDefaultMTLSamplerState());
-		uint32_t argIdx = getMetalResourceIndexOffsets().samplerIndex + sIdx;
-		mvkArgBuff.setSamplerState(mtlSamp, argIdx);
-	}
+    auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+    size_t sCnt = _immutableSamplers.size();
+    for (uint32_t sIdx = 0; sIdx < sCnt; sIdx++) {
+        MVKSampler* mvkSamp = _immutableSamplers[sIdx];
+        id<MTLSamplerState> mtlSamp =
+            (mvkSamp ? mvkSamp->getMTLSamplerState()
+                     : getDevice()->getDefaultMTLSamplerState());
+        uint32_t argIdx = getMetalResourceIndexOffsets().samplerIndex + sIdx;
+        mvkArgBuff.setSamplerState(mtlSamp, argIdx);
+    }
 }
 
-void MVKDescriptorSetLayoutBinding::populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-                                                                   MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-                                                                   uint32_t dslIndex) {
-	// For argument buffers, set variable length arrays to length 1 in shader.
-	bool isUsingMtlArgBuff = _layout->isUsingMetalArgumentBuffers();
-	uint32_t descCnt = isUsingMtlArgBuff ? getDescriptorCount(1) : getDescriptorCount();
+void MVKDescriptorSetLayoutBinding::populateShaderConversionConfig(
+    mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+    MVKShaderResourceBinding& dslMTLRezIdxOffsets, uint32_t dslIndex) {
+    // For argument buffers, set variable length arrays to length 1 in shader.
+    bool isUsingMtlArgBuff = _layout->isUsingMetalArgumentBuffers();
+    uint32_t descCnt =
+        isUsingMtlArgBuff ? getDescriptorCount(1) : getDescriptorCount();
 
-	// Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
-    MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
+    // Establish the resource indices to use, by combining the offsets of the
+    // DSL and this DSL binding.
+    MVKShaderResourceBinding mtlIdxs =
+        _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;
 
-	MVKSampler* mvkSamp = !_immutableSamplers.empty() ? _immutableSamplers.front() : nullptr;
+    MVKSampler* mvkSamp =
+        !_immutableSamplers.empty() ? _immutableSamplers.front() : nullptr;
 
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
         if (_applyToStage[stage] || isUsingMtlArgBuff) {
             mvkPopulateShaderConversionConfig(shaderConfig,
                                               mtlIdxs.stages[stage],
-                                              MVKShaderStage(stage),
-                                              dslIndex,
-                                              _info.binding,
-											  descCnt,
-											  getDescriptorType(),
-											  mvkSamp,
-											  getMetalFeatures().nativeTextureAtomics);
+                                              MVKShaderStage(stage), dslIndex,
+                                              _info.binding, descCnt,
+                                              getDescriptorType(), mvkSamp,
+                                              getMetalFeatures()
+                                                  .nativeTextureAtomics);
         }
     }
 }
 
-// If depth compare is required, but unavailable on the device, the sampler can only be used as an immutable sampler
+// If depth compare is required, but unavailable on the device, the sampler can
+// only be used as an immutable sampler
 bool MVKDescriptorSetLayoutBinding::validate(MVKSampler* mvkSampler) {
-	if (mvkSampler->getRequiresConstExprSampler()) {
-		mvkSampler->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCmdPushDescriptorSet/vkCmdPushDescriptorSetWithTemplate(): Tried to push an immutable sampler.");
-		return false;
-	}
-	return true;
+    if (mvkSampler->getRequiresConstExprSampler()) {
+        mvkSampler->reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                "vkCmdPushDescriptorSet/"
+                                "vkCmdPushDescriptorSetWithTemplate(): Tried "
+                                "to push an "
+                                "immutable sampler.");
+        return false;
+    }
+    return true;
 }
 
 MTLRenderStages MVKDescriptorSetLayoutBinding::getMTLRenderStages() {
-	MTLRenderStages mtlStages = 0;
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		if (_applyToStage[stage]) {
-			switch (stage) {
-				case kMVKShaderStageVertex:
-				case kMVKShaderStageTessCtl:
-				case kMVKShaderStageTessEval:
-					mtlStages |= MTLRenderStageVertex;
-					break;
+    MTLRenderStages mtlStages = 0;
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        if (_applyToStage[stage]) {
+            switch (stage) {
+            case kMVKShaderStageVertex:
+            case kMVKShaderStageTessCtl:
+            case kMVKShaderStageTessEval:
+                mtlStages |= MTLRenderStageVertex;
+                break;
 
-				case kMVKShaderStageFragment:
-					mtlStages |= MTLRenderStageFragment;
-					break;
+            case kMVKShaderStageFragment:
+                mtlStages |= MTLRenderStageFragment;
+                break;
 
-				default:
-					break;
-			}
-		}
-	}
-	return mtlStages;
+            default:
+                break;
+            }
+        }
+    }
+    return mtlStages;
 }
 
-std::string MVKDescriptorSetLayoutBinding::getLogDescription(std::string indent) {
-	uint32_t elemCnt = getDescriptorCount();
-	std::stringstream descStr;
-	descStr << getDescriptorIndex() << ": ";
-	descStr << std::left << std::setw(46) << mvkVkDescriptorTypeName(getDescriptorType()) << std::setw(0);
-	descStr << "with " << (hasVariableDescriptorCount() ? "up to " : "") << elemCnt << " elements";
-	descStr << " at binding " << getBinding();
-	if (elemCnt == 0) { descStr << " (inactive)"; }
-	return descStr.str();
+std::string
+MVKDescriptorSetLayoutBinding::getLogDescription(std::string indent) {
+    uint32_t elemCnt = getDescriptorCount();
+    std::stringstream descStr;
+    descStr << getDescriptorIndex() << ": ";
+    descStr << std::left << std::setw(46)
+            << mvkVkDescriptorTypeName(getDescriptorType()) << std::setw(0);
+    descStr << "with " << (hasVariableDescriptorCount() ? "up to " : "")
+            << elemCnt << " elements";
+    descStr << " at binding " << getBinding();
+    if (elemCnt == 0) {
+        descStr << " (inactive)";
+    }
+    return descStr.str();
 }
 
-MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(MVKDevice* device,
-															 MVKDescriptorSetLayout* layout,
-															 const VkDescriptorSetLayoutBinding* pBinding,
-															 VkDescriptorBindingFlagsEXT bindingFlags,
-															 uint32_t& dslDescCnt,
-															 uint32_t& dslMTLRezCnt) :
-	MVKBaseDeviceObject(device),
-	_layout(layout),
-	_info(*pBinding),
-	_flags(bindingFlags),
-	_descriptorIndex(dslDescCnt) {
+MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(
+    MVKDevice* device, MVKDescriptorSetLayout* layout,
+    const VkDescriptorSetLayoutBinding* pBinding,
+    VkDescriptorBindingFlagsEXT bindingFlags, uint32_t& dslDescCnt,
+    uint32_t& dslMTLRezCnt)
+    : MVKBaseDeviceObject(device), _layout(layout), _info(*pBinding),
+      _flags(bindingFlags), _descriptorIndex(dslDescCnt) {
 
-	// If immutable samplers are defined, copy them in.
-	// Do this before anything else, because they are referenced in getMaxPlaneCount().
-	if ( _info.pImmutableSamplers &&
-		(_info.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER ||
-		 _info.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) ) {
+    // If immutable samplers are defined, copy them in.
+    // Do this before anything else, because they are referenced in
+    // getMaxPlaneCount().
+    if (_info.pImmutableSamplers &&
+        (_info.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER ||
+         _info.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {
 
-		_immutableSamplers.reserve(_info.descriptorCount);
-		for (uint32_t i = 0; i < _info.descriptorCount; i++) {
-			_immutableSamplers.push_back((MVKSampler*)_info.pImmutableSamplers[i]);
-			_immutableSamplers.back()->retain();
-		}
-	}
-	_info.pImmutableSamplers = nullptr;     // Remove dangling pointer
+        _immutableSamplers.reserve(_info.descriptorCount);
+        for (uint32_t i = 0; i < _info.descriptorCount; i++) {
+            _immutableSamplers.push_back(
+                (MVKSampler*)_info.pImmutableSamplers[i]);
+            _immutableSamplers.back()->retain();
+        }
+    }
+    _info.pImmutableSamplers = nullptr; // Remove dangling pointer
 
-	// Determine if this binding is used by this shader stage, and initialize resource indexes.
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		_applyToStage[stage] = mvkAreAllFlagsEnabled(pBinding->stageFlags, mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(stage)));
-		initMetalResourceIndexOffsets(pBinding, stage, dslMTLRezCnt);
-	}
+    // Determine if this binding is used by this shader stage, and initialize
+    // resource indexes.
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        _applyToStage[stage] =
+            mvkAreAllFlagsEnabled(pBinding->stageFlags,
+                                  mvkVkShaderStageFlagBitsFromMVKShaderStage(
+                                      MVKShaderStage(stage)));
+        initMetalResourceIndexOffsets(pBinding, stage, dslMTLRezCnt);
+    }
 
-	// Update descriptor set layout counts
-	uint32_t descCnt = getDescriptorCount();
-	dslDescCnt += descCnt;
-	dslMTLRezCnt += getMTLResourceCount();
-	if (mvkNeedsBuffSizeAuxBuffer(pBinding)) {
-		_layout->_maxBufferIndex = std::max(_layout->_maxBufferIndex, int32_t(_mtlResourceIndexOffsets.getMaxBufferIndex() + descCnt) - 1);
-	}
+    // Update descriptor set layout counts
+    uint32_t descCnt = getDescriptorCount();
+    dslDescCnt += descCnt;
+    dslMTLRezCnt += getMTLResourceCount();
+    if (mvkNeedsBuffSizeAuxBuffer(pBinding)) {
+        _layout->_maxBufferIndex =
+            std::max(_layout->_maxBufferIndex,
+                     int32_t(_mtlResourceIndexOffsets.getMaxBufferIndex() +
+                             descCnt) -
+                         1);
+    }
 }
 
-MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(const MVKDescriptorSetLayoutBinding& binding) :
-	MVKBaseDeviceObject(binding._device),
-	_layout(binding._layout),
-	_info(binding._info),
-	_flags(binding._flags),
-	_immutableSamplers(binding._immutableSamplers),
-	_mtlResourceIndexOffsets(binding._mtlResourceIndexOffsets),
-	_descriptorIndex(binding._descriptorIndex) {
+MVKDescriptorSetLayoutBinding::MVKDescriptorSetLayoutBinding(
+    const MVKDescriptorSetLayoutBinding& binding)
+    : MVKBaseDeviceObject(binding._device), _layout(binding._layout),
+      _info(binding._info), _flags(binding._flags),
+      _immutableSamplers(binding._immutableSamplers),
+      _mtlResourceIndexOffsets(binding._mtlResourceIndexOffsets),
+      _descriptorIndex(binding._descriptorIndex) {
 
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
         _applyToStage[i] = binding._applyToStage[i];
     }
-	for (MVKSampler* sampler : _immutableSamplers) {
-		sampler->retain();
-	}
+    for (MVKSampler* sampler : _immutableSamplers) {
+        sampler->retain();
+    }
 }
 
 MVKDescriptorSetLayoutBinding::~MVKDescriptorSetLayoutBinding() {
-	for (MVKSampler* sampler : _immutableSamplers) {
-		sampler->release();
-	}
-}
-
-// Sets the appropriate Metal resource indexes within this binding from the
-// specified descriptor set binding counts, and updates those counts accordingly.
-void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(const VkDescriptorSetLayoutBinding* pBinding,
-																  uint32_t stage,
-																  uint32_t dslMTLRezCnt) {
-	// Sets an index offset and updates both that index and the general resource index.
-	// Can be used more than once for combined multi-resource descriptor types.
-	// When using Metal argument buffers, we accumulate the resource indexes cummulatively, across all resource types.
-#define setResourceIndexOffset(rezIdx, mtlRezCntPerElem)	\
-if (isUsingMtlArgBuff) {									\
-	bindIdxs.rezIdx = dslMTLRezCnt + descIdxOfst;			\
-	descIdxOfst += descCnt * mtlRezCntPerElem;				\
-} else if (_applyToStage[stage]) {							\
-	bindIdxs.rezIdx = dslCnts.rezIdx;						\
-	dslCnts.rezIdx += descCnt * mtlRezCntPerElem;			\
-}															\
-
-	bool isUsingMtlArgBuff = _layout->isUsingMetalArgumentBuffers();
-	auto& mtlFeats = getMetalFeatures();
-	MVKShaderStageResourceBinding& bindIdxs = _mtlResourceIndexOffsets.stages[stage];
-	MVKShaderStageResourceBinding& dslCnts = _layout->_mtlResourceCounts.stages[stage];
-
-	uint32_t descIdxOfst = 0;	// Updated in setResourceIndexOffset() to accommodate it being called more than once per desc type.
-	uint32_t descCnt = getDescriptorCount();
-    switch (pBinding->descriptorType) {
-        case VK_DESCRIPTOR_TYPE_SAMPLER:
-			setResourceIndexOffset(samplerIndex, 1);
-
-			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfSamplers) {
-				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of samplers.", _device->getName()));
-			}
-            break;
-
-        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			setResourceIndexOffset(textureIndex, getMaxPlaneCount());
-			setResourceIndexOffset(samplerIndex, 1);
-
-			if (pBinding->descriptorCount > 1) {
-				if ( !mtlFeats.arrayOfTextures ) {
-					_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
-				}
-				if ( !mtlFeats.arrayOfSamplers ) {
-					_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of samplers.", _device->getName()));
-				}
-			}
-            break;
-
-        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-			setResourceIndexOffset(textureIndex, 1);
-
-			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
-				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
-			}
-            break;
-
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			setResourceIndexOffset(textureIndex, 1);
-			if (!getMetalFeatures().nativeTextureAtomics) { setResourceIndexOffset(bufferIndex, 1); }
-
-			if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
-				_layout->setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Device %s does not support arrays of textures.", _device->getName()));
-			}
-			break;
-
-        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			setResourceIndexOffset(bufferIndex, 1);
-            break;
-
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			setResourceIndexOffset(bufferIndex, 1);
-			bindIdxs.dynamicOffsetBufferIndex = dslCnts.dynamicOffsetBufferIndex;
-			dslCnts.dynamicOffsetBufferIndex += descCnt;
-
-			break;
-
-        default:
-            break;
+    for (MVKSampler* sampler : _immutableSamplers) {
+        sampler->release();
     }
 }
 
+// Sets the appropriate Metal resource indexes within this binding from the
+// specified descriptor set binding counts, and updates those counts
+// accordingly.
+void MVKDescriptorSetLayoutBinding::initMetalResourceIndexOffsets(
+    const VkDescriptorSetLayoutBinding* pBinding, uint32_t stage,
+    uint32_t dslMTLRezCnt) {
+    // Sets an index offset and updates both that index and the general resource
+    // index. Can be used more than once for combined multi-resource descriptor
+    // types. When using Metal argument buffers, we accumulate the resource
+    // indexes cummulatively, across all resource types.
+#define setResourceIndexOffset(rezIdx, mtlRezCntPerElem)                       \
+    if (isUsingMtlArgBuff) {                                                   \
+        bindIdxs.rezIdx = dslMTLRezCnt + descIdxOfst;                          \
+        descIdxOfst += descCnt * mtlRezCntPerElem;                             \
+    } else if (_applyToStage[stage]) {                                         \
+        bindIdxs.rezIdx = dslCnts.rezIdx;                                      \
+        dslCnts.rezIdx += descCnt * mtlRezCntPerElem;                          \
+    }
+
+    bool isUsingMtlArgBuff = _layout->isUsingMetalArgumentBuffers();
+    auto& mtlFeats = getMetalFeatures();
+    MVKShaderStageResourceBinding& bindIdxs =
+        _mtlResourceIndexOffsets.stages[stage];
+    MVKShaderStageResourceBinding& dslCnts =
+        _layout->_mtlResourceCounts.stages[stage];
+
+    uint32_t descIdxOfst =
+        0; // Updated in setResourceIndexOffset() to accommodate it being called
+           // more than once per desc type.
+    uint32_t descCnt = getDescriptorCount();
+    switch (pBinding->descriptorType) {
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+        setResourceIndexOffset(samplerIndex, 1);
+
+        if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfSamplers) {
+            _layout->setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "Device %s does not support arrays of samplers.",
+                            _device->getName()));
+        }
+        break;
+
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        setResourceIndexOffset(textureIndex, getMaxPlaneCount());
+        setResourceIndexOffset(samplerIndex, 1);
+
+        if (pBinding->descriptorCount > 1) {
+            if (!mtlFeats.arrayOfTextures) {
+                _layout->setConfigurationResult(
+                    reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                "Device %s does not support arrays of "
+                                "textures.",
+                                _device->getName()));
+            }
+            if (!mtlFeats.arrayOfSamplers) {
+                _layout->setConfigurationResult(
+                    reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                "Device %s does not support arrays of "
+                                "samplers.",
+                                _device->getName()));
+            }
+        }
+        break;
+
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        setResourceIndexOffset(textureIndex, 1);
+
+        if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
+            _layout->setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "Device %s does not support arrays of textures.",
+                            _device->getName()));
+        }
+        break;
+
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        setResourceIndexOffset(textureIndex, 1);
+        if (!getMetalFeatures().nativeTextureAtomics) {
+            setResourceIndexOffset(bufferIndex, 1);
+        }
+
+        if (pBinding->descriptorCount > 1 && !mtlFeats.arrayOfTextures) {
+            _layout->setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "Device %s does not support arrays of textures.",
+                            _device->getName()));
+        }
+        break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        setResourceIndexOffset(bufferIndex, 1);
+        break;
+
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        setResourceIndexOffset(bufferIndex, 1);
+        bindIdxs.dynamicOffsetBufferIndex = dslCnts.dynamicOffsetBufferIndex;
+        dslCnts.dynamicOffsetBufferIndex += descCnt;
+
+        break;
+
+    default:
+        break;
+    }
+}
 
 #pragma mark -
 #pragma mark MVKDescriptor
 
 MTLResourceUsage MVKDescriptor::getMTLResourceUsage() {
-	MTLResourceUsage mtlUsage = MTLResourceUsageRead;
-	switch (getDescriptorType()) {
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			mtlUsage |= MTLResourceUsageSample;
-			break;
+    MTLResourceUsage mtlUsage = MTLResourceUsageRead;
+    switch (getDescriptorType()) {
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        mtlUsage |= MTLResourceUsageSample;
+        break;
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			mtlUsage |= MTLResourceUsageWrite;
-			break;
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        mtlUsage |= MTLResourceUsageWrite;
+        break;
 
-		default:
-			break;
-	}
-	return mtlUsage;
+    default:
+        break;
+    }
+    return mtlUsage;
 }
-
 
 #pragma mark -
 #pragma mark MVKBufferDescriptor
 
 uint32_t MVKBufferDescriptor::getBufferSize(VkDeviceSize dynamicOffset) {
-	return uint32_t((_buffRange == VK_WHOLE_SIZE
-					 ? _mvkBuffer->getByteCount() - (_mvkBuffer->getMTLBufferOffset() + _buffOffset + dynamicOffset)
-					 : _buffRange));
+    return uint32_t(
+        (_buffRange == VK_WHOLE_SIZE
+             ? _mvkBuffer->getByteCount() - (_mvkBuffer->getMTLBufferOffset() +
+                                             _buffOffset + dynamicOffset)
+             : _buffRange));
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKBufferDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-							   VkPipelineBindPoint pipelineBindPoint,
-							   MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							   uint32_t elementIndex,
-							   bool stages[],
-							   MVKShaderResourceBinding& mtlIndexes,
-							   MVKArrayRef<uint32_t> dynamicOffsets,
-							   uint32_t& dynamicOffsetIndex) {
-	MVKMTLBufferBinding bb;
-	NSUInteger bufferDynamicOffset = (usesDynamicBufferOffsets() && dynamicOffsets.size() > dynamicOffsetIndex
-									  ? dynamicOffsets[dynamicOffsetIndex++] : 0);
-	if (_mvkBuffer) {
-		bb.mtlBuffer = _mvkBuffer->getMTLBuffer();
-		bb.offset = _mvkBuffer->getMTLBufferOffset() + _buffOffset + bufferDynamicOffset;
-		bb.size = getBufferSize(bufferDynamicOffset);
-	}
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		if (stages[i]) {
-			bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex;
-			BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-		}
-	}
+                               VkPipelineBindPoint pipelineBindPoint,
+                               MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                               uint32_t elementIndex, bool stages[],
+                               MVKShaderResourceBinding& mtlIndexes,
+                               MVKArrayRef<uint32_t> dynamicOffsets,
+                               uint32_t& dynamicOffsetIndex) {
+    MVKMTLBufferBinding bb;
+    NSUInteger bufferDynamicOffset =
+        (usesDynamicBufferOffsets() &&
+                 dynamicOffsets.size() > dynamicOffsetIndex
+             ? dynamicOffsets[dynamicOffsetIndex++]
+             : 0);
+    if (_mvkBuffer) {
+        bb.mtlBuffer = _mvkBuffer->getMTLBuffer();
+        bb.offset = _mvkBuffer->getMTLBufferOffset() + _buffOffset +
+                    bufferDynamicOffset;
+        bb.size = getBufferSize(bufferDynamicOffset);
+    }
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        if (stages[i]) {
+            bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex;
+            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint,
+                                     i, bb);
+        }
+    }
 }
 
 void MVKBufferDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-								MVKDescriptorSet* mvkDescSet,
-								uint32_t dstIdx,
-								uint32_t srcIdx,
-								size_t srcStride,
-								const void* pData) {
-	auto* oldBuff = _mvkBuffer;
+                                MVKDescriptorSet* mvkDescSet, uint32_t dstIdx,
+                                uint32_t srcIdx, size_t srcStride,
+                                const void* pData) {
+    auto* oldBuff = _mvkBuffer;
 
-	const auto* pBuffInfo = &get<VkDescriptorBufferInfo>(pData, srcStride, srcIdx);
-	_mvkBuffer = (MVKBuffer*)pBuffInfo->buffer;
-	_buffOffset = pBuffInfo->offset;
-	_buffRange = pBuffInfo->range;
+    const auto* pBuffInfo =
+        &get<VkDescriptorBufferInfo>(pData, srcStride, srcIdx);
+    _mvkBuffer = (MVKBuffer*)pBuffInfo->buffer;
+    _buffOffset = pBuffInfo->offset;
+    _buffRange = pBuffInfo->range;
 
-	if (_mvkBuffer) { _mvkBuffer->retain(); }
-	if (oldBuff) { oldBuff->release(); }
+    if (_mvkBuffer) {
+        _mvkBuffer->retain();
+    }
+    if (oldBuff) {
+        oldBuff->release();
+    }
 
-	// Write resource to Metal argument buffer
-	if (mvkDescSet->hasMetalArgumentBuffer()) {
-		auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-		uint32_t argIdx = mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex + dstIdx;
-		mvkArgBuff.setBuffer(_mvkBuffer ? _mvkBuffer->getMTLBuffer() : nil,
-							 _mvkBuffer ? _mvkBuffer->getMTLBufferOffset() + _buffOffset : 0,
-							 argIdx);
-		mvkDescSet->setBufferSize(argIdx, getBufferSize());
-	}
+    // Write resource to Metal argument buffer
+    if (mvkDescSet->hasMetalArgumentBuffer()) {
+        auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+        uint32_t argIdx =
+            mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex + dstIdx;
+        mvkArgBuff.setBuffer(_mvkBuffer ? _mvkBuffer->getMTLBuffer() : nil,
+                             _mvkBuffer ? _mvkBuffer->getMTLBufferOffset() +
+                                              _buffOffset
+                                        : 0,
+                             argIdx);
+        mvkDescSet->setBufferSize(argIdx, getBufferSize());
+    }
 }
 
-void MVKBufferDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							   MVKDescriptorSet* mvkDescSet,
-							   uint32_t dstIndex,
-							   VkDescriptorImageInfo* pImageInfo,
-							   VkDescriptorBufferInfo* pBufferInfo,
-							   VkBufferView* pTexelBufferView,
-							   VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	auto& buffInfo = pBufferInfo[dstIndex];
-	buffInfo.buffer = (VkBuffer)_mvkBuffer;
-	buffInfo.offset = _buffOffset;
-	buffInfo.range = _buffRange;
+void MVKBufferDescriptor::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    auto& buffInfo = pBufferInfo[dstIndex];
+    buffInfo.buffer = (VkBuffer)_mvkBuffer;
+    buffInfo.offset = _buffOffset;
+    buffInfo.range = _buffRange;
 }
 
 void MVKBufferDescriptor::reset() {
-	if (_mvkBuffer) { _mvkBuffer->release(); }
-	_mvkBuffer = nullptr;
-	_buffOffset = 0;
-	_buffRange = 0;
-	MVKDescriptor::reset();
+    if (_mvkBuffer) {
+        _mvkBuffer->release();
+    }
+    _mvkBuffer = nullptr;
+    _buffOffset = 0;
+    _buffRange = 0;
+    MVKDescriptor::reset();
 }
 
-void MVKBufferDescriptor::encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-											  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-											  MVKShaderStage stage) {
-	id<MTLBuffer> mtlBuffer = _mvkBuffer ? _mvkBuffer->getMTLBuffer() : nil;
-	rezEncState->encodeResourceUsage(stage, mtlBuffer, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
+void MVKBufferDescriptor::encodeResourceUsage(
+    MVKResourcesCommandEncoderState* rezEncState,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKShaderStage stage) {
+    id<MTLBuffer> mtlBuffer = _mvkBuffer ? _mvkBuffer->getMTLBuffer() : nil;
+    rezEncState->encodeResourceUsage(stage, mtlBuffer, getMTLResourceUsage(),
+                                     mvkDSLBind->getMTLRenderStages());
 }
-
 
 #pragma mark -
 #pragma mark MVKInlineUniformBlockDescriptor
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKInlineUniformBlockDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-										   VkPipelineBindPoint pipelineBindPoint,
-										   MVKDescriptorSetLayoutBinding* mvkDSLBind,
-										   uint32_t elementIndex,
-										   bool stages[],
-										   MVKShaderResourceBinding& mtlIndexes,
-										   MVKArrayRef<uint32_t> dynamicOffsets,
-										   uint32_t& dynamicOffsetIndex) {
-	MVKMTLBufferBinding bb;
-	if (_mvkMTLBufferAllocation) {
-		bb.mtlBuffer = _mvkMTLBufferAllocation->_mtlBuffer;
-		bb.offset = _mvkMTLBufferAllocation->_offset;
-		bb.size = mvkDSLBind->_info.descriptorCount;
-	}
+void MVKInlineUniformBlockDescriptor::bind(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+    bool stages[], MVKShaderResourceBinding& mtlIndexes,
+    MVKArrayRef<uint32_t> dynamicOffsets, uint32_t& dynamicOffsetIndex) {
+    MVKMTLBufferBinding bb;
+    if (_mvkMTLBufferAllocation) {
+        bb.mtlBuffer = _mvkMTLBufferAllocation->_mtlBuffer;
+        bb.offset = _mvkMTLBufferAllocation->_offset;
+        bb.size = mvkDSLBind->_info.descriptorCount;
+    }
 
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		if (stages[i]) {
-			bb.index = mtlIndexes.stages[i].bufferIndex;
-			BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-		}
-	}
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        if (stages[i]) {
+            bb.index = mtlIndexes.stages[i].bufferIndex;
+            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint,
+                                     i, bb);
+        }
+    }
 }
 
-uint32_t MVKInlineUniformBlockDescriptor::writeBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-													 MVKDescriptorSet* mvkDescSet,
-													 uint32_t dstOffset,
-													 uint32_t srcOffset,
-													 uint32_t byteCount,
-													 const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	uint32_t dataLen = 0;
-	uint32_t dstBuffSize = mvkDSLBind->_info.descriptorCount;
-	uint32_t srcBuffSize = pInlineUniformBlock->dataSize;
-	if (dstOffset < dstBuffSize && srcOffset < srcBuffSize) {
-		dataLen = std::min({ byteCount, dstBuffSize - dstOffset, srcBuffSize - srcOffset });
-	}
+uint32_t MVKInlineUniformBlockDescriptor::writeBytes(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstOffset, uint32_t srcOffset, uint32_t byteCount,
+    const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    uint32_t dataLen = 0;
+    uint32_t dstBuffSize = mvkDSLBind->_info.descriptorCount;
+    uint32_t srcBuffSize = pInlineUniformBlock->dataSize;
+    if (dstOffset < dstBuffSize && srcOffset < srcBuffSize) {
+        dataLen = std::min(
+            {byteCount, dstBuffSize - dstOffset, srcBuffSize - srcOffset});
+    }
 
-	// Ensure there is a destination to write to
-	if ( !_mvkMTLBufferAllocation ) { _mvkMTLBufferAllocation = mvkDescSet->acquireMTLBufferRegion(dstBuffSize); }
+    // Ensure there is a destination to write to
+    if (!_mvkMTLBufferAllocation) {
+        _mvkMTLBufferAllocation =
+            mvkDescSet->acquireMTLBufferRegion(dstBuffSize);
+    }
 
-	uint8_t* pDstData = getData();
-	uint8_t* pSrcData = (uint8_t*)pInlineUniformBlock->pData;
-	if (pDstData && pSrcData && dataLen) {
-		memcpy(pDstData + dstOffset, pSrcData + srcOffset, dataLen);
-	}
+    uint8_t* pDstData = getData();
+    uint8_t* pSrcData = (uint8_t*)pInlineUniformBlock->pData;
+    if (pDstData && pSrcData && dataLen) {
+        memcpy(pDstData + dstOffset, pSrcData + srcOffset, dataLen);
+    }
 
-	// Write resource to Metal argument buffer
-	if (mvkDescSet->hasMetalArgumentBuffer()) {
-		auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-		uint32_t argIdx = mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex;
-		mvkArgBuff.setBuffer(_mvkMTLBufferAllocation ? _mvkMTLBufferAllocation->_mtlBuffer : nil,
-							 _mvkMTLBufferAllocation ? _mvkMTLBufferAllocation->_offset : 0,
-							 argIdx);
-	}
+    // Write resource to Metal argument buffer
+    if (mvkDescSet->hasMetalArgumentBuffer()) {
+        auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+        uint32_t argIdx =
+            mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex;
+        mvkArgBuff.setBuffer(_mvkMTLBufferAllocation
+                                 ? _mvkMTLBufferAllocation->_mtlBuffer
+                                 : nil,
+                             _mvkMTLBufferAllocation
+                                 ? _mvkMTLBufferAllocation->_offset
+                                 : 0,
+                             argIdx);
+    }
 
-	return dataLen;
+    return dataLen;
 }
 
-uint32_t MVKInlineUniformBlockDescriptor::readBytes(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-													MVKDescriptorSet* mvkDescSet,
-													uint32_t dstOffset,
-													uint32_t srcOffset,
-													uint32_t byteCount,
-													const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	uint32_t dataLen = 0;
-	uint32_t dstBuffSize = pInlineUniformBlock->dataSize;
-	uint32_t srcBuffSize = mvkDSLBind->_info.descriptorCount;
-	if (dstOffset < dstBuffSize && srcOffset < srcBuffSize) {
-		dataLen = std::min({ byteCount, dstBuffSize - dstOffset, srcBuffSize - srcOffset });
-	}
+uint32_t MVKInlineUniformBlockDescriptor::readBytes(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstOffset, uint32_t srcOffset, uint32_t byteCount,
+    const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    uint32_t dataLen = 0;
+    uint32_t dstBuffSize = pInlineUniformBlock->dataSize;
+    uint32_t srcBuffSize = mvkDSLBind->_info.descriptorCount;
+    if (dstOffset < dstBuffSize && srcOffset < srcBuffSize) {
+        dataLen = std::min(
+            {byteCount, dstBuffSize - dstOffset, srcBuffSize - srcOffset});
+    }
 
-	uint8_t* pDstData = (uint8_t*)pInlineUniformBlock->pData;
-	uint8_t* pSrcData = getData();
-	if (pDstData && pSrcData && dataLen) {
-		memcpy(pDstData + dstOffset, pSrcData + srcOffset, dataLen);
-	}
-	return dataLen;
+    uint8_t* pDstData = (uint8_t*)pInlineUniformBlock->pData;
+    uint8_t* pSrcData = getData();
+    if (pDstData && pSrcData && dataLen) {
+        memcpy(pDstData + dstOffset, pSrcData + srcOffset, dataLen);
+    }
+    return dataLen;
 }
 
-void MVKInlineUniformBlockDescriptor::encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-														  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-														  MVKShaderStage stage) {
-	id<MTLBuffer> mtlBuffer = _mvkMTLBufferAllocation ? _mvkMTLBufferAllocation->_mtlBuffer : nil;
-	rezEncState->encodeResourceUsage(stage, mtlBuffer, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
+void MVKInlineUniformBlockDescriptor::encodeResourceUsage(
+    MVKResourcesCommandEncoderState* rezEncState,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKShaderStage stage) {
+    id<MTLBuffer> mtlBuffer =
+        _mvkMTLBufferAllocation ? _mvkMTLBufferAllocation->_mtlBuffer : nil;
+    rezEncState->encodeResourceUsage(stage, mtlBuffer, getMTLResourceUsage(),
+                                     mvkDSLBind->getMTLRenderStages());
 }
 
 void MVKInlineUniformBlockDescriptor::reset() {
-	if (_mvkMTLBufferAllocation) { _mvkMTLBufferAllocation->returnToPool(); }
-	_mvkMTLBufferAllocation = nullptr;
-	MVKDescriptor::reset();
+    if (_mvkMTLBufferAllocation) {
+        _mvkMTLBufferAllocation->returnToPool();
+    }
+    _mvkMTLBufferAllocation = nullptr;
+    MVKDescriptor::reset();
 }
-
 
 #pragma mark -
 #pragma mark MVKImageDescriptor
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKImageDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-							  VkPipelineBindPoint pipelineBindPoint,
-							  MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							  uint32_t elementIndex,
-							  bool stages[],
-							  MVKShaderResourceBinding& mtlIndexes,
-							  MVKArrayRef<uint32_t> dynamicOffsets,
-							  uint32_t& dynamicOffsetIndex) {
+                              VkPipelineBindPoint pipelineBindPoint,
+                              MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                              uint32_t elementIndex, bool stages[],
+                              MVKShaderResourceBinding& mtlIndexes,
+                              MVKArrayRef<uint32_t> dynamicOffsets,
+                              uint32_t& dynamicOffsetIndex) {
 
-	VkDescriptorType descType = getDescriptorType();
-	uint8_t planeCount = (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
+    VkDescriptorType descType = getDescriptorType();
+    uint8_t planeCount = (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
     for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
         MVKMTLTextureBinding tb;
         MVKMTLBufferBinding bb;
-        
+
         if (_mvkImageView) {
             tb.mtlTexture = _mvkImageView->getMTLTexture(planeIndex);
         }
         tb.swizzle = ((descType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
                        descType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) &&
-                       tb.mtlTexture) ? _mvkImageView->getPackedSwizzle() : 0;
+                      tb.mtlTexture)
+                         ? _mvkImageView->getPackedSwizzle()
+                         : 0;
         if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && tb.mtlTexture) {
             id<MTLTexture> mtlTex = tb.mtlTexture;
-            if (mtlTex.parentTexture) { mtlTex = mtlTex.parentTexture; }
+            if (mtlTex.parentTexture) {
+                mtlTex = mtlTex.parentTexture;
+            }
             bb.mtlBuffer = mtlTex.buffer;
             bb.offset = mtlTex.bufferOffset;
             bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
         }
-        for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount;
+             i++) {
             if (stages[i]) {
-                tb.index = mtlIndexes.stages[i].textureIndex + elementIndex + planeIndex;
-                BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint, i, tb);
-                if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !cmdEncoder->getMetalFeatures().nativeTextureAtomics) {
-                    bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex + planeIndex;
-                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
+                tb.index = mtlIndexes.stages[i].textureIndex + elementIndex +
+                           planeIndex;
+                BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture,
+                                         pipelineBindPoint, i, tb);
+                if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE &&
+                    !cmdEncoder->getMetalFeatures().nativeTextureAtomics) {
+                    bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex +
+                               planeIndex;
+                    BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                             pipelineBindPoint, i, bb);
                 }
             }
         }
@@ -1006,393 +1179,435 @@ void MVKImageDescriptor::bind(MVKCommandEncoder* cmdEncoder,
 }
 
 void MVKImageDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							   MVKDescriptorSet* mvkDescSet,
-							   uint32_t dstIdx,
-							   uint32_t srcIdx,
-							   size_t srcStride,
-							   const void* pData) {
-	auto* oldImgView = _mvkImageView;
+                               MVKDescriptorSet* mvkDescSet, uint32_t dstIdx,
+                               uint32_t srcIdx, size_t srcStride,
+                               const void* pData) {
+    auto* oldImgView = _mvkImageView;
 
-	const auto* pImgInfo = &get<VkDescriptorImageInfo>(pData, srcStride, srcIdx);
-	_mvkImageView = (MVKImageView*)pImgInfo->imageView;
+    const auto* pImgInfo =
+        &get<VkDescriptorImageInfo>(pData, srcStride, srcIdx);
+    _mvkImageView = (MVKImageView*)pImgInfo->imageView;
 
-	if (_mvkImageView) { _mvkImageView->retain(); }
-	if (oldImgView) { oldImgView->release(); }
+    if (_mvkImageView) {
+        _mvkImageView->retain();
+    }
+    if (oldImgView) {
+        oldImgView->release();
+    }
 
-	// Write resource to Metal argument buffer
-	if (mvkDescSet->hasMetalArgumentBuffer()) {
-		auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-		VkDescriptorType descType = getDescriptorType();
+    // Write resource to Metal argument buffer
+    if (mvkDescSet->hasMetalArgumentBuffer()) {
+        auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+        VkDescriptorType descType = getDescriptorType();
 
-		uint8_t planeCount = (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
-		for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
-			uint32_t planeDescIdx = (dstIdx * planeCount) + planeIndex;
+        uint8_t planeCount =
+            (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
+        for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
+            uint32_t planeDescIdx = (dstIdx * planeCount) + planeIndex;
 
-			id<MTLTexture> mtlTexture = _mvkImageView ? _mvkImageView->getMTLTexture(planeIndex) : nil;
-			uint32_t texArgIdx = mvkDSLBind->getMetalResourceIndexOffsets().textureIndex + planeDescIdx;
-			mvkArgBuff.setTexture(mtlTexture, texArgIdx);
+            id<MTLTexture> mtlTexture =
+                _mvkImageView ? _mvkImageView->getMTLTexture(planeIndex) : nil;
+            uint32_t texArgIdx =
+                mvkDSLBind->getMetalResourceIndexOffsets().textureIndex +
+                planeDescIdx;
+            mvkArgBuff.setTexture(mtlTexture, texArgIdx);
 
-			if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
-				id<MTLTexture> mtlTex = mtlTexture.parentTexture ? mtlTexture.parentTexture : mtlTexture;
-				id<MTLBuffer> mtlBuff = mtlTex.buffer;
-				if (mtlBuff) {
-					uint32_t buffArgIdx = mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex + planeDescIdx;
-					mvkArgBuff.setBuffer(mtlBuff, mtlTex.bufferOffset, buffArgIdx);
-				}
-			}
-		}
-	}
+            if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE &&
+                !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
+                id<MTLTexture> mtlTex = mtlTexture.parentTexture
+                                            ? mtlTexture.parentTexture
+                                            : mtlTexture;
+                id<MTLBuffer> mtlBuff = mtlTex.buffer;
+                if (mtlBuff) {
+                    uint32_t buffArgIdx =
+                        mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex +
+                        planeDescIdx;
+                    mvkArgBuff.setBuffer(mtlBuff, mtlTex.bufferOffset,
+                                         buffArgIdx);
+                }
+            }
+        }
+    }
 }
 
-void MVKImageDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-							  MVKDescriptorSet* mvkDescSet,
-							  uint32_t dstIndex,
-							  VkDescriptorImageInfo* pImageInfo,
-							  VkDescriptorBufferInfo* pBufferInfo,
-							  VkBufferView* pTexelBufferView,
-							  VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	auto& imgInfo = pImageInfo[dstIndex];
-	imgInfo.imageView = (VkImageView)_mvkImageView;
-	imgInfo.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+void MVKImageDescriptor::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    auto& imgInfo = pImageInfo[dstIndex];
+    imgInfo.imageView = (VkImageView)_mvkImageView;
+    imgInfo.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 }
 
-void MVKImageDescriptor::encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-											 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-											 MVKShaderStage stage) {
-	VkDescriptorType descType = getDescriptorType();
-	uint8_t planeCount = (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
-	for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
-		id<MTLTexture> mtlTexture = _mvkImageView ? _mvkImageView->getMTLTexture(planeIndex) : nil;
-		rezEncState->encodeResourceUsage(stage, mtlTexture, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
+void MVKImageDescriptor::encodeResourceUsage(
+    MVKResourcesCommandEncoderState* rezEncState,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKShaderStage stage) {
+    VkDescriptorType descType = getDescriptorType();
+    uint8_t planeCount = (_mvkImageView) ? _mvkImageView->getPlaneCount() : 1;
+    for (uint8_t planeIndex = 0; planeIndex < planeCount; planeIndex++) {
+        id<MTLTexture> mtlTexture =
+            _mvkImageView ? _mvkImageView->getMTLTexture(planeIndex) : nil;
+        rezEncState->encodeResourceUsage(stage, mtlTexture,
+                                         getMTLResourceUsage(),
+                                         mvkDSLBind->getMTLRenderStages());
 
-		if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
-			id<MTLTexture> mtlTex = mtlTexture.parentTexture ? mtlTexture.parentTexture : mtlTexture;
-			id<MTLBuffer> mtlBuff = mtlTex.buffer;
-			if (mtlBuff) {
-				rezEncState->encodeResourceUsage(stage, mtlBuff, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
-			}
-		}
-	}
+        if (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE &&
+            !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
+            id<MTLTexture> mtlTex = mtlTexture.parentTexture
+                                        ? mtlTexture.parentTexture
+                                        : mtlTexture;
+            id<MTLBuffer> mtlBuff = mtlTex.buffer;
+            if (mtlBuff) {
+                rezEncState
+                    ->encodeResourceUsage(stage, mtlBuff, getMTLResourceUsage(),
+                                          mvkDSLBind->getMTLRenderStages());
+            }
+        }
+    }
 }
 
 void MVKImageDescriptor::reset() {
-	if (_mvkImageView) { _mvkImageView->release(); }
-	_mvkImageView = nullptr;
-	MVKDescriptor::reset();
+    if (_mvkImageView) {
+        _mvkImageView->release();
+    }
+    _mvkImageView = nullptr;
+    MVKDescriptor::reset();
 }
-
 
 #pragma mark -
 #pragma mark MVKSamplerDescriptorMixin
 
 // A null cmdEncoder can be passed to perform a validation pass
-// Metal validation requires each sampler in an array of samplers to be populated,
-// even if not used, so populate a default if one hasn't been set.
+// Metal validation requires each sampler in an array of samplers to be
+// populated, even if not used, so populate a default if one hasn't been set.
 void MVKSamplerDescriptorMixin::bind(MVKCommandEncoder* cmdEncoder,
-									 VkPipelineBindPoint pipelineBindPoint,
-									 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									 uint32_t elementIndex,
-									 bool stages[],
-									 MVKShaderResourceBinding& mtlIndexes,
-									 MVKArrayRef<uint32_t> dynamicOffsets,
-									 uint32_t& dynamicOffsetIndex) {
+                                     VkPipelineBindPoint pipelineBindPoint,
+                                     MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                                     uint32_t elementIndex, bool stages[],
+                                     MVKShaderResourceBinding& mtlIndexes,
+                                     MVKArrayRef<uint32_t> dynamicOffsets,
+                                     uint32_t& dynamicOffsetIndex) {
 
-	MVKSampler* imutSamp = mvkDSLBind->getImmutableSampler(elementIndex);
-	MVKSampler* mvkSamp = imutSamp ? imutSamp : _mvkSampler;
+    MVKSampler* imutSamp = mvkDSLBind->getImmutableSampler(elementIndex);
+    MVKSampler* mvkSamp = imutSamp ? imutSamp : _mvkSampler;
 
-	MVKMTLSamplerStateBinding sb;
-	sb.mtlSamplerState = (mvkSamp
-						  ? mvkSamp->getMTLSamplerState()
-						  : cmdEncoder->getDevice()->getDefaultMTLSamplerState());
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		if (stages[i]) {
-			sb.index = mtlIndexes.stages[i].samplerIndex + elementIndex;
-			BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState, pipelineBindPoint, i, sb);
-		}
-	}
+    MVKMTLSamplerStateBinding sb;
+    sb.mtlSamplerState =
+        (mvkSamp ? mvkSamp->getMTLSamplerState()
+                 : cmdEncoder->getDevice()->getDefaultMTLSamplerState());
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        if (stages[i]) {
+            sb.index = mtlIndexes.stages[i].samplerIndex + elementIndex;
+            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindSamplerState,
+                                     pipelineBindPoint, i, sb);
+        }
+    }
 }
 
 void MVKSamplerDescriptorMixin::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									  MVKDescriptorSet* mvkDescSet,
-									  uint32_t dstIdx,
-									  uint32_t srcIdx,
-									  size_t srcStride,
-									  const void* pData) {
+                                      MVKDescriptorSet* mvkDescSet,
+                                      uint32_t dstIdx, uint32_t srcIdx,
+                                      size_t srcStride, const void* pData) {
 
-	if (mvkDSLBind->usesImmutableSamplers()) { return; }
+    if (mvkDSLBind->usesImmutableSamplers()) {
+        return;
+    }
 
-	auto* oldSamp = _mvkSampler;
+    auto* oldSamp = _mvkSampler;
 
-	const auto* pImgInfo = &get<VkDescriptorImageInfo>(pData, srcStride, srcIdx);
-	_mvkSampler = (MVKSampler*)pImgInfo->sampler;
-	if (_mvkSampler && _mvkSampler->getRequiresConstExprSampler()) {
-		_mvkSampler->reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkUpdateDescriptorSets(): Tried to push an immutable sampler.");
-	}
+    const auto* pImgInfo =
+        &get<VkDescriptorImageInfo>(pData, srcStride, srcIdx);
+    _mvkSampler = (MVKSampler*)pImgInfo->sampler;
+    if (_mvkSampler && _mvkSampler->getRequiresConstExprSampler()) {
+        _mvkSampler->reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                 "vkUpdateDescriptorSets(): Tried to push an "
+                                 "immutable sampler.");
+    }
 
-	if (_mvkSampler) { _mvkSampler->retain(); }
-	if (oldSamp) { oldSamp->release(); }
+    if (_mvkSampler) {
+        _mvkSampler->retain();
+    }
+    if (oldSamp) {
+        oldSamp->release();
+    }
 
-	// Write resource to Metal argument buffer
-	if (mvkDescSet->hasMetalArgumentBuffer()) {
-		auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-		MVKSampler* imutSamp = mvkDSLBind->getImmutableSampler(dstIdx);
-		MVKSampler* mvkSamp = imutSamp ? imutSamp : _mvkSampler;
-		id<MTLSamplerState> mtlSamp = (mvkSamp
-									   ? mvkSamp->getMTLSamplerState()
-									   : mvkDSLBind->getDevice()->getDefaultMTLSamplerState());
-		uint32_t argIdx = mvkDSLBind->getMetalResourceIndexOffsets().samplerIndex + dstIdx;
-		mvkArgBuff.setSamplerState(mtlSamp, argIdx);
-	}
+    // Write resource to Metal argument buffer
+    if (mvkDescSet->hasMetalArgumentBuffer()) {
+        auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+        MVKSampler* imutSamp = mvkDSLBind->getImmutableSampler(dstIdx);
+        MVKSampler* mvkSamp = imutSamp ? imutSamp : _mvkSampler;
+        id<MTLSamplerState> mtlSamp =
+            (mvkSamp ? mvkSamp->getMTLSamplerState()
+                     : mvkDSLBind->getDevice()->getDefaultMTLSamplerState());
+        uint32_t argIdx =
+            mvkDSLBind->getMetalResourceIndexOffsets().samplerIndex + dstIdx;
+        mvkArgBuff.setSamplerState(mtlSamp, argIdx);
+    }
 }
 
-void MVKSamplerDescriptorMixin::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									 MVKDescriptorSet* mvkDescSet,
-									 uint32_t dstIndex,
-									 VkDescriptorImageInfo* pImageInfo,
-									 VkDescriptorBufferInfo* pBufferInfo,
-									 VkBufferView* pTexelBufferView,
-									 VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	auto& imgInfo = pImageInfo[dstIndex];
-	imgInfo.sampler = (VkSampler)_mvkSampler;
+void MVKSamplerDescriptorMixin::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    auto& imgInfo = pImageInfo[dstIndex];
+    imgInfo.sampler = (VkSampler)_mvkSampler;
 }
 
 void MVKSamplerDescriptorMixin::reset() {
-	if (_mvkSampler) { _mvkSampler->release(); }
-	_mvkSampler = nullptr;
+    if (_mvkSampler) {
+        _mvkSampler->release();
+    }
+    _mvkSampler = nullptr;
 }
-
 
 #pragma mark -
 #pragma mark MVKSamplerDescriptor
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKSamplerDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-								VkPipelineBindPoint pipelineBindPoint,
-								MVKDescriptorSetLayoutBinding* mvkDSLBind,
-								uint32_t elementIndex,
-								bool stages[],
-								MVKShaderResourceBinding& mtlIndexes,
-								MVKArrayRef<uint32_t> dynamicOffsets,
-								uint32_t& dynamicOffsetIndex) {
-	MVKSamplerDescriptorMixin::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind, elementIndex, stages, mtlIndexes, dynamicOffsets, dynamicOffsetIndex);
+                                VkPipelineBindPoint pipelineBindPoint,
+                                MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                                uint32_t elementIndex, bool stages[],
+                                MVKShaderResourceBinding& mtlIndexes,
+                                MVKArrayRef<uint32_t> dynamicOffsets,
+                                uint32_t& dynamicOffsetIndex) {
+    MVKSamplerDescriptorMixin::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind,
+                                    elementIndex, stages, mtlIndexes,
+                                    dynamicOffsets, dynamicOffsetIndex);
 }
 
 void MVKSamplerDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-								 MVKDescriptorSet* mvkDescSet,
-								 uint32_t dstIdx,
-								 uint32_t srcIdx,
-								 size_t srcStride,
-								 const void* pData) {
-	MVKSamplerDescriptorMixin::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx, srcStride, pData);
+                                 MVKDescriptorSet* mvkDescSet, uint32_t dstIdx,
+                                 uint32_t srcIdx, size_t srcStride,
+                                 const void* pData) {
+    MVKSamplerDescriptorMixin::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx,
+                                     srcStride, pData);
 }
 
-void MVKSamplerDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-								MVKDescriptorSet* mvkDescSet,
-								uint32_t dstIndex,
-								VkDescriptorImageInfo* pImageInfo,
-								VkDescriptorBufferInfo* pBufferInfo,
-								VkBufferView* pTexelBufferView,
-								VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	MVKSamplerDescriptorMixin::read(mvkDSLBind, mvkDescSet, dstIndex, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
+void MVKSamplerDescriptor::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    MVKSamplerDescriptorMixin::read(mvkDSLBind, mvkDescSet, dstIndex,
+                                    pImageInfo, pBufferInfo, pTexelBufferView,
+                                    pInlineUniformBlock);
 }
 
 void MVKSamplerDescriptor::reset() {
-	MVKSamplerDescriptorMixin::reset();
-	MVKDescriptor::reset();
+    MVKSamplerDescriptorMixin::reset();
+    MVKDescriptor::reset();
 }
-
 
 #pragma mark -
 #pragma mark MVKCombinedImageSamplerDescriptor
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKCombinedImageSamplerDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-											 VkPipelineBindPoint pipelineBindPoint,
-											 MVKDescriptorSetLayoutBinding* mvkDSLBind,
-											 uint32_t elementIndex,
-											 bool stages[],
-											 MVKShaderResourceBinding& mtlIndexes,
-											 MVKArrayRef<uint32_t> dynamicOffsets,
-											 uint32_t& dynamicOffsetIndex) {
-	MVKImageDescriptor::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind, elementIndex, stages, mtlIndexes, dynamicOffsets, dynamicOffsetIndex);
-	MVKSamplerDescriptorMixin::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind, elementIndex, stages, mtlIndexes, dynamicOffsets, dynamicOffsetIndex);
+void MVKCombinedImageSamplerDescriptor::bind(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, uint32_t elementIndex,
+    bool stages[], MVKShaderResourceBinding& mtlIndexes,
+    MVKArrayRef<uint32_t> dynamicOffsets, uint32_t& dynamicOffsetIndex) {
+    MVKImageDescriptor::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind,
+                             elementIndex, stages, mtlIndexes, dynamicOffsets,
+                             dynamicOffsetIndex);
+    MVKSamplerDescriptorMixin::bind(cmdEncoder, pipelineBindPoint, mvkDSLBind,
+                                    elementIndex, stages, mtlIndexes,
+                                    dynamicOffsets, dynamicOffsetIndex);
 }
 
-void MVKCombinedImageSamplerDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-											  MVKDescriptorSet* mvkDescSet,
-											  uint32_t dstIdx,
-											  uint32_t srcIdx,
-											  size_t srcStride,
-											  const void* pData) {
-	MVKImageDescriptor::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx, srcStride, pData);
-	MVKSamplerDescriptorMixin::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx, srcStride, pData);
+void MVKCombinedImageSamplerDescriptor::write(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIdx, uint32_t srcIdx, size_t srcStride, const void* pData) {
+    MVKImageDescriptor::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx, srcStride,
+                              pData);
+    MVKSamplerDescriptorMixin::write(mvkDSLBind, mvkDescSet, dstIdx, srcIdx,
+                                     srcStride, pData);
 }
 
-void MVKCombinedImageSamplerDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-											 MVKDescriptorSet* mvkDescSet,
-											 uint32_t dstIndex,
-											 VkDescriptorImageInfo* pImageInfo,
-											 VkDescriptorBufferInfo* pBufferInfo,
-											 VkBufferView* pTexelBufferView,
-											 VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	MVKImageDescriptor::read(mvkDSLBind, mvkDescSet, dstIndex, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
-	MVKSamplerDescriptorMixin::read(mvkDSLBind, mvkDescSet, dstIndex, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
+void MVKCombinedImageSamplerDescriptor::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    MVKImageDescriptor::read(mvkDSLBind, mvkDescSet, dstIndex, pImageInfo,
+                             pBufferInfo, pTexelBufferView,
+                             pInlineUniformBlock);
+    MVKSamplerDescriptorMixin::read(mvkDSLBind, mvkDescSet, dstIndex,
+                                    pImageInfo, pBufferInfo, pTexelBufferView,
+                                    pInlineUniformBlock);
 }
 
-void MVKCombinedImageSamplerDescriptor::encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-															MVKDescriptorSetLayoutBinding* mvkDSLBind,
-															MVKShaderStage stage) {
-	MVKImageDescriptor::encodeResourceUsage(rezEncState, mvkDSLBind, stage);
+void MVKCombinedImageSamplerDescriptor::encodeResourceUsage(
+    MVKResourcesCommandEncoderState* rezEncState,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKShaderStage stage) {
+    MVKImageDescriptor::encodeResourceUsage(rezEncState, mvkDSLBind, stage);
 }
 
 void MVKCombinedImageSamplerDescriptor::reset() {
-	MVKSamplerDescriptorMixin::reset();
-	MVKImageDescriptor::reset();
+    MVKSamplerDescriptorMixin::reset();
+    MVKImageDescriptor::reset();
 }
-
 
 #pragma mark -
 #pragma mark MVKTexelBufferDescriptor
 
 // A null cmdEncoder can be passed to perform a validation pass
 void MVKTexelBufferDescriptor::bind(MVKCommandEncoder* cmdEncoder,
-									VkPipelineBindPoint pipelineBindPoint,
-									MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									uint32_t elementIndex,
-									bool stages[],
-									MVKShaderResourceBinding& mtlIndexes,
-									MVKArrayRef<uint32_t> dynamicOffsets,
-									uint32_t& dynamicOffsetIndex) {
-	MVKMTLTextureBinding tb;
-	MVKMTLBufferBinding bb;
-	VkDescriptorType descType = getDescriptorType();
-	if (_mvkBufferView) {
-		tb.mtlTexture = _mvkBufferView->getMTLTexture();
-		if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
-			id<MTLTexture> mtlTex = tb.mtlTexture;
-			bb.mtlBuffer = mtlTex.buffer;
-			bb.offset = mtlTex.bufferOffset;
-			bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
-		}
-	}
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		if (stages[i]) {
-			tb.index = mtlIndexes.stages[i].textureIndex + elementIndex;
-			BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint, i, tb);
-			if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER && !cmdEncoder->getMetalFeatures().nativeTextureAtomics) {
-				bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex;
-				BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer, pipelineBindPoint, i, bb);
-			}
-		}
-	}
+                                    VkPipelineBindPoint pipelineBindPoint,
+                                    MVKDescriptorSetLayoutBinding* mvkDSLBind,
+                                    uint32_t elementIndex, bool stages[],
+                                    MVKShaderResourceBinding& mtlIndexes,
+                                    MVKArrayRef<uint32_t> dynamicOffsets,
+                                    uint32_t& dynamicOffsetIndex) {
+    MVKMTLTextureBinding tb;
+    MVKMTLBufferBinding bb;
+    VkDescriptorType descType = getDescriptorType();
+    if (_mvkBufferView) {
+        tb.mtlTexture = _mvkBufferView->getMTLTexture();
+        if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
+            id<MTLTexture> mtlTex = tb.mtlTexture;
+            bb.mtlBuffer = mtlTex.buffer;
+            bb.offset = mtlTex.bufferOffset;
+            bb.size = (uint32_t)(mtlTex.height * mtlTex.bufferBytesPerRow);
+        }
+    }
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        if (stages[i]) {
+            tb.index = mtlIndexes.stages[i].textureIndex + elementIndex;
+            BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindTexture, pipelineBindPoint,
+                                     i, tb);
+            if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER &&
+                !cmdEncoder->getMetalFeatures().nativeTextureAtomics) {
+                bb.index = mtlIndexes.stages[i].bufferIndex + elementIndex;
+                BIND_GRAPHICS_OR_COMPUTE(cmdEncoder, bindBuffer,
+                                         pipelineBindPoint, i, bb);
+            }
+        }
+    }
 }
 
 void MVKTexelBufferDescriptor::write(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									 MVKDescriptorSet* mvkDescSet,
-									 uint32_t dstIdx,
-									 uint32_t srcIdx,
-									 size_t srcStride,
-									 const void* pData) {
-	auto* oldBuffView = _mvkBufferView;
+                                     MVKDescriptorSet* mvkDescSet,
+                                     uint32_t dstIdx, uint32_t srcIdx,
+                                     size_t srcStride, const void* pData) {
+    auto* oldBuffView = _mvkBufferView;
 
-	const auto* pBuffView = &get<VkBufferView>(pData, srcStride, srcIdx);
-	_mvkBufferView = (MVKBufferView*)*pBuffView;
+    const auto* pBuffView = &get<VkBufferView>(pData, srcStride, srcIdx);
+    _mvkBufferView = (MVKBufferView*)*pBuffView;
 
-	if (_mvkBufferView) { _mvkBufferView->retain(); }
-	if (oldBuffView) { oldBuffView->release(); }
+    if (_mvkBufferView) {
+        _mvkBufferView->retain();
+    }
+    if (oldBuffView) {
+        oldBuffView->release();
+    }
 
-	// Write resource to Metal argument buffer
-	if (mvkDescSet->hasMetalArgumentBuffer()) {
-		auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
-		VkDescriptorType descType = getDescriptorType();
-		id<MTLTexture> mtlTexture = _mvkBufferView ? _mvkBufferView->getMTLTexture() : nil;
-		uint32_t texArgIdx = mvkDSLBind->getMetalResourceIndexOffsets().textureIndex + dstIdx;
-		mvkArgBuff.setTexture(mtlTexture, texArgIdx);
+    // Write resource to Metal argument buffer
+    if (mvkDescSet->hasMetalArgumentBuffer()) {
+        auto& mvkArgBuff = mvkDescSet->getMetalArgumentBuffer();
+        VkDescriptorType descType = getDescriptorType();
+        id<MTLTexture> mtlTexture =
+            _mvkBufferView ? _mvkBufferView->getMTLTexture() : nil;
+        uint32_t texArgIdx =
+            mvkDSLBind->getMetalResourceIndexOffsets().textureIndex + dstIdx;
+        mvkArgBuff.setTexture(mtlTexture, texArgIdx);
 
-		if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER && !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
-			id<MTLBuffer> mtlBuff = mtlTexture.buffer;
-			if (mtlBuff) {
-				uint32_t buffArgIdx = mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex + dstIdx;
-				mvkArgBuff.setBuffer(mtlBuff, mtlTexture.bufferOffset, buffArgIdx);
-			}
-		}
-	}
+        if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER &&
+            !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
+            id<MTLBuffer> mtlBuff = mtlTexture.buffer;
+            if (mtlBuff) {
+                uint32_t buffArgIdx =
+                    mvkDSLBind->getMetalResourceIndexOffsets().bufferIndex +
+                    dstIdx;
+                mvkArgBuff.setBuffer(mtlBuff, mtlTexture.bufferOffset,
+                                     buffArgIdx);
+            }
+        }
+    }
 }
 
-void MVKTexelBufferDescriptor::read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
-									MVKDescriptorSet* mvkDescSet,
-									uint32_t dstIndex,
-									VkDescriptorImageInfo* pImageInfo,
-									VkDescriptorBufferInfo* pBufferInfo,
-									VkBufferView* pTexelBufferView,
-									VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-	pTexelBufferView[dstIndex] = (VkBufferView)_mvkBufferView;
+void MVKTexelBufferDescriptor::read(
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKDescriptorSet* mvkDescSet,
+    uint32_t dstIndex, VkDescriptorImageInfo* pImageInfo,
+    VkDescriptorBufferInfo* pBufferInfo, VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+    pTexelBufferView[dstIndex] = (VkBufferView)_mvkBufferView;
 }
 
-void MVKTexelBufferDescriptor::encodeResourceUsage(MVKResourcesCommandEncoderState* rezEncState,
-												   MVKDescriptorSetLayoutBinding* mvkDSLBind,
-												   MVKShaderStage stage) {
-	VkDescriptorType descType = getDescriptorType();
-	id<MTLTexture> mtlTexture = _mvkBufferView ? _mvkBufferView->getMTLTexture() : nil;
-	rezEncState->encodeResourceUsage(stage, mtlTexture, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
+void MVKTexelBufferDescriptor::encodeResourceUsage(
+    MVKResourcesCommandEncoderState* rezEncState,
+    MVKDescriptorSetLayoutBinding* mvkDSLBind, MVKShaderStage stage) {
+    VkDescriptorType descType = getDescriptorType();
+    id<MTLTexture> mtlTexture =
+        _mvkBufferView ? _mvkBufferView->getMTLTexture() : nil;
+    rezEncState->encodeResourceUsage(stage, mtlTexture, getMTLResourceUsage(),
+                                     mvkDSLBind->getMTLRenderStages());
 
-	if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER && !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
-		id<MTLBuffer> mtlBuff = mtlTexture.buffer;
-		if (mtlBuff) {
-			rezEncState->encodeResourceUsage(stage, mtlBuff, getMTLResourceUsage(), mvkDSLBind->getMTLRenderStages());
-		}
-	}
+    if (descType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER &&
+        !mvkDSLBind->getMetalFeatures().nativeTextureAtomics) {
+        id<MTLBuffer> mtlBuff = mtlTexture.buffer;
+        if (mtlBuff) {
+            rezEncState->encodeResourceUsage(stage, mtlBuff,
+                                             getMTLResourceUsage(),
+                                             mvkDSLBind->getMTLRenderStages());
+        }
+    }
 }
 
 void MVKTexelBufferDescriptor::reset() {
-	if (_mvkBufferView) { _mvkBufferView->release(); }
-	_mvkBufferView = nullptr;
-	MVKDescriptor::reset();
+    if (_mvkBufferView) {
+        _mvkBufferView->release();
+    }
+    _mvkBufferView = nullptr;
+    MVKDescriptor::reset();
 }
-
 
 #pragma mark -
 #pragma mark Support functions
 
-
 bool mvkNeedsBuffSizeAuxBuffer(const VkDescriptorSetLayoutBinding* pBinding) {
-	switch (pBinding->descriptorType) {
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			return pBinding->descriptorCount > 0;
+    switch (pBinding->descriptorType) {
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        return pBinding->descriptorCount > 0;
 
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			return true;
-		
-		default:
-			return false;
-	}
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        return true;
+
+    default:
+        return false;
+    }
 }
 
-
-#define CASE_STRINGIFY(V)  case V: return #V
+#define CASE_STRINGIFY(V)                                                      \
+    case V:                                                                    \
+        return #V
 
 const char* mvkVkDescriptorTypeName(VkDescriptorType vkDescType) {
-	switch (vkDescType) {
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
-		CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_MUTABLE_EXT);
-		default: return "VK_UNKNOWN_VkDescriptorType";
-	}
+    switch (vkDescType) {
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+        CASE_STRINGIFY(VK_DESCRIPTOR_TYPE_MUTABLE_EXT);
+    default:
+        return "VK_UNKNOWN_VkDescriptorType";
+    }
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,29 +30,32 @@ class MVKPipelineLayout;
 class MVKCommandEncoder;
 class MVKResourcesCommandEncoderState;
 
-
 #pragma mark -
 #pragma mark MVKMetalArgumentBuffer
 
 /**
- * Helper object to handle the placement of resources into a Metal Argument Buffer
- * in a consistent manner, whether or not a MTLArgumentEncoder is required.
+ * Helper object to handle the placement of resources into a Metal Argument
+ * Buffer in a consistent manner, whether or not a MTLArgumentEncoder is
+ * required.
  */
 typedef struct MVKMetalArgumentBuffer {
-	void setBuffer(id<MTLBuffer> mtlBuff, NSUInteger offset, uint32_t index);
-	void setTexture(id<MTLTexture> mtlTex, uint32_t index);
-	void setSamplerState(id<MTLSamplerState> mtlSamp, uint32_t index);
-	id<MTLBuffer> getMetalArgumentBuffer() { return _mtlArgumentBuffer; }
-	NSUInteger getMetalArgumentBufferOffset() { return _mtlArgumentBufferOffset; }
-	void setArgumentBuffer(id<MTLBuffer> mtlArgBuff, NSUInteger mtlArgBuffOfst, id<MTLArgumentEncoder> mtlArgEnc);
-	~MVKMetalArgumentBuffer();
-protected:
-	void* getArgumentPointer(uint32_t index) const;
-	id<MTLArgumentEncoder> _mtlArgumentEncoder = nil;
-	id<MTLBuffer> _mtlArgumentBuffer = nil;
-	NSUInteger _mtlArgumentBufferOffset = 0;
-} MVKMetalArgumentBuffer;
+    void setBuffer(id<MTLBuffer> mtlBuff, NSUInteger offset, uint32_t index);
+    void setTexture(id<MTLTexture> mtlTex, uint32_t index);
+    void setSamplerState(id<MTLSamplerState> mtlSamp, uint32_t index);
+    id<MTLBuffer> getMetalArgumentBuffer() { return _mtlArgumentBuffer; }
+    NSUInteger getMetalArgumentBufferOffset() {
+        return _mtlArgumentBufferOffset;
+    }
+    void setArgumentBuffer(id<MTLBuffer> mtlArgBuff, NSUInteger mtlArgBuffOfst,
+                           id<MTLArgumentEncoder> mtlArgEnc);
+    ~MVKMetalArgumentBuffer();
 
+  protected:
+    void* getArgumentPointer(uint32_t index) const;
+    id<MTLArgumentEncoder> _mtlArgumentEncoder = nil;
+    id<MTLBuffer> _mtlArgumentBuffer = nil;
+    NSUInteger _mtlArgumentBufferOffset = 0;
+} MVKMetalArgumentBuffer;
 
 #pragma mark -
 #pragma mark MVKDescriptorSetLayout
@@ -60,92 +63,104 @@ protected:
 /** Represents a Vulkan descriptor set layout. */
 class MVKDescriptorSetLayout : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT; }
+    /** Encodes this descriptor set layout and the specified descriptor set on
+     * the specified command encoder. */
+    void bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                           VkPipelineBindPoint pipelineBindPoint,
+                           uint32_t descSetIndex, MVKDescriptorSet* descSet,
+                           MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+                           MVKArrayRef<uint32_t> dynamicOffsets,
+                           uint32_t& dynamicOffsetIndex);
 
-	/** Encodes this descriptor set layout and the specified descriptor set on the specified command encoder. */
-	void bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
-						   VkPipelineBindPoint pipelineBindPoint,
-						   uint32_t descSetIndex,
-						   MVKDescriptorSet* descSet,
-						   MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-						   MVKArrayRef<uint32_t> dynamicOffsets,
-						   uint32_t& dynamicOffsetIndex);
+    /** Encodes this descriptor set layout and the specified descriptor updates
+     * on the specified command encoder immediately. */
+    void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                           VkPipelineBindPoint pipelineBindPoint,
+                           MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
+                           MVKShaderResourceBinding& dslMTLRezIdxOffsets);
 
-	/** Encodes this descriptor set layout and the specified descriptor updates on the specified command encoder immediately. */
-	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-						   VkPipelineBindPoint pipelineBindPoint,
-						   MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
-						   MVKShaderResourceBinding& dslMTLRezIdxOffsets);
+    /** Encodes this descriptor set layout and the updates from the given
+     * template on the specified command encoder immediately. */
+    void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                           MVKDescriptorUpdateTemplate* descUpdateTemplates,
+                           const void* pData,
+                           MVKShaderResourceBinding& dslMTLRezIdxOffsets);
 
+    /** Populates the specified shader conversion config, at the specified DSL
+     * index. */
+    void populateShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        MVKShaderResourceBinding& dslMTLRezIdxOffsets, uint32_t descSetIndex);
 
-	/** Encodes this descriptor set layout and the updates from the given template on the specified command encoder immediately. */
-	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-						   MVKDescriptorUpdateTemplate* descUpdateTemplates,
-						   const void* pData,
-						   MVKShaderResourceBinding& dslMTLRezIdxOffsets);
+    /**
+     * Populates the bindings in this descriptor set layout used by the shader.
+     * Returns false if the shader does not use the descriptor set at all.
+     */
+    bool populateBindingUse(MVKBitArray& bindingUse,
+                            mvk::SPIRVToMSLConversionConfiguration& context,
+                            MVKShaderStage stage, uint32_t descSetIndex);
 
+    /** Returns the number of bindings. */
+    uint32_t getBindingCount() { return (uint32_t)_bindings.size(); }
 
-	/** Populates the specified shader conversion config, at the specified DSL index. */
-	void populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-                                        MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-                                        uint32_t descSetIndex);
+    /** Returns the binding at the index in a descriptor set layout. */
+    MVKDescriptorSetLayoutBinding* getBindingAt(uint32_t index) {
+        return &_bindings[index];
+    }
 
-	/**
-	 * Populates the bindings in this descriptor set layout used by the shader.
-	 * Returns false if the shader does not use the descriptor set at all.
-	 */
-	bool populateBindingUse(MVKBitArray& bindingUse,
-							mvk::SPIRVToMSLConversionConfiguration& context,
-							MVKShaderStage stage,
-							uint32_t descSetIndex);
+    /** Overridden because descriptor sets may be marked as discrete and not use
+     * an argument buffer. */
+    bool isUsingMetalArgumentBuffers() override;
 
-	/** Returns the number of bindings. */
-	uint32_t getBindingCount() { return (uint32_t)_bindings.size(); }
+    /** Returns whether descriptor sets from this layout requires an auxilliary
+     * buffer-size buffer. */
+    bool needsBufferSizeAuxBuffer() { return _maxBufferIndex >= 0; }
 
-	/** Returns the binding at the index in a descriptor set layout. */
-	MVKDescriptorSetLayoutBinding* getBindingAt(uint32_t index) { return &_bindings[index]; }
+    /** Returns a text description of this layout. */
+    std::string getLogDescription(std::string indent = "");
 
-	/** Overridden because descriptor sets may be marked as discrete and not use an argument buffer. */
-	bool isUsingMetalArgumentBuffers() override;
+    MVKDescriptorSetLayout(MVKDevice* device,
+                           const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 
-	/** Returns whether descriptor sets from this layout requires an auxilliary buffer-size buffer. */
-	bool needsBufferSizeAuxBuffer() { return _maxBufferIndex >= 0; }
+  protected:
+    friend class MVKDescriptorSetLayoutBinding;
+    friend class MVKPipelineLayout;
+    friend class MVKDescriptorSet;
+    friend class MVKDescriptorPool;
 
-	/** Returns a text description of this layout. */
-	std::string getLogDescription(std::string indent = "");
+    void propagateDebugName() override {}
+    uint32_t getDescriptorCount(uint32_t variableDescriptorCount);
+    uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) {
+        return getBinding(binding)->getDescriptorIndex(elementIndex);
+    }
+    MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding,
+                                              uint32_t bindingIndexOffset = 0);
+    uint32_t getBufferSizeBufferArgBuferIndex() { return 0; }
+    id<MTLArgumentEncoder>
+    getMTLArgumentEncoder(uint32_t variableDescriptorCount);
+    uint64_t
+    getMetal3ArgumentBufferEncodedLength(uint32_t variableDescriptorCount);
+    bool checkCanUseArgumentBuffers(
+        const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
 
-	MVKDescriptorSetLayout(MVKDevice* device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
-
-protected:
-
-	friend class MVKDescriptorSetLayoutBinding;
-	friend class MVKPipelineLayout;
-	friend class MVKDescriptorSet;
-	friend class MVKDescriptorPool;
-
-	void propagateDebugName() override {}
-	uint32_t getDescriptorCount(uint32_t variableDescriptorCount);
-	uint32_t getDescriptorIndex(uint32_t binding, uint32_t elementIndex = 0) { return getBinding(binding)->getDescriptorIndex(elementIndex); }
-	MVKDescriptorSetLayoutBinding* getBinding(uint32_t binding, uint32_t bindingIndexOffset = 0);
-	uint32_t getBufferSizeBufferArgBuferIndex() { return 0; }
-	id <MTLArgumentEncoder> getMTLArgumentEncoder(uint32_t variableDescriptorCount);
-	uint64_t getMetal3ArgumentBufferEncodedLength(uint32_t variableDescriptorCount);
-	bool checkCanUseArgumentBuffers(const VkDescriptorSetLayoutCreateInfo* pCreateInfo);
-
-	MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
-	std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
-	MVKShaderResourceBinding _mtlResourceCounts;
-	int32_t _maxBufferIndex = -1;
-	bool _isPushDescriptorLayout = false;
-	bool _canUseMetalArgumentBuffer = true;
+    MVKSmallVector<MVKDescriptorSetLayoutBinding> _bindings;
+    std::unordered_map<uint32_t, uint32_t> _bindingToIndex;
+    MVKShaderResourceBinding _mtlResourceCounts;
+    int32_t _maxBufferIndex = -1;
+    bool _isPushDescriptorLayout = false;
+    bool _canUseMetalArgumentBuffer = true;
 };
-
 
 #pragma mark -
 #pragma mark MVKDescriptorSet
@@ -153,112 +168,130 @@ protected:
 /** Represents a Vulkan descriptor set. */
 class MVKDescriptorSet : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DESCRIPTOR_SET;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DESCRIPTOR_SET; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT; }
+    /** Returns the layout that defines this descriptor set. */
+    MVKDescriptorSetLayout* getLayout() { return _layout; }
 
-	/** Returns the layout that defines this descriptor set. */
-	MVKDescriptorSetLayout* getLayout() { return _layout; }
+    /** Returns the descriptor type for the specified binding number. */
+    VkDescriptorType getDescriptorType(uint32_t binding);
 
-	/** Returns the descriptor type for the specified binding number. */
-	VkDescriptorType getDescriptorType(uint32_t binding);
+    /** Updates the resource bindings in this instance from the specified
+     * content. */
+    template <typename DescriptorAction>
+    void write(const DescriptorAction* pDescriptorAction, size_t srcStride,
+               const void* pData);
 
-	/** Updates the resource bindings in this instance from the specified content. */
-	template<typename DescriptorAction>
-	void write(const DescriptorAction* pDescriptorAction, size_t srcStride, const void* pData);
+    /**
+     * Reads the resource bindings defined in the specified content
+     * from this instance into the specified collection of bindings.
+     */
+    void read(const VkCopyDescriptorSet* pDescriptorCopies,
+              VkDescriptorImageInfo* pImageInfo,
+              VkDescriptorBufferInfo* pBufferInfo,
+              VkBufferView* pTexelBufferView,
+              VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
 
-	/** 
-	 * Reads the resource bindings defined in the specified content 
-	 * from this instance into the specified collection of bindings.
-	 */
-	void read(const VkCopyDescriptorSet* pDescriptorCopies,
-			  VkDescriptorImageInfo* pImageInfo,
-			  VkDescriptorBufferInfo* pBufferInfo,
-			  VkBufferView* pTexelBufferView,
-			  VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock);
+    /** Returns the descriptor at an index. */
+    MVKDescriptor* getDescriptorAt(uint32_t descIndex) {
+        return _descriptors[descIndex];
+    }
 
-	/** Returns the descriptor at an index. */
-	MVKDescriptor* getDescriptorAt(uint32_t descIndex) { return _descriptors[descIndex]; }
+    /** Returns the number of descriptors in this descriptor set. */
+    uint32_t getDescriptorCount() { return (uint32_t)_descriptors.size(); }
 
-	/** Returns the number of descriptors in this descriptor set. */
-	uint32_t getDescriptorCount() { return (uint32_t)_descriptors.size(); }
+    /** Returns the count of descriptors in the binding in this descriptor set
+     * that has a variable descriptor count. */
+    uint32_t getVariableDescriptorCount() const {
+        return _variableDescriptorCount;
+    }
 
-	/** Returns the count of descriptors in the binding in this descriptor set that has a variable descriptor count. */
-	uint32_t getVariableDescriptorCount() const { return _variableDescriptorCount; }
+    /** Returns the number of descriptors in this descriptor set that use
+     * dynamic offsets. */
+    uint32_t getDynamicOffsetDescriptorCount() {
+        return _dynamicOffsetDescriptorCount;
+    }
 
-	/** Returns the number of descriptors in this descriptor set that use dynamic offsets. */
-	uint32_t getDynamicOffsetDescriptorCount() { return _dynamicOffsetDescriptorCount; }
+    /** Returns true if this descriptor set is using a Metal argument buffer. */
+    bool hasMetalArgumentBuffer() {
+        return _layout->isUsingMetalArgumentBuffers();
+    };
 
-	/** Returns true if this descriptor set is using a Metal argument buffer. */
-	bool hasMetalArgumentBuffer() { return _layout->isUsingMetalArgumentBuffers(); };
+    /** Returns the argument buffer helper object used by this descriptor set.
+     */
+    MVKMetalArgumentBuffer& getMetalArgumentBuffer() { return _argumentBuffer; }
 
-	/** Returns the argument buffer helper object used by this descriptor set. */
-	MVKMetalArgumentBuffer& getMetalArgumentBuffer() { return _argumentBuffer; }
+    /** Encode the buffer sizes auxiliary buffer to the GPU. */
+    void encodeAuxBufferUsage(MVKResourcesCommandEncoderState* rezEncState,
+                              MVKShaderStage stage);
 
-	/** Encode the buffer sizes auxiliary buffer to the GPU. */
-	void encodeAuxBufferUsage(MVKResourcesCommandEncoderState* rezEncState, MVKShaderStage stage);
+    MVKDescriptorSet(MVKDescriptorPool* pool);
 
-	MVKDescriptorSet(MVKDescriptorPool* pool);
+    ~MVKDescriptorSet() override;
 
-	~MVKDescriptorSet() override;
+  protected:
+    friend class MVKDescriptorSetLayoutBinding;
+    friend class MVKDescriptorPool;
+    friend class MVKBufferDescriptor;
+    friend class MVKInlineUniformBlockDescriptor;
 
-protected:
-	friend class MVKDescriptorSetLayoutBinding;
-	friend class MVKDescriptorPool;
-	friend class MVKBufferDescriptor;
-	friend class MVKInlineUniformBlockDescriptor;
+    void propagateDebugName() override {}
+    MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex = 0);
+    VkResult allocate(MVKDescriptorSetLayout* layout,
+                      uint32_t variableDescriptorCount,
+                      NSUInteger mtlArgBufferOffset,
+                      id<MTLArgumentEncoder> mtlArgEnc);
+    void free(bool isPoolReset);
+    MVKMTLBufferAllocation* acquireMTLBufferRegion(NSUInteger length);
+    void setBufferSize(uint32_t descIdx, uint32_t value);
 
-	void propagateDebugName() override {}
-	MVKDescriptor* getDescriptor(uint32_t binding, uint32_t elementIndex = 0);
-	VkResult allocate(MVKDescriptorSetLayout* layout,
-					  uint32_t variableDescriptorCount,
-					  NSUInteger mtlArgBufferOffset,
-					  id<MTLArgumentEncoder> mtlArgEnc);
-	void free(bool isPoolReset);
-	MVKMTLBufferAllocation* acquireMTLBufferRegion(NSUInteger length);
-	void setBufferSize(uint32_t descIdx, uint32_t value);
-
-	MVKDescriptorPool* _pool;
-	MVKDescriptorSetLayout* _layout = nullptr;
-	MVKMTLBufferAllocation* _bufferSizesBuffer = nullptr;
-	MVKSmallVector<MVKDescriptor*> _descriptors;
-	MVKMetalArgumentBuffer _argumentBuffer;
-	uint32_t _dynamicOffsetDescriptorCount = 0;
-	uint32_t _variableDescriptorCount = 0;
-	bool _allDescriptorsAreFromPool = true;
+    MVKDescriptorPool* _pool;
+    MVKDescriptorSetLayout* _layout = nullptr;
+    MVKMTLBufferAllocation* _bufferSizesBuffer = nullptr;
+    MVKSmallVector<MVKDescriptor*> _descriptors;
+    MVKMetalArgumentBuffer _argumentBuffer;
+    uint32_t _dynamicOffsetDescriptorCount = 0;
+    uint32_t _variableDescriptorCount = 0;
+    bool _allDescriptorsAreFromPool = true;
 };
-
 
 #pragma mark -
 #pragma mark MVKDescriptorTypePool
 
-/** Support class for MVKDescriptorPool that holds a pool of instances of a single concrete descriptor class. */
-template<class DescriptorClass>
+/** Support class for MVKDescriptorPool that holds a pool of instances of a
+ * single concrete descriptor class. */
+template <class DescriptorClass>
 class MVKDescriptorTypePool : public MVKBaseObject {
 
-public:
+  public:
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
 
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
+    MVKDescriptorTypePool(size_t poolSize);
 
-	MVKDescriptorTypePool(size_t poolSize);
+  protected:
+    friend class MVKDescriptorPool;
 
-protected:
-	friend class MVKDescriptorPool;
+    VkResult allocateDescriptor(VkDescriptorType descType,
+                                MVKDescriptor** pMVKDesc,
+                                bool& dynamicAllocation,
+                                MVKDescriptorPool* pool);
+    void freeDescriptor(MVKDescriptor* mvkDesc, MVKDescriptorPool* pool);
+    void reset();
+    size_t size() { return _availability.size(); }
+    size_t getRemainingDescriptorCount();
 
-	VkResult allocateDescriptor(VkDescriptorType descType, MVKDescriptor** pMVKDesc, bool& dynamicAllocation, MVKDescriptorPool* pool);
-	void freeDescriptor(MVKDescriptor* mvkDesc, MVKDescriptorPool* pool);
-	void reset();
-	size_t size() { return _availability.size(); }
-	size_t getRemainingDescriptorCount();
-
-	MVKSmallVector<DescriptorClass> _descriptors;
-	MVKBitArray _availability;
+    MVKSmallVector<DescriptorClass> _descriptors;
+    MVKBitArray _availability;
 };
-
 
 #pragma mark -
 #pragma mark MVKDescriptorPool
@@ -266,68 +299,90 @@ protected:
 /** Represents a Vulkan descriptor pool. */
 class MVKDescriptorPool : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DESCRIPTOR_POOL;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DESCRIPTOR_POOL; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT; }
+    /** Allocates descriptor sets. */
+    VkResult
+    allocateDescriptorSets(const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                           VkDescriptorSet* pDescriptorSets);
 
-	/** Allocates descriptor sets. */
-	VkResult allocateDescriptorSets(const VkDescriptorSetAllocateInfo* pAllocateInfo,
-									VkDescriptorSet* pDescriptorSets);
+    /** Free's up the specified descriptor set. */
+    VkResult freeDescriptorSets(uint32_t count,
+                                const VkDescriptorSet* pDescriptorSets);
 
-	/** Free's up the specified descriptor set. */
-	VkResult freeDescriptorSets(uint32_t count, const VkDescriptorSet* pDescriptorSets);
+    /** Destroys all currently allocated descriptor sets. */
+    VkResult reset(VkDescriptorPoolResetFlags flags);
 
-	/** Destroys all currently allocated descriptor sets. */
-	VkResult reset(VkDescriptorPoolResetFlags flags);
+    /** Returns a text description of this pool. */
+    std::string getLogDescription(std::string indent = "");
 
-	/** Returns a text description of this pool. */
-	std::string getLogDescription(std::string indent = "");
+    MVKDescriptorPool(MVKDevice* device,
+                      const VkDescriptorPoolCreateInfo* pCreateInfo);
 
-	MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo);
+    ~MVKDescriptorPool() override;
 
-	~MVKDescriptorPool() override;
+  protected:
+    friend class MVKDescriptorSet;
+    template <class> friend class MVKDescriptorTypePool;
 
-protected:
-	friend class MVKDescriptorSet;
-	template<class> friend class MVKDescriptorTypePool;
+    void propagateDebugName() override {}
+    VkResult allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL,
+                                   uint32_t variableDescriptorCount,
+                                   VkDescriptorSet* pVKDS);
+    void freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset);
+    VkResult allocateDescriptor(VkDescriptorType descriptorType,
+                                MVKDescriptor** pMVKDesc,
+                                bool& dynamicAllocation);
+    void freeDescriptor(MVKDescriptor* mvkDesc);
+    void initMetalArgumentBuffer(const VkDescriptorPoolCreateInfo* pCreateInfo);
+    NSUInteger
+    getMetalArgumentBufferEncodedResourceStorageSize(NSUInteger bufferCount,
+                                                     NSUInteger textureCount,
+                                                     NSUInteger samplerCount);
+    MTLArgumentDescriptor* getMTLArgumentDescriptor(MTLDataType resourceType,
+                                                    NSUInteger argIndex,
+                                                    NSUInteger count);
+    size_t getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo,
+                       VkDescriptorType descriptorType);
 
-	void propagateDebugName() override {}
-	VkResult allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL, uint32_t variableDescriptorCount, VkDescriptorSet* pVKDS);
-	void freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset);
-	VkResult allocateDescriptor(VkDescriptorType descriptorType, MVKDescriptor** pMVKDesc, bool& dynamicAllocation);
-	void freeDescriptor(MVKDescriptor* mvkDesc);
-	void initMetalArgumentBuffer(const VkDescriptorPoolCreateInfo* pCreateInfo);
-	NSUInteger getMetalArgumentBufferEncodedResourceStorageSize(NSUInteger bufferCount, NSUInteger textureCount, NSUInteger samplerCount);
-	MTLArgumentDescriptor* getMTLArgumentDescriptor(MTLDataType resourceType, NSUInteger argIndex, NSUInteger count);
-	size_t getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo, VkDescriptorType descriptorType);
+    MVKSmallVector<MVKDescriptorSet> _descriptorSets;
+    MVKBitArray _descriptorSetAvailablility;
+    MVKMTLBufferAllocator _mtlBufferAllocator;
+    id<MTLBuffer> _metalArgumentBuffer = nil;
+    NSUInteger _nextMetalArgumentBufferOffset = 0;
 
-	MVKSmallVector<MVKDescriptorSet> _descriptorSets;
-	MVKBitArray _descriptorSetAvailablility;
-	MVKMTLBufferAllocator _mtlBufferAllocator;
-	id<MTLBuffer> _metalArgumentBuffer = nil;
-	NSUInteger _nextMetalArgumentBufferOffset = 0;
+    MVKDescriptorTypePool<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
+    MVKDescriptorTypePool<MVKStorageBufferDescriptor> _storageBufferDescriptors;
+    MVKDescriptorTypePool<MVKUniformBufferDynamicDescriptor>
+        _uniformBufferDynamicDescriptors;
+    MVKDescriptorTypePool<MVKStorageBufferDynamicDescriptor>
+        _storageBufferDynamicDescriptors;
+    MVKDescriptorTypePool<MVKInlineUniformBlockDescriptor>
+        _inlineUniformBlockDescriptors;
+    MVKDescriptorTypePool<MVKSampledImageDescriptor> _sampledImageDescriptors;
+    MVKDescriptorTypePool<MVKStorageImageDescriptor> _storageImageDescriptors;
+    MVKDescriptorTypePool<MVKInputAttachmentDescriptor>
+        _inputAttachmentDescriptors;
+    MVKDescriptorTypePool<MVKSamplerDescriptor> _samplerDescriptors;
+    MVKDescriptorTypePool<MVKCombinedImageSamplerDescriptor>
+        _combinedImageSamplerDescriptors;
+    MVKDescriptorTypePool<MVKUniformTexelBufferDescriptor>
+        _uniformTexelBufferDescriptors;
+    MVKDescriptorTypePool<MVKStorageTexelBufferDescriptor>
+        _storageTexelBufferDescriptors;
 
-	MVKDescriptorTypePool<MVKUniformBufferDescriptor> _uniformBufferDescriptors;
-	MVKDescriptorTypePool<MVKStorageBufferDescriptor> _storageBufferDescriptors;
-	MVKDescriptorTypePool<MVKUniformBufferDynamicDescriptor> _uniformBufferDynamicDescriptors;
-	MVKDescriptorTypePool<MVKStorageBufferDynamicDescriptor> _storageBufferDynamicDescriptors;
-	MVKDescriptorTypePool<MVKInlineUniformBlockDescriptor> _inlineUniformBlockDescriptors;
-	MVKDescriptorTypePool<MVKSampledImageDescriptor> _sampledImageDescriptors;
-	MVKDescriptorTypePool<MVKStorageImageDescriptor> _storageImageDescriptors;
-	MVKDescriptorTypePool<MVKInputAttachmentDescriptor> _inputAttachmentDescriptors;
-	MVKDescriptorTypePool<MVKSamplerDescriptor> _samplerDescriptors;
-	MVKDescriptorTypePool<MVKCombinedImageSamplerDescriptor> _combinedImageSamplerDescriptors;
-	MVKDescriptorTypePool<MVKUniformTexelBufferDescriptor> _uniformTexelBufferDescriptors;
-	MVKDescriptorTypePool<MVKStorageTexelBufferDescriptor> _storageTexelBufferDescriptors;
-
-	VkDescriptorPoolCreateFlags _flags = 0;
-	size_t _maxAllocDescSetCount = 0;
+    VkDescriptorPoolCreateFlags _flags = 0;
+    size_t _maxAllocDescSetCount = 0;
 };
-
 
 #pragma mark -
 #pragma mark MVKDescriptorUpdateTemplate
@@ -335,54 +390,61 @@ protected:
 /** Represents a Vulkan descriptor update template. */
 class MVKDescriptorUpdateTemplate : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT; }
+    /** Get the nth update template entry. */
+    const VkDescriptorUpdateTemplateEntry* getEntry(uint32_t n) const;
 
-	/** Get the nth update template entry. */
-	const VkDescriptorUpdateTemplateEntry* getEntry(uint32_t n) const;
+    /** Get the total number of entries. */
+    uint32_t getNumberOfEntries() const;
 
-	/** Get the total number of entries. */
-	uint32_t getNumberOfEntries() const;
+    /** Get the total number of bytes of data requried by this template. */
+    size_t getSize() const { return _size; }
 
-	/** Get the total number of bytes of data requried by this template. */
-	size_t getSize() const { return _size; }
+    /** Get the type of this template. */
+    VkDescriptorUpdateTemplateType getType() const;
 
-	/** Get the type of this template. */
-	VkDescriptorUpdateTemplateType getType() const;
+    /** Get the bind point of this template */
+    VkPipelineBindPoint getBindPoint() const { return _pipelineBindPoint; }
 
-	/** Get the bind point of this template */
-	VkPipelineBindPoint getBindPoint() const { return _pipelineBindPoint; }
+    /** Constructs an instance for the specified device. */
+    MVKDescriptorUpdateTemplate(
+        MVKDevice* device,
+        const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo);
 
-	/** Constructs an instance for the specified device. */
-	MVKDescriptorUpdateTemplate(MVKDevice* device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo);
+    /** Destructor. */
+    ~MVKDescriptorUpdateTemplate() override = default;
 
-	/** Destructor. */
-	~MVKDescriptorUpdateTemplate() override = default;
+  protected:
+    void propagateDebugName() override {}
 
-protected:
-	void propagateDebugName() override {}
-
-	MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
-	size_t _size = 0;
-	VkPipelineBindPoint _pipelineBindPoint;
-	VkDescriptorUpdateTemplateType _type;
+    MVKSmallVector<VkDescriptorUpdateTemplateEntry, 1> _entries;
+    size_t _size = 0;
+    VkPipelineBindPoint _pipelineBindPoint;
+    VkDescriptorUpdateTemplateType _type;
 };
 
 #pragma mark -
 #pragma mark Support functions
 
-/** Updates the resource bindings in the descriptor sets inditified in the specified content. */
+/** Updates the resource bindings in the descriptor sets inditified in the
+ * specified content. */
 void mvkUpdateDescriptorSets(uint32_t writeCount,
-							const VkWriteDescriptorSet* pDescriptorWrites,
-							uint32_t copyCount,
-							const VkCopyDescriptorSet* pDescriptorCopies);
+                             const VkWriteDescriptorSet* pDescriptorWrites,
+                             uint32_t copyCount,
+                             const VkCopyDescriptorSet* pDescriptorCopies);
 
-/** Updates the resource bindings in the given descriptor set from the specified template. */
-void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
-										VkDescriptorUpdateTemplate updateTemplate,
-										const void* pData);
+/** Updates the resource bindings in the given descriptor set from the specified
+ * template. */
+void mvkUpdateDescriptorSetWithTemplate(
+    VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate updateTemplate,
+    const void* pData);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,93 +24,106 @@
 #include "MVKOSExtensions.h"
 #include <sstream>
 
-
 // The size of one Metal3 Argument Buffer slot in bytes.
 static const size_t kMVKMetal3ArgBuffSlotSizeInBytes = sizeof(uint64_t);
-
 
 #pragma mark -
 #pragma mark MVKMetalArgumentBuffer
 
-void MVKMetalArgumentBuffer::setArgumentBuffer(id<MTLBuffer> mtlArgBuff,
-											   NSUInteger mtlArgBuffOfst,
-											   id<MTLArgumentEncoder> mtlArgEnc) {
-	_mtlArgumentBuffer = mtlArgBuff;
-	_mtlArgumentBufferOffset = mtlArgBuffOfst;
+void MVKMetalArgumentBuffer::setArgumentBuffer(
+    id<MTLBuffer> mtlArgBuff, NSUInteger mtlArgBuffOfst,
+    id<MTLArgumentEncoder> mtlArgEnc) {
+    _mtlArgumentBuffer = mtlArgBuff;
+    _mtlArgumentBufferOffset = mtlArgBuffOfst;
 
-	auto* oldArgEnc = _mtlArgumentEncoder;
-	_mtlArgumentEncoder = [mtlArgEnc retain];	// retained
-	[_mtlArgumentEncoder setArgumentBuffer: _mtlArgumentBuffer offset: _mtlArgumentBufferOffset];
-	[oldArgEnc release];
+    auto* oldArgEnc = _mtlArgumentEncoder;
+    _mtlArgumentEncoder = [mtlArgEnc retain]; // retained
+    [_mtlArgumentEncoder setArgumentBuffer:_mtlArgumentBuffer
+                                    offset:_mtlArgumentBufferOffset];
+    [oldArgEnc release];
 }
 
-void MVKMetalArgumentBuffer::setBuffer(id<MTLBuffer> mtlBuff, NSUInteger offset, uint32_t index) {
-	if (_mtlArgumentEncoder) {
-		[_mtlArgumentEncoder setBuffer: mtlBuff offset: offset atIndex: index];
-	} else {
+void MVKMetalArgumentBuffer::setBuffer(id<MTLBuffer> mtlBuff, NSUInteger offset,
+                                       uint32_t index) {
+    if (_mtlArgumentEncoder) {
+        [_mtlArgumentEncoder setBuffer:mtlBuff offset:offset atIndex:index];
+    } else {
 #if MVK_XCODE_14
-		*(uint64_t*)getArgumentPointer(index) = mtlBuff.gpuAddress + offset;
+        *(uint64_t*)getArgumentPointer(index) = mtlBuff.gpuAddress + offset;
 #endif
-	}
+    }
 }
 
 void MVKMetalArgumentBuffer::setTexture(id<MTLTexture> mtlTex, uint32_t index) {
-	if (_mtlArgumentEncoder) {
-		[_mtlArgumentEncoder setTexture: mtlTex atIndex: index];
-	} else {
+    if (_mtlArgumentEncoder) {
+        [_mtlArgumentEncoder setTexture:mtlTex atIndex:index];
+    } else {
 #if MVK_XCODE_14
-		*(MTLResourceID*)getArgumentPointer(index) = mtlTex.gpuResourceID;
+        *(MTLResourceID*)getArgumentPointer(index) = mtlTex.gpuResourceID;
 #endif
-	}
+    }
 }
 
-void MVKMetalArgumentBuffer::setSamplerState(id<MTLSamplerState> mtlSamp, uint32_t index) {
-	if (_mtlArgumentEncoder) {
-		[_mtlArgumentEncoder setSamplerState: mtlSamp atIndex: index];
-	} else {
+void MVKMetalArgumentBuffer::setSamplerState(id<MTLSamplerState> mtlSamp,
+                                             uint32_t index) {
+    if (_mtlArgumentEncoder) {
+        [_mtlArgumentEncoder setSamplerState:mtlSamp atIndex:index];
+    } else {
 #if MVK_XCODE_14
-		*(MTLResourceID*)getArgumentPointer(index) = mtlSamp.gpuResourceID;
+        *(MTLResourceID*)getArgumentPointer(index) = mtlSamp.gpuResourceID;
 #endif
-	}
+    }
 }
 
-// Returns the address of the slot at the index within the Metal argument buffer.
-// This is based on the Metal 3 design that all arg buffer slots are 64 bits.
+// Returns the address of the slot at the index within the Metal argument
+// buffer. This is based on the Metal 3 design that all arg buffer slots are 64
+// bits.
 void* MVKMetalArgumentBuffer::getArgumentPointer(uint32_t index) const {
-	return (void*)((uintptr_t)_mtlArgumentBuffer.contents + _mtlArgumentBufferOffset + (index * kMVKMetal3ArgBuffSlotSizeInBytes));
+    return (void*)((uintptr_t)_mtlArgumentBuffer.contents +
+                   _mtlArgumentBufferOffset +
+                   (index * kMVKMetal3ArgBuffSlotSizeInBytes));
 }
 
-MVKMetalArgumentBuffer::~MVKMetalArgumentBuffer() { [_mtlArgumentEncoder release]; }
-
+MVKMetalArgumentBuffer::~MVKMetalArgumentBuffer() {
+    [_mtlArgumentEncoder release];
+}
 
 #pragma mark -
 #pragma mark MVKDescriptorSetLayout
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKDescriptorSetLayout::bindDescriptorSet(MVKCommandEncoder* cmdEncoder,
-											   VkPipelineBindPoint pipelineBindPoint,
-											   uint32_t descSetIndex,
-											   MVKDescriptorSet* descSet,
-											   MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-											   MVKArrayRef<uint32_t> dynamicOffsets,
-											   uint32_t& dynamicOffsetIndex) {
-	if (!cmdEncoder) { clearConfigurationResult(); }
-	if (_isPushDescriptorLayout ) { return; }
+void MVKDescriptorSetLayout::bindDescriptorSet(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    uint32_t descSetIndex, MVKDescriptorSet* descSet,
+    MVKShaderResourceBinding& dslMTLRezIdxOffsets,
+    MVKArrayRef<uint32_t> dynamicOffsets, uint32_t& dynamicOffsetIndex) {
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
+    if (_isPushDescriptorLayout) {
+        return;
+    }
 
-	if (cmdEncoder) { cmdEncoder->bindDescriptorSet(pipelineBindPoint, descSetIndex,
-													descSet, dslMTLRezIdxOffsets,
-													dynamicOffsets, dynamicOffsetIndex); }
-	if ( !isUsingMetalArgumentBuffers() ) {
-		for (auto& dslBind : _bindings) {
-			dslBind.bind(cmdEncoder, pipelineBindPoint, descSet, dslMTLRezIdxOffsets, dynamicOffsets, dynamicOffsetIndex);
-		}
-	}
+    if (cmdEncoder) {
+        cmdEncoder->bindDescriptorSet(pipelineBindPoint, descSetIndex, descSet,
+                                      dslMTLRezIdxOffsets, dynamicOffsets,
+                                      dynamicOffsetIndex);
+    }
+    if (!isUsingMetalArgumentBuffers()) {
+        for (auto& dslBind : _bindings) {
+            dslBind.bind(cmdEncoder, pipelineBindPoint, descSet,
+                         dslMTLRezIdxOffsets, dynamicOffsets,
+                         dynamicOffsetIndex);
+        }
+    }
 }
 
-static const void* getWriteParameters(VkDescriptorType type, const VkDescriptorImageInfo* pImageInfo,
-                                      const VkDescriptorBufferInfo* pBufferInfo, const VkBufferView* pTexelBufferView,
-                                      const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock,
-                                      size_t& stride) {
+static const void* getWriteParameters(
+    VkDescriptorType type, const VkDescriptorImageInfo* pImageInfo,
+    const VkDescriptorBufferInfo* pBufferInfo,
+    const VkBufferView* pTexelBufferView,
+    const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock,
+    size_t& stride) {
     const void* pData;
     switch (type) {
     case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
@@ -149,29 +162,34 @@ static const void* getWriteParameters(VkDescriptorType type, const VkDescriptorI
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-                                               VkPipelineBindPoint pipelineBindPoint,
-                                               MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
-                                               MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
+void MVKDescriptorSetLayout::pushDescriptorSet(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
+    MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
 
     if (!_isPushDescriptorLayout) return;
 
-	if (!cmdEncoder) { clearConfigurationResult(); }
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
 
-	auto& enabledExtns = getEnabledExtensions();
-	for (const VkWriteDescriptorSet& descWrite : descriptorWrites) {
+    auto& enabledExtns = getEnabledExtensions();
+    for (const VkWriteDescriptorSet& descWrite : descriptorWrites) {
         uint32_t dstBinding = descWrite.dstBinding;
         uint32_t dstArrayElement = descWrite.dstArrayElement;
         uint32_t descriptorCount = descWrite.descriptorCount;
         const VkDescriptorImageInfo* pImageInfo = descWrite.pImageInfo;
         const VkDescriptorBufferInfo* pBufferInfo = descWrite.pBufferInfo;
         const VkBufferView* pTexelBufferView = descWrite.pTexelBufferView;
-        const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock = nullptr;
+        const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock =
+            nullptr;
         if (enabledExtns.vk_EXT_inline_uniform_block.enabled) {
-			for (const auto* next = (VkBaseInStructure*)descWrite.pNext; next; next = next->pNext) {
+            for (const auto* next = (VkBaseInStructure*)descWrite.pNext; next;
+                 next = next->pNext) {
                 switch (next->sType) {
                 case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: {
-					pInlineUniformBlock = (VkWriteDescriptorSetInlineUniformBlockEXT*)next;
+                    pInlineUniformBlock =
+                        (VkWriteDescriptorSetInlineUniformBlockEXT*)next;
                     break;
                 }
                 default:
@@ -185,11 +203,14 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
         for (; descriptorCount; dstBinding++) {
             if (!_bindingToIndex.count(dstBinding)) continue;
             size_t stride;
-            const void* pData = getWriteParameters(descWrite.descriptorType, pImageInfo,
-                                                   pBufferInfo, pTexelBufferView, pInlineUniformBlock, stride);
+            const void* pData =
+                getWriteParameters(descWrite.descriptorType, pImageInfo,
+                                   pBufferInfo, pTexelBufferView,
+                                   pInlineUniformBlock, stride);
             uint32_t descriptorsPushed = 0;
             uint32_t bindIdx = _bindingToIndex[dstBinding];
-            _bindings[bindIdx].push(cmdEncoder, pipelineBindPoint, dstArrayElement, descriptorCount,
+            _bindings[bindIdx].push(cmdEncoder, pipelineBindPoint,
+                                    dstArrayElement, descriptorCount,
                                     descriptorsPushed, descWrite.descriptorType,
                                     stride, pData, dslMTLRezIdxOffsets);
             pBufferInfo += descriptorsPushed;
@@ -200,19 +221,23 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-                                               MVKDescriptorUpdateTemplate* descUpdateTemplate,
-                                               const void* pData,
-                                               MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
+void MVKDescriptorSetLayout::pushDescriptorSet(
+    MVKCommandEncoder* cmdEncoder,
+    MVKDescriptorUpdateTemplate* descUpdateTemplate, const void* pData,
+    MVKShaderResourceBinding& dslMTLRezIdxOffsets) {
 
     if (!_isPushDescriptorLayout ||
-        descUpdateTemplate->getType() != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR)
+        descUpdateTemplate->getType() !=
+            VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR)
         return;
 
-	if (!cmdEncoder) { clearConfigurationResult(); }
-	VkPipelineBindPoint bindPoint = descUpdateTemplate->getBindPoint();
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
+    VkPipelineBindPoint bindPoint = descUpdateTemplate->getBindPoint();
     for (uint32_t i = 0; i < descUpdateTemplate->getNumberOfEntries(); i++) {
-        const VkDescriptorUpdateTemplateEntry* pEntry = descUpdateTemplate->getEntry(i);
+        const VkDescriptorUpdateTemplateEntry* pEntry =
+            descUpdateTemplate->getEntry(i);
         uint32_t dstBinding = pEntry->dstBinding;
         uint32_t dstArrayElement = pEntry->dstArrayElement;
         uint32_t descriptorCount = pEntry->descriptorCount;
@@ -224,1089 +249,1359 @@ void MVKDescriptorSetLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
             if (!_bindingToIndex.count(dstBinding)) continue;
             uint32_t descriptorsPushed = 0;
             uint32_t bindIdx = _bindingToIndex[dstBinding];
-            _bindings[bindIdx].push(cmdEncoder, bindPoint, dstArrayElement, descriptorCount,
-                                    descriptorsPushed, pEntry->descriptorType,
-                                    pEntry->stride, pCurData, dslMTLRezIdxOffsets);
-            pCurData = (const char*)pCurData + pEntry->stride * descriptorsPushed;
+            _bindings[bindIdx].push(cmdEncoder, bindPoint, dstArrayElement,
+                                    descriptorCount, descriptorsPushed,
+                                    pEntry->descriptorType, pEntry->stride,
+                                    pCurData, dslMTLRezIdxOffsets);
+            pCurData =
+                (const char*)pCurData + pEntry->stride * descriptorsPushed;
         }
     }
 }
 
-static void populateAuxBuffer(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-							  MVKShaderStageResourceBinding buffBinding,
-							  uint32_t descSetIndex,
-							  uint32_t descBinding,
-							  bool usingNativeTextureAtomics) {
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		mvkPopulateShaderConversionConfig(shaderConfig,
-										  buffBinding,
-										  MVKShaderStage(stage),
-										  descSetIndex,
-										  descBinding,
-										  1,
-										  VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-										  nullptr,
-										  usingNativeTextureAtomics);
-	}
+static void
+populateAuxBuffer(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+                  MVKShaderStageResourceBinding buffBinding,
+                  uint32_t descSetIndex, uint32_t descBinding,
+                  bool usingNativeTextureAtomics) {
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        mvkPopulateShaderConversionConfig(shaderConfig, buffBinding,
+                                          MVKShaderStage(stage), descSetIndex,
+                                          descBinding, 1,
+                                          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                          nullptr, usingNativeTextureAtomics);
+    }
 }
 
-void MVKDescriptorSetLayout::populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-                                                            MVKShaderResourceBinding& dslMTLRezIdxOffsets,
-															uint32_t descSetIndex) {
-	uint32_t bindCnt = (uint32_t)_bindings.size();
-	for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		_bindings[bindIdx].populateShaderConversionConfig(shaderConfig, dslMTLRezIdxOffsets, descSetIndex);
-	}
+void MVKDescriptorSetLayout::populateShaderConversionConfig(
+    mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+    MVKShaderResourceBinding& dslMTLRezIdxOffsets, uint32_t descSetIndex) {
+    uint32_t bindCnt = (uint32_t)_bindings.size();
+    for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
+        _bindings[bindIdx].populateShaderConversionConfig(shaderConfig,
+                                                          dslMTLRezIdxOffsets,
+                                                          descSetIndex);
+    }
 
-	// If this descriptor set is using an argument buffer, and needs a buffer size auxiliary buffer, add it.
-	if (isUsingMetalArgumentBuffers() && needsBufferSizeAuxBuffer()) {
-		MVKShaderStageResourceBinding buffBinding;
-		buffBinding.bufferIndex = getBufferSizeBufferArgBuferIndex();
-		populateAuxBuffer(shaderConfig, buffBinding, descSetIndex,
-						  SPIRV_CROSS_NAMESPACE::kBufferSizeBufferBinding,
-						  getMetalFeatures().nativeTextureAtomics);
-	}
+    // If this descriptor set is using an argument buffer, and needs a buffer
+    // size auxiliary buffer, add it.
+    if (isUsingMetalArgumentBuffers() && needsBufferSizeAuxBuffer()) {
+        MVKShaderStageResourceBinding buffBinding;
+        buffBinding.bufferIndex = getBufferSizeBufferArgBuferIndex();
+        populateAuxBuffer(shaderConfig, buffBinding, descSetIndex,
+                          SPIRV_CROSS_NAMESPACE::kBufferSizeBufferBinding,
+                          getMetalFeatures().nativeTextureAtomics);
+    }
 
-	// If the app is using argument buffers, but this descriptor set is 
-	// not, because this is a discrete descriptor set, mark it as such.
-	if(MVKDeviceTrackingMixin::isUsingMetalArgumentBuffers() && !isUsingMetalArgumentBuffers()) {
-		shaderConfig.discreteDescriptorSets.push_back(descSetIndex);
-	}
+    // If the app is using argument buffers, but this descriptor set is
+    // not, because this is a discrete descriptor set, mark it as such.
+    if (MVKDeviceTrackingMixin::isUsingMetalArgumentBuffers() &&
+        !isUsingMetalArgumentBuffers()) {
+        shaderConfig.discreteDescriptorSets.push_back(descSetIndex);
+    }
 }
 
-bool MVKDescriptorSetLayout::populateBindingUse(MVKBitArray& bindingUse,
-                                                mvk::SPIRVToMSLConversionConfiguration& context,
-                                                MVKShaderStage stage,
-                                                uint32_t descSetIndex) {
-	static const spv::ExecutionModel spvExecModels[] = {
-		spv::ExecutionModelVertex,
-		spv::ExecutionModelTessellationControl,
-		spv::ExecutionModelTessellationEvaluation,
-		spv::ExecutionModelFragment,
-		spv::ExecutionModelGLCompute
-	};
+bool MVKDescriptorSetLayout::populateBindingUse(
+    MVKBitArray& bindingUse, mvk::SPIRVToMSLConversionConfiguration& context,
+    MVKShaderStage stage, uint32_t descSetIndex) {
+    static const spv::ExecutionModel spvExecModels[] =
+        {spv::ExecutionModelVertex, spv::ExecutionModelTessellationControl,
+         spv::ExecutionModelTessellationEvaluation, spv::ExecutionModelFragment,
+         spv::ExecutionModelGLCompute};
 
-	bool descSetIsUsed = false;
-	uint32_t bindCnt = (uint32_t)_bindings.size();
-	bindingUse.resize(bindCnt);
-	for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		auto& dslBind = _bindings[bindIdx];
-		if (context.isResourceUsed(spvExecModels[stage], descSetIndex, dslBind.getBinding())) {
-			bindingUse.enableBit(bindIdx);
-			descSetIsUsed = true;
-		}
-	}
-	return descSetIsUsed;
+    bool descSetIsUsed = false;
+    uint32_t bindCnt = (uint32_t)_bindings.size();
+    bindingUse.resize(bindCnt);
+    for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
+        auto& dslBind = _bindings[bindIdx];
+        if (context.isResourceUsed(spvExecModels[stage], descSetIndex,
+                                   dslBind.getBinding())) {
+            bindingUse.enableBit(bindIdx);
+            descSetIsUsed = true;
+        }
+    }
+    return descSetIsUsed;
 }
 
 bool MVKDescriptorSetLayout::isUsingMetalArgumentBuffers() {
-	return MVKDeviceTrackingMixin::isUsingMetalArgumentBuffers() && _canUseMetalArgumentBuffer;
+    return MVKDeviceTrackingMixin::isUsingMetalArgumentBuffers() &&
+           _canUseMetalArgumentBuffer;
 };
 
-// Returns an autoreleased MTLArgumentDescriptor suitable for adding an auxiliary buffer to the argument buffer.
-static MTLArgumentDescriptor* getAuxBufferArgumentDescriptor(uint32_t argIndex) {
-	auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
-	argDesc.dataType = MTLDataTypePointer;
-	argDesc.access = MTLArgumentAccessReadWrite;
-	argDesc.index = argIndex;
-	argDesc.arrayLength = 1;
-	return argDesc;
+// Returns an autoreleased MTLArgumentDescriptor suitable for adding an
+// auxiliary buffer to the argument buffer.
+static MTLArgumentDescriptor*
+getAuxBufferArgumentDescriptor(uint32_t argIndex) {
+    auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
+    argDesc.dataType = MTLDataTypePointer;
+    argDesc.access = MTLArgumentAccessReadWrite;
+    argDesc.index = argIndex;
+    argDesc.arrayLength = 1;
+    return argDesc;
 }
 
-// Returns an autoreleased MTLArgumentEncoder for a descriptor set, or nil if not needed.
-// Make sure any call to this function is wrapped in @autoreleasepool.
-id <MTLArgumentEncoder> MVKDescriptorSetLayout::getMTLArgumentEncoder(uint32_t variableDescriptorCount) {
-	auto* encoderArgs = [NSMutableArray arrayWithCapacity: _bindings.size() * 2];	// Double it to cover potential multi-resource descriptors (combo image/samp, multi-planar, etc).
+// Returns an autoreleased MTLArgumentEncoder for a descriptor set, or nil if
+// not needed. Make sure any call to this function is wrapped in
+// @autoreleasepool.
+id<MTLArgumentEncoder> MVKDescriptorSetLayout::getMTLArgumentEncoder(
+    uint32_t variableDescriptorCount) {
+    auto* encoderArgs = [NSMutableArray
+        arrayWithCapacity:
+            _bindings.size() *
+            2]; // Double it to cover potential multi-resource descriptors
+                // (combo image/samp, multi-planar, etc).
 
-	// Buffer sizes buffer at front
-	if (needsBufferSizeAuxBuffer()) {
-		[encoderArgs addObject: getAuxBufferArgumentDescriptor(getBufferSizeBufferArgBuferIndex())];
-	}
-	for (auto& dslBind : _bindings) {
-		dslBind.addMTLArgumentDescriptors(encoderArgs, variableDescriptorCount);
-	}
-	return encoderArgs.count ? [[getMTLDevice() newArgumentEncoderWithArguments: encoderArgs] autorelease] : nil;
+    // Buffer sizes buffer at front
+    if (needsBufferSizeAuxBuffer()) {
+        [encoderArgs addObject:getAuxBufferArgumentDescriptor(
+                                   getBufferSizeBufferArgBuferIndex())];
+    }
+    for (auto& dslBind : _bindings) {
+        dslBind.addMTLArgumentDescriptors(encoderArgs, variableDescriptorCount);
+    }
+    return encoderArgs.count
+               ? [[getMTLDevice() newArgumentEncoderWithArguments:encoderArgs]
+                     autorelease]
+               : nil;
 }
 
-// Returns the encoded byte length of the resources from a descriptor set in an argument buffer.
-uint64_t MVKDescriptorSetLayout::getMetal3ArgumentBufferEncodedLength(uint32_t variableDescriptorCount) {
-	uint64_t encodedLen =  0;
+// Returns the encoded byte length of the resources from a descriptor set in an
+// argument buffer.
+uint64_t MVKDescriptorSetLayout::getMetal3ArgumentBufferEncodedLength(
+    uint32_t variableDescriptorCount) {
+    uint64_t encodedLen = 0;
 
-	// Buffer sizes buffer at front
-	if (needsBufferSizeAuxBuffer()) {
-		encodedLen += kMVKMetal3ArgBuffSlotSizeInBytes;
-	}
-	for (auto& dslBind : _bindings) {
-		encodedLen += dslBind.getMTLResourceCount(variableDescriptorCount) * kMVKMetal3ArgBuffSlotSizeInBytes;
-	}
-	return encodedLen;
+    // Buffer sizes buffer at front
+    if (needsBufferSizeAuxBuffer()) {
+        encodedLen += kMVKMetal3ArgBuffSlotSizeInBytes;
+    }
+    for (auto& dslBind : _bindings) {
+        encodedLen += dslBind.getMTLResourceCount(variableDescriptorCount) *
+                      kMVKMetal3ArgBuffSlotSizeInBytes;
+    }
+    return encodedLen;
 }
 
-uint32_t MVKDescriptorSetLayout::getDescriptorCount(uint32_t variableDescriptorCount) {
-	uint32_t descCnt =  0;
-	for (auto& dslBind : _bindings) {
-		descCnt += dslBind.getDescriptorCount(variableDescriptorCount);
-	}
-	return descCnt;
+uint32_t
+MVKDescriptorSetLayout::getDescriptorCount(uint32_t variableDescriptorCount) {
+    uint32_t descCnt = 0;
+    for (auto& dslBind : _bindings) {
+        descCnt += dslBind.getDescriptorCount(variableDescriptorCount);
+    }
+    return descCnt;
 }
 
-MVKDescriptorSetLayoutBinding* MVKDescriptorSetLayout::getBinding(uint32_t binding, uint32_t bindingIndexOffset) {
-	auto itr = _bindingToIndex.find(binding);
-	if (itr != _bindingToIndex.end()) {
-		uint32_t bindIdx = itr->second + bindingIndexOffset;
-		if (bindIdx < _bindings.size()) {
-			return &_bindings[bindIdx];
-		}
-	}
-	return nullptr;
+MVKDescriptorSetLayoutBinding*
+MVKDescriptorSetLayout::getBinding(uint32_t binding,
+                                   uint32_t bindingIndexOffset) {
+    auto itr = _bindingToIndex.find(binding);
+    if (itr != _bindingToIndex.end()) {
+        uint32_t bindIdx = itr->second + bindingIndexOffset;
+        if (bindIdx < _bindings.size()) {
+            return &_bindings[bindIdx];
+        }
+    }
+    return nullptr;
 }
 
-MVKDescriptorSetLayout::MVKDescriptorSetLayout(MVKDevice* device,
-                                               const VkDescriptorSetLayoutCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	const VkDescriptorBindingFlags* pBindingFlags = nullptr;
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO: {
-				auto* pDescSetLayoutBindingFlags = (VkDescriptorSetLayoutBindingFlagsCreateInfo*)next;
-				if (pDescSetLayoutBindingFlags->bindingCount) {
-					pBindingFlags = pDescSetLayoutBindingFlags->pBindingFlags;
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
+MVKDescriptorSetLayout::MVKDescriptorSetLayout(
+    MVKDevice* device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    const VkDescriptorBindingFlags* pBindingFlags = nullptr;
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO: {
+            auto* pDescSetLayoutBindingFlags =
+                (VkDescriptorSetLayoutBindingFlagsCreateInfo*)next;
+            if (pDescSetLayoutBindingFlags->bindingCount) {
+                pBindingFlags = pDescSetLayoutBindingFlags->pBindingFlags;
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	_isPushDescriptorLayout = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
-	_canUseMetalArgumentBuffer = checkCanUseArgumentBuffers(pCreateInfo);	// After _isPushDescriptorLayout
+    _isPushDescriptorLayout = mvkIsAnyFlagEnabled(
+        pCreateInfo->flags,
+        VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
+    _canUseMetalArgumentBuffer = checkCanUseArgumentBuffers(
+        pCreateInfo); // After _isPushDescriptorLayout
 
-	// The bindings in VkDescriptorSetLayoutCreateInfo do not need to be provided in order of binding number.
-	// However, several subsequent operations, such as the dynamic offsets in vkCmdBindDescriptorSets()
-	// are ordered by binding number. To prepare for this, sort the bindings by binding number.
-	struct BindInfo {
-		const VkDescriptorSetLayoutBinding* pBinding;
-		VkDescriptorBindingFlags bindingFlags;
-	};
-	MVKSmallVector<BindInfo, 64> sortedBindings;
+    // The bindings in VkDescriptorSetLayoutCreateInfo do not need to be
+    // provided in order of binding number. However, several subsequent
+    // operations, such as the dynamic offsets in vkCmdBindDescriptorSets() are
+    // ordered by binding number. To prepare for this, sort the bindings by
+    // binding number.
+    struct BindInfo {
+        const VkDescriptorSetLayoutBinding* pBinding;
+        VkDescriptorBindingFlags bindingFlags;
+    };
+    MVKSmallVector<BindInfo, 64> sortedBindings;
 
-	bool needsBuffSizeAuxBuff = false;
-	uint32_t bindCnt = pCreateInfo->bindingCount;
-	sortedBindings.reserve(bindCnt);
-	for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		auto* pBind = &pCreateInfo->pBindings[bindIdx];
-		sortedBindings.push_back( { pBind, pBindingFlags ? pBindingFlags[bindIdx] : 0 } );
-		needsBuffSizeAuxBuff = needsBuffSizeAuxBuff || mvkNeedsBuffSizeAuxBuffer(pBind);
-	}
-	std::sort(sortedBindings.begin(), sortedBindings.end(), [](BindInfo bindInfo1, BindInfo bindInfo2) {
-		return bindInfo1.pBinding->binding < bindInfo2.pBinding->binding;
-	});
-
-	// Create bindings. Must be done after _isPushDescriptorLayout & _canUseMetalArgumentBuffer are set.
-	uint32_t dslDescCnt = 0;
-	uint32_t dslMTLRezCnt = needsBuffSizeAuxBuff ? 1 : 0;	// If needed, leave a slot for the buffer sizes buffer at front.
-	_bindings.reserve(bindCnt);
+    bool needsBuffSizeAuxBuff = false;
+    uint32_t bindCnt = pCreateInfo->bindingCount;
+    sortedBindings.reserve(bindCnt);
     for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		BindInfo& bindInfo = sortedBindings[bindIdx];
-        _bindings.emplace_back(_device, this, bindInfo.pBinding, bindInfo.bindingFlags, dslDescCnt, dslMTLRezCnt);
-		_bindingToIndex[bindInfo.pBinding->binding] = bindIdx;
-	}
+        auto* pBind = &pCreateInfo->pBindings[bindIdx];
+        sortedBindings.push_back(
+            {pBind, pBindingFlags ? pBindingFlags[bindIdx] : 0});
+        needsBuffSizeAuxBuff =
+            needsBuffSizeAuxBuff || mvkNeedsBuffSizeAuxBuffer(pBind);
+    }
+    std::sort(sortedBindings.begin(), sortedBindings.end(),
+              [](BindInfo bindInfo1, BindInfo bindInfo2) {
+                  return bindInfo1.pBinding->binding <
+                         bindInfo2.pBinding->binding;
+              });
 
-	MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n", getLogDescription().c_str());
+    // Create bindings. Must be done after _isPushDescriptorLayout &
+    // _canUseMetalArgumentBuffer are set.
+    uint32_t dslDescCnt = 0;
+    uint32_t dslMTLRezCnt =
+        needsBuffSizeAuxBuff ? 1 : 0; // If needed, leave a slot for the buffer
+                                      // sizes buffer at front.
+    _bindings.reserve(bindCnt);
+    for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
+        BindInfo& bindInfo = sortedBindings[bindIdx];
+        _bindings.emplace_back(_device, this, bindInfo.pBinding,
+                               bindInfo.bindingFlags, dslDescCnt, dslMTLRezCnt);
+        _bindingToIndex[bindInfo.pBinding->binding] = bindIdx;
+    }
+
+    MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n",
+                  getLogDescription().c_str());
 }
 
 std::string MVKDescriptorSetLayout::getLogDescription(std::string indent) {
-	std::stringstream descStr;
-	descStr << "VkDescriptorSetLayout with " << _bindings.size() << " bindings:";
-	auto bindIndent = indent + "\t";
-	for (auto& dlb : _bindings) {
-		descStr << "\n" << bindIndent << dlb.getLogDescription(bindIndent);
-	}
-	return descStr.str();
+    std::stringstream descStr;
+    descStr << "VkDescriptorSetLayout with " << _bindings.size()
+            << " bindings:";
+    auto bindIndent = indent + "\t";
+    for (auto& dlb : _bindings) {
+        descStr << "\n" << bindIndent << dlb.getLogDescription(bindIndent);
+    }
+    return descStr.str();
 }
 
 // Check if argument buffers can be used, and return findings.
 // Must be called after setting _isPushDescriptorLayout.
-bool MVKDescriptorSetLayout::checkCanUseArgumentBuffers(const VkDescriptorSetLayoutCreateInfo* pCreateInfo) {
+bool MVKDescriptorSetLayout::checkCanUseArgumentBuffers(
+    const VkDescriptorSetLayoutCreateInfo* pCreateInfo) {
 
 // iOS Tier 1 argument buffers do not support writable images.
 #if MVK_IOS_OR_TVOS
-	if (getMetalFeatures().argumentBuffersTier < MTLArgumentBuffersTier2) {
-		for (uint32_t bindIdx = 0; bindIdx < pCreateInfo->bindingCount; bindIdx++) {
-			switch (pCreateInfo->pBindings[bindIdx].descriptorType) {
-				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-					return false;
-				default:
-					break;
-			}
-		}
-	}
+    if (getMetalFeatures().argumentBuffersTier < MTLArgumentBuffersTier2) {
+        for (uint32_t bindIdx = 0; bindIdx < pCreateInfo->bindingCount;
+             bindIdx++) {
+            switch (pCreateInfo->pBindings[bindIdx].descriptorType) {
+            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                return false;
+            default:
+                break;
+            }
+        }
+    }
 #endif
 
-	return !_isPushDescriptorLayout;	// Push descriptors don't use argument buffers
+    return !_isPushDescriptorLayout; // Push descriptors don't use argument
+                                     // buffers
 }
-
 
 #pragma mark -
 #pragma mark MVKDescriptorSet
 
 VkDescriptorType MVKDescriptorSet::getDescriptorType(uint32_t binding) {
-	return _layout->getBinding(binding)->getDescriptorType();
+    return _layout->getBinding(binding)->getDescriptorType();
 }
 
-MVKDescriptor* MVKDescriptorSet::getDescriptor(uint32_t binding, uint32_t elementIndex) {
-	return _descriptors[_layout->getDescriptorIndex(binding, elementIndex)];
+MVKDescriptor* MVKDescriptorSet::getDescriptor(uint32_t binding,
+                                               uint32_t elementIndex) {
+    return _descriptors[_layout->getDescriptorIndex(binding, elementIndex)];
 }
 
-template<typename DescriptorAction>
+template <typename DescriptorAction>
 void MVKDescriptorSet::write(const DescriptorAction* pDescriptorAction,
-							 size_t srcStride,
-							 const void* pData) {
+                             size_t srcStride, const void* pData) {
 
-	auto* mvkDSLBind = _layout->getBinding(pDescriptorAction->dstBinding);
-	if (mvkDSLBind->getDescriptorType() == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		// For inline buffers, descriptorCount is a byte count and dstArrayElement is a byte offset.
-		// If needed, Vulkan allows updates to extend into subsequent bindings that are of the same type,
-		// so iterate layout bindings and their associated descriptors, until all bytes are updated.
-		const auto* pInlineUniformBlock = (VkWriteDescriptorSetInlineUniformBlockEXT*)pData;
-		uint32_t numBytesToCopy = pDescriptorAction->descriptorCount;
-		uint32_t dstOffset = pDescriptorAction->dstArrayElement;
-		uint32_t srcOffset = 0;
-		while (mvkDSLBind && numBytesToCopy > 0 && srcOffset < pInlineUniformBlock->dataSize) {
-			auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)_descriptors[mvkDSLBind->_descriptorIndex];
-			auto numBytesMoved = mvkDesc->writeBytes(mvkDSLBind, this, dstOffset, srcOffset, numBytesToCopy, pInlineUniformBlock);
-			numBytesToCopy -= numBytesMoved;
-			dstOffset = 0;
-			srcOffset += numBytesMoved;
-			mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(), 1);	// Next binding if needed
-		}
-	} else {
-		// We don't test against the descriptor count of the binding, because Vulkan allows
-		// updates to extend into subsequent bindings that are of the same type, if needed.
-		uint32_t srcElemIdx = 0;
-		uint32_t dstElemIdx = pDescriptorAction->dstArrayElement;
-		uint32_t descIdx = _layout->getDescriptorIndex(pDescriptorAction->dstBinding, dstElemIdx);
-		uint32_t descCnt = pDescriptorAction->descriptorCount;
-		while (srcElemIdx < descCnt) {
-			_descriptors[descIdx++]->write(mvkDSLBind, this, dstElemIdx++, srcElemIdx++, srcStride, pData);
-		}
-	}
-}
-
-void MVKDescriptorSet::read(const VkCopyDescriptorSet* pDescriptorCopy,
-							VkDescriptorImageInfo* pImageInfo,
-							VkDescriptorBufferInfo* pBufferInfo,
-							VkBufferView* pTexelBufferView,
-							VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
-
-	MVKDescriptorSetLayoutBinding* mvkDSLBind = _layout->getBinding(pDescriptorCopy->srcBinding);
-	VkDescriptorType descType = mvkDSLBind->getDescriptorType();
-    if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		// For inline buffers, descriptorCount is a byte count and dstArrayElement is a byte offset.
-		// If needed, Vulkan allows updates to extend into subsequent bindings that are of the same type,
-		// so iterate layout bindings and their associated descriptors, until all bytes are updated.
-		uint32_t numBytesToCopy = pDescriptorCopy->descriptorCount;
-		uint32_t dstOffset = 0;
-		uint32_t srcOffset = pDescriptorCopy->srcArrayElement;
-		while (mvkDSLBind && numBytesToCopy > 0 && dstOffset < pInlineUniformBlock->dataSize) {
-			auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)_descriptors[mvkDSLBind->_descriptorIndex];
-			auto numBytesMoved = mvkDesc->readBytes(mvkDSLBind, this, dstOffset, srcOffset, numBytesToCopy, pInlineUniformBlock);
-			numBytesToCopy -= numBytesMoved;
-			dstOffset += numBytesMoved;
-			srcOffset = 0;
-			mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(), 1);	// Next binding if needed
-		}
+    auto* mvkDSLBind = _layout->getBinding(pDescriptorAction->dstBinding);
+    if (mvkDSLBind->getDescriptorType() ==
+        VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        // For inline buffers, descriptorCount is a byte count and
+        // dstArrayElement is a byte offset. If needed, Vulkan allows updates to
+        // extend into subsequent bindings that are of the same type, so iterate
+        // layout bindings and their associated descriptors, until all bytes are
+        // updated.
+        const auto* pInlineUniformBlock =
+            (VkWriteDescriptorSetInlineUniformBlockEXT*)pData;
+        uint32_t numBytesToCopy = pDescriptorAction->descriptorCount;
+        uint32_t dstOffset = pDescriptorAction->dstArrayElement;
+        uint32_t srcOffset = 0;
+        while (mvkDSLBind && numBytesToCopy > 0 &&
+               srcOffset < pInlineUniformBlock->dataSize) {
+            auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)
+                _descriptors[mvkDSLBind->_descriptorIndex];
+            auto numBytesMoved =
+                mvkDesc->writeBytes(mvkDSLBind, this, dstOffset, srcOffset,
+                                    numBytesToCopy, pInlineUniformBlock);
+            numBytesToCopy -= numBytesMoved;
+            dstOffset = 0;
+            srcOffset += numBytesMoved;
+            mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(),
+                                             1); // Next binding if needed
+        }
     } else {
-		// We don't test against the descriptor count of the binding, because Vulkan allows
-		// updates to extend into subsequent bindings that are of the same type, if needed.
-		uint32_t srcElemIdx = pDescriptorCopy->srcArrayElement;
-		uint32_t dstElemIdx = 0;
-		uint32_t descIdx = _layout->getDescriptorIndex(pDescriptorCopy->srcBinding, srcElemIdx);
-		uint32_t descCnt = pDescriptorCopy->descriptorCount;
-		while (dstElemIdx < descCnt) {
-			_descriptors[descIdx++]->read(mvkDSLBind, this, dstElemIdx++, pImageInfo, pBufferInfo, pTexelBufferView, pInlineUniformBlock);
-		}
+        // We don't test against the descriptor count of the binding, because
+        // Vulkan allows updates to extend into subsequent bindings that are of
+        // the same type, if needed.
+        uint32_t srcElemIdx = 0;
+        uint32_t dstElemIdx = pDescriptorAction->dstArrayElement;
+        uint32_t descIdx =
+            _layout->getDescriptorIndex(pDescriptorAction->dstBinding,
+                                        dstElemIdx);
+        uint32_t descCnt = pDescriptorAction->descriptorCount;
+        while (srcElemIdx < descCnt) {
+            _descriptors[descIdx++]->write(mvkDSLBind, this, dstElemIdx++,
+                                           srcElemIdx++, srcStride, pData);
+        }
     }
 }
 
-MVKMTLBufferAllocation* MVKDescriptorSet::acquireMTLBufferRegion(NSUInteger length) {
-	return _pool->_mtlBufferAllocator.acquireMTLBufferRegion(length);
+void MVKDescriptorSet::read(
+    const VkCopyDescriptorSet* pDescriptorCopy,
+    VkDescriptorImageInfo* pImageInfo, VkDescriptorBufferInfo* pBufferInfo,
+    VkBufferView* pTexelBufferView,
+    VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock) {
+
+    MVKDescriptorSetLayoutBinding* mvkDSLBind =
+        _layout->getBinding(pDescriptorCopy->srcBinding);
+    VkDescriptorType descType = mvkDSLBind->getDescriptorType();
+    if (descType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        // For inline buffers, descriptorCount is a byte count and
+        // dstArrayElement is a byte offset. If needed, Vulkan allows updates to
+        // extend into subsequent bindings that are of the same type, so iterate
+        // layout bindings and their associated descriptors, until all bytes are
+        // updated.
+        uint32_t numBytesToCopy = pDescriptorCopy->descriptorCount;
+        uint32_t dstOffset = 0;
+        uint32_t srcOffset = pDescriptorCopy->srcArrayElement;
+        while (mvkDSLBind && numBytesToCopy > 0 &&
+               dstOffset < pInlineUniformBlock->dataSize) {
+            auto* mvkDesc = (MVKInlineUniformBlockDescriptor*)
+                _descriptors[mvkDSLBind->_descriptorIndex];
+            auto numBytesMoved =
+                mvkDesc->readBytes(mvkDSLBind, this, dstOffset, srcOffset,
+                                   numBytesToCopy, pInlineUniformBlock);
+            numBytesToCopy -= numBytesMoved;
+            dstOffset += numBytesMoved;
+            srcOffset = 0;
+            mvkDSLBind = _layout->getBinding(mvkDSLBind->getBinding(),
+                                             1); // Next binding if needed
+        }
+    } else {
+        // We don't test against the descriptor count of the binding, because
+        // Vulkan allows updates to extend into subsequent bindings that are of
+        // the same type, if needed.
+        uint32_t srcElemIdx = pDescriptorCopy->srcArrayElement;
+        uint32_t dstElemIdx = 0;
+        uint32_t descIdx =
+            _layout->getDescriptorIndex(pDescriptorCopy->srcBinding,
+                                        srcElemIdx);
+        uint32_t descCnt = pDescriptorCopy->descriptorCount;
+        while (dstElemIdx < descCnt) {
+            _descriptors[descIdx++]->read(mvkDSLBind, this, dstElemIdx++,
+                                          pImageInfo, pBufferInfo,
+                                          pTexelBufferView,
+                                          pInlineUniformBlock);
+        }
+    }
+}
+
+MVKMTLBufferAllocation*
+MVKDescriptorSet::acquireMTLBufferRegion(NSUInteger length) {
+    return _pool->_mtlBufferAllocator.acquireMTLBufferRegion(length);
 }
 
 VkResult MVKDescriptorSet::allocate(MVKDescriptorSetLayout* layout,
-									uint32_t variableDescriptorCount,
-									NSUInteger mtlArgBufferOffset,
-									id<MTLArgumentEncoder> mtlArgEnc) {
-	_layout = layout;
-	_layout->retain();
-	_variableDescriptorCount = variableDescriptorCount;
-	_argumentBuffer.setArgumentBuffer(_pool->_metalArgumentBuffer, mtlArgBufferOffset, mtlArgEnc);
+                                    uint32_t variableDescriptorCount,
+                                    NSUInteger mtlArgBufferOffset,
+                                    id<MTLArgumentEncoder> mtlArgEnc) {
+    _layout = layout;
+    _layout->retain();
+    _variableDescriptorCount = variableDescriptorCount;
+    _argumentBuffer.setArgumentBuffer(_pool->_metalArgumentBuffer,
+                                      mtlArgBufferOffset, mtlArgEnc);
 
-	uint32_t descCnt = layout->getDescriptorCount(variableDescriptorCount);
-	_descriptors.reserve(descCnt);
+    uint32_t descCnt = layout->getDescriptorCount(variableDescriptorCount);
+    _descriptors.reserve(descCnt);
 
-	uint32_t bindCnt = (uint32_t)layout->_bindings.size();
-	for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
-		MVKDescriptorSetLayoutBinding* mvkDSLBind = &layout->_bindings[bindIdx];
-		uint32_t elemCnt = mvkDSLBind->getDescriptorCount(variableDescriptorCount);
-		for (uint32_t elemIdx = 0; elemIdx < elemCnt; elemIdx++) {
-			VkDescriptorType descType = mvkDSLBind->getDescriptorType();
-			MVKDescriptor* mvkDesc = nullptr;
-			bool dynamicAllocation = true;
-			setConfigurationResult(_pool->allocateDescriptor(descType, &mvkDesc, dynamicAllocation));	// Modifies dynamicAllocation.
-			if (dynamicAllocation) { _allDescriptorsAreFromPool = false; }
-			if ( !wasConfigurationSuccessful() ) { return getConfigurationResult(); }
-			if (mvkDesc->usesDynamicBufferOffsets()) { _dynamicOffsetDescriptorCount++; }
-			_descriptors.push_back(mvkDesc);
-		}
-		mvkDSLBind->encodeImmutableSamplersToMetalArgumentBuffer(this);
-	}
+    uint32_t bindCnt = (uint32_t)layout->_bindings.size();
+    for (uint32_t bindIdx = 0; bindIdx < bindCnt; bindIdx++) {
+        MVKDescriptorSetLayoutBinding* mvkDSLBind = &layout->_bindings[bindIdx];
+        uint32_t elemCnt =
+            mvkDSLBind->getDescriptorCount(variableDescriptorCount);
+        for (uint32_t elemIdx = 0; elemIdx < elemCnt; elemIdx++) {
+            VkDescriptorType descType = mvkDSLBind->getDescriptorType();
+            MVKDescriptor* mvkDesc = nullptr;
+            bool dynamicAllocation = true;
+            setConfigurationResult(_pool->allocateDescriptor(
+                descType, &mvkDesc,
+                dynamicAllocation)); // Modifies dynamicAllocation.
+            if (dynamicAllocation) {
+                _allDescriptorsAreFromPool = false;
+            }
+            if (!wasConfigurationSuccessful()) {
+                return getConfigurationResult();
+            }
+            if (mvkDesc->usesDynamicBufferOffsets()) {
+                _dynamicOffsetDescriptorCount++;
+            }
+            _descriptors.push_back(mvkDesc);
+        }
+        mvkDSLBind->encodeImmutableSamplersToMetalArgumentBuffer(this);
+    }
 
-	// If needed, allocate a MTLBuffer to track buffer sizes, and add it to the argument buffer.
-	if (hasMetalArgumentBuffer() && _layout->needsBufferSizeAuxBuffer()) {
-		uint32_t buffSizesSlotCount = _layout->_maxBufferIndex + 1;
-		_bufferSizesBuffer = acquireMTLBufferRegion(buffSizesSlotCount * sizeof(uint32_t));
-		_argumentBuffer.setBuffer(_bufferSizesBuffer->_mtlBuffer,
-								  _bufferSizesBuffer->_offset,
-								  _layout->getBufferSizeBufferArgBuferIndex());
-	}
+    // If needed, allocate a MTLBuffer to track buffer sizes, and add it to the
+    // argument buffer.
+    if (hasMetalArgumentBuffer() && _layout->needsBufferSizeAuxBuffer()) {
+        uint32_t buffSizesSlotCount = _layout->_maxBufferIndex + 1;
+        _bufferSizesBuffer =
+            acquireMTLBufferRegion(buffSizesSlotCount * sizeof(uint32_t));
+        _argumentBuffer.setBuffer(_bufferSizesBuffer->_mtlBuffer,
+                                  _bufferSizesBuffer->_offset,
+                                  _layout->getBufferSizeBufferArgBuferIndex());
+    }
 
-	return getConfigurationResult();
+    return getConfigurationResult();
 }
 
 void MVKDescriptorSet::free(bool isPoolReset) {
-	if(_layout) { _layout->release(); }
-	_layout = nullptr;
-	_dynamicOffsetDescriptorCount = 0;
-	_variableDescriptorCount = 0;
+    if (_layout) {
+        _layout->release();
+    }
+    _layout = nullptr;
+    _dynamicOffsetDescriptorCount = 0;
+    _variableDescriptorCount = 0;
 
-	if (isPoolReset) { _argumentBuffer.setArgumentBuffer(_pool->_metalArgumentBuffer, 0, nil); }
+    if (isPoolReset) {
+        _argumentBuffer.setArgumentBuffer(_pool->_metalArgumentBuffer, 0, nil);
+    }
 
-	// If this is a pool reset, and all desciptors are from the pool, we don't need to free them.
-	if ( !(isPoolReset && _allDescriptorsAreFromPool) ) {
-		for (auto mvkDesc : _descriptors) { _pool->freeDescriptor(mvkDesc); }
-	}
-	_descriptors.clear();
-	_descriptors.shrink_to_fit();
-	_allDescriptorsAreFromPool = true;
+    // If this is a pool reset, and all desciptors are from the pool, we don't
+    // need to free them.
+    if (!(isPoolReset && _allDescriptorsAreFromPool)) {
+        for (auto mvkDesc : _descriptors) {
+            _pool->freeDescriptor(mvkDesc);
+        }
+    }
+    _descriptors.clear();
+    _descriptors.shrink_to_fit();
+    _allDescriptorsAreFromPool = true;
 
-	if (_bufferSizesBuffer) {
-		_bufferSizesBuffer->returnToPool();
-		_bufferSizesBuffer = nullptr;
-	}
+    if (_bufferSizesBuffer) {
+        _bufferSizesBuffer->returnToPool();
+        _bufferSizesBuffer = nullptr;
+    }
 
-	clearConfigurationResult();
+    clearConfigurationResult();
 }
 
 void MVKDescriptorSet::setBufferSize(uint32_t descIdx, uint32_t value) {
-	if (_bufferSizesBuffer) {
-		*(uint32_t*)((uintptr_t)_bufferSizesBuffer->getContents() + (descIdx * sizeof(uint32_t))) = value;
-	}
+    if (_bufferSizesBuffer) {
+        *(uint32_t*)((uintptr_t)_bufferSizesBuffer->getContents() +
+                     (descIdx * sizeof(uint32_t))) = value;
+    }
 }
 
-void MVKDescriptorSet::encodeAuxBufferUsage(MVKResourcesCommandEncoderState* rezEncState, MVKShaderStage stage) {
-	if (_bufferSizesBuffer) {
-		MTLRenderStages mtlRendStages = MTLRenderStageVertex | MTLRenderStageFragment;
-		rezEncState->encodeResourceUsage(stage, _bufferSizesBuffer->_mtlBuffer, MTLResourceUsageRead, mtlRendStages);
-	}
+void MVKDescriptorSet::encodeAuxBufferUsage(
+    MVKResourcesCommandEncoderState* rezEncState, MVKShaderStage stage) {
+    if (_bufferSizesBuffer) {
+        MTLRenderStages mtlRendStages =
+            MTLRenderStageVertex | MTLRenderStageFragment;
+        rezEncState->encodeResourceUsage(stage, _bufferSizesBuffer->_mtlBuffer,
+                                         MTLResourceUsageRead, mtlRendStages);
+    }
 }
 
-MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorPool* pool) : MVKVulkanAPIDeviceObject(pool->_device), _pool(pool) {
-	free(true);
+MVKDescriptorSet::MVKDescriptorSet(MVKDescriptorPool* pool)
+    : MVKVulkanAPIDeviceObject(pool->_device), _pool(pool) {
+    free(true);
 }
 
 MVKDescriptorSet::~MVKDescriptorSet() {
-	if(_layout) { _layout->release(); }
+    if (_layout) {
+        _layout->release();
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKDescriptorTypePool
 
-// Find the next availalble descriptor in the pool. or if the pool is exhausted, optionally create one on the fly.
-// The dynamicAllocation parameter is both an input and output parameter. Incoming, dynamicAllocation indicates that,
-// if there are no more descriptors in this pool, a new descriptor should be created and returned.
-// On return, dynamicAllocation indicates back to the caller whether a descriptor was dynamically created.
-// If a descriptor could not be found in the pool and was not created dynamically, a null descriptor is returned.
-template<class DescriptorClass>
-VkResult MVKDescriptorTypePool<DescriptorClass>::allocateDescriptor(VkDescriptorType descType,
-																	MVKDescriptor** pMVKDesc,
-																	bool& dynamicAllocation,
-																	MVKDescriptorPool* pool) {
-	VkResult errRslt = VK_ERROR_OUT_OF_POOL_MEMORY;
-	size_t availDescIdx = _availability.getIndexOfFirstEnabledBit();
-	if (availDescIdx < size()) {
-		_availability.disableBit(availDescIdx);		// Mark the descriptor as taken
-		*pMVKDesc = &_descriptors[availDescIdx];
-		(*pMVKDesc)->reset();						// Reset descriptor before reusing.
-		dynamicAllocation = false;
-		return VK_SUCCESS;
-	} else if (dynamicAllocation) {
-		*pMVKDesc = new DescriptorClass();
-		reportWarning(errRslt, "VkDescriptorPool exhausted pool of %zu %s descriptors. Allocating descriptor dynamically.", size(), mvkVkDescriptorTypeName(descType));
-		return VK_SUCCESS;
-	} else {
-		*pMVKDesc = nullptr;
-		dynamicAllocation = false;
-		return reportError(errRslt, "VkDescriptorPool exhausted pool of %zu %s descriptors.", size(), mvkVkDescriptorTypeName(descType));
-	}
+// Find the next availalble descriptor in the pool. or if the pool is exhausted,
+// optionally create one on the fly. The dynamicAllocation parameter is both an
+// input and output parameter. Incoming, dynamicAllocation indicates that, if
+// there are no more descriptors in this pool, a new descriptor should be
+// created and returned. On return, dynamicAllocation indicates back to the
+// caller whether a descriptor was dynamically created. If a descriptor could
+// not be found in the pool and was not created dynamically, a null descriptor
+// is returned.
+template <class DescriptorClass>
+VkResult MVKDescriptorTypePool<DescriptorClass>::allocateDescriptor(
+    VkDescriptorType descType, MVKDescriptor** pMVKDesc,
+    bool& dynamicAllocation, MVKDescriptorPool* pool) {
+    VkResult errRslt = VK_ERROR_OUT_OF_POOL_MEMORY;
+    size_t availDescIdx = _availability.getIndexOfFirstEnabledBit();
+    if (availDescIdx < size()) {
+        _availability.disableBit(availDescIdx); // Mark the descriptor as taken
+        *pMVKDesc = &_descriptors[availDescIdx];
+        (*pMVKDesc)->reset(); // Reset descriptor before reusing.
+        dynamicAllocation = false;
+        return VK_SUCCESS;
+    } else if (dynamicAllocation) {
+        *pMVKDesc = new DescriptorClass();
+        reportWarning(errRslt,
+                      "VkDescriptorPool exhausted pool of %zu %s descriptors. "
+                      "Allocating descriptor dynamically.",
+                      size(), mvkVkDescriptorTypeName(descType));
+        return VK_SUCCESS;
+    } else {
+        *pMVKDesc = nullptr;
+        dynamicAllocation = false;
+        return reportError(errRslt,
+                           "VkDescriptorPool exhausted pool of %zu %s "
+                           "descriptors.",
+                           size(), mvkVkDescriptorTypeName(descType));
+    }
 }
 
-// If the descriptor is from the pool, mark it as available, otherwise destroy it.
-// Pooled descriptors are held in contiguous memory, so the index of the returning
-// descriptor can be calculated by typed pointer differences. The descriptor will
-// be reset when it is re-allocated. This streamlines a pool reset().
-template<typename DescriptorClass>
-void MVKDescriptorTypePool<DescriptorClass>::freeDescriptor(MVKDescriptor* mvkDesc,
-															MVKDescriptorPool* pool) {
-	DescriptorClass* pDesc = (DescriptorClass*)mvkDesc;
-	DescriptorClass* pFirstDesc = _descriptors.data();
-	int64_t descIdx = pDesc >= pFirstDesc ? pDesc - pFirstDesc : pFirstDesc - pDesc;
-	if (descIdx >= 0 && descIdx < size()) {
-		_availability.enableBit(descIdx);
-	} else {
-		mvkDesc->destroy();
-	}
+// If the descriptor is from the pool, mark it as available, otherwise destroy
+// it. Pooled descriptors are held in contiguous memory, so the index of the
+// returning descriptor can be calculated by typed pointer differences. The
+// descriptor will be reset when it is re-allocated. This streamlines a pool
+// reset().
+template <typename DescriptorClass>
+void MVKDescriptorTypePool<DescriptorClass>::freeDescriptor(
+    MVKDescriptor* mvkDesc, MVKDescriptorPool* pool) {
+    DescriptorClass* pDesc = (DescriptorClass*)mvkDesc;
+    DescriptorClass* pFirstDesc = _descriptors.data();
+    int64_t descIdx =
+        pDesc >= pFirstDesc ? pDesc - pFirstDesc : pFirstDesc - pDesc;
+    if (descIdx >= 0 && descIdx < size()) {
+        _availability.enableBit(descIdx);
+    } else {
+        mvkDesc->destroy();
+    }
 }
 
 // Preallocated descriptors will be reset when they are reused
-template<typename DescriptorClass>
+template <typename DescriptorClass>
 void MVKDescriptorTypePool<DescriptorClass>::reset() {
-	_availability.enableAllBits();
+    _availability.enableAllBits();
 }
 
-template<typename DescriptorClass>
+template <typename DescriptorClass>
 size_t MVKDescriptorTypePool<DescriptorClass>::getRemainingDescriptorCount() {
-	size_t enabledCount = 0;
-	_availability.enumerateEnabledBits([&](size_t bitIdx) { enabledCount++; return true; });
-	return enabledCount;
+    size_t enabledCount = 0;
+    _availability.enumerateEnabledBits([&](size_t bitIdx) {
+        enabledCount++;
+        return true;
+    });
+    return enabledCount;
 }
 
-template<typename DescriptorClass>
-MVKDescriptorTypePool<DescriptorClass>::MVKDescriptorTypePool(size_t poolSize) :
-	_descriptors(poolSize),
-	_availability(poolSize, true) {}
-
+template <typename DescriptorClass>
+MVKDescriptorTypePool<DescriptorClass>::MVKDescriptorTypePool(size_t poolSize)
+    : _descriptors(poolSize), _availability(poolSize, true) {}
 
 #pragma mark -
 #pragma mark MVKDescriptorPool
 
-VkResult MVKDescriptorPool::allocateDescriptorSets(const VkDescriptorSetAllocateInfo* pAllocateInfo,
-												   VkDescriptorSet* pDescriptorSets) {
-	const uint32_t* pVarDescCounts = nullptr;
-	for (const auto* next = (VkBaseInStructure*)pAllocateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO: {
-				auto* pVarDescSetVarCounts = (VkDescriptorSetVariableDescriptorCountAllocateInfo*)next;
-				pVarDescCounts = pVarDescSetVarCounts->descriptorSetCount ? pVarDescSetVarCounts->pDescriptorCounts : nullptr;
-			}
-			default:
-				break;
-		}
-	}
+VkResult MVKDescriptorPool::allocateDescriptorSets(
+    const VkDescriptorSetAllocateInfo* pAllocateInfo,
+    VkDescriptorSet* pDescriptorSets) {
+    const uint32_t* pVarDescCounts = nullptr;
+    for (const auto* next = (VkBaseInStructure*)pAllocateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO: {
+            auto* pVarDescSetVarCounts =
+                (VkDescriptorSetVariableDescriptorCountAllocateInfo*)next;
+            pVarDescCounts = pVarDescSetVarCounts->descriptorSetCount
+                                 ? pVarDescSetVarCounts->pDescriptorCounts
+                                 : nullptr;
+        }
+        default:
+            break;
+        }
+    }
 
-	@autoreleasepool {
-		auto dsCnt = pAllocateInfo->descriptorSetCount;
-		for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
-			MVKDescriptorSetLayout* mvkDSL = (MVKDescriptorSetLayout*)pAllocateInfo->pSetLayouts[dsIdx];
-			if ( !mvkDSL->_isPushDescriptorLayout ) {
-				VkResult rslt = allocateDescriptorSet(mvkDSL, (pVarDescCounts ? pVarDescCounts[dsIdx] : 0), &pDescriptorSets[dsIdx]);
-				if (rslt) {
-					// Per Vulkan spec, if any descriptor set allocation fails, free any successful
-					// allocations, and populate all descriptor set pointers with VK_NULL_HANDLE.
-					freeDescriptorSets(dsIdx, pDescriptorSets);
-					for (uint32_t i = 0; i < dsCnt; i++) { pDescriptorSets[i] = VK_NULL_HANDLE; }
-					return rslt;
-				}
-			} else {
-				pDescriptorSets[dsIdx] = VK_NULL_HANDLE;
-			}
-		}
-	}
+    @autoreleasepool {
+        auto dsCnt = pAllocateInfo->descriptorSetCount;
+        for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
+            MVKDescriptorSetLayout* mvkDSL =
+                (MVKDescriptorSetLayout*)pAllocateInfo->pSetLayouts[dsIdx];
+            if (!mvkDSL->_isPushDescriptorLayout) {
+                VkResult rslt =
+                    allocateDescriptorSet(mvkDSL,
+                                          (pVarDescCounts
+                                               ? pVarDescCounts[dsIdx]
+                                               : 0),
+                                          &pDescriptorSets[dsIdx]);
+                if (rslt) {
+                    // Per Vulkan spec, if any descriptor set allocation fails,
+                    // free any successful allocations, and populate all
+                    // descriptor set pointers with VK_NULL_HANDLE.
+                    freeDescriptorSets(dsIdx, pDescriptorSets);
+                    for (uint32_t i = 0; i < dsCnt; i++) {
+                        pDescriptorSets[i] = VK_NULL_HANDLE;
+                    }
+                    return rslt;
+                }
+            } else {
+                pDescriptorSets[dsIdx] = VK_NULL_HANDLE;
+            }
+        }
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-// Retrieves the first available descriptor set from the pool, and configures it.
-// If none are available, returns an error.
-VkResult MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL,
-												  uint32_t variableDescriptorCount,
-												  VkDescriptorSet* pVKDS) {
-	VkResult rslt = VK_ERROR_FRAGMENTED_POOL;
-	uint64_t mtlArgBuffEncSize = 0;
-	id<MTLArgumentEncoder> mtlArgEnc = nil;
-	if (mvkDSL->isUsingMetalArgumentBuffers()) {
-		if (needsMetalArgumentBufferEncoders()) {
-			mtlArgEnc = mvkDSL->getMTLArgumentEncoder(variableDescriptorCount);
-			mtlArgBuffEncSize = mtlArgEnc.encodedLength;
-		} else {
-			mtlArgBuffEncSize = mvkDSL->getMetal3ArgumentBufferEncodedLength(variableDescriptorCount);
-		}
-	}
-	uint64_t mtlArgBuffEncAlignedSize = mvkAlignByteCount(mtlArgBuffEncSize, getMetalFeatures().mtlBufferAlignment);
+// Retrieves the first available descriptor set from the pool, and configures
+// it. If none are available, returns an error.
+VkResult
+MVKDescriptorPool::allocateDescriptorSet(MVKDescriptorSetLayout* mvkDSL,
+                                         uint32_t variableDescriptorCount,
+                                         VkDescriptorSet* pVKDS) {
+    VkResult rslt = VK_ERROR_FRAGMENTED_POOL;
+    uint64_t mtlArgBuffEncSize = 0;
+    id<MTLArgumentEncoder> mtlArgEnc = nil;
+    if (mvkDSL->isUsingMetalArgumentBuffers()) {
+        if (needsMetalArgumentBufferEncoders()) {
+            mtlArgEnc = mvkDSL->getMTLArgumentEncoder(variableDescriptorCount);
+            mtlArgBuffEncSize = mtlArgEnc.encodedLength;
+        } else {
+            mtlArgBuffEncSize = mvkDSL->getMetal3ArgumentBufferEncodedLength(
+                variableDescriptorCount);
+        }
+    }
+    uint64_t mtlArgBuffEncAlignedSize =
+        mvkAlignByteCount(mtlArgBuffEncSize,
+                          getMetalFeatures().mtlBufferAlignment);
 
-	size_t dsCnt = _descriptorSetAvailablility.size();
-	_descriptorSetAvailablility.enumerateEnabledBits([&](size_t dsIdx) {
-		bool isSpaceAvail = true;		// If not using Metal arg buffers, space will always be available.
-		MVKDescriptorSet* mvkDS = &_descriptorSets[dsIdx];
-		NSUInteger mtlArgBuffOffset = mvkDS->getMetalArgumentBuffer().getMetalArgumentBufferOffset();
+    size_t dsCnt = _descriptorSetAvailablility.size();
+    _descriptorSetAvailablility.enumerateEnabledBits([&](size_t dsIdx) {
+        bool isSpaceAvail = true; // If not using Metal arg buffers, space will
+                                  // always be available.
+        MVKDescriptorSet* mvkDS = &_descriptorSets[dsIdx];
+        NSUInteger mtlArgBuffOffset =
+            mvkDS->getMetalArgumentBuffer().getMetalArgumentBufferOffset();
 
-		// If the desc set is using a Metal argument buffer, we also need to see if the desc set
-		// will fit in the slot that might already have been allocated for it in the Metal argument
-		// buffer from a previous allocation that was returned. If this pool has been reset recently,
-		// then the desc sets will not have had a Metal argument buffer allocation assigned yet.
-		if (mtlArgBuffEncSize) {
+        // If the desc set is using a Metal argument buffer, we also need to see
+        // if the desc set will fit in the slot that might already have been
+        // allocated for it in the Metal argument buffer from a previous
+        // allocation that was returned. If this pool has been reset recently,
+        // then the desc sets will not have had a Metal argument buffer
+        // allocation assigned yet.
+        if (mtlArgBuffEncSize) {
 
-			// If the offset has not been set (and it's not the first desc set except
-			// on a reset pool), set the offset and update the next available offset value.
-			if ( !mtlArgBuffOffset && (dsIdx || !_nextMetalArgumentBufferOffset)) {
-				mtlArgBuffOffset = _nextMetalArgumentBufferOffset;
-				_nextMetalArgumentBufferOffset += mtlArgBuffEncAlignedSize;
-			}
+            // If the offset has not been set (and it's not the first desc set
+            // except on a reset pool), set the offset and update the next
+            // available offset value.
+            if (!mtlArgBuffOffset &&
+                (dsIdx || !_nextMetalArgumentBufferOffset)) {
+                mtlArgBuffOffset = _nextMetalArgumentBufferOffset;
+                _nextMetalArgumentBufferOffset += mtlArgBuffEncAlignedSize;
+            }
 
-			// Get the offset of the next desc set, if one exists and
-			// its offset has been set, or the end of the arg buffer.
-			size_t nextDSIdx = dsIdx + 1;
-			NSUInteger nextOffset = (nextDSIdx < dsCnt ? _descriptorSets[nextDSIdx].getMetalArgumentBuffer().getMetalArgumentBufferOffset() : 0);
-			if ( !nextOffset ) { nextOffset = _metalArgumentBuffer.length; }
+            // Get the offset of the next desc set, if one exists and
+            // its offset has been set, or the end of the arg buffer.
+            size_t nextDSIdx = dsIdx + 1;
+            NSUInteger nextOffset =
+                (nextDSIdx < dsCnt ? _descriptorSets[nextDSIdx]
+                                         .getMetalArgumentBuffer()
+                                         .getMetalArgumentBufferOffset()
+                                   : 0);
+            if (!nextOffset) {
+                nextOffset = _metalArgumentBuffer.length;
+            }
 
-			isSpaceAvail = (mtlArgBuffOffset + mtlArgBuffEncSize) <= nextOffset;
-		}
+            isSpaceAvail = (mtlArgBuffOffset + mtlArgBuffEncSize) <= nextOffset;
+        }
 
-		if (isSpaceAvail) {
-			rslt = mvkDS->allocate(mvkDSL, variableDescriptorCount, mtlArgBuffOffset, mtlArgEnc);
-			if (rslt) {
-				freeDescriptorSet(mvkDS, false);
-			} else {
-				_descriptorSetAvailablility.disableBit(dsIdx);
-				_maxAllocDescSetCount = std::max(_maxAllocDescSetCount, dsIdx + 1);
-				*pVKDS = (VkDescriptorSet)mvkDS;
-			}
-			return false;
-		} else {
-			return true;
-		}
-	});
-	return rslt;
+        if (isSpaceAvail) {
+            rslt = mvkDS->allocate(mvkDSL, variableDescriptorCount,
+                                   mtlArgBuffOffset, mtlArgEnc);
+            if (rslt) {
+                freeDescriptorSet(mvkDS, false);
+            } else {
+                _descriptorSetAvailablility.disableBit(dsIdx);
+                _maxAllocDescSetCount =
+                    std::max(_maxAllocDescSetCount, dsIdx + 1);
+                *pVKDS = (VkDescriptorSet)mvkDS;
+            }
+            return false;
+        } else {
+            return true;
+        }
+    });
+    return rslt;
 }
 
-VkResult MVKDescriptorPool::freeDescriptorSets(uint32_t count, const VkDescriptorSet* pDescriptorSets) {
-	for (uint32_t dsIdx = 0; dsIdx < count; dsIdx++) {
-		freeDescriptorSet((MVKDescriptorSet*)pDescriptorSets[dsIdx], false);
-	}
-	return VK_SUCCESS;
+VkResult
+MVKDescriptorPool::freeDescriptorSets(uint32_t count,
+                                      const VkDescriptorSet* pDescriptorSets) {
+    for (uint32_t dsIdx = 0; dsIdx < count; dsIdx++) {
+        freeDescriptorSet((MVKDescriptorSet*)pDescriptorSets[dsIdx], false);
+    }
+    return VK_SUCCESS;
 }
 
-// Descriptor sets are held in contiguous memory, so the index of the returning descriptor
-// set can be calculated by pointer differences, and it can be marked as available.
-// Don't bother individually set descriptor set availability if pool is being reset.
-void MVKDescriptorPool::freeDescriptorSet(MVKDescriptorSet* mvkDS, bool isPoolReset) {
-	if ( !mvkDS ) { return; }	// Vulkan allows NULL refs.
+// Descriptor sets are held in contiguous memory, so the index of the returning
+// descriptor set can be calculated by pointer differences, and it can be marked
+// as available. Don't bother individually set descriptor set availability if
+// pool is being reset.
+void MVKDescriptorPool::freeDescriptorSet(MVKDescriptorSet* mvkDS,
+                                          bool isPoolReset) {
+    if (!mvkDS) {
+        return;
+    } // Vulkan allows NULL refs.
 
-	if (mvkDS->_pool == this) {
-		mvkDS->free(isPoolReset);
-		if ( !isPoolReset ) {
-			size_t dsIdx = mvkDS - _descriptorSets.data();
-			_descriptorSetAvailablility.enableBit(dsIdx);
-		}
-	} else {
-		reportError(VK_ERROR_INITIALIZATION_FAILED, "A descriptor set is being returned to a descriptor pool that did not allocate it.");
-	}
+    if (mvkDS->_pool == this) {
+        mvkDS->free(isPoolReset);
+        if (!isPoolReset) {
+            size_t dsIdx = mvkDS - _descriptorSets.data();
+            _descriptorSetAvailablility.enableBit(dsIdx);
+        }
+    } else {
+        reportError(VK_ERROR_INITIALIZATION_FAILED,
+                    "A descriptor set is being returned to a descriptor pool "
+                    "that did not allocate it.");
+    }
 }
 
 // Free allocated descriptor sets and reset descriptor pools.
 // Don't waste time freeing desc sets that were never allocated.
 VkResult MVKDescriptorPool::reset(VkDescriptorPoolResetFlags flags) {
-	for (uint32_t dsIdx = 0; dsIdx < _maxAllocDescSetCount; dsIdx++) {
-		freeDescriptorSet(&_descriptorSets[dsIdx], true);
-	}
-	_descriptorSetAvailablility.enableAllBits();
+    for (uint32_t dsIdx = 0; dsIdx < _maxAllocDescSetCount; dsIdx++) {
+        freeDescriptorSet(&_descriptorSets[dsIdx], true);
+    }
+    _descriptorSetAvailablility.enableAllBits();
 
-	_uniformBufferDescriptors.reset();
-	_storageBufferDescriptors.reset();
-	_uniformBufferDynamicDescriptors.reset();
-	_storageBufferDynamicDescriptors.reset();
-	_inlineUniformBlockDescriptors.reset();
-	_sampledImageDescriptors.reset();
-	_storageImageDescriptors.reset();
-	_inputAttachmentDescriptors.reset();
-	_samplerDescriptors.reset();
-	_combinedImageSamplerDescriptors.reset();
-	_uniformTexelBufferDescriptors.reset();
-	_storageTexelBufferDescriptors.reset();
+    _uniformBufferDescriptors.reset();
+    _storageBufferDescriptors.reset();
+    _uniformBufferDynamicDescriptors.reset();
+    _storageBufferDynamicDescriptors.reset();
+    _inlineUniformBlockDescriptors.reset();
+    _sampledImageDescriptors.reset();
+    _storageImageDescriptors.reset();
+    _inputAttachmentDescriptors.reset();
+    _samplerDescriptors.reset();
+    _combinedImageSamplerDescriptors.reset();
+    _uniformTexelBufferDescriptors.reset();
+    _storageTexelBufferDescriptors.reset();
 
-	_nextMetalArgumentBufferOffset = 0;
-	_maxAllocDescSetCount = 0;
+    _nextMetalArgumentBufferOffset = 0;
+    _maxAllocDescSetCount = 0;
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 // Allocate a descriptor of the specified type
 VkResult MVKDescriptorPool::allocateDescriptor(VkDescriptorType descriptorType,
-											   MVKDescriptor** pMVKDesc,
-											   bool& dynamicAllocation) {
-	switch (descriptorType) {
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-			return _uniformBufferDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+                                               MVKDescriptor** pMVKDesc,
+                                               bool& dynamicAllocation) {
+    switch (descriptorType) {
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        return _uniformBufferDescriptors.allocateDescriptor(descriptorType,
+                                                            pMVKDesc,
+                                                            dynamicAllocation,
+                                                            this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-			return _storageBufferDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+        return _storageBufferDescriptors.allocateDescriptor(descriptorType,
+                                                            pMVKDesc,
+                                                            dynamicAllocation,
+                                                            this);
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-			return _uniformBufferDynamicDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+        return _uniformBufferDynamicDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			return _storageBufferDynamicDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        return _storageBufferDynamicDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			return _inlineUniformBlockDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        return _inlineUniformBlockDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-			return _sampledImageDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        return _sampledImageDescriptors.allocateDescriptor(descriptorType,
+                                                           pMVKDesc,
+                                                           dynamicAllocation,
+                                                           this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-			return _storageImageDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+        return _storageImageDescriptors.allocateDescriptor(descriptorType,
+                                                           pMVKDesc,
+                                                           dynamicAllocation,
+                                                           this);
 
-		case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-			return _inputAttachmentDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        return _inputAttachmentDescriptors.allocateDescriptor(descriptorType,
+                                                              pMVKDesc,
+                                                              dynamicAllocation,
+                                                              this);
 
-		case VK_DESCRIPTOR_TYPE_SAMPLER:
-			return _samplerDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+        return _samplerDescriptors.allocateDescriptor(descriptorType, pMVKDesc,
+                                                      dynamicAllocation, this);
 
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			return _combinedImageSamplerDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        return _combinedImageSamplerDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-			return _uniformTexelBufferDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        return _uniformTexelBufferDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			return _storageTexelBufferDescriptors.allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        return _storageTexelBufferDescriptors
+            .allocateDescriptor(descriptorType, pMVKDesc, dynamicAllocation,
+                                this);
 
-		default:
-			return reportError(VK_ERROR_INITIALIZATION_FAILED, "Unrecognized VkDescriptorType %d.", descriptorType);
-	}
+    default:
+        return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                           "Unrecognized VkDescriptorType %d.", descriptorType);
+    }
 }
 
 void MVKDescriptorPool::freeDescriptor(MVKDescriptor* mvkDesc) {
-	VkDescriptorType descriptorType = mvkDesc->getDescriptorType();
-	switch (descriptorType) {
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-			return _uniformBufferDescriptors.freeDescriptor(mvkDesc, this);
+    VkDescriptorType descriptorType = mvkDesc->getDescriptorType();
+    switch (descriptorType) {
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        return _uniformBufferDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-			return _storageBufferDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+        return _storageBufferDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-			return _uniformBufferDynamicDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+        return _uniformBufferDynamicDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-			return _storageBufferDynamicDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+        return _storageBufferDynamicDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-			return _inlineUniformBlockDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+        return _inlineUniformBlockDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-			return _sampledImageDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+        return _sampledImageDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-			return _storageImageDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+        return _storageImageDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-			return _inputAttachmentDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+        return _inputAttachmentDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_SAMPLER:
-			return _samplerDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_SAMPLER:
+        return _samplerDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-			return _combinedImageSamplerDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+        return _combinedImageSamplerDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-			return _uniformTexelBufferDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+        return _uniformTexelBufferDescriptors.freeDescriptor(mvkDesc, this);
 
-		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-			return _storageTexelBufferDescriptors.freeDescriptor(mvkDesc, this);
+    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        return _storageTexelBufferDescriptors.freeDescriptor(mvkDesc, this);
 
-		default:
-			reportError(VK_ERROR_INITIALIZATION_FAILED, "Unrecognized VkDescriptorType %d.", descriptorType);
-	}
+    default:
+        reportError(VK_ERROR_INITIALIZATION_FAILED,
+                    "Unrecognized VkDescriptorType %d.", descriptorType);
+    }
 }
 
-// Return the size of the preallocated pool for descriptors of the specified type.
-// There may be more than one poolSizeCount instance for the desired VkDescriptorType.
-// Accumulate the descriptor count for the desired VkDescriptorType accordingly.
-// For descriptors of the VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT type,
-// we accumulate the count via the pNext chain.
-size_t MVKDescriptorPool::getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo, VkDescriptorType descriptorType) {
-	uint32_t descCnt = 0;
-	if (descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-		for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-			switch (next->sType) {
-				case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: {
-					auto* pDescPoolInlineBlockCreateInfo = (VkDescriptorPoolInlineUniformBlockCreateInfoEXT*)next;
-					descCnt += pDescPoolInlineBlockCreateInfo->maxInlineUniformBlockBindings;
-					break;
-				}
-				default:
-					break;
-			}
-		}
-	} else {
-		for (uint32_t poolIdx = 0; poolIdx < pCreateInfo->poolSizeCount; poolIdx++) {
-			auto& poolSize = pCreateInfo->pPoolSizes[poolIdx];
-			if (poolSize.type == descriptorType) { descCnt += poolSize.descriptorCount; }
-		}
-	}
-	return descCnt;
+// Return the size of the preallocated pool for descriptors of the specified
+// type. There may be more than one poolSizeCount instance for the desired
+// VkDescriptorType. Accumulate the descriptor count for the desired
+// VkDescriptorType accordingly. For descriptors of the
+// VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT type, we accumulate the count via
+// the pNext chain.
+size_t
+MVKDescriptorPool::getPoolSize(const VkDescriptorPoolCreateInfo* pCreateInfo,
+                               VkDescriptorType descriptorType) {
+    uint32_t descCnt = 0;
+    if (descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+        for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+             next = next->pNext) {
+            switch (next->sType) {
+            case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: {
+                auto* pDescPoolInlineBlockCreateInfo =
+                    (VkDescriptorPoolInlineUniformBlockCreateInfoEXT*)next;
+                descCnt += pDescPoolInlineBlockCreateInfo
+                               ->maxInlineUniformBlockBindings;
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    } else {
+        for (uint32_t poolIdx = 0; poolIdx < pCreateInfo->poolSizeCount;
+             poolIdx++) {
+            auto& poolSize = pCreateInfo->pPoolSizes[poolIdx];
+            if (poolSize.type == descriptorType) {
+                descCnt += poolSize.descriptorCount;
+            }
+        }
+    }
+    return descCnt;
 }
 
 std::string MVKDescriptorPool::getLogDescription(std::string indent) {
 #define STR(name) #name
-#define printDescCnt(descType, spacing, descPool)  \
-	if (_##descPool##Descriptors.size()) {  \
-		descStr << "\n" << descCntIndent << STR(VK_DESCRIPTOR_TYPE_##descType) ": " spacing << _##descPool##Descriptors.size()  \
-		<< "  (" << _##descPool##Descriptors.getRemainingDescriptorCount() << " remaining)"; }
+#define printDescCnt(descType, spacing, descPool)                              \
+    if (_##descPool##Descriptors.size()) {                                     \
+        descStr << "\n"                                                        \
+                << descCntIndent                                               \
+                << STR(VK_DESCRIPTOR_TYPE_##descType) ": " spacing             \
+                << _##descPool##Descriptors.size() << "  ("                    \
+                << _##descPool##Descriptors.getRemainingDescriptorCount()      \
+                << " remaining)";                                              \
+    }
 
-	std::stringstream descStr;
-	descStr << "VkDescriptorPool with " << _descriptorSetAvailablility.size() << " descriptor sets";
-	descStr << " (reset " << (mvkIsAnyFlagEnabled(_flags, VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT) ? "or free" : "only") << ")";
-	descStr << ", and pooled descriptors:";
+    std::stringstream descStr;
+    descStr << "VkDescriptorPool with " << _descriptorSetAvailablility.size()
+            << " descriptor sets";
+    descStr << " (reset "
+            << (mvkIsAnyFlagEnabled(
+                    _flags, VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT)
+                    ? "or free"
+                    : "only")
+            << ")";
+    descStr << ", and pooled descriptors:";
 
-	auto descCntIndent = indent + "\t";
-	printDescCnt(UNIFORM_BUFFER, "          ", uniformBuffer);
-	printDescCnt(STORAGE_BUFFER, "          ", storageBuffer);
-	printDescCnt(UNIFORM_BUFFER_DYNAMIC, "  ", uniformBufferDynamic);
-	printDescCnt(STORAGE_BUFFER_DYNAMIC, "  ", storageBufferDynamic);
-	printDescCnt(INLINE_UNIFORM_BLOCK_EXT, "", inlineUniformBlock);
-	printDescCnt(SAMPLED_IMAGE, "           ", sampledImage);
-	printDescCnt(STORAGE_IMAGE, "           ", storageImage);
-	printDescCnt(INPUT_ATTACHMENT, "        ", inputAttachment);
-	printDescCnt(SAMPLER, "                 ", sampler);
-	printDescCnt(COMBINED_IMAGE_SAMPLER, "  ", combinedImageSampler);
-	printDescCnt(UNIFORM_TEXEL_BUFFER, "    ", uniformTexelBuffer);
-	printDescCnt(STORAGE_TEXEL_BUFFER, "    ", storageTexelBuffer);
-	return descStr.str();
+    auto descCntIndent = indent + "\t";
+    printDescCnt(UNIFORM_BUFFER, "          ", uniformBuffer);
+    printDescCnt(STORAGE_BUFFER, "          ", storageBuffer);
+    printDescCnt(UNIFORM_BUFFER_DYNAMIC, "  ", uniformBufferDynamic);
+    printDescCnt(STORAGE_BUFFER_DYNAMIC, "  ", storageBufferDynamic);
+    printDescCnt(INLINE_UNIFORM_BLOCK_EXT, "", inlineUniformBlock);
+    printDescCnt(SAMPLED_IMAGE, "           ", sampledImage);
+    printDescCnt(STORAGE_IMAGE, "           ", storageImage);
+    printDescCnt(INPUT_ATTACHMENT, "        ", inputAttachment);
+    printDescCnt(SAMPLER, "                 ", sampler);
+    printDescCnt(COMBINED_IMAGE_SAMPLER, "  ", combinedImageSampler);
+    printDescCnt(UNIFORM_TEXEL_BUFFER, "    ", uniformTexelBuffer);
+    printDescCnt(STORAGE_TEXEL_BUFFER, "    ", storageTexelBuffer);
+    return descStr.str();
 }
 
-MVKDescriptorPool::MVKDescriptorPool(MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo) :
-	MVKVulkanAPIDeviceObject(device),
-	_descriptorSets(pCreateInfo->maxSets, MVKDescriptorSet(this)),
-	_descriptorSetAvailablility(pCreateInfo->maxSets, true),
-	_mtlBufferAllocator(_device, getMetalFeatures().maxMTLBufferSize, true),
-	_uniformBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)),
-	_storageBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)),
-	_uniformBufferDynamicDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)),
-	_storageBufferDynamicDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)),
-	_inlineUniformBlockDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT)),
-	_sampledImageDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)),
-	_storageImageDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)),
-	_inputAttachmentDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)),
-	_samplerDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_SAMPLER)),
-	_combinedImageSamplerDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)),
-	_uniformTexelBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)),
-    _storageTexelBufferDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)),
-    _flags(pCreateInfo->flags) {
+MVKDescriptorPool::MVKDescriptorPool(
+    MVKDevice* device, const VkDescriptorPoolCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device),
+      _descriptorSets(pCreateInfo->maxSets, MVKDescriptorSet(this)),
+      _descriptorSetAvailablility(pCreateInfo->maxSets, true),
+      _mtlBufferAllocator(_device, getMetalFeatures().maxMTLBufferSize, true),
+      _uniformBufferDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)),
+      _storageBufferDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)),
+      _uniformBufferDynamicDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)),
+      _storageBufferDynamicDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)),
+      _inlineUniformBlockDescriptors(
+          getPoolSize(pCreateInfo,
+                      VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT)),
+      _sampledImageDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)),
+      _storageImageDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)),
+      _inputAttachmentDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)),
+      _samplerDescriptors(getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_SAMPLER)),
+      _combinedImageSamplerDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)),
+      _uniformTexelBufferDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)),
+      _storageTexelBufferDescriptors(
+          getPoolSize(pCreateInfo, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)),
+      _flags(pCreateInfo->flags) {
 
-		initMetalArgumentBuffer(pCreateInfo);
-		MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n", getLogDescription().c_str());
-	}
-
-void MVKDescriptorPool::initMetalArgumentBuffer(const VkDescriptorPoolCreateInfo* pCreateInfo) {
-	if ( !isUsingMetalArgumentBuffers() ) { return; }
-
-	auto& mtlFeats = getMetalFeatures();
-	@autoreleasepool {
-		NSUInteger mtlBuffCnt = 0;
-		NSUInteger mtlTexCnt = 0;
-		NSUInteger mtlSampCnt = 0;
-
-		uint32_t poolCnt = pCreateInfo->poolSizeCount;
-		for (uint32_t poolIdx = 0; poolIdx < poolCnt; poolIdx++) {
-			auto& poolSize = pCreateInfo->pPoolSizes[poolIdx];
-			switch (poolSize.type) {
-				// VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT counts handled separately below
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-					mtlBuffCnt += poolSize.descriptorCount;
-					break;
-
-				case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-				case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-				case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-					mtlTexCnt += poolSize.descriptorCount;
-					break;
-
-				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-					mtlTexCnt += poolSize.descriptorCount;
-					if (!getMetalFeatures().nativeTextureAtomics)
-						mtlBuffCnt += poolSize.descriptorCount;
-					break;
-
-				case VK_DESCRIPTOR_TYPE_SAMPLER:
-					mtlSampCnt += poolSize.descriptorCount;
-					break;
-
-				case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-					mtlTexCnt += poolSize.descriptorCount;
-					mtlSampCnt += poolSize.descriptorCount;
-					break;
-
-				default:
-					break;
-			}
-		}
-
-		// VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT counts pulled separately
-		for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-			switch (next->sType) {
-				case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: {
-					auto* pDescPoolInlineBlockCreateInfo = (VkDescriptorPoolInlineUniformBlockCreateInfoEXT*)next;
-					mtlBuffCnt += pDescPoolInlineBlockCreateInfo->maxInlineUniformBlockBindings;
-					break;
-				}
-				default:
-					break;
-			}
-		}
-
-		// To support the SPIR-V OpArrayLength operation, for each descriptor set that 
-		// contain buffers, we add an additional buffer at the end to track buffer sizes.
-		mtlBuffCnt += std::min<NSUInteger>(mtlBuffCnt, pCreateInfo->maxSets);
-
-		// Each descriptor set uses a separate Metal argument buffer, but all of these
-		// descriptor set Metal argument buffers share a single MTLBuffer. This single
-		// MTLBuffer needs to be large enough to hold all of the encoded resources for the
-		// descriptors, plus additional buffer offset alignment space for each descriptor set.
-		NSUInteger metalArgBuffSize = 0;
-		if (needsMetalArgumentBufferEncoders()) {
-			// If argument buffer encoders are required, depending on the platform, a Metal argument
-			// buffer may have a fixed overhead storage, in addition to the storage required to hold
-			// the resources. This overhead per descriptor set is conservatively calculated by measuring
-			// the size of a Metal argument buffer containing one of each type of resource (S1), and
-			// the size of a Metal argument buffer containing two of each type of resource (S2), and
-			// then calculating the fixed overhead per argument buffer as (2 * S1 - S2). To this is
-			// added the overhead due to the alignment of each descriptor set Metal argument buffer offset.
-			NSUInteger overheadPerDescSet = (2 * getMetalArgumentBufferEncodedResourceStorageSize(1, 1, 1) -
-											 getMetalArgumentBufferEncodedResourceStorageSize(2, 2, 2) +
-											 mtlFeats.mtlBufferAlignment);
-
-			// Measure the size of an argument buffer that would hold all of the encoded resources
-			// managed in this pool, then add any overhead for all the descriptor sets.
-			metalArgBuffSize = getMetalArgumentBufferEncodedResourceStorageSize(mtlBuffCnt, mtlTexCnt, mtlSampCnt);
-			metalArgBuffSize += (overheadPerDescSet * (pCreateInfo->maxSets - 1));	// metalArgBuffSize already includes overhead for one descriptor set
-		} else {
-			// For Metal 3, encoders are not required, and each arg buffer entry fits into 64 bits.
-			metalArgBuffSize = (mtlBuffCnt + mtlTexCnt + mtlSampCnt) * kMVKMetal3ArgBuffSlotSizeInBytes;
-			metalArgBuffSize += (mtlFeats.mtlBufferAlignment * pCreateInfo->maxSets);
-		}
-
-		if (metalArgBuffSize) {
-			NSUInteger maxMTLBuffSize = mtlFeats.maxMTLBufferSize;
-			if (metalArgBuffSize > maxMTLBuffSize) {
-				setConfigurationResult(reportError(VK_ERROR_FRAGMENTATION, "vkCreateDescriptorPool(): The requested descriptor storage of %d MB is larger than the maximum descriptor storage of %d MB per VkDescriptorPool.", (uint32_t)(metalArgBuffSize / MEBI), (uint32_t)(maxMTLBuffSize / MEBI)));
-				metalArgBuffSize = maxMTLBuffSize;
-			}
-			_metalArgumentBuffer = [getMTLDevice() newBufferWithLength: metalArgBuffSize options: MTLResourceStorageModeShared];	// retained
-			setMetalObjectLabel(_metalArgumentBuffer, @"Descriptor set argument buffer");
-		}
-	}
+    initMetalArgumentBuffer(pCreateInfo);
+    MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n",
+                  getLogDescription().c_str());
 }
 
-// Returns the size of a Metal argument buffer containing the number of various types
-// of encoded resources. This is only required if argument buffers are required.
-// Make sure any call to this function is wrapped in @autoreleasepool.
-NSUInteger MVKDescriptorPool::getMetalArgumentBufferEncodedResourceStorageSize(NSUInteger bufferCount,
-																			   NSUInteger textureCount,
-																			   NSUInteger samplerCount) {
-	NSMutableArray<MTLArgumentDescriptor*>* args = [NSMutableArray arrayWithCapacity: 3];
+void MVKDescriptorPool::initMetalArgumentBuffer(
+    const VkDescriptorPoolCreateInfo* pCreateInfo) {
+    if (!isUsingMetalArgumentBuffers()) {
+        return;
+    }
 
-	NSUInteger argIdx = 0;
-	[args addObject: getMTLArgumentDescriptor(MTLDataTypePointer, argIdx, bufferCount)];
-	argIdx += bufferCount;
-	[args addObject: getMTLArgumentDescriptor(MTLDataTypeTexture, argIdx, textureCount)];
-	argIdx += textureCount;
-	[args addObject: getMTLArgumentDescriptor(MTLDataTypeSampler, argIdx, samplerCount)];
-	argIdx += samplerCount;
+    auto& mtlFeats = getMetalFeatures();
+    @autoreleasepool {
+        NSUInteger mtlBuffCnt = 0;
+        NSUInteger mtlTexCnt = 0;
+        NSUInteger mtlSampCnt = 0;
 
-	id<MTLArgumentEncoder> argEnc = [getMTLDevice() newArgumentEncoderWithArguments: args];
-	NSUInteger metalArgBuffSize = argEnc.encodedLength;
-	[argEnc release];
+        uint32_t poolCnt = pCreateInfo->poolSizeCount;
+        for (uint32_t poolIdx = 0; poolIdx < poolCnt; poolIdx++) {
+            auto& poolSize = pCreateInfo->pPoolSizes[poolIdx];
+            switch (poolSize.type) {
+            // VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT counts handled
+            // separately below
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                mtlBuffCnt += poolSize.descriptorCount;
+                break;
 
-	return metalArgBuffSize;
+            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                mtlTexCnt += poolSize.descriptorCount;
+                break;
+
+            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                mtlTexCnt += poolSize.descriptorCount;
+                if (!getMetalFeatures().nativeTextureAtomics)
+                    mtlBuffCnt += poolSize.descriptorCount;
+                break;
+
+            case VK_DESCRIPTOR_TYPE_SAMPLER:
+                mtlSampCnt += poolSize.descriptorCount;
+                break;
+
+            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                mtlTexCnt += poolSize.descriptorCount;
+                mtlSampCnt += poolSize.descriptorCount;
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        // VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT counts pulled separately
+        for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+             next = next->pNext) {
+            switch (next->sType) {
+            case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT: {
+                auto* pDescPoolInlineBlockCreateInfo =
+                    (VkDescriptorPoolInlineUniformBlockCreateInfoEXT*)next;
+                mtlBuffCnt += pDescPoolInlineBlockCreateInfo
+                                  ->maxInlineUniformBlockBindings;
+                break;
+            }
+            default:
+                break;
+            }
+        }
+
+        // To support the SPIR-V OpArrayLength operation, for each descriptor
+        // set that contain buffers, we add an additional buffer at the end to
+        // track buffer sizes.
+        mtlBuffCnt += std::min<NSUInteger>(mtlBuffCnt, pCreateInfo->maxSets);
+
+        // Each descriptor set uses a separate Metal argument buffer, but all of
+        // these descriptor set Metal argument buffers share a single MTLBuffer.
+        // This single MTLBuffer needs to be large enough to hold all of the
+        // encoded resources for the descriptors, plus additional buffer offset
+        // alignment space for each descriptor set.
+        NSUInteger metalArgBuffSize = 0;
+        if (needsMetalArgumentBufferEncoders()) {
+            // If argument buffer encoders are required, depending on the
+            // platform, a Metal argument buffer may have a fixed overhead
+            // storage, in addition to the storage required to hold the
+            // resources. This overhead per descriptor set is conservatively
+            // calculated by measuring the size of a Metal argument buffer
+            // containing one of each type of resource (S1), and the size of a
+            // Metal argument buffer containing two of each type of resource
+            // (S2), and then calculating the fixed overhead per argument buffer
+            // as (2 * S1 - S2). To this is added the overhead due to the
+            // alignment of each descriptor set Metal argument buffer offset.
+            NSUInteger overheadPerDescSet =
+                (2 * getMetalArgumentBufferEncodedResourceStorageSize(1, 1, 1) -
+                 getMetalArgumentBufferEncodedResourceStorageSize(2, 2, 2) +
+                 mtlFeats.mtlBufferAlignment);
+
+            // Measure the size of an argument buffer that would hold all of the
+            // encoded resources managed in this pool, then add any overhead for
+            // all the descriptor sets.
+            metalArgBuffSize =
+                getMetalArgumentBufferEncodedResourceStorageSize(mtlBuffCnt,
+                                                                 mtlTexCnt,
+                                                                 mtlSampCnt);
+            metalArgBuffSize +=
+                (overheadPerDescSet * (pCreateInfo->maxSets -
+                                       1)); // metalArgBuffSize already includes
+                                            // overhead for one descriptor set
+        } else {
+            // For Metal 3, encoders are not required, and each arg buffer entry
+            // fits into 64 bits.
+            metalArgBuffSize = (mtlBuffCnt + mtlTexCnt + mtlSampCnt) *
+                               kMVKMetal3ArgBuffSlotSizeInBytes;
+            metalArgBuffSize +=
+                (mtlFeats.mtlBufferAlignment * pCreateInfo->maxSets);
+        }
+
+        if (metalArgBuffSize) {
+            NSUInteger maxMTLBuffSize = mtlFeats.maxMTLBufferSize;
+            if (metalArgBuffSize > maxMTLBuffSize) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_FRAGMENTATION,
+                                "vkCreateDescriptorPool(): The requested "
+                                "descriptor storage of %d MB is larger than "
+                                "the maximum descriptor storage of %d MB per "
+                                "VkDescriptorPool.",
+                                (uint32_t)(metalArgBuffSize / MEBI),
+                                (uint32_t)(maxMTLBuffSize / MEBI)));
+                metalArgBuffSize = maxMTLBuffSize;
+            }
+            _metalArgumentBuffer = [getMTLDevice()
+                newBufferWithLength:metalArgBuffSize
+                            options:MTLResourceStorageModeShared]; // retained
+            setMetalObjectLabel(_metalArgumentBuffer,
+                                @"Descriptor set argument buffer");
+        }
+    }
+}
+
+// Returns the size of a Metal argument buffer containing the number of various
+// types of encoded resources. This is only required if argument buffers are
+// required. Make sure any call to this function is wrapped in @autoreleasepool.
+NSUInteger MVKDescriptorPool::getMetalArgumentBufferEncodedResourceStorageSize(
+    NSUInteger bufferCount, NSUInteger textureCount, NSUInteger samplerCount) {
+    NSMutableArray<MTLArgumentDescriptor*>* args =
+        [NSMutableArray arrayWithCapacity:3];
+
+    NSUInteger argIdx = 0;
+    [args addObject:getMTLArgumentDescriptor(MTLDataTypePointer, argIdx,
+                                             bufferCount)];
+    argIdx += bufferCount;
+    [args addObject:getMTLArgumentDescriptor(MTLDataTypeTexture, argIdx,
+                                             textureCount)];
+    argIdx += textureCount;
+    [args addObject:getMTLArgumentDescriptor(MTLDataTypeSampler, argIdx,
+                                             samplerCount)];
+    argIdx += samplerCount;
+
+    id<MTLArgumentEncoder> argEnc =
+        [getMTLDevice() newArgumentEncoderWithArguments:args];
+    NSUInteger metalArgBuffSize = argEnc.encodedLength;
+    [argEnc release];
+
+    return metalArgBuffSize;
 }
 
 // Returns a MTLArgumentDescriptor of a particular type.
-// To be conservative, use some worse-case values, in case content makes a difference in argument size.
-MTLArgumentDescriptor* MVKDescriptorPool::getMTLArgumentDescriptor(MTLDataType resourceType, NSUInteger argIndex, NSUInteger count) {
-	auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
-	argDesc.dataType = resourceType;
-	argDesc.access = MTLArgumentAccessReadWrite;
-	argDesc.index = argIndex;
-	argDesc.arrayLength = count;
-	argDesc.textureType = MTLTextureTypeCubeArray;
-	return argDesc;
+// To be conservative, use some worse-case values, in case content makes a
+// difference in argument size.
+MTLArgumentDescriptor* MVKDescriptorPool::getMTLArgumentDescriptor(
+    MTLDataType resourceType, NSUInteger argIndex, NSUInteger count) {
+    auto* argDesc = [MTLArgumentDescriptor argumentDescriptor];
+    argDesc.dataType = resourceType;
+    argDesc.access = MTLArgumentAccessReadWrite;
+    argDesc.index = argIndex;
+    argDesc.arrayLength = count;
+    argDesc.textureType = MTLTextureTypeCubeArray;
+    return argDesc;
 }
 
 MVKDescriptorPool::~MVKDescriptorPool() {
-	reset(0);
-	[_metalArgumentBuffer release];
-	_metalArgumentBuffer = nil;
+    reset(0);
+    [_metalArgumentBuffer release];
+    _metalArgumentBuffer = nil;
 }
-
 
 #pragma mark -
 #pragma mark MVKDescriptorUpdateTemplate
 
-const VkDescriptorUpdateTemplateEntry* MVKDescriptorUpdateTemplate::getEntry(uint32_t n) const {
-	return &_entries[n];
+const VkDescriptorUpdateTemplateEntry*
+MVKDescriptorUpdateTemplate::getEntry(uint32_t n) const {
+    return &_entries[n];
 }
 
 uint32_t MVKDescriptorUpdateTemplate::getNumberOfEntries() const {
-	return (uint32_t)_entries.size();
+    return (uint32_t)_entries.size();
 }
 
 VkDescriptorUpdateTemplateType MVKDescriptorUpdateTemplate::getType() const {
-	return _type;
+    return _type;
 }
 
-MVKDescriptorUpdateTemplate::MVKDescriptorUpdateTemplate(MVKDevice* device,
-														 const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo) :
-MVKVulkanAPIDeviceObject(device), _pipelineBindPoint(pCreateInfo->pipelineBindPoint), _type(pCreateInfo->templateType) {
+MVKDescriptorUpdateTemplate::MVKDescriptorUpdateTemplate(
+    MVKDevice* device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device),
+      _pipelineBindPoint(pCreateInfo->pipelineBindPoint),
+      _type(pCreateInfo->templateType) {
 
-	for (uint32_t i = 0; i < pCreateInfo->descriptorUpdateEntryCount; i++) {
-		const auto& entry = pCreateInfo->pDescriptorUpdateEntries[i];
-		_entries.push_back(entry);
+    for (uint32_t i = 0; i < pCreateInfo->descriptorUpdateEntryCount; i++) {
+        const auto& entry = pCreateInfo->pDescriptorUpdateEntries[i];
+        _entries.push_back(entry);
 
-		// Accumulate the size of the template. If we were given a stride, use that;
-		// otherwise, assume only one info struct of the appropriate type.
-		size_t entryEnd = entry.offset;
-		if (entry.stride) {
-			entryEnd += entry.stride * entry.descriptorCount;
-		} else {
-			switch (entry.descriptorType) {
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-					entryEnd += sizeof(VkDescriptorBufferInfo);
-					break;
+        // Accumulate the size of the template. If we were given a stride, use
+        // that; otherwise, assume only one info struct of the appropriate type.
+        size_t entryEnd = entry.offset;
+        if (entry.stride) {
+            entryEnd += entry.stride * entry.descriptorCount;
+        } else {
+            switch (entry.descriptorType) {
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                entryEnd += sizeof(VkDescriptorBufferInfo);
+                break;
 
-				case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-				case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-				case VK_DESCRIPTOR_TYPE_SAMPLER:
-				case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-					entryEnd += sizeof(VkDescriptorImageInfo);
-					break;
+            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            case VK_DESCRIPTOR_TYPE_SAMPLER:
+            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                entryEnd += sizeof(VkDescriptorImageInfo);
+                break;
 
-				case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-					entryEnd += sizeof(VkBufferView);
-					break;
+            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                entryEnd += sizeof(VkBufferView);
+                break;
 
-				default:
-					break;
-			}
-		}
-		_size = std::max(_size, entryEnd);
-	}
+            default:
+                break;
+            }
+        }
+        _size = std::max(_size, entryEnd);
+    }
 }
-
 
 #pragma mark -
 #pragma mark Support functions
 
-// Updates the resource bindings in the descriptor sets inditified in the specified content.
+// Updates the resource bindings in the descriptor sets inditified in the
+// specified content.
 void mvkUpdateDescriptorSets(uint32_t writeCount,
-							 const VkWriteDescriptorSet* pDescriptorWrites,
-							 uint32_t copyCount,
-							 const VkCopyDescriptorSet* pDescriptorCopies) {
+                             const VkWriteDescriptorSet* pDescriptorWrites,
+                             uint32_t copyCount,
+                             const VkCopyDescriptorSet* pDescriptorCopies) {
 
-	// Perform the write updates
-	for (uint32_t i = 0; i < writeCount; i++) {
-		const VkWriteDescriptorSet* pDescWrite = &pDescriptorWrites[i];
-		size_t stride;
-		MVKDescriptorSet* dstSet = (MVKDescriptorSet*)pDescWrite->dstSet;
+    // Perform the write updates
+    for (uint32_t i = 0; i < writeCount; i++) {
+        const VkWriteDescriptorSet* pDescWrite = &pDescriptorWrites[i];
+        size_t stride;
+        MVKDescriptorSet* dstSet = (MVKDescriptorSet*)pDescWrite->dstSet;
 
-		if( !dstSet ) { continue; }		// Nulls are permitted
+        if (!dstSet) {
+            continue;
+        } // Nulls are permitted
 
-		const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock = nullptr;
-		if (dstSet->getEnabledExtensions().vk_EXT_inline_uniform_block.enabled) {
-			for (const auto* next = (VkBaseInStructure*)pDescWrite->pNext; next; next = next->pNext) {
-				switch (next->sType) {
-				case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: {
-					pInlineUniformBlock = (VkWriteDescriptorSetInlineUniformBlockEXT*)next;
-					break;
-				}
-				default:
-					break;
-				}
-			}
-		}
+        const VkWriteDescriptorSetInlineUniformBlockEXT* pInlineUniformBlock =
+            nullptr;
+        if (dstSet->getEnabledExtensions()
+                .vk_EXT_inline_uniform_block.enabled) {
+            for (const auto* next = (VkBaseInStructure*)pDescWrite->pNext; next;
+                 next = next->pNext) {
+                switch (next->sType) {
+                case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT: {
+                    pInlineUniformBlock =
+                        (VkWriteDescriptorSetInlineUniformBlockEXT*)next;
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+        }
 
-		const void* pData = getWriteParameters(pDescWrite->descriptorType, pDescWrite->pImageInfo,
-											   pDescWrite->pBufferInfo, pDescWrite->pTexelBufferView,
-											   pInlineUniformBlock, stride);
-		dstSet->write(pDescWrite, stride, pData);
-	}
+        const void* pData =
+            getWriteParameters(pDescWrite->descriptorType,
+                               pDescWrite->pImageInfo, pDescWrite->pBufferInfo,
+                               pDescWrite->pTexelBufferView,
+                               pInlineUniformBlock, stride);
+        dstSet->write(pDescWrite, stride, pData);
+    }
 
-	// Perform the copy updates by reading bindings from one set and writing to other set.
-	for (uint32_t i = 0; i < copyCount; i++) {
-		const VkCopyDescriptorSet* pDescCopy = &pDescriptorCopies[i];
+    // Perform the copy updates by reading bindings from one set and writing to
+    // other set.
+    for (uint32_t i = 0; i < copyCount; i++) {
+        const VkCopyDescriptorSet* pDescCopy = &pDescriptorCopies[i];
 
-		uint32_t descCnt = pDescCopy->descriptorCount;
-		VkDescriptorImageInfo imgInfos[descCnt];
-		VkDescriptorBufferInfo buffInfos[descCnt];
-		VkBufferView texelBuffInfos[descCnt];
+        uint32_t descCnt = pDescCopy->descriptorCount;
+        VkDescriptorImageInfo imgInfos[descCnt];
+        VkDescriptorBufferInfo buffInfos[descCnt];
+        VkBufferView texelBuffInfos[descCnt];
 
-		// For inline block create a temp buffer of descCnt bytes to hold data during copy.
-		uint8_t dstBuffer[descCnt];
-		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
-		inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
-		inlineUniformBlock.pNext = nullptr;
-		inlineUniformBlock.pData = dstBuffer;
-		inlineUniformBlock.dataSize = descCnt;
+        // For inline block create a temp buffer of descCnt bytes to hold data
+        // during copy.
+        uint8_t dstBuffer[descCnt];
+        VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
+        inlineUniformBlock.sType =
+            VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
+        inlineUniformBlock.pNext = nullptr;
+        inlineUniformBlock.pData = dstBuffer;
+        inlineUniformBlock.dataSize = descCnt;
 
-		MVKDescriptorSet* srcSet = (MVKDescriptorSet*)pDescCopy->srcSet;
-		MVKDescriptorSet* dstSet = (MVKDescriptorSet*)pDescCopy->dstSet;
-		if( !srcSet || !dstSet ) { continue; }		// Nulls are permitted
+        MVKDescriptorSet* srcSet = (MVKDescriptorSet*)pDescCopy->srcSet;
+        MVKDescriptorSet* dstSet = (MVKDescriptorSet*)pDescCopy->dstSet;
+        if (!srcSet || !dstSet) {
+            continue;
+        } // Nulls are permitted
 
-		srcSet->read(pDescCopy, imgInfos, buffInfos, texelBuffInfos, &inlineUniformBlock);
-		VkDescriptorType descType = dstSet->getDescriptorType(pDescCopy->dstBinding);
-		size_t stride;
-		const void* pData = getWriteParameters(descType, imgInfos, buffInfos, texelBuffInfos, &inlineUniformBlock, stride);
-		dstSet->write(pDescCopy, stride, pData);
-	}
+        srcSet->read(pDescCopy, imgInfos, buffInfos, texelBuffInfos,
+                     &inlineUniformBlock);
+        VkDescriptorType descType =
+            dstSet->getDescriptorType(pDescCopy->dstBinding);
+        size_t stride;
+        const void* pData =
+            getWriteParameters(descType, imgInfos, buffInfos, texelBuffInfos,
+                               &inlineUniformBlock, stride);
+        dstSet->write(pDescCopy, stride, pData);
+    }
 }
 
-// Updates the resource bindings in the given descriptor set from the specified template.
-void mvkUpdateDescriptorSetWithTemplate(VkDescriptorSet descriptorSet,
-										VkDescriptorUpdateTemplate updateTemplate,
-										const void* pData) {
+// Updates the resource bindings in the given descriptor set from the specified
+// template.
+void mvkUpdateDescriptorSetWithTemplate(
+    VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate updateTemplate,
+    const void* pData) {
 
-	MVKDescriptorSet* dstSet = (MVKDescriptorSet*)descriptorSet;
-	MVKDescriptorUpdateTemplate* pTemplate = (MVKDescriptorUpdateTemplate*)updateTemplate;
+    MVKDescriptorSet* dstSet = (MVKDescriptorSet*)descriptorSet;
+    MVKDescriptorUpdateTemplate* pTemplate =
+        (MVKDescriptorUpdateTemplate*)updateTemplate;
 
-	if (pTemplate->getType() != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET)
-		return;
+    if (pTemplate->getType() !=
+        VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET)
+        return;
 
-	// Perform the updates
-	for (uint32_t i = 0; i < pTemplate->getNumberOfEntries(); i++) {
-		const VkDescriptorUpdateTemplateEntry* pEntry = pTemplate->getEntry(i);
-		const void* pCurData = (const char*)pData + pEntry->offset;
+    // Perform the updates
+    for (uint32_t i = 0; i < pTemplate->getNumberOfEntries(); i++) {
+        const VkDescriptorUpdateTemplateEntry* pEntry = pTemplate->getEntry(i);
+        const void* pCurData = (const char*)pData + pEntry->offset;
 
-		// For inline block, wrap the raw data in in inline update struct.
-		VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
-		if (pEntry->descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
-			inlineUniformBlock.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
-			inlineUniformBlock.pNext = nullptr;
-			inlineUniformBlock.pData = pCurData;
-			inlineUniformBlock.dataSize = pEntry->descriptorCount;
-			pCurData = &inlineUniformBlock;
-		}
-		dstSet->write(pEntry, pEntry->stride, pCurData);
-	}
+        // For inline block, wrap the raw data in in inline update struct.
+        VkWriteDescriptorSetInlineUniformBlockEXT inlineUniformBlock;
+        if (pEntry->descriptorType ==
+            VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+            inlineUniformBlock.sType =
+                VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
+            inlineUniformBlock.pNext = nullptr;
+            inlineUniformBlock.pData = pCurData;
+            inlineUniformBlock.dataSize = pEntry->descriptorCount;
+            pCurData = &inlineUniformBlock;
+        }
+        dstSet->write(pEntry, pEntry->stride, pCurData);
+    }
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -70,766 +70,890 @@ class MVKCommandEncoder;
 class MVKCommandResourceFactory;
 class MVKPrivateDataSlot;
 
-
 /** The buffer index to use for vertex content. */
 static constexpr uint32_t kMVKVertexContentBufferIndex = 0;
 
 // Parameters to define the sizing of inline collections
-static constexpr uint32_t   kMVKQueueFamilyCount = 4;
-static constexpr uint32_t   kMVKQueueCountPerQueueFamily = 1;		// Must be 1. See comments in MVKPhysicalDevice::getQueueFamilies()
-static constexpr uint32_t   kMVKMinSwapchainImageCount = 2;
-static constexpr uint32_t   kMVKMaxSwapchainImageCount = 3;
-static constexpr uint32_t   kMVKMaxColorAttachmentCount = 8;
-static constexpr uint32_t   kMVKMaxViewportScissorCount = 16;
-static constexpr uint32_t   kMVKMaxDescriptorSetCount = SPIRV_CROSS_NAMESPACE::kMaxArgumentBuffers;
-static constexpr uint32_t   kMVKMaxSampleCount = 8;
-static constexpr uint32_t   kMVKSampleLocationCoordinateGridSize = 16;
-static constexpr float      kMVKMinSampleLocationCoordinate = 0.0;
-static constexpr float      kMVKMaxSampleLocationCoordinate = (float)(kMVKSampleLocationCoordinateGridSize - 1) / (float)kMVKSampleLocationCoordinateGridSize;
-static constexpr VkExtent2D kMVKSampleLocationPixelGridSize = { 1, 1 };
-static constexpr VkExtent2D kMVKSampleLocationPixelGridSizeNotSupported = { 0, 0 };
+static constexpr uint32_t kMVKQueueFamilyCount = 4;
+static constexpr uint32_t kMVKQueueCountPerQueueFamily =
+    1; // Must be 1. See comments in MVKPhysicalDevice::getQueueFamilies()
+static constexpr uint32_t kMVKMinSwapchainImageCount = 2;
+static constexpr uint32_t kMVKMaxSwapchainImageCount = 3;
+static constexpr uint32_t kMVKMaxColorAttachmentCount = 8;
+static constexpr uint32_t kMVKMaxViewportScissorCount = 16;
+static constexpr uint32_t kMVKMaxDescriptorSetCount =
+    SPIRV_CROSS_NAMESPACE::kMaxArgumentBuffers;
+static constexpr uint32_t kMVKMaxSampleCount = 8;
+static constexpr uint32_t kMVKSampleLocationCoordinateGridSize = 16;
+static constexpr float kMVKMinSampleLocationCoordinate = 0.0;
+static constexpr float kMVKMaxSampleLocationCoordinate =
+    (float)(kMVKSampleLocationCoordinateGridSize - 1) /
+    (float)kMVKSampleLocationCoordinateGridSize;
+static constexpr VkExtent2D kMVKSampleLocationPixelGridSize = {1, 1};
+static constexpr VkExtent2D kMVKSampleLocationPixelGridSizeNotSupported = {0,
+                                                                           0};
 
 #if !MVK_XCODE_12
 typedef NSUInteger MTLTimestamp;
 #endif
 
-
 #pragma mark -
 #pragma mark MVKMTLDeviceCapabilities
 
 typedef struct MVKMTLDeviceCapabilities {
-	bool supportsApple1;
-	bool supportsApple2;
-	bool supportsApple3;
-	bool supportsApple4;
-	bool supportsApple5;
-	bool supportsApple6;
-	bool supportsApple7;
-	bool supportsApple8;
-	bool supportsApple9;
-	bool supportsMac1;
-	bool supportsMac2;
-	bool supportsMetal3;
+    bool supportsApple1;
+    bool supportsApple2;
+    bool supportsApple3;
+    bool supportsApple4;
+    bool supportsApple5;
+    bool supportsApple6;
+    bool supportsApple7;
+    bool supportsApple8;
+    bool supportsApple9;
+    bool supportsMac1;
+    bool supportsMac2;
+    bool supportsMetal3;
 
-	bool isAppleGPU;
-	bool supportsBCTextureCompression;
-	bool supportsDepth24Stencil8;
-	bool supports32BitFloatFiltering;
-	bool supports32BitMSAA;
+    bool isAppleGPU;
+    bool supportsBCTextureCompression;
+    bool supportsDepth24Stencil8;
+    bool supports32BitFloatFiltering;
+    bool supports32BitMSAA;
 
-	uint8_t getHighestAppleGPU() const;
-	uint8_t getHighestMacGPU() const;
+    uint8_t getHighestAppleGPU() const;
+    uint8_t getHighestMacGPU() const;
 
-	MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev);
+    MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev);
 } MVKMTLDeviceCapabilities;
-
 
 #pragma mark -
 #pragma mark MVKPhysicalDevice
 
 typedef enum {
-	MVKSemaphoreStyleUseMTLEvent,
-	MVKSemaphoreStyleUseEmulation,
-	MVKSemaphoreStyleSingleQueue,
+    MVKSemaphoreStyleUseMTLEvent,
+    MVKSemaphoreStyleUseEmulation,
+    MVKSemaphoreStyleSingleQueue,
 } MVKSemaphoreStyle;
 
-/** VkPhysicalDeviceVulkan12Features entries that did not originate in a prior extension. */
+/** VkPhysicalDeviceVulkan12Features entries that did not originate in a prior
+ * extension. */
 typedef struct MVKPhysicalDeviceVulkan12FeaturesNoExt {
-	VkBool32 samplerMirrorClampToEdge;
-	VkBool32 drawIndirectCount;
-	VkBool32 descriptorIndexing;
-	VkBool32 samplerFilterMinmax;
-	VkBool32 shaderOutputViewportIndex;
-	VkBool32 shaderOutputLayer;
-	VkBool32 subgroupBroadcastDynamicId;
+    VkBool32 samplerMirrorClampToEdge;
+    VkBool32 drawIndirectCount;
+    VkBool32 descriptorIndexing;
+    VkBool32 samplerFilterMinmax;
+    VkBool32 shaderOutputViewportIndex;
+    VkBool32 shaderOutputLayer;
+    VkBool32 subgroupBroadcastDynamicId;
 } MVKPhysicalDeviceVulkan12FeaturesNoExt;
 
 /** Represents a Vulkan physical GPU device. */
 class MVKPhysicalDevice : public MVKDispatchableVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_PHYSICAL_DEVICE;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PHYSICAL_DEVICE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return _mvkInstance; }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _mvkInstance; }
+    /** Populates the specified array with the supported extensions of this
+     * device. */
+    VkResult getExtensionProperties(const char* pLayerName, uint32_t* pCount,
+                                    VkExtensionProperties* pProperties);
 
-	/** Populates the specified array with the supported extensions of this device. */
-	VkResult getExtensionProperties(const char* pLayerName, uint32_t* pCount, VkExtensionProperties* pProperties);
+    /** Populates the specified structure with the features of this device. */
+    void getFeatures(VkPhysicalDeviceFeatures* features);
 
-	/** Populates the specified structure with the features of this device. */
-	void getFeatures(VkPhysicalDeviceFeatures* features);
+    /** Populates the specified structure with the features of this device. */
+    void getFeatures(VkPhysicalDeviceFeatures2* features);
 
-	/** Populates the specified structure with the features of this device. */
-	void getFeatures(VkPhysicalDeviceFeatures2* features);
+    /** Populates the specified structure with the properties of this device. */
+    void getProperties(VkPhysicalDeviceProperties* properties);
 
-	/** Populates the specified structure with the properties of this device. */
-	void getProperties(VkPhysicalDeviceProperties* properties);
+    /** Populates the specified structure with the properties of this device. */
+    void getProperties(VkPhysicalDeviceProperties2* properties);
 
-	/** Populates the specified structure with the properties of this device. */
-	void getProperties(VkPhysicalDeviceProperties2* properties);
+    /** Returns the name of this device. */
+    const char* getName() { return _properties.deviceName; }
 
-	/** Returns the name of this device. */
-	const char* getName() { return _properties.deviceName; }
+    /** Populates the specified structure with the format properties of this
+     * device. */
+    void getFormatProperties(VkFormat format,
+                             VkFormatProperties* pFormatProperties);
 
-	/** Populates the specified structure with the format properties of this device. */
-	void getFormatProperties(VkFormat format, VkFormatProperties* pFormatProperties);
+    /** Populates the specified structure with the format properties of this
+     * device. */
+    void getFormatProperties(VkFormat format,
+                             VkFormatProperties2* pFormatProperties);
 
-	/** Populates the specified structure with the format properties of this device. */
-	void getFormatProperties(VkFormat format, VkFormatProperties2* pFormatProperties);
-
-	/** Populates the specified structure with the multisample properties of this device. */
-	void getMultisampleProperties(VkSampleCountFlagBits samples,
-								  VkMultisamplePropertiesEXT* pMultisampleProperties);
-
-	/** Populates the image format properties supported on this device. */
-    VkResult getImageFormatProperties(VkFormat format,
-                                      VkImageType type,
-                                      VkImageTiling tiling,
-                                      VkImageUsageFlags usage,
-                                      VkImageCreateFlags flags,
-                                      VkImageFormatProperties* pImageFormatProperties);
+    /** Populates the specified structure with the multisample properties of
+     * this device. */
+    void getMultisampleProperties(
+        VkSampleCountFlagBits samples,
+        VkMultisamplePropertiesEXT* pMultisampleProperties);
 
     /** Populates the image format properties supported on this device. */
-    VkResult getImageFormatProperties(const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
-                                      VkImageFormatProperties2* pImageFormatProperties);
+    VkResult
+    getImageFormatProperties(VkFormat format, VkImageType type,
+                             VkImageTiling tiling, VkImageUsageFlags usage,
+                             VkImageCreateFlags flags,
+                             VkImageFormatProperties* pImageFormatProperties);
 
-	/** Populates the external buffer properties supported on this device. */
-	void getExternalBufferProperties(const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
-									 VkExternalBufferProperties* pExternalBufferProperties);
+    /** Populates the image format properties supported on this device. */
+    VkResult getImageFormatProperties(
+        const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+        VkImageFormatProperties2* pImageFormatProperties);
 
-	/** Populates the external fence properties supported on this device. */
-	void getExternalFenceProperties(const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
-									VkExternalFenceProperties* pExternalFenceProperties);
+    /** Populates the external buffer properties supported on this device. */
+    void getExternalBufferProperties(
+        const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
+        VkExternalBufferProperties* pExternalBufferProperties);
 
-	/** Populates the external semaphore properties supported on this device. */
-	void getExternalSemaphoreProperties(const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
-										VkExternalSemaphoreProperties* pExternalSemaphoreProperties);
+    /** Populates the external fence properties supported on this device. */
+    void getExternalFenceProperties(
+        const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
+        VkExternalFenceProperties* pExternalFenceProperties);
 
-	/** Returns the supported time domains for calibration on this device. */
-	VkResult getCalibrateableTimeDomains(uint32_t* pTimeDomainCount, VkTimeDomainEXT* pTimeDomains);
+    /** Populates the external semaphore properties supported on this device. */
+    void getExternalSemaphoreProperties(
+        const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
+        VkExternalSemaphoreProperties* pExternalSemaphoreProperties);
+
+    /** Returns the supported time domains for calibration on this device. */
+    VkResult getCalibrateableTimeDomains(uint32_t* pTimeDomainCount,
+                                         VkTimeDomainEXT* pTimeDomains);
 
 #pragma mark Surfaces
 
-	/**
-	 * Queries whether this device supports presentation to the specified surface,
-	 * using a queue of the specified queue family.
-	 */
-	VkResult getSurfaceSupport(uint32_t queueFamilyIndex, MVKSurface* surface, VkBool32* pSupported);
+    /**
+     * Queries whether this device supports presentation to the specified
+     * surface, using a queue of the specified queue family.
+     */
+    VkResult getSurfaceSupport(uint32_t queueFamilyIndex, MVKSurface* surface,
+                               VkBool32* pSupported);
 
-	/** Returns the capabilities of the surface. */
-	VkResult getSurfaceCapabilities(VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities);
+    /** Returns the capabilities of the surface. */
+    VkResult
+    getSurfaceCapabilities(VkSurfaceKHR surface,
+                           VkSurfaceCapabilitiesKHR* pSurfaceCapabilities);
 
-	/** Returns the capabilities of the surface. */
-	VkResult getSurfaceCapabilities(const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
-									VkSurfaceCapabilities2KHR* pSurfaceCapabilities);
+    /** Returns the capabilities of the surface. */
+    VkResult
+    getSurfaceCapabilities(const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                           VkSurfaceCapabilities2KHR* pSurfaceCapabilities);
 
-	/**
-	 * Returns the pixel formats supported by the surface.
-	 *
-	 * If pSurfaceFormats is null, the value of pCount is updated with the number of
-	 * pixel formats supported by the surface.
-	 *
-	 * If pSurfaceFormats is not null, then pCount formats are copied into the array.
-	 * If the number of available formats is less than pCount, the value of pCount is
-	 * updated to indicate the number of formats actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of supported
-	 * formats is larger than pCount. Returns other values if an error occurs.
-	 */
-	VkResult getSurfaceFormats(MVKSurface* surface, uint32_t* pCount, VkSurfaceFormatKHR* pSurfaceFormats);
+    /**
+     * Returns the pixel formats supported by the surface.
+     *
+     * If pSurfaceFormats is null, the value of pCount is updated with the
+     * number of pixel formats supported by the surface.
+     *
+     * If pSurfaceFormats is not null, then pCount formats are copied into the
+     * array. If the number of available formats is less than pCount, the value
+     * of pCount is updated to indicate the number of formats actually returned
+     * in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * supported formats is larger than pCount. Returns other values if an error
+     * occurs.
+     */
+    VkResult getSurfaceFormats(MVKSurface* surface, uint32_t* pCount,
+                               VkSurfaceFormatKHR* pSurfaceFormats);
 
-	/**
-	 * Returns the pixel formats supported by the surface.
-	 *
-	 * If pSurfaceFormats is null, the value of pCount is updated with the number of
-	 * pixel formats supported by the surface.
-	 *
-	 * If pSurfaceFormats is not null, then pCount formats are copied into the array.
-	 * If the number of available formats is less than pCount, the value of pCount is
-	 * updated to indicate the number of formats actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of supported
-	 * formats is larger than pCount. Returns other values if an error occurs.
-	 */
-	VkResult getSurfaceFormats(MVKSurface* surface, uint32_t* pCount, VkSurfaceFormat2KHR* pSurfaceFormats);
+    /**
+     * Returns the pixel formats supported by the surface.
+     *
+     * If pSurfaceFormats is null, the value of pCount is updated with the
+     * number of pixel formats supported by the surface.
+     *
+     * If pSurfaceFormats is not null, then pCount formats are copied into the
+     * array. If the number of available formats is less than pCount, the value
+     * of pCount is updated to indicate the number of formats actually returned
+     * in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * supported formats is larger than pCount. Returns other values if an error
+     * occurs.
+     */
+    VkResult getSurfaceFormats(MVKSurface* surface, uint32_t* pCount,
+                               VkSurfaceFormat2KHR* pSurfaceFormats);
 
-	/**
-	 * Returns the presentation modes supported by the surface.
-	 *
-	 * If pPresentModes is null, the value of pCount is updated with the number of
-	 * presentation modes supported by the surface.
-	 *
-	 * If pPresentModes is not null, then pCount presentation modes are copied into the array.
-	 * If the number of available modes is less than pCount, the value of pCount is updated
-	 * to indicate the number of presentation modes actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of supported
-	 * presentation modes is larger than pCount. Returns other values if an error occurs.
-	 */
-	VkResult getSurfacePresentModes(MVKSurface* surface, uint32_t* pCount, VkPresentModeKHR* pPresentModes);
+    /**
+     * Returns the presentation modes supported by the surface.
+     *
+     * If pPresentModes is null, the value of pCount is updated with the number
+     * of presentation modes supported by the surface.
+     *
+     * If pPresentModes is not null, then pCount presentation modes are copied
+     * into the array. If the number of available modes is less than pCount, the
+     * value of pCount is updated to indicate the number of presentation modes
+     * actually returned in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * supported presentation modes is larger than pCount. Returns other values
+     * if an error occurs.
+     */
+    VkResult getSurfacePresentModes(MVKSurface* surface, uint32_t* pCount,
+                                    VkPresentModeKHR* pPresentModes);
 
-	/**
-	 * Returns the rectangles that will be used on the surface by this physical device
-	 * when the surface is presented.
-	 *
-	 * If pRects is null, the value of pRectCount is updated with the number of
-	 * rectangles used the surface by this physical device.
-	 *
-	 * If pRects is not null, then pCount rectangles are copied into the array.
-	 * If the number of rectangles is less than pCount, the value of pCount is updated
-	 * to indicate the number of rectangles actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of rectangles
-	 * is larger than pCount. Returns other values if an error occurs.
-	 */
-	VkResult getPresentRectangles(MVKSurface* surface, uint32_t* pRectCount, VkRect2D* pRects);
-
+    /**
+     * Returns the rectangles that will be used on the surface by this physical
+     * device when the surface is presented.
+     *
+     * If pRects is null, the value of pRectCount is updated with the number of
+     * rectangles used the surface by this physical device.
+     *
+     * If pRects is not null, then pCount rectangles are copied into the array.
+     * If the number of rectangles is less than pCount, the value of pCount is
+     * updated to indicate the number of rectangles actually returned in the
+     * array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * rectangles is larger than pCount. Returns other values if an error
+     * occurs.
+     */
+    VkResult getPresentRectangles(MVKSurface* surface, uint32_t* pRectCount,
+                                  VkRect2D* pRects);
 
 #pragma mark Queues
 
-	/**
-	 * If pQueueFamilyProperties is null, the value of pCount is updated with the number of
-	 * queue families supported by this instance.
-	 *
-	 * If pQueueFamilyProperties is not null, then pCount queue family properties are copied into
-	 * the array. If the number of available queue families is less than pCount, the value of
-	 * pCount is updated to indicate the number of queue families actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of queue families
-	 * available in this instance is larger than the specified pCount. Returns other values if
-	 * an error occurs.
-	 */
-	VkResult getQueueFamilyProperties(uint32_t* pCount, VkQueueFamilyProperties* pQueueFamilyProperties);
+    /**
+     * If pQueueFamilyProperties is null, the value of pCount is updated with
+     * the number of queue families supported by this instance.
+     *
+     * If pQueueFamilyProperties is not null, then pCount queue family
+     * properties are copied into the array. If the number of available queue
+     * families is less than pCount, the value of pCount is updated to indicate
+     * the number of queue families actually returned in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * queue families available in this instance is larger than the specified
+     * pCount. Returns other values if an error occurs.
+     */
+    VkResult
+    getQueueFamilyProperties(uint32_t* pCount,
+                             VkQueueFamilyProperties* pQueueFamilyProperties);
 
-	/**
-	 * If pQueueFamilyProperties is null, the value of pCount is updated with the number of
-	 * queue families supported by this instance.
-	 *
-	 * If pQueueFamilyProperties is not null, then pCount queue family properties are copied into
-	 * the array. If the number of available queue families is less than pCount, the value of 
-	 * pCount is updated to indicate the number of queue families actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of queue families
-	 * available in this instance is larger than the specified pCount. Returns other values if
-	 * an error occurs.
-	 */
-	VkResult getQueueFamilyProperties(uint32_t* pCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties);
-
+    /**
+     * If pQueueFamilyProperties is null, the value of pCount is updated with
+     * the number of queue families supported by this instance.
+     *
+     * If pQueueFamilyProperties is not null, then pCount queue family
+     * properties are copied into the array. If the number of available queue
+     * families is less than pCount, the value of pCount is updated to indicate
+     * the number of queue families actually returned in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * queue families available in this instance is larger than the specified
+     * pCount. Returns other values if an error occurs.
+     */
+    VkResult getQueueFamilyProperties(
+        uint32_t* pCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties);
 
 #pragma mark Memory models
 
-	/** Returns a pointer to the memory characteristics of this device. */
-    const VkPhysicalDeviceMemoryProperties* getMemoryProperties() { return &_memoryProperties; }
+    /** Returns a pointer to the memory characteristics of this device. */
+    const VkPhysicalDeviceMemoryProperties* getMemoryProperties() {
+        return &_memoryProperties;
+    }
 
-	/** Populates the specified memory properties with the memory characteristics of this device. */
-	VkResult getMemoryProperties(VkPhysicalDeviceMemoryProperties* pMemoryProperties);
+    /** Populates the specified memory properties with the memory
+     * characteristics of this device. */
+    VkResult
+    getMemoryProperties(VkPhysicalDeviceMemoryProperties* pMemoryProperties);
 
-	/** Populates the specified memory properties with the memory characteristics of this device. */
-	VkResult getMemoryProperties(VkPhysicalDeviceMemoryProperties2* pMemoryProperties);
+    /** Populates the specified memory properties with the memory
+     * characteristics of this device. */
+    VkResult
+    getMemoryProperties(VkPhysicalDeviceMemoryProperties2* pMemoryProperties);
 
-	/**
-	 * Returns a bit mask of all memory type indices. 
-	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
-	 */
-	uint32_t getAllMemoryTypes() { return _allMemoryTypes; }
+    /**
+     * Returns a bit mask of all memory type indices.
+     * Each bit [0..31] in the returned bit mask indicates a distinct memory
+     * type.
+     */
+    uint32_t getAllMemoryTypes() { return _allMemoryTypes; }
 
-	/**
-	 * Returns a bit mask of all memory type indices that allow host visibility to the memory. 
-	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
-	 */
-	uint32_t getHostVisibleMemoryTypes() { return _hostVisibleMemoryTypes; }
+    /**
+     * Returns a bit mask of all memory type indices that allow host visibility
+     * to the memory. Each bit [0..31] in the returned bit mask indicates a
+     * distinct memory type.
+     */
+    uint32_t getHostVisibleMemoryTypes() { return _hostVisibleMemoryTypes; }
 
-	/**
-	 * Returns a bit mask of all memory type indices that are coherent between host and device.
-	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
-	 */
-	uint32_t getHostCoherentMemoryTypes() { return _hostCoherentMemoryTypes; }
+    /**
+     * Returns a bit mask of all memory type indices that are coherent between
+     * host and device. Each bit [0..31] in the returned bit mask indicates a
+     * distinct memory type.
+     */
+    uint32_t getHostCoherentMemoryTypes() { return _hostCoherentMemoryTypes; }
 
-	/**
-	 * Returns a bit mask of all memory type indices that do NOT allow host visibility to the memory.
-	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
-	 */
-	uint32_t getPrivateMemoryTypes() { return _privateMemoryTypes; }
+    /**
+     * Returns a bit mask of all memory type indices that do NOT allow host
+     * visibility to the memory. Each bit [0..31] in the returned bit mask
+     * indicates a distinct memory type.
+     */
+    uint32_t getPrivateMemoryTypes() { return _privateMemoryTypes; }
 
-	/**
-	 * Returns a bit mask of all memory type indices that are lazily allocated.
-	 * Each bit [0..31] in the returned bit mask indicates a distinct memory type.
-	 */
-	uint32_t getLazilyAllocatedMemoryTypes() { return _lazilyAllocatedMemoryTypes; }
+    /**
+     * Returns a bit mask of all memory type indices that are lazily allocated.
+     * Each bit [0..31] in the returned bit mask indicates a distinct memory
+     * type.
+     */
+    uint32_t getLazilyAllocatedMemoryTypes() {
+        return _lazilyAllocatedMemoryTypes;
+    }
 
-	/** Returns the external memory properties supported for buffers for the handle type. */
-	VkExternalMemoryProperties& getExternalBufferProperties(VkExternalMemoryHandleTypeFlagBits handleType);
+    /** Returns the external memory properties supported for buffers for the
+     * handle type. */
+    VkExternalMemoryProperties&
+    getExternalBufferProperties(VkExternalMemoryHandleTypeFlagBits handleType);
 
-	/** Returns the external memory properties supported for images for the handle type. */
-	VkExternalMemoryProperties& getExternalImageProperties(VkExternalMemoryHandleTypeFlagBits handleType);
+    /** Returns the external memory properties supported for images for the
+     * handle type. */
+    VkExternalMemoryProperties&
+    getExternalImageProperties(VkExternalMemoryHandleTypeFlagBits handleType);
 
-	/** Returns the amount of memory currently consumed by the GPU. */
-	size_t getCurrentAllocatedSize();
-
+    /** Returns the amount of memory currently consumed by the GPU. */
+    size_t getCurrentAllocatedSize();
 
 #pragma mark Metal
 
-	/** Populates the specified structure with the Metal-specific features of this device. */
-	const MVKPhysicalDeviceMetalFeatures* getMetalFeatures() { return &_metalFeatures; }
+    /** Populates the specified structure with the Metal-specific features of
+     * this device. */
+    const MVKPhysicalDeviceMetalFeatures* getMetalFeatures() {
+        return &_metalFeatures;
+    }
 
-	/** Returns whether or not vertex instancing can be used to implement multiview. */
-	bool canUseInstancingForMultiview() { return _metalFeatures.layeredRendering && _metalFeatures.deferredStoreActions; }
+    /** Returns whether or not vertex instancing can be used to implement
+     * multiview. */
+    bool canUseInstancingForMultiview() {
+        return _metalFeatures.layeredRendering &&
+               _metalFeatures.deferredStoreActions;
+    }
 
-	/** Returns the underlying Metal device. */
-	id<MTLDevice> getMTLDevice() { return _mtlDevice; }
+    /** Returns the underlying Metal device. */
+    id<MTLDevice> getMTLDevice() { return _mtlDevice; }
 
-	/** Returns whether the MSL version is supported on this device. */
-	bool mslVersionIsAtLeast(MTLLanguageVersion minVer) { return _metalFeatures.mslVersionEnum >= minVer; }
+    /** Returns whether the MSL version is supported on this device. */
+    bool mslVersionIsAtLeast(MTLLanguageVersion minVer) {
+        return _metalFeatures.mslVersionEnum >= minVer;
+    }
 
-	/** Returns the MTLStorageMode that matches the Vulkan memory property flags. */
-	MTLStorageMode getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
+    /** Returns the MTLStorageMode that matches the Vulkan memory property
+     * flags. */
+    MTLStorageMode
+    getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 
-	/** Returns the MTLDevice capabilities. */
-	const MVKMTLDeviceCapabilities getMTLDeviceCapabilities() { return _gpuCapabilities; }
-
+    /** Returns the MTLDevice capabilities. */
+    const MVKMTLDeviceCapabilities getMTLDeviceCapabilities() {
+        return _gpuCapabilities;
+    }
 
 #pragma mark Construction
 
-	/** Constructs an instance wrapping the specified Vulkan instance and Metal device. */
-	MVKPhysicalDevice(MVKInstance* mvkInstance, id<MTLDevice> mtlDevice);
+    /** Constructs an instance wrapping the specified Vulkan instance and Metal
+     * device. */
+    MVKPhysicalDevice(MVKInstance* mvkInstance, id<MTLDevice> mtlDevice);
 
-	/** Default destructor. */
-	~MVKPhysicalDevice() override;
-
-    /**
-     * Returns a reference to this object suitable for use as a Vulkan API handle.
-     * This is the compliment of the getMVKPhysicalDevice() method.
-     */
-    VkPhysicalDevice getVkPhysicalDevice() { return (VkPhysicalDevice)getVkHandle(); }
+    /** Default destructor. */
+    ~MVKPhysicalDevice() override;
 
     /**
-     * Retrieves the MVKPhysicalDevice instance referenced by the VkPhysicalDevice handle.
-     * This is the compliment of the getVkPhysicalDevice() method.
+     * Returns a reference to this object suitable for use as a Vulkan API
+     * handle. This is the compliment of the getMVKPhysicalDevice() method.
      */
-    static inline MVKPhysicalDevice* getMVKPhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
+    VkPhysicalDevice getVkPhysicalDevice() {
+        return (VkPhysicalDevice)getVkHandle();
+    }
+
+    /**
+     * Retrieves the MVKPhysicalDevice instance referenced by the
+     * VkPhysicalDevice handle. This is the compliment of the
+     * getVkPhysicalDevice() method.
+     */
+    static inline MVKPhysicalDevice*
+    getMVKPhysicalDevice(VkPhysicalDevice vkPhysicalDevice) {
         return (MVKPhysicalDevice*)getDispatchableObject(vkPhysicalDevice);
     }
 
-protected:
-	friend class MVKDevice;
-	friend class MVKDeviceTrackingMixin;
+  protected:
+    friend class MVKDevice;
+    friend class MVKDeviceTrackingMixin;
 
-	void propagateDebugName() override {}
-	MTLFeatureSet getMaximalMTLFeatureSet();
+    void propagateDebugName() override {}
+    MTLFeatureSet getMaximalMTLFeatureSet();
     void initMetalFeatures();
-	void initFeatures();
-	void initMTLDevice();
-	void initProperties();
-	void initLimits();
-	void initGPUInfoProperties();
-	void initMemoryProperties();
-	void initVkSemaphoreStyle();
-	void setMemoryHeap(uint32_t heapIndex, VkDeviceSize heapSize, VkMemoryHeapFlags heapFlags);
-	void setMemoryType(uint32_t typeIndex, uint32_t heapIndex, VkMemoryPropertyFlags propertyFlags);
-	uint64_t getVRAMSize();
-	uint64_t getRecommendedMaxWorkingSetSize();
-	uint32_t getMaxSamplerCount();
-	uint32_t getMaxPerSetDescriptorCount();
-	void initExternalMemoryProperties();
-	void initExtensions();
-	void initCounterSets();
-	bool needsCounterSetRetained();
-	void updateTimestampPeriod();
-	MVKArrayRef<MVKQueueFamily*> getQueueFamilies();
-	void initPipelineCacheUUID();
-	uint32_t getHighestGPUCapability();
-	uint32_t getMoltenVKGitRevision();
-	void populateDeviceIDProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
-	void populateSubgroupProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
-	void populateHostImageCopyProperties(VkPhysicalDeviceHostImageCopyPropertiesEXT* pHostImageCopyProps);
-	void logGPUInfo();
+    void initFeatures();
+    void initMTLDevice();
+    void initProperties();
+    void initLimits();
+    void initGPUInfoProperties();
+    void initMemoryProperties();
+    void initVkSemaphoreStyle();
+    void setMemoryHeap(uint32_t heapIndex, VkDeviceSize heapSize,
+                       VkMemoryHeapFlags heapFlags);
+    void setMemoryType(uint32_t typeIndex, uint32_t heapIndex,
+                       VkMemoryPropertyFlags propertyFlags);
+    uint64_t getVRAMSize();
+    uint64_t getRecommendedMaxWorkingSetSize();
+    uint32_t getMaxSamplerCount();
+    uint32_t getMaxPerSetDescriptorCount();
+    void initExternalMemoryProperties();
+    void initExtensions();
+    void initCounterSets();
+    bool needsCounterSetRetained();
+    void updateTimestampPeriod();
+    MVKArrayRef<MVKQueueFamily*> getQueueFamilies();
+    void initPipelineCacheUUID();
+    uint32_t getHighestGPUCapability();
+    uint32_t getMoltenVKGitRevision();
+    void
+    populateDeviceIDProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
+    void
+    populateSubgroupProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props);
+    void populateHostImageCopyProperties(
+        VkPhysicalDeviceHostImageCopyPropertiesEXT* pHostImageCopyProps);
+    void logGPUInfo();
 
-	MVKInstance* _mvkInstance;
-	id<MTLDevice> _mtlDevice;
-	const MVKMTLDeviceCapabilities _gpuCapabilities;
-	const MVKExtensionList _supportedExtensions;
-	MVKPixelFormats _pixelFormats;
-	VkPhysicalDeviceFeatures _features;
-	MVKPhysicalDeviceVulkan12FeaturesNoExt _vulkan12FeaturesNoExt;
-	MVKPhysicalDeviceMetalFeatures _metalFeatures;
-	VkPhysicalDeviceProperties _properties;
-	VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT _texelBuffAlignProperties;
-	VkPhysicalDeviceMemoryProperties _memoryProperties;
-	MVKSmallVector<MVKQueueFamily*, kMVKQueueFamilyCount> _queueFamilies;
-	VkExternalMemoryProperties _hostPointerExternalMemoryProperties;
-	VkExternalMemoryProperties _mtlBufferExternalMemoryProperties;
-	VkExternalMemoryProperties _mtlTextureExternalMemoryProperties;
-	id<MTLCounterSet> _timestampMTLCounterSet;
-	MVKSemaphoreStyle _vkSemaphoreStyle;
-	MTLTimestamp _prevCPUTimestamp = 0;
-	MTLTimestamp _prevGPUTimestamp = 0;
-	uint32_t _allMemoryTypes;
-	uint32_t _hostVisibleMemoryTypes;
-	uint32_t _hostCoherentMemoryTypes;
-	uint32_t _privateMemoryTypes;
-	uint32_t _lazilyAllocatedMemoryTypes;
-	bool _hasUnifiedMemory = true;
-	bool _isUsingMetalArgumentBuffers = true;
+    MVKInstance* _mvkInstance;
+    id<MTLDevice> _mtlDevice;
+    const MVKMTLDeviceCapabilities _gpuCapabilities;
+    const MVKExtensionList _supportedExtensions;
+    MVKPixelFormats _pixelFormats;
+    VkPhysicalDeviceFeatures _features;
+    MVKPhysicalDeviceVulkan12FeaturesNoExt _vulkan12FeaturesNoExt;
+    MVKPhysicalDeviceMetalFeatures _metalFeatures;
+    VkPhysicalDeviceProperties _properties;
+    VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT _texelBuffAlignProperties;
+    VkPhysicalDeviceMemoryProperties _memoryProperties;
+    MVKSmallVector<MVKQueueFamily*, kMVKQueueFamilyCount> _queueFamilies;
+    VkExternalMemoryProperties _hostPointerExternalMemoryProperties;
+    VkExternalMemoryProperties _mtlBufferExternalMemoryProperties;
+    VkExternalMemoryProperties _mtlTextureExternalMemoryProperties;
+    id<MTLCounterSet> _timestampMTLCounterSet;
+    MVKSemaphoreStyle _vkSemaphoreStyle;
+    MTLTimestamp _prevCPUTimestamp = 0;
+    MTLTimestamp _prevGPUTimestamp = 0;
+    uint32_t _allMemoryTypes;
+    uint32_t _hostVisibleMemoryTypes;
+    uint32_t _hostCoherentMemoryTypes;
+    uint32_t _privateMemoryTypes;
+    uint32_t _lazilyAllocatedMemoryTypes;
+    bool _hasUnifiedMemory = true;
+    bool _isUsingMetalArgumentBuffers = true;
 };
-
 
 #pragma mark -
 #pragma mark MVKDevice
 
 typedef enum {
-	MVKActivityPerformanceValueTypeDuration,
-	MVKActivityPerformanceValueTypeByteCount,
+    MVKActivityPerformanceValueTypeDuration,
+    MVKActivityPerformanceValueTypeByteCount,
 } MVKActivityPerformanceValueType;
 
 typedef struct MVKMTLBlitEncoder {
-	id<MTLBlitCommandEncoder> mtlBlitEncoder = nil;
-	id<MTLCommandBuffer> mtlCmdBuffer = nil;
+    id<MTLBlitCommandEncoder> mtlBlitEncoder = nil;
+    id<MTLCommandBuffer> mtlCmdBuffer = nil;
 } MVKMTLBlitEncoder;
 
-/** Represents a Vulkan logical GPU device, associated with a physical device. */
+/** Represents a Vulkan logical GPU device, associated with a physical device.
+ */
 class MVKDevice : public MVKDispatchableVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEVICE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEVICE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override {
+        return _physicalDevice->_mvkInstance;
+    }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _physicalDevice->_mvkInstance; }
-
-	/** Returns the name of this device. */
-	const char* getName() { return _physicalDevice->_properties.deviceName; }
+    /** Returns the name of this device. */
+    const char* getName() { return _physicalDevice->_properties.deviceName; }
 
     /** Returns the common resource factory for creating command resources. */
-    MVKCommandResourceFactory* getCommandResourceFactory() { return _commandResourceFactory; }
+    MVKCommandResourceFactory* getCommandResourceFactory() {
+        return _commandResourceFactory;
+    }
 
-	/** Returns the function pointer corresponding to the specified named entry point. */
-	PFN_vkVoidFunction getProcAddr(const char* pName);
+    /** Returns the function pointer corresponding to the specified named entry
+     * point. */
+    PFN_vkVoidFunction getProcAddr(const char* pName);
 
-	/** Returns the queue at the specified index within the specified family. */
-	MVKQueue* getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex);
+    /** Returns the queue at the specified index within the specified family. */
+    MVKQueue* getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex);
 
-	/** Returns the queue described by the specified structure. */
-	MVKQueue* getQueue(const VkDeviceQueueInfo2* queueInfo);
+    /** Returns the queue described by the specified structure. */
+    MVKQueue* getQueue(const VkDeviceQueueInfo2* queueInfo);
 
-	/** Retrieves the queue at the lowest queue and queue family indices used by the app. */
-	MVKQueue* getAnyQueue();
+    /** Retrieves the queue at the lowest queue and queue family indices used by
+     * the app. */
+    MVKQueue* getAnyQueue();
 
-	/** Block the current thread until all queues in this device are idle. */
-	VkResult waitIdle();
-	
-	/** Mark this device (and optionally the physical device) as lost. Releases all waits for this device. */
-	VkResult markLost(bool alsoMarkPhysicalDevice = false);
+    /** Block the current thread until all queues in this device are idle. */
+    VkResult waitIdle();
 
-	/** Returns whether or not the given descriptor set layout is supported. */
-	void getDescriptorSetLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-									   VkDescriptorSetLayoutSupport* pSupport);
+    /** Mark this device (and optionally the physical device) as lost. Releases
+     * all waits for this device. */
+    VkResult markLost(bool alsoMarkPhysicalDevice = false);
 
-	/** Populates the device group presentation capabilities. */
-	VkResult getDeviceGroupPresentCapabilities(VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities);
+    /** Returns whether or not the given descriptor set layout is supported. */
+    void getDescriptorSetLayoutSupport(
+        const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+        VkDescriptorSetLayoutSupport* pSupport);
 
-	/** Populates the device group surface presentation modes. */
-	VkResult getDeviceGroupSurfacePresentModes(MVKSurface* surface, VkDeviceGroupPresentModeFlagsKHR* pModes);
+    /** Populates the device group presentation capabilities. */
+    VkResult getDeviceGroupPresentCapabilities(
+        VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities);
 
-	/** Populates the device group peer memory features. */
-	void getPeerMemoryFeatures(uint32_t heapIndex, uint32_t localDevice, uint32_t remoteDevice, VkPeerMemoryFeatureFlags* pPeerMemoryFeatures);
+    /** Populates the device group surface presentation modes. */
+    VkResult
+    getDeviceGroupSurfacePresentModes(MVKSurface* surface,
+                                      VkDeviceGroupPresentModeFlagsKHR* pModes);
 
-	/** Returns the properties of the host memory pointer. */
-	VkResult getMemoryHostPointerProperties(VkExternalMemoryHandleTypeFlagBits handleType,
-											const void* pHostPointer,
-											VkMemoryHostPointerPropertiesEXT* pMemHostPtrProps);
+    /** Populates the device group peer memory features. */
+    void getPeerMemoryFeatures(uint32_t heapIndex, uint32_t localDevice,
+                               uint32_t remoteDevice,
+                               VkPeerMemoryFeatureFlags* pPeerMemoryFeatures);
 
-	/** Samples timestamps from the specified domains and returns the sampled values. */
-	void getCalibratedTimestamps(uint32_t timestampCount,
-								 const VkCalibratedTimestampInfoEXT* pTimestampInfos,
-								 uint64_t* pTimestamps,
-								 uint64_t* pMaxDeviation);
+    /** Returns the properties of the host memory pointer. */
+    VkResult getMemoryHostPointerProperties(
+        VkExternalMemoryHandleTypeFlagBits handleType, const void* pHostPointer,
+        VkMemoryHostPointerPropertiesEXT* pMemHostPtrProps);
+
+    /** Samples timestamps from the specified domains and returns the sampled
+     * values. */
+    void
+    getCalibratedTimestamps(uint32_t timestampCount,
+                            const VkCalibratedTimestampInfoEXT* pTimestampInfos,
+                            uint64_t* pTimestamps, uint64_t* pMaxDeviation);
 
 #pragma mark Object lifecycle
 
-	MVKBuffer* createBuffer(const VkBufferCreateInfo* pCreateInfo,
-							const VkAllocationCallbacks* pAllocator);
-	void destroyBuffer(MVKBuffer* mvkBuff,
-					   const VkAllocationCallbacks* pAllocator);
+    MVKBuffer* createBuffer(const VkBufferCreateInfo* pCreateInfo,
+                            const VkAllocationCallbacks* pAllocator);
+    void destroyBuffer(MVKBuffer* mvkBuff,
+                       const VkAllocationCallbacks* pAllocator);
 
     MVKBufferView* createBufferView(const VkBufferViewCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator);
     void destroyBufferView(MVKBufferView* mvkBuffView,
-                       const VkAllocationCallbacks* pAllocator);
+                           const VkAllocationCallbacks* pAllocator);
 
-	MVKImage* createImage(const VkImageCreateInfo* pCreateInfo,
-						  const VkAllocationCallbacks* pAllocator);
-	void destroyImage(MVKImage* mvkImg,
-					  const VkAllocationCallbacks* pAllocator);
+    MVKImage* createImage(const VkImageCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator);
+    void destroyImage(MVKImage* mvkImg,
+                      const VkAllocationCallbacks* pAllocator);
 
-	MVKImageView* createImageView(const VkImageViewCreateInfo* pCreateInfo,
-								  const VkAllocationCallbacks* pAllocator);
-	void destroyImageView(MVKImageView* mvkImgView, const VkAllocationCallbacks* pAllocator);
+    MVKImageView* createImageView(const VkImageViewCreateInfo* pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator);
+    void destroyImageView(MVKImageView* mvkImgView,
+                          const VkAllocationCallbacks* pAllocator);
 
-	MVKSwapchain* createSwapchain(const VkSwapchainCreateInfoKHR* pCreateInfo,
-								  const VkAllocationCallbacks* pAllocator);
-	void destroySwapchain(MVKSwapchain* mvkSwpChn,
-						  const VkAllocationCallbacks* pAllocator);
+    MVKSwapchain* createSwapchain(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator);
+    void destroySwapchain(MVKSwapchain* mvkSwpChn,
+                          const VkAllocationCallbacks* pAllocator);
 
-	MVKPresentableSwapchainImage* createPresentableSwapchainImage(const VkImageCreateInfo* pCreateInfo,
-																  MVKSwapchain* swapchain,
-																  uint32_t swapchainIndex,
-																  const VkAllocationCallbacks* pAllocator);
-	void destroyPresentableSwapchainImage(MVKPresentableSwapchainImage* mvkImg,
-										  const VkAllocationCallbacks* pAllocator);
+    MVKPresentableSwapchainImage* createPresentableSwapchainImage(
+        const VkImageCreateInfo* pCreateInfo, MVKSwapchain* swapchain,
+        uint32_t swapchainIndex, const VkAllocationCallbacks* pAllocator);
+    void
+    destroyPresentableSwapchainImage(MVKPresentableSwapchainImage* mvkImg,
+                                     const VkAllocationCallbacks* pAllocator);
 
-	MVKFence* createFence(const VkFenceCreateInfo* pCreateInfo,
-						  const VkAllocationCallbacks* pAllocator);
-	void destroyFence(MVKFence* mvkFence,
-					  const VkAllocationCallbacks* pAllocator);
+    MVKFence* createFence(const VkFenceCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator);
+    void destroyFence(MVKFence* mvkFence,
+                      const VkAllocationCallbacks* pAllocator);
 
-	MVKSemaphore* createSemaphore(const VkSemaphoreCreateInfo* pCreateInfo,
-								  const VkAllocationCallbacks* pAllocator);
-	void destroySemaphore(MVKSemaphore* mvkSem4,
-						  const VkAllocationCallbacks* pAllocator);
-    
-    MVKDeferredOperation* createDeferredOperation(const VkAllocationCallbacks* pAllocator);
+    MVKSemaphore* createSemaphore(const VkSemaphoreCreateInfo* pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator);
+    void destroySemaphore(MVKSemaphore* mvkSem4,
+                          const VkAllocationCallbacks* pAllocator);
+
+    MVKDeferredOperation*
+    createDeferredOperation(const VkAllocationCallbacks* pAllocator);
     void destroyDeferredOperation(MVKDeferredOperation* mvkDeferredOperation,
                                   const VkAllocationCallbacks* pAllocator);
 
-	MVKEvent* createEvent(const VkEventCreateInfo* pCreateInfo,
-						  const VkAllocationCallbacks* pAllocator);
-	void destroyEvent(MVKEvent* mvkEvent,
-					  const VkAllocationCallbacks* pAllocator);
+    MVKEvent* createEvent(const VkEventCreateInfo* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator);
+    void destroyEvent(MVKEvent* mvkEvent,
+                      const VkAllocationCallbacks* pAllocator);
 
-	MVKQueryPool* createQueryPool(const VkQueryPoolCreateInfo* pCreateInfo,
-								  const VkAllocationCallbacks* pAllocator);
-	void destroyQueryPool(MVKQueryPool* mvkQP,
-						  const VkAllocationCallbacks* pAllocator);
+    MVKQueryPool* createQueryPool(const VkQueryPoolCreateInfo* pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator);
+    void destroyQueryPool(MVKQueryPool* mvkQP,
+                          const VkAllocationCallbacks* pAllocator);
 
-	MVKShaderModule* createShaderModule(const VkShaderModuleCreateInfo* pCreateInfo,
-										const VkAllocationCallbacks* pAllocator);
-	void destroyShaderModule(MVKShaderModule* mvkShdrMod,
-							 const VkAllocationCallbacks* pAllocator);
+    MVKShaderModule*
+    createShaderModule(const VkShaderModuleCreateInfo* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator);
+    void destroyShaderModule(MVKShaderModule* mvkShdrMod,
+                             const VkAllocationCallbacks* pAllocator);
 
-	MVKPipelineCache* createPipelineCache(const VkPipelineCacheCreateInfo* pCreateInfo,
-										  const VkAllocationCallbacks* pAllocator);
-	void destroyPipelineCache(MVKPipelineCache* mvkPLC,
-							  const VkAllocationCallbacks* pAllocator);
+    MVKPipelineCache*
+    createPipelineCache(const VkPipelineCacheCreateInfo* pCreateInfo,
+                        const VkAllocationCallbacks* pAllocator);
+    void destroyPipelineCache(MVKPipelineCache* mvkPLC,
+                              const VkAllocationCallbacks* pAllocator);
 
-	MVKPipelineLayout* createPipelineLayout(const VkPipelineLayoutCreateInfo* pCreateInfo,
-											const VkAllocationCallbacks* pAllocator);
-	void destroyPipelineLayout(MVKPipelineLayout* mvkPLL,
-							   const VkAllocationCallbacks* pAllocator);
+    MVKPipelineLayout*
+    createPipelineLayout(const VkPipelineLayoutCreateInfo* pCreateInfo,
+                         const VkAllocationCallbacks* pAllocator);
+    void destroyPipelineLayout(MVKPipelineLayout* mvkPLL,
+                               const VkAllocationCallbacks* pAllocator);
 
     /**
-     * Template function that creates count number of pipelines of type PipelineType,
-     * using a collection of configuration information of type PipelineInfoType,
-     * and adds the new pipelines to the specified pipeline cache.
+     * Template function that creates count number of pipelines of type
+     * PipelineType, using a collection of configuration information of type
+     * PipelineInfoType, and adds the new pipelines to the specified pipeline
+     * cache.
      */
-    template<typename PipelineType, typename PipelineInfoType>
-    VkResult createPipelines(VkPipelineCache pipelineCache,
-                             uint32_t count,
+    template <typename PipelineType, typename PipelineInfoType>
+    VkResult createPipelines(VkPipelineCache pipelineCache, uint32_t count,
                              const PipelineInfoType* pCreateInfos,
                              const VkAllocationCallbacks* pAllocator,
                              VkPipeline* pPipelines);
     void destroyPipeline(MVKPipeline* mvkPPL,
                          const VkAllocationCallbacks* pAllocator);
 
-	MVKSampler* createSampler(const VkSamplerCreateInfo* pCreateInfo,
-							  const VkAllocationCallbacks* pAllocator);
-	void destroySampler(MVKSampler* mvkSamp,
-						const VkAllocationCallbacks* pAllocator);
+    MVKSampler* createSampler(const VkSamplerCreateInfo* pCreateInfo,
+                              const VkAllocationCallbacks* pAllocator);
+    void destroySampler(MVKSampler* mvkSamp,
+                        const VkAllocationCallbacks* pAllocator);
 
-	MVKSamplerYcbcrConversion* createSamplerYcbcrConversion(const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
-										                    const VkAllocationCallbacks* pAllocator);
-	void destroySamplerYcbcrConversion(MVKSamplerYcbcrConversion* mvkSampConv,
-								       const VkAllocationCallbacks* pAllocator);
+    MVKSamplerYcbcrConversion* createSamplerYcbcrConversion(
+        const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator);
+    void destroySamplerYcbcrConversion(MVKSamplerYcbcrConversion* mvkSampConv,
+                                       const VkAllocationCallbacks* pAllocator);
 
-	MVKDescriptorSetLayout* createDescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-													  const VkAllocationCallbacks* pAllocator);
-	void destroyDescriptorSetLayout(MVKDescriptorSetLayout* mvkDSL,
-									const VkAllocationCallbacks* pAllocator);
+    MVKDescriptorSetLayout* createDescriptorSetLayout(
+        const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator);
+    void destroyDescriptorSetLayout(MVKDescriptorSetLayout* mvkDSL,
+                                    const VkAllocationCallbacks* pAllocator);
 
-	MVKDescriptorPool* createDescriptorPool(const VkDescriptorPoolCreateInfo* pCreateInfo,
-											const VkAllocationCallbacks* pAllocator);
-	void destroyDescriptorPool(MVKDescriptorPool* mvkDP,
-							   const VkAllocationCallbacks* pAllocator);
+    MVKDescriptorPool*
+    createDescriptorPool(const VkDescriptorPoolCreateInfo* pCreateInfo,
+                         const VkAllocationCallbacks* pAllocator);
+    void destroyDescriptorPool(MVKDescriptorPool* mvkDP,
+                               const VkAllocationCallbacks* pAllocator);
 
-	MVKDescriptorUpdateTemplate* createDescriptorUpdateTemplate(const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-																const VkAllocationCallbacks* pAllocator);
-	void destroyDescriptorUpdateTemplate(MVKDescriptorUpdateTemplate* mvkDUT,
-										 const VkAllocationCallbacks* pAllocator);
+    MVKDescriptorUpdateTemplate* createDescriptorUpdateTemplate(
+        const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator);
+    void
+    destroyDescriptorUpdateTemplate(MVKDescriptorUpdateTemplate* mvkDUT,
+                                    const VkAllocationCallbacks* pAllocator);
 
-	MVKFramebuffer* createFramebuffer(const VkFramebufferCreateInfo* pCreateInfo,
-									  const VkAllocationCallbacks* pAllocator);
-	MVKFramebuffer* createFramebuffer(const VkRenderingInfo* pRenderingInfo,
-									  const VkAllocationCallbacks* pAllocator);
-	void destroyFramebuffer(MVKFramebuffer* mvkFB,
-							const VkAllocationCallbacks* pAllocator);
+    MVKFramebuffer*
+    createFramebuffer(const VkFramebufferCreateInfo* pCreateInfo,
+                      const VkAllocationCallbacks* pAllocator);
+    MVKFramebuffer* createFramebuffer(const VkRenderingInfo* pRenderingInfo,
+                                      const VkAllocationCallbacks* pAllocator);
+    void destroyFramebuffer(MVKFramebuffer* mvkFB,
+                            const VkAllocationCallbacks* pAllocator);
 
-	MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo* pCreateInfo,
-									const VkAllocationCallbacks* pAllocator);
-	MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
-									const VkAllocationCallbacks* pAllocator);
-	MVKRenderPass* createRenderPass(const VkRenderingInfo* pRenderingInfo,
-									const VkAllocationCallbacks* pAllocator);
-	void destroyRenderPass(MVKRenderPass* mvkRP,
-						   const VkAllocationCallbacks* pAllocator);
+    MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator);
+    MVKRenderPass* createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
+                                    const VkAllocationCallbacks* pAllocator);
+    MVKRenderPass* createRenderPass(const VkRenderingInfo* pRenderingInfo,
+                                    const VkAllocationCallbacks* pAllocator);
+    void destroyRenderPass(MVKRenderPass* mvkRP,
+                           const VkAllocationCallbacks* pAllocator);
 
-	MVKCommandPool* createCommandPool(const VkCommandPoolCreateInfo* pCreateInfo,
-									  const VkAllocationCallbacks* pAllocator);
-	void destroyCommandPool(MVKCommandPool* mvkCmdPool,
-							const VkAllocationCallbacks* pAllocator);
+    MVKCommandPool*
+    createCommandPool(const VkCommandPoolCreateInfo* pCreateInfo,
+                      const VkAllocationCallbacks* pAllocator);
+    void destroyCommandPool(MVKCommandPool* mvkCmdPool,
+                            const VkAllocationCallbacks* pAllocator);
 
-	MVKDeviceMemory* allocateMemory(const VkMemoryAllocateInfo* pAllocateInfo,
-									const VkAllocationCallbacks* pAllocator);
-	void freeMemory(MVKDeviceMemory* mvkDevMem,
-					const VkAllocationCallbacks* pAllocator);
+    MVKDeviceMemory* allocateMemory(const VkMemoryAllocateInfo* pAllocateInfo,
+                                    const VkAllocationCallbacks* pAllocator);
+    void freeMemory(MVKDeviceMemory* mvkDevMem,
+                    const VkAllocationCallbacks* pAllocator);
 
-	VkResult createPrivateDataSlot(const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
-								   const VkAllocationCallbacks* pAllocator,
-								   VkPrivateDataSlotEXT* pPrivateDataSlot);
+    VkResult
+    createPrivateDataSlot(const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
+                          const VkAllocationCallbacks* pAllocator,
+                          VkPrivateDataSlotEXT* pPrivateDataSlot);
 
-	void destroyPrivateDataSlot(VkPrivateDataSlotEXT privateDataSlot,
-								const VkAllocationCallbacks* pAllocator);
-
+    void destroyPrivateDataSlot(VkPrivateDataSlotEXT privateDataSlot,
+                                const VkAllocationCallbacks* pAllocator);
 
 #pragma mark Operations
 
-	/** Tell the GPU to be ready to use any of the GPU-addressable buffers. */
-	void encodeGPUAddressableBuffers(MVKResourcesCommandEncoderState* rezEncState,
-										 MVKShaderStage stage);
+    /** Tell the GPU to be ready to use any of the GPU-addressable buffers. */
+    void
+    encodeGPUAddressableBuffers(MVKResourcesCommandEncoderState* rezEncState,
+                                MVKShaderStage stage);
 
-	/** Adds the specified host semaphore to be woken upon device loss. */
-	void addSemaphore(MVKSemaphoreImpl* sem4);
+    /** Adds the specified host semaphore to be woken upon device loss. */
+    void addSemaphore(MVKSemaphoreImpl* sem4);
 
-	/** Removes the specified host semaphore. */
-	void removeSemaphore(MVKSemaphoreImpl* sem4);
+    /** Removes the specified host semaphore. */
+    void removeSemaphore(MVKSemaphoreImpl* sem4);
 
-	/** Adds the specified timeline semaphore to be woken at the specified value upon device loss. */
-	void addTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value);
+    /** Adds the specified timeline semaphore to be woken at the specified value
+     * upon device loss. */
+    void addTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value);
 
-	/** Removes the specified timeline semaphore. */
-	void removeTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value);
+    /** Removes the specified timeline semaphore. */
+    void removeTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value);
 
-	/** Applies the specified global memory barrier to all resource issued by this device. */
-	void applyMemoryBarrier(MVKPipelineBarrier& barrier,
-							MVKCommandEncoder* cmdEncoder,
-							MVKCommandUse cmdUse);
+    /** Applies the specified global memory barrier to all resource issued by
+     * this device. */
+    void applyMemoryBarrier(MVKPipelineBarrier& barrier,
+                            MVKCommandEncoder* cmdEncoder,
+                            MVKCommandUse cmdUse);
 
-	/** Invalidates the memory regions. */
-	VkResult invalidateMappedMemoryRanges(uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges);
+    /** Invalidates the memory regions. */
+    VkResult
+    invalidateMappedMemoryRanges(uint32_t memRangeCount,
+                                 const VkMappedMemoryRange* pMemRanges);
 
-	/** Returns the number of Metal render passes needed to render all views. */
-	uint32_t getMultiviewMetalPassCount(uint32_t viewMask) const;
+    /** Returns the number of Metal render passes needed to render all views. */
+    uint32_t getMultiviewMetalPassCount(uint32_t viewMask) const;
 
-	/** Returns the first view to be rendered in the given multiview pass. */
-	uint32_t getFirstViewIndexInMetalPass(uint32_t viewMask, uint32_t passIdx) const;
+    /** Returns the first view to be rendered in the given multiview pass. */
+    uint32_t getFirstViewIndexInMetalPass(uint32_t viewMask,
+                                          uint32_t passIdx) const;
 
-	/** Returns the number of views to be rendered in the given multiview pass. */
-	uint32_t getViewCountInMetalPass(uint32_t viewMask, uint32_t passIdx) const;
+    /** Returns the number of views to be rendered in the given multiview pass.
+     */
+    uint32_t getViewCountInMetalPass(uint32_t viewMask, uint32_t passIdx) const;
 
-	/** Populates the specified statistics structure from the current activity performance statistics. */
-	void getPerformanceStatistics(MVKPerformanceStatistics* pPerf);
+    /** Populates the specified statistics structure from the current activity
+     * performance statistics. */
+    void getPerformanceStatistics(MVKPerformanceStatistics* pPerf);
 
-	/** Log all performance statistics. */
-	void logPerformanceSummary();
-
+    /** Log all performance statistics. */
+    void logPerformanceSummary();
 
 #pragma mark Metal
 
-	/**
-	 * Returns an autoreleased options object to be used when compiling MSL shaders.
-	 * The requestFastMath parameter is combined with the value of MVKConfiguration::fastMathEnabled
-	 * to determine whether to enable fast math optimizations in the compiled shader.
-	 * The preserveInvariance parameter indicates that the shader requires the position
-	 * output invariance across invocations (typically for the position output).
-	 */
-	MTLCompileOptions* getMTLCompileOptions(bool requestFastMath = true, bool preserveInvariance = false);
+    /**
+     * Returns an autoreleased options object to be used when compiling MSL
+     * shaders. The requestFastMath parameter is combined with the value of
+     * MVKConfiguration::fastMathEnabled to determine whether to enable fast
+     * math optimizations in the compiled shader. The preserveInvariance
+     * parameter indicates that the shader requires the position output
+     * invariance across invocations (typically for the position output).
+     */
+    MTLCompileOptions* getMTLCompileOptions(bool requestFastMath = true,
+                                            bool preserveInvariance = false);
 
-	/** Returns the Metal vertex buffer index to use for the specified vertex attribute binding number.  */
-	uint32_t getMetalBufferIndexForVertexAttributeBinding(uint32_t binding);
+    /** Returns the Metal vertex buffer index to use for the specified vertex
+     * attribute binding number.  */
+    uint32_t getMetalBufferIndexForVertexAttributeBinding(uint32_t binding);
 
-	/** Returns the memory alignment required for the format when used in a texel buffer. */
-	VkDeviceSize getVkFormatTexelBufferAlignment(VkFormat format, MVKBaseObject* mvkObj);
+    /** Returns the memory alignment required for the format when used in a
+     * texel buffer. */
+    VkDeviceSize getVkFormatTexelBufferAlignment(VkFormat format,
+                                                 MVKBaseObject* mvkObj);
 
-    /** 
-     * Returns the MTLBuffer used to hold occlusion query results, 
+    /**
+     * Returns the MTLBuffer used to hold occlusion query results,
      * when all query pools use the same MTLBuffer.
      */
     id<MTLBuffer> getGlobalVisibilityResultMTLBuffer();
 
     /**
-     * Expands the visibility results buffer, used for occlusion queries, by replacing the
-     * existing buffer with a new MTLBuffer that is large enough to accommodate all occlusion
-     * queries created to date, including those defined in the specified query pool.
-     * Returns the previous query count, before the new queries were added, which can
-     * be used by the new query pool to locate its queries within the single large buffer.
+     * Expands the visibility results buffer, used for occlusion queries, by
+     * replacing the existing buffer with a new MTLBuffer that is large enough
+     * to accommodate all occlusion queries created to date, including those
+     * defined in the specified query pool. Returns the previous query count,
+     * before the new queries were added, which can be used by the new query
+     * pool to locate its queries within the single large buffer.
      */
     uint32_t expandVisibilityResultMTLBuffer(uint32_t queryCount);
 
-	/** Returns the GPU sample counter used for timestamps. */
-	id<MTLCounterSet> getTimestampMTLCounterSet() { return _physicalDevice->_timestampMTLCounterSet; }
+    /** Returns the GPU sample counter used for timestamps. */
+    id<MTLCounterSet> getTimestampMTLCounterSet() {
+        return _physicalDevice->_timestampMTLCounterSet;
+    }
 
-    /** Returns the memory type index corresponding to the specified Metal memory storage mode. */
+    /** Returns the memory type index corresponding to the specified Metal
+     * memory storage mode. */
     uint32_t getVulkanMemoryTypeIndex(MTLStorageMode mtlStorageMode);
 
-	/** Returns a default MTLSamplerState to populate empty array element descriptors. */
-	id<MTLSamplerState> getDefaultMTLSamplerState();
+    /** Returns a default MTLSamplerState to populate empty array element
+     * descriptors. */
+    id<MTLSamplerState> getDefaultMTLSamplerState();
 
-	/**
-	 * Returns a MTLBuffer of length one that can be used as a dummy to
-	 * create a no-op BLIT encoder based on filling this single-byte buffer.
-	 */
-	id<MTLBuffer> getDummyBlitMTLBuffer();
+    /**
+     * Returns a MTLBuffer of length one that can be used as a dummy to
+     * create a no-op BLIT encoder based on filling this single-byte buffer.
+     */
+    id<MTLBuffer> getDummyBlitMTLBuffer();
 
-	/**
-	 * Returns whether MTLCommandBuffers can be prefilled.
-	 *
-	 * This depends both on whether the app config has requested prefilling, and whether doing so will
-	 * interfere with other requested features, such as updating resource descriptors after bindings.
-	 */
-	bool shouldPrefillMTLCommandBuffers();
+    /**
+     * Returns whether MTLCommandBuffers can be prefilled.
+     *
+     * This depends both on whether the app config has requested prefilling, and
+     * whether doing so will interfere with other requested features, such as
+     * updating resource descriptors after bindings.
+     */
+    bool shouldPrefillMTLCommandBuffers();
 
-	/**
-	 * Checks if automatic GPU capture is supported, and is enabled for the specified auto
-	 * capture scope, and if so, starts capturing from the specified Metal capture object.
-	 * The capture will be made either to Xcode, or to a file if one has been configured.
-	 *
-	 * The mtlCaptureObject must be one of:
-	 *   - MTLDevice for scope MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE
-	 *   - MTLCommandQueue for scopes MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME
-	 *       and MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND.
-	 */
-	void startAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope, id mtlCaptureObject);
+    /**
+     * Checks if automatic GPU capture is supported, and is enabled for the
+     * specified auto capture scope, and if so, starts capturing from the
+     * specified Metal capture object. The capture will be made either to Xcode,
+     * or to a file if one has been configured.
+     *
+     * The mtlCaptureObject must be one of:
+     *   - MTLDevice for scope MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE
+     *   - MTLCommandQueue for scopes MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME
+     *       and MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND.
+     */
+    void startAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope,
+                             id mtlCaptureObject);
 
-	/**
-	 * Checks if automatic GPU capture is enabled for the specified
-	 * auto capture scope, and if so, stops capturing.
-	 */
-	void stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope);
+    /**
+     * Checks if automatic GPU capture is enabled for the specified
+     * auto capture scope, and if so, stops capturing.
+     */
+    void stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope);
 
-	/** Returns whether this instance is currently automatically capturing a GPU trace. */
-	bool isCurrentlyAutoGPUCapturing() { return _isCurrentlyAutoGPUCapturing; }
+    /** Returns whether this instance is currently automatically capturing a GPU
+     * trace. */
+    bool isCurrentlyAutoGPUCapturing() { return _isCurrentlyAutoGPUCapturing; }
 
-	/** Returns the Metal objects underpinning the Vulkan objects indicated in the pNext chain of pMetalObjectsInfo. */
-	void getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);
-
+    /** Returns the Metal objects underpinning the Vulkan objects indicated in
+     * the pNext chain of pMetalObjectsInfo. */
+    void getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);
 
 #pragma mark Construction
 
-	/** Constructs an instance on the specified physical device. */
-	MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo);
+    /** Constructs an instance on the specified physical device. */
+    MVKDevice(MVKPhysicalDevice* physicalDevice,
+              const VkDeviceCreateInfo* pCreateInfo);
 
-	~MVKDevice() override;
+    ~MVKDevice() override;
 
     /**
-     * Returns a reference to this object suitable for use as a Vulkan API handle.
-     * This is the compliment of the getMVKDevice() method.
+     * Returns a reference to this object suitable for use as a Vulkan API
+     * handle. This is the compliment of the getMVKDevice() method.
      */
     VkDevice getVkDevice() { return (VkDevice)getVkHandle(); }
 
@@ -841,193 +965,269 @@ public:
         return (MVKDevice*)getDispatchableObject(vkDevice);
     }
 
-protected:
-	friend class MVKDeviceTrackingMixin;
+  protected:
+    friend class MVKDeviceTrackingMixin;
 
-	void propagateDebugName() override  {}
-	MVKBuffer* addBuffer(MVKBuffer* mvkBuff);
-	MVKBuffer* removeBuffer(MVKBuffer* mvkBuff);
-	MVKImage* addImage(MVKImage* mvkImg);
-	MVKImage* removeImage(MVKImage* mvkImg);
+    void propagateDebugName() override {}
+    MVKBuffer* addBuffer(MVKBuffer* mvkBuff);
+    MVKBuffer* removeBuffer(MVKBuffer* mvkBuff);
+    MVKImage* addImage(MVKImage* mvkImg);
+    MVKImage* removeImage(MVKImage* mvkImg);
     void initPerformanceTracking();
-	void initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo);
-	void initQueues(const VkDeviceCreateInfo* pCreateInfo);
-	void reservePrivateData(const VkDeviceCreateInfo* pCreateInfo);
-	void enableFeatures(const VkDeviceCreateInfo* pCreateInfo);
-	template<typename S> void enableFeatures(S* pEnabled, const S* pRequested, const S* pAvailable, uint32_t count);
-	template<typename S> void enableFeatures(S* pRequested, VkBool32* pEnabledBools, const VkBool32* pRequestedBools, const VkBool32* pAvailableBools, uint32_t count);
-	void enableExtensions(const VkDeviceCreateInfo* pCreateInfo);
-	void updateActivityPerformance(MVKPerformanceTracker& activity, double currentValue);
-    const char* getActivityPerformanceDescription(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
-	MVKActivityPerformanceValueType getActivityPerformanceValueType(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
-	void logActivityInline(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats);
-	void logActivityDuration(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats, bool isInline = false);
-	void logActivityByteCount(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats, bool isInline = false);
-	void getDescriptorVariableDescriptorCountLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-														   VkDescriptorSetLayoutSupport* pSupport,
-														   VkDescriptorSetVariableDescriptorCountLayoutSupport* pVarDescSetCountSupport);
-	bool readGPUCapturePipe() { char dummy; return _capturePipeFileDesc >= 0 && read(_capturePipeFileDesc, &dummy, 1) > 0; };
+    void initPhysicalDevice(MVKPhysicalDevice* physicalDevice,
+                            const VkDeviceCreateInfo* pCreateInfo);
+    void initQueues(const VkDeviceCreateInfo* pCreateInfo);
+    void reservePrivateData(const VkDeviceCreateInfo* pCreateInfo);
+    void enableFeatures(const VkDeviceCreateInfo* pCreateInfo);
+    template <typename S>
+    void enableFeatures(S* pEnabled, const S* pRequested, const S* pAvailable,
+                        uint32_t count);
+    template <typename S>
+    void enableFeatures(S* pRequested, VkBool32* pEnabledBools,
+                        const VkBool32* pRequestedBools,
+                        const VkBool32* pAvailableBools, uint32_t count);
+    void enableExtensions(const VkDeviceCreateInfo* pCreateInfo);
+    void updateActivityPerformance(MVKPerformanceTracker& activity,
+                                   double currentValue);
+    const char*
+    getActivityPerformanceDescription(MVKPerformanceTracker& activity,
+                                      MVKPerformanceStatistics& perfStats);
+    MVKActivityPerformanceValueType
+    getActivityPerformanceValueType(MVKPerformanceTracker& activity,
+                                    MVKPerformanceStatistics& perfStats);
+    void logActivityInline(MVKPerformanceTracker& activity,
+                           MVKPerformanceStatistics& perfStats);
+    void logActivityDuration(MVKPerformanceTracker& activity,
+                             MVKPerformanceStatistics& perfStats,
+                             bool isInline = false);
+    void logActivityByteCount(MVKPerformanceTracker& activity,
+                              MVKPerformanceStatistics& perfStats,
+                              bool isInline = false);
+    void getDescriptorVariableDescriptorCountLayoutSupport(
+        const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+        VkDescriptorSetLayoutSupport* pSupport,
+        VkDescriptorSetVariableDescriptorCountLayoutSupport*
+            pVarDescSetCountSupport);
+    bool readGPUCapturePipe() {
+        char dummy;
+        return _capturePipeFileDesc >= 0 &&
+               read(_capturePipeFileDesc, &dummy, 1) > 0;
+    };
 
-	MVKPhysicalDevice* _physicalDevice = nullptr;
-	MVKExtensionList _enabledExtensions;
-	VkPhysicalDeviceFeatures _enabledFeatures;
-	MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
+    MVKPhysicalDevice* _physicalDevice = nullptr;
+    MVKExtensionList _enabledExtensions;
+    VkPhysicalDeviceFeatures _enabledFeatures;
+    MVKPhysicalDeviceVulkan12FeaturesNoExt _enabledVulkan12FeaturesNoExt;
 
-	// List of extended device feature enabling structures, as member variables.
-#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
-	VkPhysicalDevice##structName##Features _enabled##structName##Features;
-#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
-	VkPhysicalDevice##structName##Features##extnSfx _enabled##structName##Features;
+    // List of extended device feature enabling structures, as member variables.
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount)                    \
+    VkPhysicalDevice##structName##Features _enabled##structName##Features;
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount)      \
+    VkPhysicalDevice##structName##Features##extnSfx                            \
+        _enabled##structName##Features;
 #include "MVKDeviceFeatureStructs.def"
 
-	MVKPerformanceStatistics _performanceStats;
+    MVKPerformanceStatistics _performanceStats;
     MVKCommandResourceFactory* _commandResourceFactory = nullptr;
-	MVKSmallVector<MVKSmallVector<MVKQueue*, kMVKQueueCountPerQueueFamily>, kMVKQueueFamilyCount> _queuesByQueueFamilyIndex;
-	MVKSmallVector<MVKResource*> _resources;
-	MVKSmallVector<MVKBuffer*> _gpuAddressableBuffers;
-	MVKSmallVector<MVKPrivateDataSlot*> _privateDataSlots;
-	MVKSmallVector<bool> _privateDataSlotsAvailability;
-	MVKSmallVector<MVKSemaphoreImpl*> _awaitingSemaphores;
-	MVKSmallVector<std::pair<MVKTimelineSemaphore*, uint64_t>> _awaitingTimelineSem4s;
-	std::mutex _rezLock;
-	std::mutex _sem4Lock;
+    MVKSmallVector<MVKSmallVector<MVKQueue*, kMVKQueueCountPerQueueFamily>,
+                   kMVKQueueFamilyCount>
+        _queuesByQueueFamilyIndex;
+    MVKSmallVector<MVKResource*> _resources;
+    MVKSmallVector<MVKBuffer*> _gpuAddressableBuffers;
+    MVKSmallVector<MVKPrivateDataSlot*> _privateDataSlots;
+    MVKSmallVector<bool> _privateDataSlotsAvailability;
+    MVKSmallVector<MVKSemaphoreImpl*> _awaitingSemaphores;
+    MVKSmallVector<std::pair<MVKTimelineSemaphore*, uint64_t>>
+        _awaitingTimelineSem4s;
+    std::mutex _rezLock;
+    std::mutex _sem4Lock;
     std::mutex _perfLock;
-	std::mutex _vizLock;
-	std::string _capturePipeFileName;
+    std::mutex _vizLock;
+    std::string _capturePipeFileName;
     id<MTLBuffer> _globalVisibilityResultMTLBuffer = nil;
-	id<MTLSamplerState> _defaultMTLSamplerState = nil;
-	id<MTLBuffer> _dummyBlitMTLBuffer = nil;
+    id<MTLSamplerState> _defaultMTLSamplerState = nil;
+    id<MTLBuffer> _dummyBlitMTLBuffer = nil;
     uint32_t _globalVisibilityQueryCount = 0;
-	int _capturePipeFileDesc = -1;
-	bool _isPerformanceTracking = false;
-	bool _isCurrentlyAutoGPUCapturing = false;
-
+    int _capturePipeFileDesc = -1;
+    bool _isPerformanceTracking = false;
+    bool _isCurrentlyAutoGPUCapturing = false;
 };
-
 
 #pragma mark -
 #pragma mark MVKDeviceTrackingMixin
 
 /**
- * This mixin class adds the ability for an object to track the device that created it.
+ * This mixin class adds the ability for an object to track the device that
+ * created it.
  *
- * As a mixin, this class should only be used as a component of multiple inheritance.
- * Any class that inherits from this class should also inherit from MVKBaseObject.
- * This requirement is to avoid the diamond problem of multiple inheritance.
+ * As a mixin, this class should only be used as a component of multiple
+ * inheritance. Any class that inherits from this class should also inherit from
+ * MVKBaseObject. This requirement is to avoid the diamond problem of multiple
+ * inheritance.
  */
 class MVKDeviceTrackingMixin {
 
-public:
+  public:
+    /** Returns the device for which this object was created. */
+    MVKDevice* getDevice() { return _device; }
 
-	/** Returns the device for which this object was created. */
-	MVKDevice* getDevice() { return _device; }
+    /** Returns the physical device underlying this logical device. */
+    MVKPhysicalDevice* getPhysicalDevice() { return _device->_physicalDevice; }
 
-	/** Returns the physical device underlying this logical device. */
-	MVKPhysicalDevice* getPhysicalDevice() { return _device->_physicalDevice; }
+    /** Returns the underlying Metal device. */
+    id<MTLDevice> getMTLDevice() {
+        return _device->_physicalDevice->_mtlDevice;
+    }
 
-	/** Returns the underlying Metal device. */
-	id<MTLDevice> getMTLDevice() { return _device->_physicalDevice->_mtlDevice; }
+    /** Returns whether the GPU is a unified memory device. */
+    bool isUnifiedMemoryGPU() {
+        return _device->_physicalDevice->_hasUnifiedMemory;
+    }
 
-	/** Returns whether the GPU is a unified memory device. */
-	bool isUnifiedMemoryGPU() { return _device->_physicalDevice->_hasUnifiedMemory; }
+    /** Returns whether the GPU is Apple Silicon. */
+    bool isAppleGPU() {
+        return _device->_physicalDevice->_gpuCapabilities.isAppleGPU;
+    }
 
-	/** Returns whether the GPU is Apple Silicon. */
-	bool isAppleGPU() { return _device->_physicalDevice->_gpuCapabilities.isAppleGPU; }
+    /** Returns whether this device is using one Metal argument buffer for each
+     * descriptor set, on multiple pipeline and pipeline stages. */
+    virtual bool isUsingMetalArgumentBuffers() {
+        return _device->_physicalDevice->_isUsingMetalArgumentBuffers;
+    };
 
-	/** Returns whether this device is using one Metal argument buffer for each descriptor set, on multiple pipeline and pipeline stages. */
-	virtual bool isUsingMetalArgumentBuffers() { return _device->_physicalDevice->_isUsingMetalArgumentBuffers; };
+    /** Returns whether this device needs Metal argument buffer encoders to
+     * populate argument buffer content. */
+    bool needsMetalArgumentBufferEncoders() {
+        return _device->_physicalDevice->_metalFeatures
+            .needsArgumentBufferEncoders;
+    };
 
-	/** Returns whether this device needs Metal argument buffer encoders to populate argument buffer content. */
-	bool needsMetalArgumentBufferEncoders() { return _device->_physicalDevice->_metalFeatures.needsArgumentBufferEncoders; };
+    /** Returns info about the pixel format supported by the physical device. */
+    MVKPixelFormats* getPixelFormats() {
+        return &_device->_physicalDevice->_pixelFormats;
+    }
 
-	/** Returns info about the pixel format supported by the physical device. */
-	MVKPixelFormats* getPixelFormats() { return &_device->_physicalDevice->_pixelFormats; }
+    /** The list of Vulkan extensions, indicating whether each has been enabled
+     * by the app for this device. */
+    MVKExtensionList& getEnabledExtensions() {
+        return _device->_enabledExtensions;
+    }
 
-	/** The list of Vulkan extensions, indicating whether each has been enabled by the app for this device. */
-	MVKExtensionList& getEnabledExtensions() { return _device->_enabledExtensions; }
+    /** Device features available and enabled. */
+    VkPhysicalDeviceFeatures& getEnabledFeatures() {
+        return _device->_enabledFeatures;
+    }
 
-	/** Device features available and enabled. */
-	VkPhysicalDeviceFeatures& getEnabledFeatures() { return _device->_enabledFeatures; }
-
-	// List of extended device feature enabling structures, as getEnabledXXXFeatures() functions.
-#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
-	VkPhysicalDevice##structName##Features& getEnabled##structName##Features() { return _device->_enabled##structName##Features; }
-#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
-	VkPhysicalDevice##structName##Features##extnSfx& getEnabled##structName##Features() { return _device->_enabled##structName##Features; }
+    // List of extended device feature enabling structures, as
+    // getEnabledXXXFeatures() functions.
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount)                    \
+    VkPhysicalDevice##structName##Features&                                    \
+        getEnabled##structName##Features() {                                   \
+        return _device->_enabled##structName##Features;                        \
+    }
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount)      \
+    VkPhysicalDevice##structName##Features##extnSfx&                           \
+        getEnabled##structName##Features() {                                   \
+        return _device->_enabled##structName##Features;                        \
+    }
 #include "MVKDeviceFeatureStructs.def"
 
-	/** Pointer to the Metal-specific features of the underlying physical device. */
-	const MVKPhysicalDeviceMetalFeatures& getMetalFeatures() { return _device->_physicalDevice->_metalFeatures; }
+    /** Pointer to the Metal-specific features of the underlying physical
+     * device. */
+    const MVKPhysicalDeviceMetalFeatures& getMetalFeatures() {
+        return _device->_physicalDevice->_metalFeatures;
+    }
 
-	/** Pointer to the properties of the underlying physical device. */
-	const VkPhysicalDeviceProperties& getDeviceProperties() { return _device->_physicalDevice->_properties; }
+    /** Pointer to the properties of the underlying physical device. */
+    const VkPhysicalDeviceProperties& getDeviceProperties() {
+        return _device->_physicalDevice->_properties;
+    }
 
-	/** Pointer to the memory properties of the underlying physical device. */
-	const VkPhysicalDeviceMemoryProperties& getDeviceMemoryProperties() { return _device->_physicalDevice->_memoryProperties; }
+    /** Pointer to the memory properties of the underlying physical device. */
+    const VkPhysicalDeviceMemoryProperties& getDeviceMemoryProperties() {
+        return _device->_physicalDevice->_memoryProperties;
+    }
 
-	/** Performance statistics. */
-	MVKPerformanceStatistics& getPerformanceStats() { return _device->_performanceStats; }
+    /** Performance statistics. */
+    MVKPerformanceStatistics& getPerformanceStats() {
+        return _device->_performanceStats;
+    }
 
-	/**
-	 * If performance is being tracked, returns a monotonic timestamp value for use performance timestamping.
-	 * The returned value corresponds to the number of CPU "ticks" since the app was initialized.
-	 *
-	 * Call this function twice, then use the functions mvkGetElapsedNanoseconds() or mvkGetElapsedMilliseconds()
-	 * to determine the number of nanoseconds or milliseconds between the two calls.
-	 */
-	uint64_t getPerformanceTimestamp() { return _device->_isPerformanceTracking ? mvkGetTimestamp() : 0; }
+    /**
+     * If performance is being tracked, returns a monotonic timestamp value for
+     * use performance timestamping. The returned value corresponds to the
+     * number of CPU "ticks" since the app was initialized.
+     *
+     * Call this function twice, then use the functions
+     * mvkGetElapsedNanoseconds() or mvkGetElapsedMilliseconds() to determine
+     * the number of nanoseconds or milliseconds between the two calls.
+     */
+    uint64_t getPerformanceTimestamp() {
+        return _device->_isPerformanceTracking ? mvkGetTimestamp() : 0;
+    }
 
-	/**
-	 * If performance is being tracked, adds the performance for an activity with a duration interval
-	 * between the start and end times, measured in milliseconds, to the given performance statistics.
-	 *
-	 * If endTime is zero or not supplied, the current time is used.
-	 * If addAlways is true, the duration is tracked even if performance tracking is disabled.
-	 */
-	void addPerformanceInterval(MVKPerformanceTracker& perfTracker, uint64_t startTime, uint64_t endTime = 0, bool addAlways = false) {
-		if (_device->_isPerformanceTracking || addAlways) {
-			_device->updateActivityPerformance(perfTracker, mvkGetElapsedMilliseconds(startTime, endTime));
-		}
-	};
+    /**
+     * If performance is being tracked, adds the performance for an activity
+     * with a duration interval between the start and end times, measured in
+     * milliseconds, to the given performance statistics.
+     *
+     * If endTime is zero or not supplied, the current time is used.
+     * If addAlways is true, the duration is tracked even if performance
+     * tracking is disabled.
+     */
+    void addPerformanceInterval(MVKPerformanceTracker& perfTracker,
+                                uint64_t startTime, uint64_t endTime = 0,
+                                bool addAlways = false) {
+        if (_device->_isPerformanceTracking || addAlways) {
+            _device
+                ->updateActivityPerformance(perfTracker,
+                                            mvkGetElapsedMilliseconds(startTime,
+                                                                      endTime));
+        }
+    };
 
-	/** Constructs an instance for the specified device. */
-	MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) { assert(_device); }
+    /** Constructs an instance for the specified device. */
+    MVKDeviceTrackingMixin(MVKDevice* device) : _device(device) {
+        assert(_device);
+    }
 
-	virtual ~MVKDeviceTrackingMixin() {}
+    virtual ~MVKDeviceTrackingMixin() {}
 
-protected:
-	MVKDevice* _device;
+  protected:
+    MVKDevice* _device;
 };
-
 
 #pragma mark -
 #pragma mark MVKBaseDeviceObject
 
-/** Represents an object that is spawned from a Vulkan device, and tracks that device. */
-class MVKBaseDeviceObject : public MVKBaseObject, public MVKDeviceTrackingMixin {
+/** Represents an object that is spawned from a Vulkan device, and tracks that
+ * device. */
+class MVKBaseDeviceObject : public MVKBaseObject,
+                            public MVKDeviceTrackingMixin {
 
-public:
-
-	/** Constructs an instance for the specified device. */
-	MVKBaseDeviceObject(MVKDevice* device) : MVKDeviceTrackingMixin(device) {}
+  public:
+    /** Constructs an instance for the specified device. */
+    MVKBaseDeviceObject(MVKDevice* device) : MVKDeviceTrackingMixin(device) {}
 };
-
 
 #pragma mark -
 #pragma mark MVKVulkanAPIDeviceObject
 
-/** Abstract class that represents an opaque Vulkan API handle object spawned from a Vulkan device. */
-class MVKVulkanAPIDeviceObject : public MVKVulkanAPIObject, public MVKDeviceTrackingMixin {
+/** Abstract class that represents an opaque Vulkan API handle object spawned
+ * from a Vulkan device. */
+class MVKVulkanAPIDeviceObject : public MVKVulkanAPIObject,
+                                 public MVKDeviceTrackingMixin {
 
-public:
+  public:
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override {
+        return _device ? _device->getInstance() : nullptr;
+    }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _device ? _device->getInstance() : nullptr; }
-
-	/** Constructs an instance for the specified device. */
-	MVKVulkanAPIDeviceObject(MVKDevice* device) : MVKDeviceTrackingMixin(device) {}
+    /** Constructs an instance for the specified device. */
+    MVKVulkanAPIDeviceObject(MVKDevice* device)
+        : MVKDeviceTrackingMixin(device) {}
 };
-
 
 #pragma mark -
 #pragma mark MVKPrivateDataSlot
@@ -1035,72 +1235,82 @@ public:
 /** Private data slot. */
 class MVKPrivateDataSlot : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT; }
+    void setData(VkObjectType objectType, uint64_t objectHandle,
+                 uint64_t data) {
+        _privateData[objectHandle] = data;
+    }
 
-	void setData(VkObjectType objectType, uint64_t objectHandle, uint64_t data) { _privateData[objectHandle] = data; }
+    uint64_t getData(VkObjectType objectType, uint64_t objectHandle) {
+        return _privateData[objectHandle];
+    }
 
-	uint64_t getData(VkObjectType objectType, uint64_t objectHandle) { return _privateData[objectHandle]; }
+    void clearData() { _privateData.clear(); }
 
-	void clearData() { _privateData.clear(); }
+    MVKPrivateDataSlot(MVKDevice* device) : MVKVulkanAPIDeviceObject(device) {}
 
-	MVKPrivateDataSlot(MVKDevice* device) : MVKVulkanAPIDeviceObject(device) {}
+  protected:
+    void propagateDebugName() override {}
 
-protected:
-	void propagateDebugName() override {}
-
-	std::unordered_map<uint64_t, uint64_t> _privateData;
+    std::unordered_map<uint64_t, uint64_t> _privateData;
 };
-
 
 #pragma mark -
 #pragma mark MVKDeviceObjectPool
 
-/** Manages a pool of instances of a particular object type that requires an MVKDevice during construction. */
+/** Manages a pool of instances of a particular object type that requires an
+ * MVKDevice during construction. */
 template <class T>
-class MVKDeviceObjectPool : public MVKObjectPool<T>, public MVKDeviceTrackingMixin {
+class MVKDeviceObjectPool : public MVKObjectPool<T>,
+                            public MVKDeviceTrackingMixin {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return _device; };
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _device; };
+    /**
+     * Configures this instance for the device, and either use pooling, or not,
+     * depending on the value of isPooling, which defaults to true if not
+     * indicated explicitly.
+     */
+    MVKDeviceObjectPool(MVKDevice* device, bool isPooling = true)
+        : MVKObjectPool<T>(isPooling), MVKDeviceTrackingMixin(device) {}
 
-	/**
-	 * Configures this instance for the device, and either use pooling, or not, depending
-	 * on the value of isPooling, which defaults to true if not indicated explicitly.
-	 */
-	MVKDeviceObjectPool(MVKDevice* device, bool isPooling = true) : MVKObjectPool<T>(isPooling), MVKDeviceTrackingMixin(device) {}
-
-protected:
-	T* newObject() override { return new T(_device); }
-
+  protected:
+    T* newObject() override { return new T(_device); }
 };
-
 
 #pragma mark -
 #pragma mark Support functions
 
 /**
- * Returns an autoreleased array containing the MTLDevices available on this system,
- * sorted according to power, with higher power GPU's at the front of the array.
- * This ensures that a lazy app that simply grabs the first GPU will get a high-power
- * one by default. If MVKConfiguration::forceLowPowerGPU is enabled, the returned
- * array will only include low-power devices. The instance may be a nullptr.
+ * Returns an autoreleased array containing the MTLDevices available on this
+ * system, sorted according to power, with higher power GPU's at the front of
+ * the array. This ensures that a lazy app that simply grabs the first GPU will
+ * get a high-power one by default. If MVKConfiguration::forceLowPowerGPU is
+ * enabled, the returned array will only include low-power devices. The instance
+ * may be a nullptr.
  */
 NSArray<id<MTLDevice>>* mvkGetAvailableMTLDevicesArray(MVKInstance* instance);
 
-/** Returns the registry ID of the specified device, or zero if the device does not have a registry ID. */
+/** Returns the registry ID of the specified device, or zero if the device does
+ * not have a registry ID. */
 uint64_t mvkGetRegistryID(id<MTLDevice> mtlDevice);
 
 /**
  * Returns a value identifying the physical location of the specified device.
  * The returned value is a hash of the location, locationNumber, peerGroupID,
- * and peerIndex properties of the device. On devices with only one built-in GPU,
- * the returned value will be zero.
+ * and peerIndex properties of the device. On devices with only one built-in
+ * GPU, the returned value will be zero.
  */
 uint64_t mvkGetLocationID(id<MTLDevice> mtlDevice);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,18 +42,17 @@
 
 using namespace std;
 
-
 #if MVK_IOS_OR_TVOS
-#	include <UIKit/UIKit.h>
-#	define MVKViewClass		UIView
+#include <UIKit/UIKit.h>
+#define MVKViewClass UIView
 #endif
 #if MVK_MACOS
-#	include <AppKit/AppKit.h>
-#	define MVKViewClass		NSView
+#include <AppKit/AppKit.h>
+#define MVKViewClass NSView
 #endif
 
-// Suppress unused variable warnings to allow us to define these all in one place,
-// but use them in platform-conditional code blocks.
+// Suppress unused variable warnings to allow us to define these all in one
+// place, but use them in platform-conditional code blocks.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 
@@ -72,98 +71,111 @@ static const uint32_t kMaxTimeDomains = 2;
 
 #pragma clang diagnostic pop
 
-
 #pragma mark -
 #pragma mark MVKMTLDeviceCapabilities
 
-#define supportsGPUFam(gpuFam, mtlDev)  ([mtlDev respondsToSelector: @selector(supportsFamily:)] && [mtlDev supportsFamily: MTLGPUFamily ##gpuFam])
+#define supportsGPUFam(gpuFam, mtlDev)                                         \
+    ([mtlDev respondsToSelector:@selector(supportsFamily:)] &&                 \
+     [mtlDev supportsFamily:MTLGPUFamily##gpuFam])
 
 #if MVK_IOS
-#define supportsIOSGPU(gpuIdx, mtlDev)  [mtlDev supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily ##gpuIdx ##_v1]
+#define supportsIOSGPU(gpuIdx, mtlDev)                                         \
+    [mtlDev supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily##gpuIdx##_v1]
 #else
-#define supportsIOSGPU(gpuIdx, mtlDev)  false
+#define supportsIOSGPU(gpuIdx, mtlDev) false
 #endif
 
 #if MVK_TVOS
-#define supportsTVOSGPU(gpuIdx, mtlDev)  [mtlDev supportsFeatureSet: MTLFeatureSet_tvOS_GPUFamily ##gpuIdx ##_v1]
+#define supportsTVOSGPU(gpuIdx, mtlDev)                                        \
+    [mtlDev supportsFeatureSet:MTLFeatureSet_tvOS_GPUFamily##gpuIdx##_v1]
 #else
-#define supportsTVOSGPU(gpuIdx, mtlDev)  false
+#define supportsTVOSGPU(gpuIdx, mtlDev) false
 #endif
 
-#define returnGPUValIf(gpuType, gpuIdx)  if (supports ##gpuType ##gpuIdx) { return gpuIdx; }
+#define returnGPUValIf(gpuType, gpuIdx)                                        \
+    if (supports##gpuType##gpuIdx) {                                           \
+        return gpuIdx;                                                         \
+    }
 
 uint8_t MVKMTLDeviceCapabilities::getHighestAppleGPU() const {
-	returnGPUValIf(Apple, 9);
-	returnGPUValIf(Apple, 8);
-	returnGPUValIf(Apple, 7);
-	returnGPUValIf(Apple, 6);
-	returnGPUValIf(Apple, 5);
-	returnGPUValIf(Apple, 4);
-	returnGPUValIf(Apple, 3);
-	returnGPUValIf(Apple, 2);
-	returnGPUValIf(Apple, 1);
-	return 0;
+    returnGPUValIf(Apple, 9);
+    returnGPUValIf(Apple, 8);
+    returnGPUValIf(Apple, 7);
+    returnGPUValIf(Apple, 6);
+    returnGPUValIf(Apple, 5);
+    returnGPUValIf(Apple, 4);
+    returnGPUValIf(Apple, 3);
+    returnGPUValIf(Apple, 2);
+    returnGPUValIf(Apple, 1);
+    return 0;
 }
 
 uint8_t MVKMTLDeviceCapabilities::getHighestMacGPU() const {
-	returnGPUValIf(Mac, 2);
-	returnGPUValIf(Mac, 1);
-	return 0;
+    returnGPUValIf(Mac, 2);
+    returnGPUValIf(Mac, 1);
+    return 0;
 }
 
 MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
-	mvkClear(this);
-	supportsApple1 = supportsGPUFam(Apple1, mtlDev) || supportsIOSGPU(1, mtlDev) || supportsTVOSGPU(1, mtlDev);
-	supportsApple2 = supportsGPUFam(Apple2, mtlDev) || supportsIOSGPU(2, mtlDev) || supportsTVOSGPU(1, mtlDev);
-	supportsApple3 = supportsGPUFam(Apple3, mtlDev) || supportsIOSGPU(3, mtlDev) || supportsTVOSGPU(2, mtlDev);
-	supportsApple4 = supportsGPUFam(Apple4, mtlDev) || supportsIOSGPU(4, mtlDev);
-	supportsApple5 = supportsGPUFam(Apple5, mtlDev) || supportsIOSGPU(5, mtlDev);
+    mvkClear(this);
+    supportsApple1 = supportsGPUFam(Apple1, mtlDev) ||
+                     supportsIOSGPU(1, mtlDev) || supportsTVOSGPU(1, mtlDev);
+    supportsApple2 = supportsGPUFam(Apple2, mtlDev) ||
+                     supportsIOSGPU(2, mtlDev) || supportsTVOSGPU(1, mtlDev);
+    supportsApple3 = supportsGPUFam(Apple3, mtlDev) ||
+                     supportsIOSGPU(3, mtlDev) || supportsTVOSGPU(2, mtlDev);
+    supportsApple4 =
+        supportsGPUFam(Apple4, mtlDev) || supportsIOSGPU(4, mtlDev);
+    supportsApple5 =
+        supportsGPUFam(Apple5, mtlDev) || supportsIOSGPU(5, mtlDev);
 #if MVK_XCODE_12
-	supportsApple6 = supportsGPUFam(Apple6, mtlDev);
+    supportsApple6 = supportsGPUFam(Apple6, mtlDev);
 #endif
 #if MVK_XCODE_13
-	supportsApple7 = supportsGPUFam(Apple7, mtlDev);
+    supportsApple7 = supportsGPUFam(Apple7, mtlDev);
 #endif
 #if MVK_XCODE_14
-	supportsApple8 = supportsGPUFam(Apple8, mtlDev);
-	supportsMetal3 = supportsGPUFam(Metal3, mtlDev);
+    supportsApple8 = supportsGPUFam(Apple8, mtlDev);
+    supportsMetal3 = supportsGPUFam(Metal3, mtlDev);
 #endif
 #if MVK_XCODE_15 && !MVK_TVOS && !MVK_VISIONOS
-	supportsApple9 = supportsGPUFam(Apple9, mtlDev);
+    supportsApple9 = supportsGPUFam(Apple9, mtlDev);
 #endif
-	supportsMac1 = MVK_MACOS;	// Incl Mac1 & MacCatalyst1
-	supportsMac2 = MVK_MACOS;	// Incl Mac2 & MacCatalyst2
+    supportsMac1 = MVK_MACOS; // Incl Mac1 & MacCatalyst1
+    supportsMac2 = MVK_MACOS; // Incl Mac2 & MacCatalyst2
 
-	isAppleGPU = supportsApple1;
+    isAppleGPU = supportsApple1;
 
 #if MVK_XCODE_14_3 || (MVK_XCODE_12 && MVK_MACOS && !MVK_MACCAT)
-	if ([mtlDev respondsToSelector: @selector(supportsBCTextureCompression)]) {
-		supportsBCTextureCompression = mtlDev.supportsBCTextureCompression;
-	}
+    if ([mtlDev respondsToSelector:@selector(supportsBCTextureCompression)]) {
+        supportsBCTextureCompression = mtlDev.supportsBCTextureCompression;
+    }
 #else
-	supportsBCTextureCompression = supportsMac1;
+    supportsBCTextureCompression = supportsMac1;
 #endif
 #if MVK_MACOS
-	supportsDepth24Stencil8 = mtlDev.isDepth24Stencil8PixelFormatSupported;
+    supportsDepth24Stencil8 = mtlDev.isDepth24Stencil8PixelFormatSupported;
 #endif
 #if MVK_XCODE_14 || (MVK_XCODE_12 && !MVK_TVOS)
-	if ([mtlDev respondsToSelector: @selector(supports32BitFloatFiltering)]) {
-		supports32BitFloatFiltering = mtlDev.supports32BitFloatFiltering;
-	}
-	if ([mtlDev respondsToSelector: @selector(supports32BitMSAA)]) {
-		supports32BitMSAA = mtlDev.supports32BitMSAA;
-	}
+    if ([mtlDev respondsToSelector:@selector(supports32BitFloatFiltering)]) {
+        supports32BitFloatFiltering = mtlDev.supports32BitFloatFiltering;
+    }
+    if ([mtlDev respondsToSelector:@selector(supports32BitMSAA)]) {
+        supports32BitMSAA = mtlDev.supports32BitMSAA;
+    }
 #endif
 }
-
 
 #pragma mark -
 #pragma mark MVKPhysicalDevice
 
-#define supportsMTLGPUFamily(gpuFam)  _gpuCapabilities.supports ##gpuFam
+#define supportsMTLGPUFamily(gpuFam) _gpuCapabilities.supports##gpuFam
 
-VkResult MVKPhysicalDevice::getExtensionProperties(const char* pLayerName, uint32_t* pCount, VkExtensionProperties* pProperties) {
-	return _supportedExtensions.getProperties(pCount, pProperties);
+VkResult
+MVKPhysicalDevice::getExtensionProperties(const char* pLayerName,
+                                          uint32_t* pCount,
+                                          VkExtensionProperties* pProperties) {
+    return _supportedExtensions.getProperties(pCount, pProperties);
 }
 
 void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures* features) {
@@ -172,1440 +184,1931 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures* features) {
 
 void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 
-	// Create a SSOT for these Vulkan 1.1 features, which can be queried via two mechanisms here.
-	VkPhysicalDeviceVulkan11Features supportedFeats11 = {
-		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,
-		.pNext = nullptr,
-		.storageBuffer16BitAccess = true,
-		.uniformAndStorageBuffer16BitAccess = true,
-		.storagePushConstant16 = true,
-		.storageInputOutput16 = true,
-		.multiview = true,
-		.multiviewGeometryShader = false,
-		.multiviewTessellationShader = false,		// FIXME
-		.variablePointersStorageBuffer = true,
-		.variablePointers = true,
-		.protectedMemory = false,
-		.samplerYcbcrConversion = true,
-		.shaderDrawParameters = true,
-	};
+    // Create a SSOT for these Vulkan 1.1 features, which can be queried via two
+    // mechanisms here.
+    VkPhysicalDeviceVulkan11Features supportedFeats11 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,
+        .pNext = nullptr,
+        .storageBuffer16BitAccess = true,
+        .uniformAndStorageBuffer16BitAccess = true,
+        .storagePushConstant16 = true,
+        .storageInputOutput16 = true,
+        .multiview = true,
+        .multiviewGeometryShader = false,
+        .multiviewTessellationShader = false, // FIXME
+        .variablePointersStorageBuffer = true,
+        .variablePointers = true,
+        .protectedMemory = false,
+        .samplerYcbcrConversion = true,
+        .shaderDrawParameters = true,
+    };
 
-	// Create a SSOT for these Vulkan 1.2 features, which can be queried via two mechanisms here.
-	VkPhysicalDeviceVulkan12Features supportedFeats12 = {
-		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
-		.pNext = nullptr,
-		.samplerMirrorClampToEdge = _vulkan12FeaturesNoExt.samplerMirrorClampToEdge,
-		.drawIndirectCount = _vulkan12FeaturesNoExt.drawIndirectCount,
-		.storageBuffer8BitAccess = true,
-		.uniformAndStorageBuffer8BitAccess = true,
-		.storagePushConstant8 = true,
-		.shaderBufferInt64Atomics = false,
-		.shaderSharedInt64Atomics = false,
-		.shaderFloat16 = true,
-		.shaderInt8 = true,
-		.descriptorIndexing = _vulkan12FeaturesNoExt.descriptorIndexing,
-		.shaderInputAttachmentArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
-		.shaderUniformTexelBufferArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
-		.shaderStorageTexelBufferArrayDynamicIndexing = _metalFeatures.arrayOfTextures,
-		.shaderUniformBufferArrayNonUniformIndexing = true,
-		.shaderSampledImageArrayNonUniformIndexing = _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers,
-		.shaderStorageBufferArrayNonUniformIndexing = true,
-		.shaderStorageImageArrayNonUniformIndexing = _metalFeatures.arrayOfTextures,
-		.shaderInputAttachmentArrayNonUniformIndexing = _metalFeatures.arrayOfTextures,
-		.shaderUniformTexelBufferArrayNonUniformIndexing = _metalFeatures.arrayOfTextures,
-		.shaderStorageTexelBufferArrayNonUniformIndexing = _metalFeatures.arrayOfTextures,
-		.descriptorBindingUniformBufferUpdateAfterBind = true,
-		.descriptorBindingSampledImageUpdateAfterBind = true,
-		.descriptorBindingStorageImageUpdateAfterBind = true,
-		.descriptorBindingStorageBufferUpdateAfterBind = true,
-		.descriptorBindingUniformTexelBufferUpdateAfterBind = true,
-		.descriptorBindingStorageTexelBufferUpdateAfterBind = true,
-		.descriptorBindingUpdateUnusedWhilePending = true,
-		.descriptorBindingPartiallyBound = true,
-		.descriptorBindingVariableDescriptorCount = true,
-		.runtimeDescriptorArray = true,
-		.samplerFilterMinmax = _vulkan12FeaturesNoExt.samplerFilterMinmax,
-		.scalarBlockLayout = true,
-		.imagelessFramebuffer = true,
-		.uniformBufferStandardLayout = true,
-		.shaderSubgroupExtendedTypes = _metalFeatures.simdPermute || _metalFeatures.quadPermute,
-		.separateDepthStencilLayouts = true,
-		.hostQueryReset = true,
-		.timelineSemaphore = true,
-		.bufferDeviceAddress = mvkOSVersionIsAtLeast(13.0, 16.0, 1.0),
-		.bufferDeviceAddressCaptureReplay = false,
-		.bufferDeviceAddressMultiDevice = false,
-		.vulkanMemoryModel = false,
-		.vulkanMemoryModelDeviceScope = false,
-		.vulkanMemoryModelAvailabilityVisibilityChains = false,
-		.shaderOutputViewportIndex = _vulkan12FeaturesNoExt.shaderOutputViewportIndex,
-		.shaderOutputLayer = _vulkan12FeaturesNoExt.shaderOutputLayer,
-		.subgroupBroadcastDynamicId = _vulkan12FeaturesNoExt.subgroupBroadcastDynamicId,
-	};
+    // Create a SSOT for these Vulkan 1.2 features, which can be queried via two
+    // mechanisms here.
+    VkPhysicalDeviceVulkan12Features supportedFeats12 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+        .pNext = nullptr,
+        .samplerMirrorClampToEdge =
+            _vulkan12FeaturesNoExt.samplerMirrorClampToEdge,
+        .drawIndirectCount = _vulkan12FeaturesNoExt.drawIndirectCount,
+        .storageBuffer8BitAccess = true,
+        .uniformAndStorageBuffer8BitAccess = true,
+        .storagePushConstant8 = true,
+        .shaderBufferInt64Atomics = false,
+        .shaderSharedInt64Atomics = false,
+        .shaderFloat16 = true,
+        .shaderInt8 = true,
+        .descriptorIndexing = _vulkan12FeaturesNoExt.descriptorIndexing,
+        .shaderInputAttachmentArrayDynamicIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderUniformTexelBufferArrayDynamicIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderStorageTexelBufferArrayDynamicIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderUniformBufferArrayNonUniformIndexing = true,
+        .shaderSampledImageArrayNonUniformIndexing =
+            _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers,
+        .shaderStorageBufferArrayNonUniformIndexing = true,
+        .shaderStorageImageArrayNonUniformIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderInputAttachmentArrayNonUniformIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderUniformTexelBufferArrayNonUniformIndexing =
+            _metalFeatures.arrayOfTextures,
+        .shaderStorageTexelBufferArrayNonUniformIndexing =
+            _metalFeatures.arrayOfTextures,
+        .descriptorBindingUniformBufferUpdateAfterBind = true,
+        .descriptorBindingSampledImageUpdateAfterBind = true,
+        .descriptorBindingStorageImageUpdateAfterBind = true,
+        .descriptorBindingStorageBufferUpdateAfterBind = true,
+        .descriptorBindingUniformTexelBufferUpdateAfterBind = true,
+        .descriptorBindingStorageTexelBufferUpdateAfterBind = true,
+        .descriptorBindingUpdateUnusedWhilePending = true,
+        .descriptorBindingPartiallyBound = true,
+        .descriptorBindingVariableDescriptorCount = true,
+        .runtimeDescriptorArray = true,
+        .samplerFilterMinmax = _vulkan12FeaturesNoExt.samplerFilterMinmax,
+        .scalarBlockLayout = true,
+        .imagelessFramebuffer = true,
+        .uniformBufferStandardLayout = true,
+        .shaderSubgroupExtendedTypes =
+            _metalFeatures.simdPermute || _metalFeatures.quadPermute,
+        .separateDepthStencilLayouts = true,
+        .hostQueryReset = true,
+        .timelineSemaphore = true,
+        .bufferDeviceAddress = mvkOSVersionIsAtLeast(13.0, 16.0, 1.0),
+        .bufferDeviceAddressCaptureReplay = false,
+        .bufferDeviceAddressMultiDevice = false,
+        .vulkanMemoryModel = false,
+        .vulkanMemoryModelDeviceScope = false,
+        .vulkanMemoryModelAvailabilityVisibilityChains = false,
+        .shaderOutputViewportIndex =
+            _vulkan12FeaturesNoExt.shaderOutputViewportIndex,
+        .shaderOutputLayer = _vulkan12FeaturesNoExt.shaderOutputLayer,
+        .subgroupBroadcastDynamicId =
+            _vulkan12FeaturesNoExt.subgroupBroadcastDynamicId,
+    };
 
-	features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-	features->features = _features;
-	for (auto* next = (VkBaseOutStructure*)features->pNext; next; next = next->pNext) {
-		switch ((uint32_t)next->sType) {
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
-				// Copy from supportedFeats11, but keep pNext as is.
-				auto* pFeats11 = (VkPhysicalDeviceVulkan11Features*)next;
-				supportedFeats11.pNext = pFeats11->pNext;
-				*pFeats11 = supportedFeats11;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
-				// Copy from supportedFeats12, but keep pNext as is.
-				auto* pFeats12 = (VkPhysicalDeviceVulkan12Features*)next;
-				supportedFeats12.pNext = pFeats12->pNext;
-				*pFeats12 = supportedFeats12;
-				break;
-			}
+    features->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    features->features = _features;
+    for (auto* next = (VkBaseOutStructure*)features->pNext; next;
+         next = next->pNext) {
+        switch ((uint32_t)next->sType) {
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
+            // Copy from supportedFeats11, but keep pNext as is.
+            auto* pFeats11 = (VkPhysicalDeviceVulkan11Features*)next;
+            supportedFeats11.pNext = pFeats11->pNext;
+            *pFeats11 = supportedFeats11;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
+            // Copy from supportedFeats12, but keep pNext as is.
+            auto* pFeats12 = (VkPhysicalDeviceVulkan12Features*)next;
+            supportedFeats12.pNext = pFeats12->pNext;
+            *pFeats12 = supportedFeats12;
+            break;
+        }
 
-			// For consistency and ease of admin, keep the following list in the same order as in MVKDeviceFeatureStructs.def
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
-				auto* storageFeatures = (VkPhysicalDevice16BitStorageFeatures*)next;
-				storageFeatures->storageBuffer16BitAccess = supportedFeats11.storageBuffer16BitAccess;
-				storageFeatures->uniformAndStorageBuffer16BitAccess = supportedFeats11.uniformAndStorageBuffer16BitAccess;
-				storageFeatures->storagePushConstant16 = supportedFeats11.storagePushConstant16;
-				storageFeatures->storageInputOutput16 = supportedFeats11.storageInputOutput16;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES: {
-				auto* storageFeatures = (VkPhysicalDevice8BitStorageFeatures*)next;
-				storageFeatures->storageBuffer8BitAccess = supportedFeats12.storagePushConstant8;
-				storageFeatures->uniformAndStorageBuffer8BitAccess = supportedFeats12.storagePushConstant8;
-				storageFeatures->storagePushConstant8 = supportedFeats12.storagePushConstant8;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT: {
-				auto* bufferDeviceAddressFeatures = (VkPhysicalDeviceBufferDeviceAddressFeatures*)next;
-				bufferDeviceAddressFeatures->bufferDeviceAddress = supportedFeats12.bufferDeviceAddress;
-				bufferDeviceAddressFeatures->bufferDeviceAddressCaptureReplay = supportedFeats12.bufferDeviceAddressCaptureReplay;
-				bufferDeviceAddressFeatures->bufferDeviceAddressMultiDevice = supportedFeats12.bufferDeviceAddressMultiDevice;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES: {
-				auto* pDescIdxFeatures = (VkPhysicalDeviceDescriptorIndexingFeatures*)next;
-				pDescIdxFeatures->shaderInputAttachmentArrayDynamicIndexing = supportedFeats12.shaderInputAttachmentArrayDynamicIndexing;
-				pDescIdxFeatures->shaderUniformTexelBufferArrayDynamicIndexing = supportedFeats12.shaderUniformTexelBufferArrayDynamicIndexing;
-				pDescIdxFeatures->shaderStorageTexelBufferArrayDynamicIndexing = supportedFeats12.shaderStorageTexelBufferArrayDynamicIndexing;
-				pDescIdxFeatures->shaderUniformBufferArrayNonUniformIndexing = supportedFeats12.shaderUniformBufferArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderSampledImageArrayNonUniformIndexing = supportedFeats12.shaderSampledImageArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderStorageBufferArrayNonUniformIndexing = supportedFeats12.shaderStorageBufferArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderStorageImageArrayNonUniformIndexing = supportedFeats12.shaderStorageImageArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderInputAttachmentArrayNonUniformIndexing = supportedFeats12.shaderInputAttachmentArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderUniformTexelBufferArrayNonUniformIndexing = supportedFeats12.shaderUniformTexelBufferArrayNonUniformIndexing;
-				pDescIdxFeatures->shaderStorageTexelBufferArrayNonUniformIndexing = supportedFeats12.shaderStorageTexelBufferArrayNonUniformIndexing;
-				pDescIdxFeatures->descriptorBindingUniformBufferUpdateAfterBind = supportedFeats12.descriptorBindingUniformBufferUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingSampledImageUpdateAfterBind = supportedFeats12.descriptorBindingSampledImageUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingStorageImageUpdateAfterBind = supportedFeats12.descriptorBindingStorageImageUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingStorageBufferUpdateAfterBind = supportedFeats12.descriptorBindingStorageBufferUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingUniformTexelBufferUpdateAfterBind = supportedFeats12.descriptorBindingUniformTexelBufferUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingStorageTexelBufferUpdateAfterBind = supportedFeats12.descriptorBindingStorageTexelBufferUpdateAfterBind;
-				pDescIdxFeatures->descriptorBindingUpdateUnusedWhilePending = supportedFeats12.descriptorBindingUpdateUnusedWhilePending;
-				pDescIdxFeatures->descriptorBindingPartiallyBound = supportedFeats12.descriptorBindingPartiallyBound;
-				pDescIdxFeatures->descriptorBindingVariableDescriptorCount = supportedFeats12.descriptorBindingVariableDescriptorCount;
-				pDescIdxFeatures->runtimeDescriptorArray = supportedFeats12.runtimeDescriptorArray;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES: {
-				auto* dynamicRenderingFeatures = (VkPhysicalDeviceDynamicRenderingFeatures*)next;
-				dynamicRenderingFeatures->dynamicRendering = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES: {
-				auto* hostQueryResetFeatures = (VkPhysicalDeviceHostQueryResetFeatures*)next;
-				hostQueryResetFeatures->hostQueryReset = supportedFeats12.hostQueryReset;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES: {
-				auto* imagelessFramebufferFeatures = (VkPhysicalDeviceImagelessFramebufferFeatures*)next;
-				imagelessFramebufferFeatures->imagelessFramebuffer = supportedFeats12.imagelessFramebuffer;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES: {
-				auto *imageRobustnessFeatures = (VkPhysicalDeviceImageRobustnessFeatures*)next;
-				imageRobustnessFeatures->robustImageAccess = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES: {
-				auto* inlineUniformBlockFeatures = (VkPhysicalDeviceInlineUniformBlockFeatures*)next;
-				inlineUniformBlockFeatures->inlineUniformBlock = true;
-				inlineUniformBlockFeatures->descriptorBindingInlineUniformBlockUpdateAfterBind = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES: {
-				auto* multiviewFeatures = (VkPhysicalDeviceMultiviewFeatures*)next;
-				multiviewFeatures->multiview = supportedFeats11.multiview;
-				multiviewFeatures->multiviewGeometryShader = supportedFeats11.multiviewGeometryShader;
-				multiviewFeatures->multiviewTessellationShader = supportedFeats11.multiviewTessellationShader;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES: {
-				auto* privateDataFeatures = (VkPhysicalDevicePrivateDataFeatures*)next;
-				privateDataFeatures->privateData = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES: {
-				auto* protectedMemFeatures = (VkPhysicalDeviceProtectedMemoryFeatures*)next;
-				protectedMemFeatures->protectedMemory = supportedFeats11.protectedMemory;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES: {
-				auto* samplerYcbcrConvFeatures = (VkPhysicalDeviceSamplerYcbcrConversionFeatures*)next;
-				samplerYcbcrConvFeatures->samplerYcbcrConversion = supportedFeats11.samplerYcbcrConversion;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES: {
-				auto* scalarLayoutFeatures = (VkPhysicalDeviceScalarBlockLayoutFeatures*)next;
-				scalarLayoutFeatures->scalarBlockLayout = supportedFeats12.scalarBlockLayout;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES: {
-				auto* separateDepthStencilLayoutsFeatures = (VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*)next;
-				separateDepthStencilLayoutsFeatures->separateDepthStencilLayouts = supportedFeats12.separateDepthStencilLayouts;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES: {
-				auto* shaderDrawParamsFeatures = (VkPhysicalDeviceShaderDrawParametersFeatures*)next;
-				shaderDrawParamsFeatures->shaderDrawParameters = supportedFeats11.shaderDrawParameters;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES: {
-				auto* i64Features = (VkPhysicalDeviceShaderAtomicInt64Features*)next;
-				i64Features->shaderBufferInt64Atomics = supportedFeats12.shaderBufferInt64Atomics;
-				i64Features->shaderSharedInt64Atomics = supportedFeats12.shaderSharedInt64Atomics;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES: {
-				auto* f16Features = (VkPhysicalDeviceShaderFloat16Int8Features*)next;
-				f16Features->shaderFloat16 = supportedFeats12.shaderFloat16;
-				f16Features->shaderInt8 = supportedFeats12.shaderInt8;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES: {
-				auto* shaderSGTypesFeatures = (VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*)next;
-				shaderSGTypesFeatures->shaderSubgroupExtendedTypes = supportedFeats12.shaderSubgroupExtendedTypes;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES: {
-				auto* subgroupSizeFeatures = (VkPhysicalDeviceSubgroupSizeControlFeatures*)next;
-				subgroupSizeFeatures->subgroupSizeControl = _metalFeatures.simdPermute || _metalFeatures.quadPermute;
-				subgroupSizeFeatures->computeFullSubgroups = _metalFeatures.simdPermute || _metalFeatures.quadPermute;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES: {
-				auto* synch2Features = (VkPhysicalDeviceSynchronization2Features*)next;
-				synch2Features->synchronization2 = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES: {
-				auto* astcHDRFeatures = (VkPhysicalDeviceTextureCompressionASTCHDRFeatures*)next;
-				astcHDRFeatures->textureCompressionASTC_HDR = _metalFeatures.astcHDRTextures;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES: {
-				auto* timelineSem4Features = (VkPhysicalDeviceTimelineSemaphoreFeatures*)next;
-				timelineSem4Features->timelineSemaphore = supportedFeats12.timelineSemaphore;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES: {
-				auto* uboLayoutFeatures = (VkPhysicalDeviceUniformBufferStandardLayoutFeatures*)next;
-				uboLayoutFeatures->uniformBufferStandardLayout = supportedFeats12.uniformBufferStandardLayout;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES: {
-				auto* varPtrFeatures = (VkPhysicalDeviceVariablePointerFeatures*)next;
-				varPtrFeatures->variablePointersStorageBuffer = supportedFeats11.variablePointersStorageBuffer;
-				varPtrFeatures->variablePointers = supportedFeats11.variablePointers;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES: {
-				auto* vmmFeatures = (VkPhysicalDeviceVulkanMemoryModelFeatures*)next;
-				vmmFeatures->vulkanMemoryModel = supportedFeats12.vulkanMemoryModel;
-				vmmFeatures->vulkanMemoryModelDeviceScope = supportedFeats12.vulkanMemoryModelDeviceScope;
-				vmmFeatures->vulkanMemoryModelAvailabilityVisibilityChains = supportedFeats12.vulkanMemoryModelAvailabilityVisibilityChains;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR: {
-				auto* barycentricFeatures = (VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*)next;
-				barycentricFeatures->fragmentShaderBarycentric = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
-				auto* portabilityFeatures = (VkPhysicalDevicePortabilitySubsetFeaturesKHR*)next;
-				portabilityFeatures->constantAlphaColorBlendFactors = true;
-				portabilityFeatures->events = true;
-				portabilityFeatures->imageViewFormatReinterpretation = true;
-				portabilityFeatures->imageViewFormatSwizzle = (_metalFeatures.nativeTextureSwizzle ||
-															   getMVKConfig().fullImageViewSwizzle);
-				portabilityFeatures->imageView2DOn3DImage = false;
-				portabilityFeatures->multisampleArrayImage = _metalFeatures.multisampleArrayTextures;
-				portabilityFeatures->mutableComparisonSamplers = _metalFeatures.depthSampleCompare;
-				portabilityFeatures->pointPolygons = false;
-				portabilityFeatures->samplerMipLodBias = getMVKConfig().useMetalPrivateAPI;
-				portabilityFeatures->separateStencilMaskRef = true;
-				portabilityFeatures->shaderSampleRateInterpolationFunctions = _metalFeatures.pullModelInterpolation;
-				portabilityFeatures->tessellationIsolines = false;
-				portabilityFeatures->tessellationPointMode = false;
-				portabilityFeatures->triangleFans = true;
-				portabilityFeatures->vertexAttributeAccessBeyondStride = true;	// Costs additional buffers. Should make configuration switch.
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: {
-				auto* shaderIntDotFeatures = (VkPhysicalDeviceShaderIntegerDotProductFeatures*)next;
-				shaderIntDotFeatures->shaderIntegerDotProduct = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
-				auto* formatFeatures = (VkPhysicalDevice4444FormatsFeaturesEXT*)next;
-				bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering &&
-									  (_metalFeatures.nativeTextureSwizzle ||
-									   getMVKConfig().fullImageViewSwizzle);
-				formatFeatures->formatA4R4G4B4 = canSupport4444;
-				formatFeatures->formatA4B4G4R4 = canSupport4444;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
-				auto* extDynState = (VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*)next;
-				extDynState->extendedDynamicState = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: {
-				auto* extDynState2 = (VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*)next;
-				extDynState2->extendedDynamicState2 = true;
-				extDynState2->extendedDynamicState2LogicOp = false;
-				extDynState2->extendedDynamicState2PatchControlPoints = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT: {
-				auto* extDynState3 = (VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*)next;
-				extDynState3->extendedDynamicState3TessellationDomainOrigin = false;
-				extDynState3->extendedDynamicState3DepthClampEnable = true;
-				extDynState3->extendedDynamicState3PolygonMode = true;
-				extDynState3->extendedDynamicState3RasterizationSamples = false;
-				extDynState3->extendedDynamicState3SampleMask = false;
-				extDynState3->extendedDynamicState3AlphaToCoverageEnable = false;
-				extDynState3->extendedDynamicState3AlphaToOneEnable = false;
-				extDynState3->extendedDynamicState3LogicOpEnable = false;
-				extDynState3->extendedDynamicState3ColorBlendEnable = false;
-				extDynState3->extendedDynamicState3ColorBlendEquation = false;
-				extDynState3->extendedDynamicState3ColorWriteMask = false;
-				extDynState3->extendedDynamicState3RasterizationStream = false;
-				extDynState3->extendedDynamicState3ConservativeRasterizationMode = false;
-				extDynState3->extendedDynamicState3ExtraPrimitiveOverestimationSize = false;
-				extDynState3->extendedDynamicState3DepthClipEnable = true;
-				extDynState3->extendedDynamicState3SampleLocationsEnable = true;
-				extDynState3->extendedDynamicState3ColorBlendAdvanced = false;
-				extDynState3->extendedDynamicState3ProvokingVertexMode = false;
-				extDynState3->extendedDynamicState3LineRasterizationMode = false;
-				extDynState3->extendedDynamicState3LineStippleEnable = false;
-				extDynState3->extendedDynamicState3DepthClipNegativeOneToOne = false;
-				extDynState3->extendedDynamicState3ViewportWScalingEnable = false;
-				extDynState3->extendedDynamicState3ViewportSwizzle = false;
-				extDynState3->extendedDynamicState3CoverageToColorEnable = false;
-				extDynState3->extendedDynamicState3CoverageToColorLocation = false;
-				extDynState3->extendedDynamicState3CoverageModulationMode = false;
-				extDynState3->extendedDynamicState3CoverageModulationTableEnable = false;
-				extDynState3->extendedDynamicState3CoverageModulationTable = false;
-				extDynState3->extendedDynamicState3CoverageReductionMode = false;
-				extDynState3->extendedDynamicState3RepresentativeFragmentTestEnable = false;
-				extDynState3->extendedDynamicState3ShadingRateImageEnable = false;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: {
-				auto* interlockFeatures = (VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*)next;
-				interlockFeatures->fragmentShaderSampleInterlock = _metalFeatures.rasterOrderGroups;
-				interlockFeatures->fragmentShaderPixelInterlock = _metalFeatures.rasterOrderGroups;
-				interlockFeatures->fragmentShaderShadingRateInterlock = false;    // Requires variable rate shading; not supported yet in Metal
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT: {
-				auto* hostImageCopyFeatures = (VkPhysicalDeviceHostImageCopyFeaturesEXT*)next;
-				hostImageCopyFeatures->hostImageCopy = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT: {
-				auto* pipelineCreationCacheControlFeatures = (VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT*)next;
-				pipelineCreationCacheControlFeatures->pipelineCreationCacheControl = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT: {
-				auto* robustness2Features = (VkPhysicalDeviceRobustness2FeaturesEXT*)next;
-				robustness2Features->robustBufferAccess2 = false;
-				robustness2Features->robustImageAccess2 = true;
-				robustness2Features->nullDescriptor = false;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT: {
-				auto* atomicFloatFeatures = (VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*)next;
-				bool atomicFloatEnabled = _metalFeatures.mslVersion >= 030000;
-				atomicFloatFeatures->shaderBufferFloat32Atomics = atomicFloatEnabled;
-				atomicFloatFeatures->shaderBufferFloat32AtomicAdd = atomicFloatEnabled;
-				atomicFloatFeatures->shaderBufferFloat64Atomics = false;
-				atomicFloatFeatures->shaderBufferFloat64AtomicAdd = false;
-				atomicFloatFeatures->shaderSharedFloat32Atomics = atomicFloatEnabled;
-				atomicFloatFeatures->shaderSharedFloat32AtomicAdd = atomicFloatEnabled;
-				atomicFloatFeatures->shaderSharedFloat64Atomics = false;
-				atomicFloatFeatures->shaderSharedFloat64AtomicAdd = false;
-				atomicFloatFeatures->shaderImageFloat32Atomics = false;
-				atomicFloatFeatures->shaderImageFloat32AtomicAdd = false;
-				atomicFloatFeatures->sparseImageFloat32Atomics = false;
-				atomicFloatFeatures->sparseImageFloat32AtomicAdd = false;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT: {
-				auto* demoteFeatures = (VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT*)next;
-				demoteFeatures->shaderDemoteToHelperInvocation = mvkOSVersionIsAtLeast(11.0, 14.0, 1.0);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT: {
-				auto* swapchainMaintenance1Features = (VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*)next;
-				swapchainMaintenance1Features->swapchainMaintenance1 = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT: {
-				auto* texelBuffAlignFeatures = (VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*)next;
-				texelBuffAlignFeatures->texelBufferAlignment = _metalFeatures.texelBuffers && [_mtlDevice respondsToSelector: @selector(minimumLinearTextureAlignmentForPixelFormat:)];
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT: {
-				auto* divisorFeatures = (VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*)next;
-				divisorFeatures->vertexAttributeInstanceRateDivisor = true;
-				divisorFeatures->vertexAttributeInstanceRateZeroDivisor = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {
-				auto* shaderIntFuncsFeatures = (VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*)next;
-				shaderIntFuncsFeatures->shaderIntegerFunctions2 = true;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+        // For consistency and ease of admin, keep the following list in the
+        // same order as in MVKDeviceFeatureStructs.def
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
+            auto* storageFeatures = (VkPhysicalDevice16BitStorageFeatures*)next;
+            storageFeatures->storageBuffer16BitAccess =
+                supportedFeats11.storageBuffer16BitAccess;
+            storageFeatures->uniformAndStorageBuffer16BitAccess =
+                supportedFeats11.uniformAndStorageBuffer16BitAccess;
+            storageFeatures->storagePushConstant16 =
+                supportedFeats11.storagePushConstant16;
+            storageFeatures->storageInputOutput16 =
+                supportedFeats11.storageInputOutput16;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES: {
+            auto* storageFeatures = (VkPhysicalDevice8BitStorageFeatures*)next;
+            storageFeatures->storageBuffer8BitAccess =
+                supportedFeats12.storagePushConstant8;
+            storageFeatures->uniformAndStorageBuffer8BitAccess =
+                supportedFeats12.storagePushConstant8;
+            storageFeatures->storagePushConstant8 =
+                supportedFeats12.storagePushConstant8;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT: {
+            auto* bufferDeviceAddressFeatures =
+                (VkPhysicalDeviceBufferDeviceAddressFeatures*)next;
+            bufferDeviceAddressFeatures->bufferDeviceAddress =
+                supportedFeats12.bufferDeviceAddress;
+            bufferDeviceAddressFeatures->bufferDeviceAddressCaptureReplay =
+                supportedFeats12.bufferDeviceAddressCaptureReplay;
+            bufferDeviceAddressFeatures->bufferDeviceAddressMultiDevice =
+                supportedFeats12.bufferDeviceAddressMultiDevice;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES: {
+            auto* pDescIdxFeatures =
+                (VkPhysicalDeviceDescriptorIndexingFeatures*)next;
+            pDescIdxFeatures->shaderInputAttachmentArrayDynamicIndexing =
+                supportedFeats12.shaderInputAttachmentArrayDynamicIndexing;
+            pDescIdxFeatures->shaderUniformTexelBufferArrayDynamicIndexing =
+                supportedFeats12.shaderUniformTexelBufferArrayDynamicIndexing;
+            pDescIdxFeatures->shaderStorageTexelBufferArrayDynamicIndexing =
+                supportedFeats12.shaderStorageTexelBufferArrayDynamicIndexing;
+            pDescIdxFeatures->shaderUniformBufferArrayNonUniformIndexing =
+                supportedFeats12.shaderUniformBufferArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderSampledImageArrayNonUniformIndexing =
+                supportedFeats12.shaderSampledImageArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderStorageBufferArrayNonUniformIndexing =
+                supportedFeats12.shaderStorageBufferArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderStorageImageArrayNonUniformIndexing =
+                supportedFeats12.shaderStorageImageArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderInputAttachmentArrayNonUniformIndexing =
+                supportedFeats12.shaderInputAttachmentArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderUniformTexelBufferArrayNonUniformIndexing =
+                supportedFeats12
+                    .shaderUniformTexelBufferArrayNonUniformIndexing;
+            pDescIdxFeatures->shaderStorageTexelBufferArrayNonUniformIndexing =
+                supportedFeats12
+                    .shaderStorageTexelBufferArrayNonUniformIndexing;
+            pDescIdxFeatures->descriptorBindingUniformBufferUpdateAfterBind =
+                supportedFeats12.descriptorBindingUniformBufferUpdateAfterBind;
+            pDescIdxFeatures->descriptorBindingSampledImageUpdateAfterBind =
+                supportedFeats12.descriptorBindingSampledImageUpdateAfterBind;
+            pDescIdxFeatures->descriptorBindingStorageImageUpdateAfterBind =
+                supportedFeats12.descriptorBindingStorageImageUpdateAfterBind;
+            pDescIdxFeatures->descriptorBindingStorageBufferUpdateAfterBind =
+                supportedFeats12.descriptorBindingStorageBufferUpdateAfterBind;
+            pDescIdxFeatures
+                ->descriptorBindingUniformTexelBufferUpdateAfterBind =
+                supportedFeats12
+                    .descriptorBindingUniformTexelBufferUpdateAfterBind;
+            pDescIdxFeatures
+                ->descriptorBindingStorageTexelBufferUpdateAfterBind =
+                supportedFeats12
+                    .descriptorBindingStorageTexelBufferUpdateAfterBind;
+            pDescIdxFeatures->descriptorBindingUpdateUnusedWhilePending =
+                supportedFeats12.descriptorBindingUpdateUnusedWhilePending;
+            pDescIdxFeatures->descriptorBindingPartiallyBound =
+                supportedFeats12.descriptorBindingPartiallyBound;
+            pDescIdxFeatures->descriptorBindingVariableDescriptorCount =
+                supportedFeats12.descriptorBindingVariableDescriptorCount;
+            pDescIdxFeatures->runtimeDescriptorArray =
+                supportedFeats12.runtimeDescriptorArray;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES: {
+            auto* dynamicRenderingFeatures =
+                (VkPhysicalDeviceDynamicRenderingFeatures*)next;
+            dynamicRenderingFeatures->dynamicRendering = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES: {
+            auto* hostQueryResetFeatures =
+                (VkPhysicalDeviceHostQueryResetFeatures*)next;
+            hostQueryResetFeatures->hostQueryReset =
+                supportedFeats12.hostQueryReset;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES: {
+            auto* imagelessFramebufferFeatures =
+                (VkPhysicalDeviceImagelessFramebufferFeatures*)next;
+            imagelessFramebufferFeatures->imagelessFramebuffer =
+                supportedFeats12.imagelessFramebuffer;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES: {
+            auto* imageRobustnessFeatures =
+                (VkPhysicalDeviceImageRobustnessFeatures*)next;
+            imageRobustnessFeatures->robustImageAccess = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES: {
+            auto* inlineUniformBlockFeatures =
+                (VkPhysicalDeviceInlineUniformBlockFeatures*)next;
+            inlineUniformBlockFeatures->inlineUniformBlock = true;
+            inlineUniformBlockFeatures
+                ->descriptorBindingInlineUniformBlockUpdateAfterBind = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES: {
+            auto* multiviewFeatures = (VkPhysicalDeviceMultiviewFeatures*)next;
+            multiviewFeatures->multiview = supportedFeats11.multiview;
+            multiviewFeatures->multiviewGeometryShader =
+                supportedFeats11.multiviewGeometryShader;
+            multiviewFeatures->multiviewTessellationShader =
+                supportedFeats11.multiviewTessellationShader;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES: {
+            auto* privateDataFeatures =
+                (VkPhysicalDevicePrivateDataFeatures*)next;
+            privateDataFeatures->privateData = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES: {
+            auto* protectedMemFeatures =
+                (VkPhysicalDeviceProtectedMemoryFeatures*)next;
+            protectedMemFeatures->protectedMemory =
+                supportedFeats11.protectedMemory;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES: {
+            auto* samplerYcbcrConvFeatures =
+                (VkPhysicalDeviceSamplerYcbcrConversionFeatures*)next;
+            samplerYcbcrConvFeatures->samplerYcbcrConversion =
+                supportedFeats11.samplerYcbcrConversion;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES: {
+            auto* scalarLayoutFeatures =
+                (VkPhysicalDeviceScalarBlockLayoutFeatures*)next;
+            scalarLayoutFeatures->scalarBlockLayout =
+                supportedFeats12.scalarBlockLayout;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES: {
+            auto* separateDepthStencilLayoutsFeatures =
+                (VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*)next;
+            separateDepthStencilLayoutsFeatures->separateDepthStencilLayouts =
+                supportedFeats12.separateDepthStencilLayouts;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES: {
+            auto* shaderDrawParamsFeatures =
+                (VkPhysicalDeviceShaderDrawParametersFeatures*)next;
+            shaderDrawParamsFeatures->shaderDrawParameters =
+                supportedFeats11.shaderDrawParameters;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES: {
+            auto* i64Features =
+                (VkPhysicalDeviceShaderAtomicInt64Features*)next;
+            i64Features->shaderBufferInt64Atomics =
+                supportedFeats12.shaderBufferInt64Atomics;
+            i64Features->shaderSharedInt64Atomics =
+                supportedFeats12.shaderSharedInt64Atomics;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES: {
+            auto* f16Features =
+                (VkPhysicalDeviceShaderFloat16Int8Features*)next;
+            f16Features->shaderFloat16 = supportedFeats12.shaderFloat16;
+            f16Features->shaderInt8 = supportedFeats12.shaderInt8;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES: {
+            auto* shaderSGTypesFeatures =
+                (VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*)next;
+            shaderSGTypesFeatures->shaderSubgroupExtendedTypes =
+                supportedFeats12.shaderSubgroupExtendedTypes;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES: {
+            auto* subgroupSizeFeatures =
+                (VkPhysicalDeviceSubgroupSizeControlFeatures*)next;
+            subgroupSizeFeatures->subgroupSizeControl =
+                _metalFeatures.simdPermute || _metalFeatures.quadPermute;
+            subgroupSizeFeatures->computeFullSubgroups =
+                _metalFeatures.simdPermute || _metalFeatures.quadPermute;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES: {
+            auto* synch2Features =
+                (VkPhysicalDeviceSynchronization2Features*)next;
+            synch2Features->synchronization2 = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES: {
+            auto* astcHDRFeatures =
+                (VkPhysicalDeviceTextureCompressionASTCHDRFeatures*)next;
+            astcHDRFeatures->textureCompressionASTC_HDR =
+                _metalFeatures.astcHDRTextures;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES: {
+            auto* timelineSem4Features =
+                (VkPhysicalDeviceTimelineSemaphoreFeatures*)next;
+            timelineSem4Features->timelineSemaphore =
+                supportedFeats12.timelineSemaphore;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES: {
+            auto* uboLayoutFeatures =
+                (VkPhysicalDeviceUniformBufferStandardLayoutFeatures*)next;
+            uboLayoutFeatures->uniformBufferStandardLayout =
+                supportedFeats12.uniformBufferStandardLayout;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES: {
+            auto* varPtrFeatures =
+                (VkPhysicalDeviceVariablePointerFeatures*)next;
+            varPtrFeatures->variablePointersStorageBuffer =
+                supportedFeats11.variablePointersStorageBuffer;
+            varPtrFeatures->variablePointers =
+                supportedFeats11.variablePointers;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES: {
+            auto* vmmFeatures =
+                (VkPhysicalDeviceVulkanMemoryModelFeatures*)next;
+            vmmFeatures->vulkanMemoryModel = supportedFeats12.vulkanMemoryModel;
+            vmmFeatures->vulkanMemoryModelDeviceScope =
+                supportedFeats12.vulkanMemoryModelDeviceScope;
+            vmmFeatures->vulkanMemoryModelAvailabilityVisibilityChains =
+                supportedFeats12.vulkanMemoryModelAvailabilityVisibilityChains;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR: {
+            auto* barycentricFeatures =
+                (VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*)next;
+            barycentricFeatures->fragmentShaderBarycentric = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
+            auto* portabilityFeatures =
+                (VkPhysicalDevicePortabilitySubsetFeaturesKHR*)next;
+            portabilityFeatures->constantAlphaColorBlendFactors = true;
+            portabilityFeatures->events = true;
+            portabilityFeatures->imageViewFormatReinterpretation = true;
+            portabilityFeatures->imageViewFormatSwizzle =
+                (_metalFeatures.nativeTextureSwizzle ||
+                 getMVKConfig().fullImageViewSwizzle);
+            portabilityFeatures->imageView2DOn3DImage = false;
+            portabilityFeatures->multisampleArrayImage =
+                _metalFeatures.multisampleArrayTextures;
+            portabilityFeatures->mutableComparisonSamplers =
+                _metalFeatures.depthSampleCompare;
+            portabilityFeatures->pointPolygons = false;
+            portabilityFeatures->samplerMipLodBias =
+                getMVKConfig().useMetalPrivateAPI;
+            portabilityFeatures->separateStencilMaskRef = true;
+            portabilityFeatures->shaderSampleRateInterpolationFunctions =
+                _metalFeatures.pullModelInterpolation;
+            portabilityFeatures->tessellationIsolines = false;
+            portabilityFeatures->tessellationPointMode = false;
+            portabilityFeatures->triangleFans = true;
+            portabilityFeatures->vertexAttributeAccessBeyondStride =
+                true; // Costs additional buffers. Should make configuration
+                      // switch.
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: {
+            auto* shaderIntDotFeatures =
+                (VkPhysicalDeviceShaderIntegerDotProductFeatures*)next;
+            shaderIntDotFeatures->shaderIntegerDotProduct = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
+            auto* formatFeatures =
+                (VkPhysicalDevice4444FormatsFeaturesEXT*)next;
+            bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering &&
+                                  (_metalFeatures.nativeTextureSwizzle ||
+                                   getMVKConfig().fullImageViewSwizzle);
+            formatFeatures->formatA4R4G4B4 = canSupport4444;
+            formatFeatures->formatA4B4G4R4 = canSupport4444;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
+            auto* extDynState =
+                (VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*)next;
+            extDynState->extendedDynamicState = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: {
+            auto* extDynState2 =
+                (VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*)next;
+            extDynState2->extendedDynamicState2 = true;
+            extDynState2->extendedDynamicState2LogicOp = false;
+            extDynState2->extendedDynamicState2PatchControlPoints = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT: {
+            auto* extDynState3 =
+                (VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*)next;
+            extDynState3->extendedDynamicState3TessellationDomainOrigin = false;
+            extDynState3->extendedDynamicState3DepthClampEnable = true;
+            extDynState3->extendedDynamicState3PolygonMode = true;
+            extDynState3->extendedDynamicState3RasterizationSamples = false;
+            extDynState3->extendedDynamicState3SampleMask = false;
+            extDynState3->extendedDynamicState3AlphaToCoverageEnable = false;
+            extDynState3->extendedDynamicState3AlphaToOneEnable = false;
+            extDynState3->extendedDynamicState3LogicOpEnable = false;
+            extDynState3->extendedDynamicState3ColorBlendEnable = false;
+            extDynState3->extendedDynamicState3ColorBlendEquation = false;
+            extDynState3->extendedDynamicState3ColorWriteMask = false;
+            extDynState3->extendedDynamicState3RasterizationStream = false;
+            extDynState3->extendedDynamicState3ConservativeRasterizationMode =
+                false;
+            extDynState3
+                ->extendedDynamicState3ExtraPrimitiveOverestimationSize = false;
+            extDynState3->extendedDynamicState3DepthClipEnable = true;
+            extDynState3->extendedDynamicState3SampleLocationsEnable = true;
+            extDynState3->extendedDynamicState3ColorBlendAdvanced = false;
+            extDynState3->extendedDynamicState3ProvokingVertexMode = false;
+            extDynState3->extendedDynamicState3LineRasterizationMode = false;
+            extDynState3->extendedDynamicState3LineStippleEnable = false;
+            extDynState3->extendedDynamicState3DepthClipNegativeOneToOne =
+                false;
+            extDynState3->extendedDynamicState3ViewportWScalingEnable = false;
+            extDynState3->extendedDynamicState3ViewportSwizzle = false;
+            extDynState3->extendedDynamicState3CoverageToColorEnable = false;
+            extDynState3->extendedDynamicState3CoverageToColorLocation = false;
+            extDynState3->extendedDynamicState3CoverageModulationMode = false;
+            extDynState3->extendedDynamicState3CoverageModulationTableEnable =
+                false;
+            extDynState3->extendedDynamicState3CoverageModulationTable = false;
+            extDynState3->extendedDynamicState3CoverageReductionMode = false;
+            extDynState3
+                ->extendedDynamicState3RepresentativeFragmentTestEnable = false;
+            extDynState3->extendedDynamicState3ShadingRateImageEnable = false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: {
+            auto* interlockFeatures =
+                (VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*)next;
+            interlockFeatures->fragmentShaderSampleInterlock =
+                _metalFeatures.rasterOrderGroups;
+            interlockFeatures->fragmentShaderPixelInterlock =
+                _metalFeatures.rasterOrderGroups;
+            interlockFeatures->fragmentShaderShadingRateInterlock =
+                false; // Requires variable rate shading; not supported yet in
+                       // Metal
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT: {
+            auto* hostImageCopyFeatures =
+                (VkPhysicalDeviceHostImageCopyFeaturesEXT*)next;
+            hostImageCopyFeatures->hostImageCopy = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT: {
+            auto* pipelineCreationCacheControlFeatures =
+                (VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT*)next;
+            pipelineCreationCacheControlFeatures->pipelineCreationCacheControl =
+                true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT: {
+            auto* robustness2Features =
+                (VkPhysicalDeviceRobustness2FeaturesEXT*)next;
+            robustness2Features->robustBufferAccess2 = false;
+            robustness2Features->robustImageAccess2 = true;
+            robustness2Features->nullDescriptor = false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT: {
+            auto* atomicFloatFeatures =
+                (VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*)next;
+            bool atomicFloatEnabled = _metalFeatures.mslVersion >= 030000;
+            atomicFloatFeatures->shaderBufferFloat32Atomics =
+                atomicFloatEnabled;
+            atomicFloatFeatures->shaderBufferFloat32AtomicAdd =
+                atomicFloatEnabled;
+            atomicFloatFeatures->shaderBufferFloat64Atomics = false;
+            atomicFloatFeatures->shaderBufferFloat64AtomicAdd = false;
+            atomicFloatFeatures->shaderSharedFloat32Atomics =
+                atomicFloatEnabled;
+            atomicFloatFeatures->shaderSharedFloat32AtomicAdd =
+                atomicFloatEnabled;
+            atomicFloatFeatures->shaderSharedFloat64Atomics = false;
+            atomicFloatFeatures->shaderSharedFloat64AtomicAdd = false;
+            atomicFloatFeatures->shaderImageFloat32Atomics = false;
+            atomicFloatFeatures->shaderImageFloat32AtomicAdd = false;
+            atomicFloatFeatures->sparseImageFloat32Atomics = false;
+            atomicFloatFeatures->sparseImageFloat32AtomicAdd = false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT: {
+            auto* demoteFeatures =
+                (VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT*)
+                    next;
+            demoteFeatures->shaderDemoteToHelperInvocation =
+                mvkOSVersionIsAtLeast(11.0, 14.0, 1.0);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT: {
+            auto* swapchainMaintenance1Features =
+                (VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT*)next;
+            swapchainMaintenance1Features->swapchainMaintenance1 = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT: {
+            auto* texelBuffAlignFeatures =
+                (VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*)next;
+            texelBuffAlignFeatures->texelBufferAlignment =
+                _metalFeatures.texelBuffers &&
+                [_mtlDevice respondsToSelector:@selector
+                            (minimumLinearTextureAlignmentForPixelFormat:)];
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT: {
+            auto* divisorFeatures =
+                (VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*)next;
+            divisorFeatures->vertexAttributeInstanceRateDivisor = true;
+            divisorFeatures->vertexAttributeInstanceRateZeroDivisor = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {
+            auto* shaderIntFuncsFeatures =
+                (VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*)next;
+            shaderIntFuncsFeatures->shaderIntegerFunctions2 = true;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
 void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties* properties) {
-	updateTimestampPeriod();
-	*properties = _properties;
+    updateTimestampPeriod();
+    *properties = _properties;
 }
 
 void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 
-	properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-	getProperties(&properties->properties);
+    properties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    getProperties(&properties->properties);
 
-	if ( !properties->pNext ) { return; }
+    if (!properties->pNext) {
+        return;
+    }
 
-	uint32_t uintMax = std::numeric_limits<uint32_t>::max();
-	uint32_t maxSamplerCnt = getMaxSamplerCount();
-	bool isTier2 = _isUsingMetalArgumentBuffers && (_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2);
+    uint32_t uintMax = std::numeric_limits<uint32_t>::max();
+    uint32_t maxSamplerCnt = getMaxSamplerCount();
+    bool isTier2 =
+        _isUsingMetalArgumentBuffers &&
+        (_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2);
 
-	// Create a SSOT for these Vulkan 1.1 properties, which can be queried via two mechanisms here.
-	VkPhysicalDeviceVulkan11Properties supportedProps11;
-	supportedProps11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES;
-	supportedProps11.pNext = nullptr;
-	populateDeviceIDProperties(&supportedProps11);
-	populateSubgroupProperties(&supportedProps11);
-	supportedProps11.pointClippingBehavior = VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES;
-	supportedProps11.maxMultiviewViewCount = 32;
-	supportedProps11.maxMultiviewInstanceIndex = canUseInstancingForMultiview() ? uintMax / 32 : uintMax;
-	supportedProps11.protectedNoFault = false;
-	supportedProps11.maxPerSetDescriptors = getMaxPerSetDescriptorCount();
-	supportedProps11.maxMemoryAllocationSize = _metalFeatures.maxMTLBufferSize;
+    // Create a SSOT for these Vulkan 1.1 properties, which can be queried via
+    // two mechanisms here.
+    VkPhysicalDeviceVulkan11Properties supportedProps11;
+    supportedProps11.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES;
+    supportedProps11.pNext = nullptr;
+    populateDeviceIDProperties(&supportedProps11);
+    populateSubgroupProperties(&supportedProps11);
+    supportedProps11.pointClippingBehavior =
+        VK_POINT_CLIPPING_BEHAVIOR_ALL_CLIP_PLANES;
+    supportedProps11.maxMultiviewViewCount = 32;
+    supportedProps11.maxMultiviewInstanceIndex =
+        canUseInstancingForMultiview() ? uintMax / 32 : uintMax;
+    supportedProps11.protectedNoFault = false;
+    supportedProps11.maxPerSetDescriptors = getMaxPerSetDescriptorCount();
+    supportedProps11.maxMemoryAllocationSize = _metalFeatures.maxMTLBufferSize;
 
-	// Create a SSOT for these Vulkan 1.2 properties, which can be queried via two mechanisms here.
-	VkPhysicalDeviceVulkan12Properties supportedProps12;
-	supportedProps12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES;
-	supportedProps12.pNext = nullptr;
-	supportedProps12.driverID = VK_DRIVER_ID_MOLTENVK;
-	strcpy(supportedProps12.driverName, kMVKMoltenVKDriverLayerName);
-	strcpy(supportedProps12.driverInfo, MVK_VERSION_STRING);
-	supportedProps12.conformanceVersion.major = 0;
-	supportedProps12.conformanceVersion.minor = 0;
-	supportedProps12.conformanceVersion.subminor = 0;
-	supportedProps12.conformanceVersion.patch = 0;
-	supportedProps12.denormBehaviorIndependence = VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
-	supportedProps12.roundingModeIndependence = VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
-	supportedProps12.shaderSignedZeroInfNanPreserveFloat16 = true;
-	supportedProps12.shaderSignedZeroInfNanPreserveFloat32 = true;
-	supportedProps12.shaderSignedZeroInfNanPreserveFloat64 = false;
-	supportedProps12.shaderDenormPreserveFloat16 = false;
-	supportedProps12.shaderDenormPreserveFloat32 = false;
-	supportedProps12.shaderDenormPreserveFloat64 = false;
-	supportedProps12.shaderDenormFlushToZeroFloat16 = false;
-	supportedProps12.shaderDenormFlushToZeroFloat32 = false;
-	supportedProps12.shaderDenormFlushToZeroFloat64 = false;
-	supportedProps12.shaderRoundingModeRTEFloat16 = false;
-	supportedProps12.shaderRoundingModeRTEFloat32 = false;
-	supportedProps12.shaderRoundingModeRTEFloat64 = false;
-	supportedProps12.shaderRoundingModeRTZFloat16 = false;
-	supportedProps12.shaderRoundingModeRTZFloat32 = false;
-	supportedProps12.shaderRoundingModeRTZFloat64 = false;
-	supportedProps12.maxUpdateAfterBindDescriptorsInAllPools				= kMVKUndefinedLargeUInt32;
-	supportedProps12.shaderUniformBufferArrayNonUniformIndexingNative		= false;
-	supportedProps12.shaderSampledImageArrayNonUniformIndexingNative		= _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers;
-	supportedProps12.shaderStorageBufferArrayNonUniformIndexingNative		= false;
-	supportedProps12.shaderStorageImageArrayNonUniformIndexingNative		= _metalFeatures.arrayOfTextures;
-	supportedProps12.shaderInputAttachmentArrayNonUniformIndexingNative		= _metalFeatures.arrayOfTextures;
-	supportedProps12.robustBufferAccessUpdateAfterBind						= _features.robustBufferAccess;
-	supportedProps12.quadDivergentImplicitLod								= false;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindSamplers			= isTier2 ? maxSamplerCnt : _properties.limits.maxPerStageDescriptorSamplers;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindUniformBuffers		= isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorUniformBuffers;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageBuffers		= isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorStorageBuffers;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindSampledImages		= isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorSampledImages;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageImages		= isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorStorageImages;
-	supportedProps12.maxPerStageDescriptorUpdateAfterBindInputAttachments	= _properties.limits.maxPerStageDescriptorInputAttachments;
-	supportedProps12.maxPerStageUpdateAfterBindResources					= isTier2 ? 1e6 : _properties.limits.maxPerStageResources;
-	supportedProps12.maxDescriptorSetUpdateAfterBindSamplers				= isTier2 ? maxSamplerCnt : _properties.limits.maxDescriptorSetSamplers;
-	supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffers			= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetUniformBuffers;
-	supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic	= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetUniformBuffersDynamic;
-	supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffers			= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetStorageBuffers;
-	supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic	= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetStorageBuffersDynamic;
-	supportedProps12.maxDescriptorSetUpdateAfterBindSampledImages			= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetSampledImages;
-	supportedProps12.maxDescriptorSetUpdateAfterBindStorageImages			= isTier2 ? 1e6 : _properties.limits.maxDescriptorSetStorageImages;
-	supportedProps12.maxDescriptorSetUpdateAfterBindInputAttachments		= _properties.limits.maxDescriptorSetInputAttachments;
-	supportedProps12.supportedDepthResolveModes = (_metalFeatures.depthResolve
-												   ? VK_RESOLVE_MODE_SAMPLE_ZERO_BIT | VK_RESOLVE_MODE_MIN_BIT | VK_RESOLVE_MODE_MAX_BIT
-												   : VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
-	supportedProps12.supportedStencilResolveModes = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT;	// Metal allows you to set the stencil resolve filter to either Sample0 or the same sample used for depth resolve. This is impossible to express in Vulkan.
-	supportedProps12.independentResolveNone = true;
-	supportedProps12.independentResolve = true;
-	supportedProps12.filterMinmaxSingleComponentFormats = false;
-	supportedProps12.filterMinmaxImageComponentMapping = false;
-	supportedProps12.maxTimelineSemaphoreValueDifference = std::numeric_limits<uint64_t>::max();
-	supportedProps12.framebufferIntegerColorSampleCounts = _metalFeatures.supportedSampleCounts;
+    // Create a SSOT for these Vulkan 1.2 properties, which can be queried via
+    // two mechanisms here.
+    VkPhysicalDeviceVulkan12Properties supportedProps12;
+    supportedProps12.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES;
+    supportedProps12.pNext = nullptr;
+    supportedProps12.driverID = VK_DRIVER_ID_MOLTENVK;
+    strcpy(supportedProps12.driverName, kMVKMoltenVKDriverLayerName);
+    strcpy(supportedProps12.driverInfo, MVK_VERSION_STRING);
+    supportedProps12.conformanceVersion.major = 0;
+    supportedProps12.conformanceVersion.minor = 0;
+    supportedProps12.conformanceVersion.subminor = 0;
+    supportedProps12.conformanceVersion.patch = 0;
+    supportedProps12.denormBehaviorIndependence =
+        VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
+    supportedProps12.roundingModeIndependence =
+        VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
+    supportedProps12.shaderSignedZeroInfNanPreserveFloat16 = true;
+    supportedProps12.shaderSignedZeroInfNanPreserveFloat32 = true;
+    supportedProps12.shaderSignedZeroInfNanPreserveFloat64 = false;
+    supportedProps12.shaderDenormPreserveFloat16 = false;
+    supportedProps12.shaderDenormPreserveFloat32 = false;
+    supportedProps12.shaderDenormPreserveFloat64 = false;
+    supportedProps12.shaderDenormFlushToZeroFloat16 = false;
+    supportedProps12.shaderDenormFlushToZeroFloat32 = false;
+    supportedProps12.shaderDenormFlushToZeroFloat64 = false;
+    supportedProps12.shaderRoundingModeRTEFloat16 = false;
+    supportedProps12.shaderRoundingModeRTEFloat32 = false;
+    supportedProps12.shaderRoundingModeRTEFloat64 = false;
+    supportedProps12.shaderRoundingModeRTZFloat16 = false;
+    supportedProps12.shaderRoundingModeRTZFloat32 = false;
+    supportedProps12.shaderRoundingModeRTZFloat64 = false;
+    supportedProps12.maxUpdateAfterBindDescriptorsInAllPools =
+        kMVKUndefinedLargeUInt32;
+    supportedProps12.shaderUniformBufferArrayNonUniformIndexingNative = false;
+    supportedProps12.shaderSampledImageArrayNonUniformIndexingNative =
+        _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers;
+    supportedProps12.shaderStorageBufferArrayNonUniformIndexingNative = false;
+    supportedProps12.shaderStorageImageArrayNonUniformIndexingNative =
+        _metalFeatures.arrayOfTextures;
+    supportedProps12.shaderInputAttachmentArrayNonUniformIndexingNative =
+        _metalFeatures.arrayOfTextures;
+    supportedProps12.robustBufferAccessUpdateAfterBind =
+        _features.robustBufferAccess;
+    supportedProps12.quadDivergentImplicitLod = false;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindSamplers =
+        isTier2 ? maxSamplerCnt
+                : _properties.limits.maxPerStageDescriptorSamplers;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindUniformBuffers =
+        isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorUniformBuffers;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageBuffers =
+        isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorStorageBuffers;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindSampledImages =
+        isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorSampledImages;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageImages =
+        isTier2 ? 1e6 : _properties.limits.maxPerStageDescriptorStorageImages;
+    supportedProps12.maxPerStageDescriptorUpdateAfterBindInputAttachments =
+        _properties.limits.maxPerStageDescriptorInputAttachments;
+    supportedProps12.maxPerStageUpdateAfterBindResources =
+        isTier2 ? 1e6 : _properties.limits.maxPerStageResources;
+    supportedProps12.maxDescriptorSetUpdateAfterBindSamplers =
+        isTier2 ? maxSamplerCnt : _properties.limits.maxDescriptorSetSamplers;
+    supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffers =
+        isTier2 ? 1e6 : _properties.limits.maxDescriptorSetUniformBuffers;
+    supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic =
+        isTier2 ? 1e6
+                : _properties.limits.maxDescriptorSetUniformBuffersDynamic;
+    supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffers =
+        isTier2 ? 1e6 : _properties.limits.maxDescriptorSetStorageBuffers;
+    supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic =
+        isTier2 ? 1e6
+                : _properties.limits.maxDescriptorSetStorageBuffersDynamic;
+    supportedProps12.maxDescriptorSetUpdateAfterBindSampledImages =
+        isTier2 ? 1e6 : _properties.limits.maxDescriptorSetSampledImages;
+    supportedProps12.maxDescriptorSetUpdateAfterBindStorageImages =
+        isTier2 ? 1e6 : _properties.limits.maxDescriptorSetStorageImages;
+    supportedProps12.maxDescriptorSetUpdateAfterBindInputAttachments =
+        _properties.limits.maxDescriptorSetInputAttachments;
+    supportedProps12.supportedDepthResolveModes =
+        (_metalFeatures.depthResolve
+             ? VK_RESOLVE_MODE_SAMPLE_ZERO_BIT | VK_RESOLVE_MODE_MIN_BIT |
+                   VK_RESOLVE_MODE_MAX_BIT
+             : VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
+    supportedProps12.supportedStencilResolveModes =
+        VK_RESOLVE_MODE_SAMPLE_ZERO_BIT; // Metal allows you to set the stencil
+                                         // resolve filter to either Sample0 or
+                                         // the same sample used for depth
+                                         // resolve. This is impossible to
+                                         // express in Vulkan.
+    supportedProps12.independentResolveNone = true;
+    supportedProps12.independentResolve = true;
+    supportedProps12.filterMinmaxSingleComponentFormats = false;
+    supportedProps12.filterMinmaxImageComponentMapping = false;
+    supportedProps12.maxTimelineSemaphoreValueDifference =
+        std::numeric_limits<uint64_t>::max();
+    supportedProps12.framebufferIntegerColorSampleCounts =
+        _metalFeatures.supportedSampleCounts;
 
-	for (auto* next = (VkBaseOutStructure*)properties->pNext; next; next = next->pNext) {
-		switch ((uint32_t)next->sType) {
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES: {
-				// Copy from supportedProps11, but keep pNext as is.
-				auto* pProps11 = (VkPhysicalDeviceVulkan11Properties*)next;
-				supportedProps11.pNext = pProps11->pNext;
-				*pProps11 = supportedProps11;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES: {
-				// Copy from supportedProps12, but keep pNext as is.
-				auto* pProps12 = (VkPhysicalDeviceVulkan12Properties*)next;
-				supportedProps12.pNext = pProps12->pNext;
-				*pProps12 = supportedProps12;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES: {
-				auto* dvcIDProps = (VkPhysicalDeviceIDProperties*)next;
-				mvkCopy(dvcIDProps->deviceUUID, supportedProps11.deviceUUID, VK_UUID_SIZE);
-				mvkCopy(dvcIDProps->driverUUID, supportedProps11.driverUUID, VK_UUID_SIZE);
-				mvkCopy(dvcIDProps->deviceLUID, supportedProps11.deviceLUID, VK_LUID_SIZE);
-				dvcIDProps->deviceNodeMask = supportedProps11.deviceNodeMask;
-				dvcIDProps->deviceLUIDValid = supportedProps11.deviceLUIDValid;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES: {
-				auto* subgroupProps = (VkPhysicalDeviceSubgroupProperties*)next;
-				subgroupProps->subgroupSize = supportedProps11.subgroupSize;
-				subgroupProps->supportedStages = supportedProps11.subgroupSupportedStages;
-				subgroupProps->supportedOperations = supportedProps11.subgroupSupportedOperations;
-				subgroupProps->quadOperationsInAllStages = supportedProps11.subgroupQuadOperationsInAllStages;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES: {
-				auto* pointClipProps = (VkPhysicalDevicePointClippingProperties*)next;
-				pointClipProps->pointClippingBehavior = supportedProps11.pointClippingBehavior;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES: {
-				auto* multiviewProps = (VkPhysicalDeviceMultiviewProperties*)next;
-				multiviewProps->maxMultiviewViewCount = supportedProps11.maxMultiviewViewCount;
-				multiviewProps->maxMultiviewInstanceIndex = supportedProps11.maxMultiviewInstanceIndex;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES: {
-				auto* protectedMemProps = (VkPhysicalDeviceProtectedMemoryProperties*)next;
-				protectedMemProps->protectedNoFault = supportedProps11.protectedNoFault;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES: {
-				auto* maint3Props = (VkPhysicalDeviceMaintenance3Properties*)next;
-				maint3Props->maxPerSetDescriptors = supportedProps11.maxPerSetDescriptors;
-				maint3Props->maxMemoryAllocationSize = supportedProps11.maxMemoryAllocationSize;
-				break;
-			}
+    for (auto* next = (VkBaseOutStructure*)properties->pNext; next;
+         next = next->pNext) {
+        switch ((uint32_t)next->sType) {
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES: {
+            // Copy from supportedProps11, but keep pNext as is.
+            auto* pProps11 = (VkPhysicalDeviceVulkan11Properties*)next;
+            supportedProps11.pNext = pProps11->pNext;
+            *pProps11 = supportedProps11;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES: {
+            // Copy from supportedProps12, but keep pNext as is.
+            auto* pProps12 = (VkPhysicalDeviceVulkan12Properties*)next;
+            supportedProps12.pNext = pProps12->pNext;
+            *pProps12 = supportedProps12;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES: {
+            auto* dvcIDProps = (VkPhysicalDeviceIDProperties*)next;
+            mvkCopy(dvcIDProps->deviceUUID, supportedProps11.deviceUUID,
+                    VK_UUID_SIZE);
+            mvkCopy(dvcIDProps->driverUUID, supportedProps11.driverUUID,
+                    VK_UUID_SIZE);
+            mvkCopy(dvcIDProps->deviceLUID, supportedProps11.deviceLUID,
+                    VK_LUID_SIZE);
+            dvcIDProps->deviceNodeMask = supportedProps11.deviceNodeMask;
+            dvcIDProps->deviceLUIDValid = supportedProps11.deviceLUIDValid;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES: {
+            auto* subgroupProps = (VkPhysicalDeviceSubgroupProperties*)next;
+            subgroupProps->subgroupSize = supportedProps11.subgroupSize;
+            subgroupProps->supportedStages =
+                supportedProps11.subgroupSupportedStages;
+            subgroupProps->supportedOperations =
+                supportedProps11.subgroupSupportedOperations;
+            subgroupProps->quadOperationsInAllStages =
+                supportedProps11.subgroupQuadOperationsInAllStages;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES: {
+            auto* pointClipProps =
+                (VkPhysicalDevicePointClippingProperties*)next;
+            pointClipProps->pointClippingBehavior =
+                supportedProps11.pointClippingBehavior;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES: {
+            auto* multiviewProps = (VkPhysicalDeviceMultiviewProperties*)next;
+            multiviewProps->maxMultiviewViewCount =
+                supportedProps11.maxMultiviewViewCount;
+            multiviewProps->maxMultiviewInstanceIndex =
+                supportedProps11.maxMultiviewInstanceIndex;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES: {
+            auto* protectedMemProps =
+                (VkPhysicalDeviceProtectedMemoryProperties*)next;
+            protectedMemProps->protectedNoFault =
+                supportedProps11.protectedNoFault;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES: {
+            auto* maint3Props = (VkPhysicalDeviceMaintenance3Properties*)next;
+            maint3Props->maxPerSetDescriptors =
+                supportedProps11.maxPerSetDescriptors;
+            maint3Props->maxMemoryAllocationSize =
+                supportedProps11.maxMemoryAllocationSize;
+            break;
+        }
 
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES: {
-				auto* depthStencilResolveProps = (VkPhysicalDeviceDepthStencilResolveProperties*)next;
-				depthStencilResolveProps->supportedDepthResolveModes = supportedProps12.supportedDepthResolveModes;
-				depthStencilResolveProps->supportedStencilResolveModes = supportedProps12.supportedStencilResolveModes;
-				depthStencilResolveProps->independentResolveNone = supportedProps12.independentResolveNone;
-				depthStencilResolveProps->independentResolve = supportedProps12.independentResolve;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES: {
-				auto* physicalDeviceDriverProps = (VkPhysicalDeviceDriverProperties*)next;
-				physicalDeviceDriverProps->driverID = supportedProps12.driverID;
-				mvkCopy(physicalDeviceDriverProps->driverName, supportedProps12.driverName, VK_MAX_DRIVER_NAME_SIZE);
-				mvkCopy(physicalDeviceDriverProps->driverInfo, supportedProps12.driverInfo, VK_MAX_DRIVER_INFO_SIZE);
-				physicalDeviceDriverProps->conformanceVersion = supportedProps12.conformanceVersion;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES: {
-				auto* sfmmProps = (VkPhysicalDeviceSamplerFilterMinmaxProperties*)next;
-				sfmmProps->filterMinmaxSingleComponentFormats = supportedProps12.filterMinmaxSingleComponentFormats;
-				sfmmProps->filterMinmaxImageComponentMapping = supportedProps12.filterMinmaxImageComponentMapping;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES: {
-                auto* timelineSem4Props = (VkPhysicalDeviceTimelineSemaphoreProperties*)next;
-                timelineSem4Props->maxTimelineSemaphoreValueDifference = supportedProps12.maxTimelineSemaphoreValueDifference;
-                break;
-            }
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES: {
-				auto* pDescIdxProps = (VkPhysicalDeviceDescriptorIndexingProperties*)next;
-				pDescIdxProps->maxUpdateAfterBindDescriptorsInAllPools				= supportedProps12.maxUpdateAfterBindDescriptorsInAllPools;
-				pDescIdxProps->shaderUniformBufferArrayNonUniformIndexingNative		= supportedProps12.shaderUniformBufferArrayNonUniformIndexingNative;
-				pDescIdxProps->shaderSampledImageArrayNonUniformIndexingNative		= supportedProps12.shaderSampledImageArrayNonUniformIndexingNative;
-				pDescIdxProps->shaderStorageBufferArrayNonUniformIndexingNative		= supportedProps12.shaderStorageBufferArrayNonUniformIndexingNative;
-				pDescIdxProps->shaderStorageImageArrayNonUniformIndexingNative		= supportedProps12.shaderStorageImageArrayNonUniformIndexingNative;
-				pDescIdxProps->shaderInputAttachmentArrayNonUniformIndexingNative	= supportedProps12.shaderInputAttachmentArrayNonUniformIndexingNative;
-				pDescIdxProps->robustBufferAccessUpdateAfterBind					= supportedProps12.robustBufferAccessUpdateAfterBind;
-				pDescIdxProps->quadDivergentImplicitLod								= supportedProps12.quadDivergentImplicitLod;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindSamplers			= supportedProps12.maxPerStageDescriptorUpdateAfterBindSamplers;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindUniformBuffers	= supportedProps12.maxPerStageDescriptorUpdateAfterBindUniformBuffers;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindStorageBuffers	= supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageBuffers;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindSampledImages	= supportedProps12.maxPerStageDescriptorUpdateAfterBindSampledImages;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindStorageImages	= supportedProps12.maxPerStageDescriptorUpdateAfterBindStorageImages;
-				pDescIdxProps->maxPerStageDescriptorUpdateAfterBindInputAttachments	= supportedProps12.maxPerStageDescriptorUpdateAfterBindInputAttachments;
-				pDescIdxProps->maxPerStageUpdateAfterBindResources					= supportedProps12.maxPerStageUpdateAfterBindResources;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindSamplers				= supportedProps12.maxDescriptorSetUpdateAfterBindSamplers;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindUniformBuffers		= supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffers;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindUniformBuffersDynamic	= supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindStorageBuffers		= supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffers;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindStorageBuffersDynamic	= supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindSampledImages			= supportedProps12.maxDescriptorSetUpdateAfterBindSampledImages;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindStorageImages			= supportedProps12.maxDescriptorSetUpdateAfterBindStorageImages;
-				pDescIdxProps->maxDescriptorSetUpdateAfterBindInputAttachments		= supportedProps12.maxDescriptorSetUpdateAfterBindInputAttachments;
-				break;
-			}
-            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES: {
-				auto* inlineUniformBlockProps = (VkPhysicalDeviceInlineUniformBlockProperties*)next;
-				inlineUniformBlockProps->maxInlineUniformBlockSize = _metalFeatures.dynamicMTLBufferSize;
-                inlineUniformBlockProps->maxPerStageDescriptorInlineUniformBlocks = _metalFeatures.dynamicMTLBufferSize ? _metalFeatures.maxPerStageDynamicMTLBufferCount - 1 : 0;    // Less one for push constants
-                inlineUniformBlockProps->maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = inlineUniformBlockProps->maxPerStageDescriptorInlineUniformBlocks;
-                inlineUniformBlockProps->maxDescriptorSetInlineUniformBlocks = (inlineUniformBlockProps->maxPerStageDescriptorInlineUniformBlocks * 4);
-                inlineUniformBlockProps->maxDescriptorSetUpdateAfterBindInlineUniformBlocks = (inlineUniformBlockProps->maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks * 4);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES: {
-				auto* subgroupSizeProps = (VkPhysicalDeviceSubgroupSizeControlProperties*)next;
-				subgroupSizeProps->minSubgroupSize = _metalFeatures.minSubgroupSize;
-				subgroupSizeProps->maxSubgroupSize = _metalFeatures.maxSubgroupSize;
-				subgroupSizeProps->maxComputeWorkgroupSubgroups = _properties.limits.maxComputeWorkGroupInvocations / _metalFeatures.minSubgroupSize;
-				subgroupSizeProps->requiredSubgroupSizeStages = 0;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES: {
-				// Save the 'next' pointer; we'll unintentionally overwrite it
-				// on the next line. Put it back when we're done.
-				auto* texelBuffAlignProps = (VkPhysicalDeviceTexelBufferAlignmentProperties*)next;
-				void* pNext = texelBuffAlignProps->pNext;
-				*texelBuffAlignProps = _texelBuffAlignProperties;
-				texelBuffAlignProps->pNext = pNext;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES: {
-				auto* floatControlsProperties = (VkPhysicalDeviceFloatControlsProperties*)next;
-				floatControlsProperties->denormBehaviorIndependence = supportedProps12.denormBehaviorIndependence;
-				floatControlsProperties->roundingModeIndependence = supportedProps12.roundingModeIndependence;
-				floatControlsProperties->shaderSignedZeroInfNanPreserveFloat16 = supportedProps12.shaderSignedZeroInfNanPreserveFloat16;
-				floatControlsProperties->shaderSignedZeroInfNanPreserveFloat32 = supportedProps12.shaderSignedZeroInfNanPreserveFloat32;
-				floatControlsProperties->shaderSignedZeroInfNanPreserveFloat64 = supportedProps12.shaderSignedZeroInfNanPreserveFloat64;
-				floatControlsProperties->shaderDenormPreserveFloat16 = supportedProps12.shaderDenormPreserveFloat16;
-				floatControlsProperties->shaderDenormPreserveFloat32 = supportedProps12.shaderDenormPreserveFloat32;
-				floatControlsProperties->shaderDenormPreserveFloat64 = supportedProps12.shaderDenormPreserveFloat64;
-				floatControlsProperties->shaderDenormFlushToZeroFloat16 = supportedProps12.shaderDenormFlushToZeroFloat16;
-				floatControlsProperties->shaderDenormFlushToZeroFloat32 = supportedProps12.shaderDenormFlushToZeroFloat32;
-				floatControlsProperties->shaderDenormFlushToZeroFloat64 = supportedProps12.shaderDenormFlushToZeroFloat64;
-				floatControlsProperties->shaderRoundingModeRTEFloat16 = supportedProps12.shaderRoundingModeRTEFloat16;
-				floatControlsProperties->shaderRoundingModeRTEFloat32 = supportedProps12.shaderRoundingModeRTEFloat32;
-				floatControlsProperties->shaderRoundingModeRTEFloat64 = supportedProps12.shaderRoundingModeRTEFloat64;
-				floatControlsProperties->shaderRoundingModeRTZFloat16 = supportedProps12.shaderRoundingModeRTZFloat16;
-				floatControlsProperties->shaderRoundingModeRTZFloat32 = supportedProps12.shaderRoundingModeRTZFloat32;
-				floatControlsProperties->shaderRoundingModeRTZFloat64 = supportedProps12.shaderRoundingModeRTZFloat64;
-				break;
-			}
-            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR: {
-                auto* barycentricProperties = (VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*)next;
-                barycentricProperties->triStripVertexOrderIndependentOfProvokingVertex = false;
-                break;
-            }
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: {
-				auto* shaderIntDotProperties = (VkPhysicalDeviceShaderIntegerDotProductProperties*)next;
-				shaderIntDotProperties->integerDotProduct8BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct8BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct8BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProduct4x8BitPackedUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct4x8BitPackedSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct4x8BitPackedMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProduct16BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct16BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct16BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProduct32BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct32BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct32BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProduct64BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct64BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProduct64BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating8BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating8BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating16BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating16BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating32BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating32BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating64BitUnsignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating64BitSignedAccelerated = false;
-				shaderIntDotProperties->integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated = false;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR: {
-				auto* pushDescProps = (VkPhysicalDevicePushDescriptorPropertiesKHR*)next;
-				pushDescProps->maxPushDescriptors = _properties.limits.maxPerStageResources;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR: {
-				auto* portabilityProps = (VkPhysicalDevicePortabilitySubsetPropertiesKHR*)next;
-				portabilityProps->minVertexInputBindingStrideAlignment = (uint32_t)_metalFeatures.vertexStrideAlignment;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR: {
-				auto* divisorProps = (VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR*)next;
-				divisorProps->maxVertexAttribDivisor = kMVKUndefinedLargeUInt32;
-				divisorProps->supportsNonZeroFirstInstance = VK_TRUE;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT: {
-				auto* extDynState3Props = (VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*)next;
-				extDynState3Props->dynamicPrimitiveTopologyUnrestricted = false;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT: {
-				auto* extMemHostProps = (VkPhysicalDeviceExternalMemoryHostPropertiesEXT*)next;
-				extMemHostProps->minImportedHostPointerAlignment = _metalFeatures.hostMemoryPageSize;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT: {
-				populateHostImageCopyProperties((VkPhysicalDeviceHostImageCopyPropertiesEXT*)next);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT: {
-				// This isn't implemented yet, but when it is, it is expected that we'll wind up doing it manually.
-				auto* robustness2Props = (VkPhysicalDeviceRobustness2PropertiesEXT*)next;
-				robustness2Props->robustStorageBufferAccessSizeAlignment = 1;
-				robustness2Props->robustUniformBufferAccessSizeAlignment = 1;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT: {
-				auto* sampLocnProps = (VkPhysicalDeviceSampleLocationsPropertiesEXT*)next;
-				sampLocnProps->sampleLocationSampleCounts = _metalFeatures.supportedSampleCounts;
-				sampLocnProps->maxSampleLocationGridSize = kMVKSampleLocationPixelGridSize;
-				sampLocnProps->sampleLocationCoordinateRange[0] = kMVKMinSampleLocationCoordinate;
-				sampLocnProps->sampleLocationCoordinateRange[1] = kMVKMaxSampleLocationCoordinate;
-				sampLocnProps->sampleLocationSubPixelBits = mvkPowerOfTwoExponent(kMVKSampleLocationCoordinateGridSize);
-				sampLocnProps->variableSampleLocations = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT: {
-				auto* divisorProps = (VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*)next;
-				divisorProps->maxVertexAttribDivisor = kMVKUndefinedLargeUInt32;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES: {
+            auto* depthStencilResolveProps =
+                (VkPhysicalDeviceDepthStencilResolveProperties*)next;
+            depthStencilResolveProps->supportedDepthResolveModes =
+                supportedProps12.supportedDepthResolveModes;
+            depthStencilResolveProps->supportedStencilResolveModes =
+                supportedProps12.supportedStencilResolveModes;
+            depthStencilResolveProps->independentResolveNone =
+                supportedProps12.independentResolveNone;
+            depthStencilResolveProps->independentResolve =
+                supportedProps12.independentResolve;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES: {
+            auto* physicalDeviceDriverProps =
+                (VkPhysicalDeviceDriverProperties*)next;
+            physicalDeviceDriverProps->driverID = supportedProps12.driverID;
+            mvkCopy(physicalDeviceDriverProps->driverName,
+                    supportedProps12.driverName, VK_MAX_DRIVER_NAME_SIZE);
+            mvkCopy(physicalDeviceDriverProps->driverInfo,
+                    supportedProps12.driverInfo, VK_MAX_DRIVER_INFO_SIZE);
+            physicalDeviceDriverProps->conformanceVersion =
+                supportedProps12.conformanceVersion;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES: {
+            auto* sfmmProps =
+                (VkPhysicalDeviceSamplerFilterMinmaxProperties*)next;
+            sfmmProps->filterMinmaxSingleComponentFormats =
+                supportedProps12.filterMinmaxSingleComponentFormats;
+            sfmmProps->filterMinmaxImageComponentMapping =
+                supportedProps12.filterMinmaxImageComponentMapping;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES: {
+            auto* timelineSem4Props =
+                (VkPhysicalDeviceTimelineSemaphoreProperties*)next;
+            timelineSem4Props->maxTimelineSemaphoreValueDifference =
+                supportedProps12.maxTimelineSemaphoreValueDifference;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES: {
+            auto* pDescIdxProps =
+                (VkPhysicalDeviceDescriptorIndexingProperties*)next;
+            pDescIdxProps->maxUpdateAfterBindDescriptorsInAllPools =
+                supportedProps12.maxUpdateAfterBindDescriptorsInAllPools;
+            pDescIdxProps->shaderUniformBufferArrayNonUniformIndexingNative =
+                supportedProps12
+                    .shaderUniformBufferArrayNonUniformIndexingNative;
+            pDescIdxProps->shaderSampledImageArrayNonUniformIndexingNative =
+                supportedProps12
+                    .shaderSampledImageArrayNonUniformIndexingNative;
+            pDescIdxProps->shaderStorageBufferArrayNonUniformIndexingNative =
+                supportedProps12
+                    .shaderStorageBufferArrayNonUniformIndexingNative;
+            pDescIdxProps->shaderStorageImageArrayNonUniformIndexingNative =
+                supportedProps12
+                    .shaderStorageImageArrayNonUniformIndexingNative;
+            pDescIdxProps->shaderInputAttachmentArrayNonUniformIndexingNative =
+                supportedProps12
+                    .shaderInputAttachmentArrayNonUniformIndexingNative;
+            pDescIdxProps->robustBufferAccessUpdateAfterBind =
+                supportedProps12.robustBufferAccessUpdateAfterBind;
+            pDescIdxProps->quadDivergentImplicitLod =
+                supportedProps12.quadDivergentImplicitLod;
+            pDescIdxProps->maxPerStageDescriptorUpdateAfterBindSamplers =
+                supportedProps12.maxPerStageDescriptorUpdateAfterBindSamplers;
+            pDescIdxProps->maxPerStageDescriptorUpdateAfterBindUniformBuffers =
+                supportedProps12
+                    .maxPerStageDescriptorUpdateAfterBindUniformBuffers;
+            pDescIdxProps->maxPerStageDescriptorUpdateAfterBindStorageBuffers =
+                supportedProps12
+                    .maxPerStageDescriptorUpdateAfterBindStorageBuffers;
+            pDescIdxProps->maxPerStageDescriptorUpdateAfterBindSampledImages =
+                supportedProps12
+                    .maxPerStageDescriptorUpdateAfterBindSampledImages;
+            pDescIdxProps->maxPerStageDescriptorUpdateAfterBindStorageImages =
+                supportedProps12
+                    .maxPerStageDescriptorUpdateAfterBindStorageImages;
+            pDescIdxProps
+                ->maxPerStageDescriptorUpdateAfterBindInputAttachments =
+                supportedProps12
+                    .maxPerStageDescriptorUpdateAfterBindInputAttachments;
+            pDescIdxProps->maxPerStageUpdateAfterBindResources =
+                supportedProps12.maxPerStageUpdateAfterBindResources;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindSamplers =
+                supportedProps12.maxDescriptorSetUpdateAfterBindSamplers;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindUniformBuffers =
+                supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffers;
+            pDescIdxProps
+                ->maxDescriptorSetUpdateAfterBindUniformBuffersDynamic =
+                supportedProps12
+                    .maxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindStorageBuffers =
+                supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffers;
+            pDescIdxProps
+                ->maxDescriptorSetUpdateAfterBindStorageBuffersDynamic =
+                supportedProps12
+                    .maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindSampledImages =
+                supportedProps12.maxDescriptorSetUpdateAfterBindSampledImages;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindStorageImages =
+                supportedProps12.maxDescriptorSetUpdateAfterBindStorageImages;
+            pDescIdxProps->maxDescriptorSetUpdateAfterBindInputAttachments =
+                supportedProps12
+                    .maxDescriptorSetUpdateAfterBindInputAttachments;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES: {
+            auto* inlineUniformBlockProps =
+                (VkPhysicalDeviceInlineUniformBlockProperties*)next;
+            inlineUniformBlockProps->maxInlineUniformBlockSize =
+                _metalFeatures.dynamicMTLBufferSize;
+            inlineUniformBlockProps->maxPerStageDescriptorInlineUniformBlocks =
+                _metalFeatures.dynamicMTLBufferSize
+                    ? _metalFeatures.maxPerStageDynamicMTLBufferCount - 1
+                    : 0; // Less one for push constants
+            inlineUniformBlockProps
+                ->maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks =
+                inlineUniformBlockProps
+                    ->maxPerStageDescriptorInlineUniformBlocks;
+            inlineUniformBlockProps->maxDescriptorSetInlineUniformBlocks =
+                (inlineUniformBlockProps
+                     ->maxPerStageDescriptorInlineUniformBlocks *
+                 4);
+            inlineUniformBlockProps
+                ->maxDescriptorSetUpdateAfterBindInlineUniformBlocks =
+                (inlineUniformBlockProps
+                     ->maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks *
+                 4);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES: {
+            auto* subgroupSizeProps =
+                (VkPhysicalDeviceSubgroupSizeControlProperties*)next;
+            subgroupSizeProps->minSubgroupSize = _metalFeatures.minSubgroupSize;
+            subgroupSizeProps->maxSubgroupSize = _metalFeatures.maxSubgroupSize;
+            subgroupSizeProps->maxComputeWorkgroupSubgroups =
+                _properties.limits.maxComputeWorkGroupInvocations /
+                _metalFeatures.minSubgroupSize;
+            subgroupSizeProps->requiredSubgroupSizeStages = 0;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES: {
+            // Save the 'next' pointer; we'll unintentionally overwrite it
+            // on the next line. Put it back when we're done.
+            auto* texelBuffAlignProps =
+                (VkPhysicalDeviceTexelBufferAlignmentProperties*)next;
+            void* pNext = texelBuffAlignProps->pNext;
+            *texelBuffAlignProps = _texelBuffAlignProperties;
+            texelBuffAlignProps->pNext = pNext;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES: {
+            auto* floatControlsProperties =
+                (VkPhysicalDeviceFloatControlsProperties*)next;
+            floatControlsProperties->denormBehaviorIndependence =
+                supportedProps12.denormBehaviorIndependence;
+            floatControlsProperties->roundingModeIndependence =
+                supportedProps12.roundingModeIndependence;
+            floatControlsProperties->shaderSignedZeroInfNanPreserveFloat16 =
+                supportedProps12.shaderSignedZeroInfNanPreserveFloat16;
+            floatControlsProperties->shaderSignedZeroInfNanPreserveFloat32 =
+                supportedProps12.shaderSignedZeroInfNanPreserveFloat32;
+            floatControlsProperties->shaderSignedZeroInfNanPreserveFloat64 =
+                supportedProps12.shaderSignedZeroInfNanPreserveFloat64;
+            floatControlsProperties->shaderDenormPreserveFloat16 =
+                supportedProps12.shaderDenormPreserveFloat16;
+            floatControlsProperties->shaderDenormPreserveFloat32 =
+                supportedProps12.shaderDenormPreserveFloat32;
+            floatControlsProperties->shaderDenormPreserveFloat64 =
+                supportedProps12.shaderDenormPreserveFloat64;
+            floatControlsProperties->shaderDenormFlushToZeroFloat16 =
+                supportedProps12.shaderDenormFlushToZeroFloat16;
+            floatControlsProperties->shaderDenormFlushToZeroFloat32 =
+                supportedProps12.shaderDenormFlushToZeroFloat32;
+            floatControlsProperties->shaderDenormFlushToZeroFloat64 =
+                supportedProps12.shaderDenormFlushToZeroFloat64;
+            floatControlsProperties->shaderRoundingModeRTEFloat16 =
+                supportedProps12.shaderRoundingModeRTEFloat16;
+            floatControlsProperties->shaderRoundingModeRTEFloat32 =
+                supportedProps12.shaderRoundingModeRTEFloat32;
+            floatControlsProperties->shaderRoundingModeRTEFloat64 =
+                supportedProps12.shaderRoundingModeRTEFloat64;
+            floatControlsProperties->shaderRoundingModeRTZFloat16 =
+                supportedProps12.shaderRoundingModeRTZFloat16;
+            floatControlsProperties->shaderRoundingModeRTZFloat32 =
+                supportedProps12.shaderRoundingModeRTZFloat32;
+            floatControlsProperties->shaderRoundingModeRTZFloat64 =
+                supportedProps12.shaderRoundingModeRTZFloat64;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR: {
+            auto* barycentricProperties =
+                (VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*)next;
+            barycentricProperties
+                ->triStripVertexOrderIndependentOfProvokingVertex = false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: {
+            auto* shaderIntDotProperties =
+                (VkPhysicalDeviceShaderIntegerDotProductProperties*)next;
+            shaderIntDotProperties->integerDotProduct8BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties->integerDotProduct8BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProduct8BitMixedSignednessAccelerated = false;
+            shaderIntDotProperties
+                ->integerDotProduct4x8BitPackedUnsignedAccelerated = false;
+            shaderIntDotProperties
+                ->integerDotProduct4x8BitPackedSignedAccelerated = false;
+            shaderIntDotProperties
+                ->integerDotProduct4x8BitPackedMixedSignednessAccelerated =
+                false;
+            shaderIntDotProperties->integerDotProduct16BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties->integerDotProduct16BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProduct16BitMixedSignednessAccelerated = false;
+            shaderIntDotProperties->integerDotProduct32BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties->integerDotProduct32BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProduct32BitMixedSignednessAccelerated = false;
+            shaderIntDotProperties->integerDotProduct64BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties->integerDotProduct64BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProduct64BitMixedSignednessAccelerated = false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating8BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating8BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating16BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating16BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating32BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating32BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating64BitUnsignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating64BitSignedAccelerated =
+                false;
+            shaderIntDotProperties
+                ->integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated =
+                false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR: {
+            auto* pushDescProps =
+                (VkPhysicalDevicePushDescriptorPropertiesKHR*)next;
+            pushDescProps->maxPushDescriptors =
+                _properties.limits.maxPerStageResources;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR: {
+            auto* portabilityProps =
+                (VkPhysicalDevicePortabilitySubsetPropertiesKHR*)next;
+            portabilityProps->minVertexInputBindingStrideAlignment =
+                (uint32_t)_metalFeatures.vertexStrideAlignment;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR: {
+            auto* divisorProps =
+                (VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR*)next;
+            divisorProps->maxVertexAttribDivisor = kMVKUndefinedLargeUInt32;
+            divisorProps->supportsNonZeroFirstInstance = VK_TRUE;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT: {
+            auto* extDynState3Props =
+                (VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*)next;
+            extDynState3Props->dynamicPrimitiveTopologyUnrestricted = false;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT: {
+            auto* extMemHostProps =
+                (VkPhysicalDeviceExternalMemoryHostPropertiesEXT*)next;
+            extMemHostProps->minImportedHostPointerAlignment =
+                _metalFeatures.hostMemoryPageSize;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT: {
+            populateHostImageCopyProperties(
+                (VkPhysicalDeviceHostImageCopyPropertiesEXT*)next);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT: {
+            // This isn't implemented yet, but when it is, it is expected that
+            // we'll wind up doing it manually.
+            auto* robustness2Props =
+                (VkPhysicalDeviceRobustness2PropertiesEXT*)next;
+            robustness2Props->robustStorageBufferAccessSizeAlignment = 1;
+            robustness2Props->robustUniformBufferAccessSizeAlignment = 1;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT: {
+            auto* sampLocnProps =
+                (VkPhysicalDeviceSampleLocationsPropertiesEXT*)next;
+            sampLocnProps->sampleLocationSampleCounts =
+                _metalFeatures.supportedSampleCounts;
+            sampLocnProps->maxSampleLocationGridSize =
+                kMVKSampleLocationPixelGridSize;
+            sampLocnProps->sampleLocationCoordinateRange[0] =
+                kMVKMinSampleLocationCoordinate;
+            sampLocnProps->sampleLocationCoordinateRange[1] =
+                kMVKMaxSampleLocationCoordinate;
+            sampLocnProps->sampleLocationSubPixelBits =
+                mvkPowerOfTwoExponent(kMVKSampleLocationCoordinateGridSize);
+            sampLocnProps->variableSampleLocations = true;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT: {
+            auto* divisorProps =
+                (VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*)next;
+            divisorProps->maxVertexAttribDivisor = kMVKUndefinedLargeUInt32;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
-void MVKPhysicalDevice::populateHostImageCopyProperties(VkPhysicalDeviceHostImageCopyPropertiesEXT* pHostImageCopyProps) {
+void MVKPhysicalDevice::populateHostImageCopyProperties(
+    VkPhysicalDeviceHostImageCopyPropertiesEXT* pHostImageCopyProps) {
 
-	// Metal lacks the concept of image layouts, and so does not restrict 
-	// host copy transfers based on them. Assume all image layouts are supported.
-	// TODO: As extensions that add layouts are implemented, this list should be extended.
-	VkImageLayout supportedImgLayouts[] =  {
-		VK_IMAGE_LAYOUT_UNDEFINED,
-		VK_IMAGE_LAYOUT_GENERAL,
-		VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-		VK_IMAGE_LAYOUT_PREINITIALIZED,
-		VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
-		VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
-		VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-	};
-	uint32_t supportedImgLayoutsCnt = sizeof(supportedImgLayouts) / sizeof(VkImageLayout);
+    // Metal lacks the concept of image layouts, and so does not restrict
+    // host copy transfers based on them. Assume all image layouts are
+    // supported.
+    // TODO: As extensions that add layouts are implemented, this list should be
+    // extended.
+    VkImageLayout supportedImgLayouts[] = {
+        VK_IMAGE_LAYOUT_UNDEFINED,
+        VK_IMAGE_LAYOUT_GENERAL,
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        VK_IMAGE_LAYOUT_PREINITIALIZED,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    };
+    uint32_t supportedImgLayoutsCnt =
+        sizeof(supportedImgLayouts) / sizeof(VkImageLayout);
 
-	// pCopySrcLayouts
-	// If pCopySrcLayouts is NULL, return the number of supported layouts.
-	if (pHostImageCopyProps->pCopySrcLayouts) {
-		mvkCopy(pHostImageCopyProps->pCopySrcLayouts, supportedImgLayouts, min(pHostImageCopyProps->copySrcLayoutCount, supportedImgLayoutsCnt));
-	} else {
-		pHostImageCopyProps->copySrcLayoutCount = supportedImgLayoutsCnt;
-	}
+    // pCopySrcLayouts
+    // If pCopySrcLayouts is NULL, return the number of supported layouts.
+    if (pHostImageCopyProps->pCopySrcLayouts) {
+        mvkCopy(pHostImageCopyProps->pCopySrcLayouts, supportedImgLayouts,
+                min(pHostImageCopyProps->copySrcLayoutCount,
+                    supportedImgLayoutsCnt));
+    } else {
+        pHostImageCopyProps->copySrcLayoutCount = supportedImgLayoutsCnt;
+    }
 
-	// pCopyDstLayouts
-	// If pCopyDstLayouts is NULL, return the number of supported layouts.
-	if (pHostImageCopyProps->pCopyDstLayouts) {
-		mvkCopy(pHostImageCopyProps->pCopyDstLayouts, supportedImgLayouts, min(pHostImageCopyProps->copyDstLayoutCount, supportedImgLayoutsCnt));
-	} else {
-		pHostImageCopyProps->copyDstLayoutCount = supportedImgLayoutsCnt;
-	}
+    // pCopyDstLayouts
+    // If pCopyDstLayouts is NULL, return the number of supported layouts.
+    if (pHostImageCopyProps->pCopyDstLayouts) {
+        mvkCopy(pHostImageCopyProps->pCopyDstLayouts, supportedImgLayouts,
+                min(pHostImageCopyProps->copyDstLayoutCount,
+                    supportedImgLayoutsCnt));
+    } else {
+        pHostImageCopyProps->copyDstLayoutCount = supportedImgLayoutsCnt;
+    }
 
-	// optimalTilingLayoutUUID
-	// Since optimalTilingLayoutUUID is an uint8_t array, use Big-Endian byte ordering,
-	// so a hex dump of the array is human readable in its parts.
-	uint8_t* uuid = pHostImageCopyProps->optimalTilingLayoutUUID;
-	size_t uuidComponentOffset = 0;
-	mvkClear(uuid, VK_UUID_SIZE);
+    // optimalTilingLayoutUUID
+    // Since optimalTilingLayoutUUID is an uint8_t array, use Big-Endian byte
+    // ordering, so a hex dump of the array is human readable in its parts.
+    uint8_t* uuid = pHostImageCopyProps->optimalTilingLayoutUUID;
+    size_t uuidComponentOffset = 0;
+    mvkClear(uuid, VK_UUID_SIZE);
 
-	// First 4 bytes contains GPU vendor ID.
-	// Use Big-Endian byte ordering, so a hex dump is human readable
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(_properties.vendorID);
-	uuidComponentOffset += sizeof(uint32_t);
+    // First 4 bytes contains GPU vendor ID.
+    // Use Big-Endian byte ordering, so a hex dump is human readable
+    *(uint32_t*)&uuid[uuidComponentOffset] =
+        NSSwapHostIntToBig(_properties.vendorID);
+    uuidComponentOffset += sizeof(uint32_t);
 
-	// Next 4 bytes contains GPU device ID
-	// Use Big-Endian byte ordering, so a hex dump is human readable
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(_properties.deviceID);
-	uuidComponentOffset += sizeof(uint32_t);
+    // Next 4 bytes contains GPU device ID
+    // Use Big-Endian byte ordering, so a hex dump is human readable
+    *(uint32_t*)&uuid[uuidComponentOffset] =
+        NSSwapHostIntToBig(_properties.deviceID);
+    uuidComponentOffset += sizeof(uint32_t);
 
-	// Next 4 bytes contains OS version
-	*(MVKOSVersion*)&uuid[uuidComponentOffset] = mvkOSVersion();
-	uuidComponentOffset += sizeof(MVKOSVersion);
+    // Next 4 bytes contains OS version
+    *(MVKOSVersion*)&uuid[uuidComponentOffset] = mvkOSVersion();
+    uuidComponentOffset += sizeof(MVKOSVersion);
 
-	// Last 4 bytes are left zero
+    // Last 4 bytes are left zero
 
-	// identicalMemoryTypeRequirements
-	// Metal cannot use Private storage mode with host memory access.
-	pHostImageCopyProps->identicalMemoryTypeRequirements = false;
+    // identicalMemoryTypeRequirements
+    // Metal cannot use Private storage mode with host memory access.
+    pHostImageCopyProps->identicalMemoryTypeRequirements = false;
 }
 
 // Since these are uint8_t arrays, use Big-Endian byte ordering,
 // so a hex dump of the array is human readable in its parts.
-void MVKPhysicalDevice::populateDeviceIDProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props) {
-	uint8_t* uuid;
-	size_t uuidComponentOffset;
+void MVKPhysicalDevice::populateDeviceIDProperties(
+    VkPhysicalDeviceVulkan11Properties* pVk11Props) {
+    uint8_t* uuid;
+    size_t uuidComponentOffset;
 
-	//  ---- Device UUID ----------------------------------------------
-	uuid = pVk11Props->deviceUUID;
-	uuidComponentOffset = 0;
-	mvkClear(uuid, VK_UUID_SIZE);
+    //  ---- Device UUID ----------------------------------------------
+    uuid = pVk11Props->deviceUUID;
+    uuidComponentOffset = 0;
+    mvkClear(uuid, VK_UUID_SIZE);
 
-	// From Vulkan spec: deviceUUID must be universally unique for the device,
-	// AND must be immutable for a given device across instances, processes,
-	// driver APIs, driver versions, and system reboots.
+    // From Vulkan spec: deviceUUID must be universally unique for the device,
+    // AND must be immutable for a given device across instances, processes,
+    // driver APIs, driver versions, and system reboots.
 
-	// First 4 bytes contains GPU vendor ID
-	uint32_t vendorID = _properties.vendorID;
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(vendorID);
-	uuidComponentOffset += sizeof(vendorID);
+    // First 4 bytes contains GPU vendor ID
+    uint32_t vendorID = _properties.vendorID;
+    *(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(vendorID);
+    uuidComponentOffset += sizeof(vendorID);
 
-	// Next 4 bytes contains GPU device ID
-	uint32_t deviceID = _properties.deviceID;
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(deviceID);
-	uuidComponentOffset += sizeof(deviceID);
+    // Next 4 bytes contains GPU device ID
+    uint32_t deviceID = _properties.deviceID;
+    *(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(deviceID);
+    uuidComponentOffset += sizeof(deviceID);
 
-	// Last 8 bytes contain the GPU location identifier
-	uint64_t locID = mvkGetLocationID(_mtlDevice);
-	*(uint64_t*)&uuid[uuidComponentOffset] = NSSwapHostLongLongToBig(locID);
-	uuidComponentOffset += sizeof(locID);
+    // Last 8 bytes contain the GPU location identifier
+    uint64_t locID = mvkGetLocationID(_mtlDevice);
+    *(uint64_t*)&uuid[uuidComponentOffset] = NSSwapHostLongLongToBig(locID);
+    uuidComponentOffset += sizeof(locID);
 
-	// ---- Driver ID ----------------------------------------------
-	uuid = pVk11Props->driverUUID;
-	uuidComponentOffset = 0;
-	mvkClear(uuid, VK_UUID_SIZE);
+    // ---- Driver ID ----------------------------------------------
+    uuid = pVk11Props->driverUUID;
+    uuidComponentOffset = 0;
+    mvkClear(uuid, VK_UUID_SIZE);
 
-	// First 4 bytes contains MoltenVK prefix
-	const char* mvkPfx = "MVK";
-	size_t mvkPfxLen = strlen(mvkPfx);
-	mvkCopy(&uuid[uuidComponentOffset], (uint8_t*)mvkPfx, mvkPfxLen);
-	uuidComponentOffset += mvkPfxLen + 1;
+    // First 4 bytes contains MoltenVK prefix
+    const char* mvkPfx = "MVK";
+    size_t mvkPfxLen = strlen(mvkPfx);
+    mvkCopy(&uuid[uuidComponentOffset], (uint8_t*)mvkPfx, mvkPfxLen);
+    uuidComponentOffset += mvkPfxLen + 1;
 
-	// Next 4 bytes contains MoltenVK version
-	uint32_t mvkVersion = MVK_VERSION;
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(mvkVersion);
-	uuidComponentOffset += sizeof(mvkVersion);
+    // Next 4 bytes contains MoltenVK version
+    uint32_t mvkVersion = MVK_VERSION;
+    *(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(mvkVersion);
+    uuidComponentOffset += sizeof(mvkVersion);
 
-	// Next 4 bytes contains highest GPU capability supported by this device
-	uint32_t gpuCap = getHighestGPUCapability();
-	*(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(gpuCap);
-	uuidComponentOffset += sizeof(gpuCap);
+    // Next 4 bytes contains highest GPU capability supported by this device
+    uint32_t gpuCap = getHighestGPUCapability();
+    *(uint32_t*)&uuid[uuidComponentOffset] = NSSwapHostIntToBig(gpuCap);
+    uuidComponentOffset += sizeof(gpuCap);
 
-	// ---- Device LUID ------------------------
-	*(uint64_t*)pVk11Props->deviceLUID = NSSwapHostLongLongToBig(mvkGetRegistryID(_mtlDevice));
-	pVk11Props->deviceNodeMask = 1;		// Per Vulkan spec
-	pVk11Props->deviceLUIDValid = VK_TRUE;
+    // ---- Device LUID ------------------------
+    *(uint64_t*)pVk11Props->deviceLUID =
+        NSSwapHostLongLongToBig(mvkGetRegistryID(_mtlDevice));
+    pVk11Props->deviceNodeMask = 1; // Per Vulkan spec
+    pVk11Props->deviceLUIDValid = VK_TRUE;
 }
 
-void MVKPhysicalDevice::populateSubgroupProperties(VkPhysicalDeviceVulkan11Properties* pVk11Props) {
-	pVk11Props->subgroupSize = _metalFeatures.maxSubgroupSize;
-	pVk11Props->subgroupSupportedStages = VK_SHADER_STAGE_COMPUTE_BIT;
-	if (_features.tessellationShader) {
-		pVk11Props->subgroupSupportedStages |= VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-	}
-	if (mvkOSVersionIsAtLeast(10.15, 13.0, 1.0)) {
-		pVk11Props->subgroupSupportedStages |= VK_SHADER_STAGE_FRAGMENT_BIT;
-	}
-	pVk11Props->subgroupSupportedOperations = VK_SUBGROUP_FEATURE_BASIC_BIT;
-	if (_metalFeatures.simdPermute || _metalFeatures.quadPermute) {
-		pVk11Props->subgroupSupportedOperations |= (VK_SUBGROUP_FEATURE_VOTE_BIT |
-													VK_SUBGROUP_FEATURE_BALLOT_BIT |
-													VK_SUBGROUP_FEATURE_SHUFFLE_BIT |
-													VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT);
-	}
-	if (_metalFeatures.simdReduction) {
-		pVk11Props->subgroupSupportedOperations |= VK_SUBGROUP_FEATURE_ARITHMETIC_BIT;
-	}
-	if (_metalFeatures.quadPermute) {
-		pVk11Props->subgroupSupportedOperations |= VK_SUBGROUP_FEATURE_QUAD_BIT;
-	}
-	pVk11Props->subgroupQuadOperationsInAllStages = _metalFeatures.quadPermute;
+void MVKPhysicalDevice::populateSubgroupProperties(
+    VkPhysicalDeviceVulkan11Properties* pVk11Props) {
+    pVk11Props->subgroupSize = _metalFeatures.maxSubgroupSize;
+    pVk11Props->subgroupSupportedStages = VK_SHADER_STAGE_COMPUTE_BIT;
+    if (_features.tessellationShader) {
+        pVk11Props->subgroupSupportedStages |=
+            VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+    }
+    if (mvkOSVersionIsAtLeast(10.15, 13.0, 1.0)) {
+        pVk11Props->subgroupSupportedStages |= VK_SHADER_STAGE_FRAGMENT_BIT;
+    }
+    pVk11Props->subgroupSupportedOperations = VK_SUBGROUP_FEATURE_BASIC_BIT;
+    if (_metalFeatures.simdPermute || _metalFeatures.quadPermute) {
+        pVk11Props->subgroupSupportedOperations |=
+            (VK_SUBGROUP_FEATURE_VOTE_BIT | VK_SUBGROUP_FEATURE_BALLOT_BIT |
+             VK_SUBGROUP_FEATURE_SHUFFLE_BIT |
+             VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT);
+    }
+    if (_metalFeatures.simdReduction) {
+        pVk11Props->subgroupSupportedOperations |=
+            VK_SUBGROUP_FEATURE_ARITHMETIC_BIT;
+    }
+    if (_metalFeatures.quadPermute) {
+        pVk11Props->subgroupSupportedOperations |= VK_SUBGROUP_FEATURE_QUAD_BIT;
+    }
+    pVk11Props->subgroupQuadOperationsInAllStages = _metalFeatures.quadPermute;
 }
 
-void MVKPhysicalDevice::getFormatProperties(VkFormat format, VkFormatProperties* pFormatProperties) {
-	*pFormatProperties = _pixelFormats.getVkFormatProperties(format);
+void MVKPhysicalDevice::getFormatProperties(
+    VkFormat format, VkFormatProperties* pFormatProperties) {
+    *pFormatProperties = _pixelFormats.getVkFormatProperties(format);
 }
 
-void MVKPhysicalDevice::getFormatProperties(VkFormat format, VkFormatProperties2KHR* pFormatProperties) {
-	pFormatProperties->sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR;
+void MVKPhysicalDevice::getFormatProperties(
+    VkFormat format, VkFormatProperties2KHR* pFormatProperties) {
+    pFormatProperties->sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR;
 
-    for (auto* next = (VkBaseOutStructure*)pFormatProperties->pNext; next; next = next->pNext) {
+    for (auto* next = (VkBaseOutStructure*)pFormatProperties->pNext; next;
+         next = next->pNext) {
         switch (next->sType) {
-            case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR: {
-                auto* properties3 = (VkFormatProperties3*)next;
-                auto& properties = _pixelFormats.getVkFormatProperties3(format);
-                properties3->linearTilingFeatures = properties.linearTilingFeatures;
-                properties3->optimalTilingFeatures = properties.optimalTilingFeatures;
-                properties3->bufferFeatures = properties.bufferFeatures;
-                break;
-            }
-            default:
-                break;
+        case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3_KHR: {
+            auto* properties3 = (VkFormatProperties3*)next;
+            auto& properties = _pixelFormats.getVkFormatProperties3(format);
+            properties3->linearTilingFeatures = properties.linearTilingFeatures;
+            properties3->optimalTilingFeatures =
+                properties.optimalTilingFeatures;
+            properties3->bufferFeatures = properties.bufferFeatures;
+            break;
+        }
+        default:
+            break;
         }
     }
 
-	getFormatProperties(format, &pFormatProperties->formatProperties);
+    getFormatProperties(format, &pFormatProperties->formatProperties);
 }
 
-void MVKPhysicalDevice::getMultisampleProperties(VkSampleCountFlagBits samples,
-												 VkMultisamplePropertiesEXT* pMultisampleProperties) {
-	if (pMultisampleProperties) {
-		pMultisampleProperties->maxSampleLocationGridSize = (mvkIsOnlyAnyFlagEnabled(samples, _metalFeatures.supportedSampleCounts)
-															 ? kMVKSampleLocationPixelGridSize
-															 : kMVKSampleLocationPixelGridSizeNotSupported);
-	}
+void MVKPhysicalDevice::getMultisampleProperties(
+    VkSampleCountFlagBits samples,
+    VkMultisamplePropertiesEXT* pMultisampleProperties) {
+    if (pMultisampleProperties) {
+        pMultisampleProperties->maxSampleLocationGridSize =
+            (mvkIsOnlyAnyFlagEnabled(samples,
+                                     _metalFeatures.supportedSampleCounts)
+                 ? kMVKSampleLocationPixelGridSize
+                 : kMVKSampleLocationPixelGridSizeNotSupported);
+    }
 }
 
-VkResult MVKPhysicalDevice::getImageFormatProperties(VkFormat format,
-													 VkImageType type,
-													 VkImageTiling tiling,
-													 VkImageUsageFlags usage,
-													 VkImageCreateFlags flags,
-													 VkImageFormatProperties* pImageFormatProperties) {
+VkResult MVKPhysicalDevice::getImageFormatProperties(
+    VkFormat format, VkImageType type, VkImageTiling tiling,
+    VkImageUsageFlags usage, VkImageCreateFlags flags,
+    VkImageFormatProperties* pImageFormatProperties) {
 
-	if ( !_pixelFormats.isSupported(format) ) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
+    if (!_pixelFormats.isSupported(format)) {
+        return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
 
-	if ( !pImageFormatProperties ) { return VK_SUCCESS; }
+    if (!pImageFormatProperties) {
+        return VK_SUCCESS;
+    }
 
-	mvkClear(pImageFormatProperties);
+    mvkClear(pImageFormatProperties);
 
-	// Metal does not support creating uncompressed views of compressed formats.
-	// Metal does not support split-instance images.
-	if (mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
-		return VK_ERROR_FORMAT_NOT_SUPPORTED;
-	}
+    // Metal does not support creating uncompressed views of compressed formats.
+    // Metal does not support split-instance images.
+    if (mvkIsAnyFlagEnabled(
+            flags, VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT |
+                       VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
+        return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
 
-	MVKFormatType mvkFmt = _pixelFormats.getFormatType(format);
-	bool isChromaSubsampled = _pixelFormats.getChromaSubsamplingPlaneCount(format) > 0;
-	bool isMultiPlanar = _pixelFormats.getChromaSubsamplingPlaneCount(format) > 1;
-	bool isBGRG = isChromaSubsampled && !isMultiPlanar && _pixelFormats.getBlockTexelSize(format).width > 1;
-	bool hasAttachmentUsage = mvkIsAnyFlagEnabled(usage, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-														  VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-														  VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
-														  VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
+    MVKFormatType mvkFmt = _pixelFormats.getFormatType(format);
+    bool isChromaSubsampled =
+        _pixelFormats.getChromaSubsamplingPlaneCount(format) > 0;
+    bool isMultiPlanar =
+        _pixelFormats.getChromaSubsamplingPlaneCount(format) > 1;
+    bool isBGRG = isChromaSubsampled && !isMultiPlanar &&
+                  _pixelFormats.getBlockTexelSize(format).width > 1;
+    bool hasAttachmentUsage =
+        mvkIsAnyFlagEnabled(usage,
+                            (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
 
-	// Disjoint memory requires a multiplanar format.
-	if (!isMultiPlanar && mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_DISJOINT_BIT)) {
-		return VK_ERROR_FORMAT_NOT_SUPPORTED;
-	}
+    // Disjoint memory requires a multiplanar format.
+    if (!isMultiPlanar &&
+        mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_DISJOINT_BIT)) {
+        return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
 
-	VkPhysicalDeviceLimits* pLimits = &_properties.limits;
-	VkExtent3D maxExt = { 1, 1, 1};
-	uint32_t maxLevels = 1;
-	uint32_t maxLayers = hasAttachmentUsage ? pLimits->maxFramebufferLayers : pLimits->maxImageArrayLayers;
+    VkPhysicalDeviceLimits* pLimits = &_properties.limits;
+    VkExtent3D maxExt = {1, 1, 1};
+    uint32_t maxLevels = 1;
+    uint32_t maxLayers = hasAttachmentUsage ? pLimits->maxFramebufferLayers
+                                            : pLimits->maxImageArrayLayers;
 
-	bool supportsMSAA =  mvkAreAllFlagsEnabled(_pixelFormats.getCapabilities(format), kMVKMTLFmtCapsMSAA);
-	VkSampleCountFlags sampleCounts = supportsMSAA ? _metalFeatures.supportedSampleCounts : VK_SAMPLE_COUNT_1_BIT;
+    bool supportsMSAA =
+        mvkAreAllFlagsEnabled(_pixelFormats.getCapabilities(format),
+                              kMVKMTLFmtCapsMSAA);
+    VkSampleCountFlags sampleCounts = supportsMSAA
+                                          ? _metalFeatures.supportedSampleCounts
+                                          : VK_SAMPLE_COUNT_1_BIT;
 
-	switch (type) {
-		case VK_IMAGE_TYPE_1D:
-			maxExt.height = 1;
-			maxExt.depth = 1;
-			if (!getMVKConfig().texture1DAs2D) {
-				maxExt.width = pLimits->maxImageDimension1D;
-				maxLevels = 1;
-				sampleCounts = VK_SAMPLE_COUNT_1_BIT;
+    switch (type) {
+    case VK_IMAGE_TYPE_1D:
+        maxExt.height = 1;
+        maxExt.depth = 1;
+        if (!getMVKConfig().texture1DAs2D) {
+            maxExt.width = pLimits->maxImageDimension1D;
+            maxLevels = 1;
+            sampleCounts = VK_SAMPLE_COUNT_1_BIT;
 
-				// Metal does not allow native 1D textures to be used as attachments
-				if (hasAttachmentUsage ) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
+            // Metal does not allow native 1D textures to be used as attachments
+            if (hasAttachmentUsage) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
 
-				// Metal does not allow linear tiling on native 1D textures
-				if (tiling == VK_IMAGE_TILING_LINEAR) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
+            // Metal does not allow linear tiling on native 1D textures
+            if (tiling == VK_IMAGE_TILING_LINEAR) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
 
-				// Metal does not allow compressed or depth/stencil formats on native 1D textures
-				if (mvkFmt == kMVKFormatDepthStencil) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-				if (mvkFmt == kMVKFormatCompressed) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-				if (isChromaSubsampled) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-				break;
-			}
+            // Metal does not allow compressed or depth/stencil formats on
+            // native 1D textures
+            if (mvkFmt == kMVKFormatDepthStencil) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
+            if (mvkFmt == kMVKFormatCompressed) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
+            if (isChromaSubsampled) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
+            break;
+        }
 
-			// A 420 1D image doesn't make much sense.
-			if (isChromaSubsampled && _pixelFormats.getBlockTexelSize(format).height > 1) {
-				return VK_ERROR_FORMAT_NOT_SUPPORTED;
-			}
-			// Vulkan doesn't allow 1D multisampled images.
-			sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-			/* fallthrough */
-		case VK_IMAGE_TYPE_2D:
-			if (mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ) {
-				// Chroma-subsampled cube images aren't supported.
-				if (isChromaSubsampled) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-				// 1D cube images aren't supported.
-				if (type == VK_IMAGE_TYPE_1D) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
-				maxExt.width = pLimits->maxImageDimensionCube;
-				maxExt.height = pLimits->maxImageDimensionCube;
-			} else {
-				maxExt.width = pLimits->maxImageDimension2D;
-				maxExt.height = (type == VK_IMAGE_TYPE_1D ? 1 : pLimits->maxImageDimension2D);
-			}
-			maxExt.depth = 1;
-			if (tiling == VK_IMAGE_TILING_LINEAR) {
-				// Linear textures have additional restrictions under Metal:
-				// - They may not be depth/stencil, compressed, or chroma subsampled textures.
-				//   We allow multi-planar formats because those internally use non-subsampled formats.
-				if (mvkFmt == kMVKFormatDepthStencil || mvkFmt == kMVKFormatCompressed || isBGRG) {
-					return VK_ERROR_FORMAT_NOT_SUPPORTED;
-				}
+        // A 420 1D image doesn't make much sense.
+        if (isChromaSubsampled &&
+            _pixelFormats.getBlockTexelSize(format).height > 1) {
+            return VK_ERROR_FORMAT_NOT_SUPPORTED;
+        }
+        // Vulkan doesn't allow 1D multisampled images.
+        sampleCounts = VK_SAMPLE_COUNT_1_BIT;
+        /* fallthrough */
+    case VK_IMAGE_TYPE_2D:
+        if (mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)) {
+            // Chroma-subsampled cube images aren't supported.
+            if (isChromaSubsampled) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
+            // 1D cube images aren't supported.
+            if (type == VK_IMAGE_TYPE_1D) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
+            maxExt.width = pLimits->maxImageDimensionCube;
+            maxExt.height = pLimits->maxImageDimensionCube;
+        } else {
+            maxExt.width = pLimits->maxImageDimension2D;
+            maxExt.height =
+                (type == VK_IMAGE_TYPE_1D ? 1 : pLimits->maxImageDimension2D);
+        }
+        maxExt.depth = 1;
+        if (tiling == VK_IMAGE_TILING_LINEAR) {
+            // Linear textures have additional restrictions under Metal:
+            // - They may not be depth/stencil, compressed, or chroma subsampled
+            // textures.
+            //   We allow multi-planar formats because those internally use
+            //   non-subsampled formats.
+            if (mvkFmt == kMVKFormatDepthStencil ||
+                mvkFmt == kMVKFormatCompressed || isBGRG) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
 #if !MVK_APPLE_SILICON
-				// - On macOS IMR GPUs, Linear textures may not be used as framebuffer attachments.
-				if (hasAttachmentUsage) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
+            // - On macOS IMR GPUs, Linear textures may not be used as
+            // framebuffer attachments.
+            if (hasAttachmentUsage) {
+                return VK_ERROR_FORMAT_NOT_SUPPORTED;
+            }
 #endif
-				// Linear textures may only have one mip level, layer & sample.
-				maxLevels = 1;
-				maxLayers = 1;
-				sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-			} else {
-				VkFormatProperties3& fmtProps = _pixelFormats.getVkFormatProperties3(format);
-				// Compressed multisampled textures aren't supported.
-				// Chroma-subsampled multisampled textures aren't supported.
-				// Multisampled cube textures aren't supported.
-				// Non-renderable multisampled textures aren't supported.
-				if (mvkFmt == kMVKFormatCompressed || isChromaSubsampled ||
-					mvkIsAnyFlagEnabled(flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
-					!mvkIsAnyFlagEnabled(fmtProps.optimalTilingFeatures, VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) ) {
-					sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-				}
-				// BGRG and GBGR images may only have one mip level and one layer.
-				// Other chroma subsampled formats may have multiple mip levels, but still only one layer.
-				if (isChromaSubsampled) {
-					maxLevels = isBGRG ? 1 : mvkMipmapLevels3D(maxExt);
-					maxLayers = 1;
-				} else {
-					maxLevels = mvkMipmapLevels3D(maxExt);
-				}
-			}
-			break;
+            // Linear textures may only have one mip level, layer & sample.
+            maxLevels = 1;
+            maxLayers = 1;
+            sampleCounts = VK_SAMPLE_COUNT_1_BIT;
+        } else {
+            VkFormatProperties3& fmtProps =
+                _pixelFormats.getVkFormatProperties3(format);
+            // Compressed multisampled textures aren't supported.
+            // Chroma-subsampled multisampled textures aren't supported.
+            // Multisampled cube textures aren't supported.
+            // Non-renderable multisampled textures aren't supported.
+            if (mvkFmt == kMVKFormatCompressed || isChromaSubsampled ||
+                mvkIsAnyFlagEnabled(flags,
+                                    VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
+                !mvkIsAnyFlagEnabled(
+                    fmtProps.optimalTilingFeatures,
+                    VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
+                        VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+                sampleCounts = VK_SAMPLE_COUNT_1_BIT;
+            }
+            // BGRG and GBGR images may only have one mip level and one layer.
+            // Other chroma subsampled formats may have multiple mip levels, but
+            // still only one layer.
+            if (isChromaSubsampled) {
+                maxLevels = isBGRG ? 1 : mvkMipmapLevels3D(maxExt);
+                maxLayers = 1;
+            } else {
+                maxLevels = mvkMipmapLevels3D(maxExt);
+            }
+        }
+        break;
 
-		case VK_IMAGE_TYPE_3D:
-			// Metal does not allow linear tiling on 3D textures
-			if (tiling == VK_IMAGE_TILING_LINEAR) {
-				return VK_ERROR_FORMAT_NOT_SUPPORTED;
-			}
-			// Metal does not allow compressed or depth/stencil formats on 3D textures
-			if (mvkFmt == kMVKFormatDepthStencil ||
-				isChromaSubsampled
+    case VK_IMAGE_TYPE_3D:
+        // Metal does not allow linear tiling on 3D textures
+        if (tiling == VK_IMAGE_TILING_LINEAR) {
+            return VK_ERROR_FORMAT_NOT_SUPPORTED;
+        }
+        // Metal does not allow compressed or depth/stencil formats on 3D
+        // textures
+        if (mvkFmt == kMVKFormatDepthStencil || isChromaSubsampled
 #if MVK_IOS_OR_TVOS
-				|| (mvkFmt == kMVKFormatCompressed && !_metalFeatures.native3DCompressedTextures)
+            || (mvkFmt == kMVKFormatCompressed &&
+                !_metalFeatures.native3DCompressedTextures)
 #endif
-				) {
-				return VK_ERROR_FORMAT_NOT_SUPPORTED;
-			}
+        ) {
+            return VK_ERROR_FORMAT_NOT_SUPPORTED;
+        }
 #if MVK_MACOS
-			// If this is a compressed format and there's no codec, it isn't supported.
-			if ((mvkFmt == kMVKFormatCompressed) && !mvkCanDecodeFormat(format) && !_metalFeatures.native3DCompressedTextures) {
-				return VK_ERROR_FORMAT_NOT_SUPPORTED;
-			}
+        // If this is a compressed format and there's no codec, it isn't
+        // supported.
+        if ((mvkFmt == kMVKFormatCompressed) && !mvkCanDecodeFormat(format) &&
+            !_metalFeatures.native3DCompressedTextures) {
+            return VK_ERROR_FORMAT_NOT_SUPPORTED;
+        }
 #endif
 #if MVK_APPLE_SILICON
-			// ETC2 and EAC formats aren't supported for 3D textures.
-			switch (format) {
-				case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
-				case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
-				case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
-				case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
-				case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
-				case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
-				case VK_FORMAT_EAC_R11_UNORM_BLOCK:
-				case VK_FORMAT_EAC_R11_SNORM_BLOCK:
-				case VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
-				case VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
-					return VK_ERROR_FORMAT_NOT_SUPPORTED;
-				default:
-					break;
-			}
+        // ETC2 and EAC formats aren't supported for 3D textures.
+        switch (format) {
+        case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
+        case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
+        case VK_FORMAT_EAC_R11_UNORM_BLOCK:
+        case VK_FORMAT_EAC_R11_SNORM_BLOCK:
+        case VK_FORMAT_EAC_R11G11_UNORM_BLOCK:
+        case VK_FORMAT_EAC_R11G11_SNORM_BLOCK:
+            return VK_ERROR_FORMAT_NOT_SUPPORTED;
+        default:
+            break;
+        }
 #endif
-			maxExt.width = pLimits->maxImageDimension3D;
-			maxExt.height = pLimits->maxImageDimension3D;
-			maxExt.depth = pLimits->maxImageDimension3D;
-			maxLevels = mvkMipmapLevels3D(maxExt);
-			maxLayers = 1;
-			sampleCounts = VK_SAMPLE_COUNT_1_BIT;
-			break;
+        maxExt.width = pLimits->maxImageDimension3D;
+        maxExt.height = pLimits->maxImageDimension3D;
+        maxExt.depth = pLimits->maxImageDimension3D;
+        maxLevels = mvkMipmapLevels3D(maxExt);
+        maxLayers = 1;
+        sampleCounts = VK_SAMPLE_COUNT_1_BIT;
+        break;
 
-		default:
-			return VK_ERROR_FORMAT_NOT_SUPPORTED;	// Illegal VkImageType
-	}
+    default:
+        return VK_ERROR_FORMAT_NOT_SUPPORTED; // Illegal VkImageType
+    }
 
-	pImageFormatProperties->maxExtent = maxExt;
-	pImageFormatProperties->maxMipLevels = maxLevels;
-	pImageFormatProperties->maxArrayLayers = maxLayers;
-	pImageFormatProperties->sampleCounts = sampleCounts;
-	pImageFormatProperties->maxResourceSize = kMVKUndefinedLargeUInt64;
+    pImageFormatProperties->maxExtent = maxExt;
+    pImageFormatProperties->maxMipLevels = maxLevels;
+    pImageFormatProperties->maxArrayLayers = maxLayers;
+    pImageFormatProperties->sampleCounts = sampleCounts;
+    pImageFormatProperties->maxResourceSize = kMVKUndefinedLargeUInt64;
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-VkResult MVKPhysicalDevice::getImageFormatProperties(const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-													 VkImageFormatProperties2* pImageFormatProperties) {
+VkResult MVKPhysicalDevice::getImageFormatProperties(
+    const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties) {
 
-	auto usage = pImageFormatInfo->usage;
-	for (const auto* nextInfo = (VkBaseInStructure*)pImageFormatInfo->pNext; nextInfo; nextInfo = nextInfo->pNext) {
-		switch (nextInfo->sType) {
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO: {
-				// Return information about external memory support for MTLTexture.
-				// Search VkImageFormatProperties2 for the corresponding VkExternalImageFormatProperties and populate it.
-				auto* pExtImgFmtInfo = (VkPhysicalDeviceExternalImageFormatInfo*)nextInfo;
-				for (auto* nextProps = (VkBaseOutStructure*)pImageFormatProperties->pNext; nextProps; nextProps = nextProps->pNext) {
-					if (nextProps->sType == VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES) {
-						auto* pExtImgFmtProps = (VkExternalImageFormatProperties*)nextProps;
-						pExtImgFmtProps->externalMemoryProperties = getExternalImageProperties(pExtImgFmtInfo->handleType);
-					}
-				}
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO: {
-				// If the format includes a stencil component, combine any separate stencil usage with non-stencil usage.
-				if (_pixelFormats.isStencilFormat(_pixelFormats.getMTLPixelFormat(pImageFormatInfo->format))) {
-					usage |= ((VkImageStencilUsageCreateInfo*)nextInfo)->stencilUsage;
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
-
-    for (const auto* nextProps = (VkBaseInStructure*)pImageFormatProperties->pNext; nextProps; nextProps = nextProps->pNext) {
-        switch (nextProps->sType) {
-            case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES: {
-                auto* samplerYcbcrConvProps = (VkSamplerYcbcrConversionImageFormatProperties*)nextProps;
-                samplerYcbcrConvProps->combinedImageSamplerDescriptorCount = std::max(_pixelFormats.getChromaSubsamplingPlaneCount(pImageFormatInfo->format), (uint8_t)1u);
-                break;
+    auto usage = pImageFormatInfo->usage;
+    for (const auto* nextInfo = (VkBaseInStructure*)pImageFormatInfo->pNext;
+         nextInfo; nextInfo = nextInfo->pNext) {
+        switch (nextInfo->sType) {
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO: {
+            // Return information about external memory support for MTLTexture.
+            // Search VkImageFormatProperties2 for the corresponding
+            // VkExternalImageFormatProperties and populate it.
+            auto* pExtImgFmtInfo =
+                (VkPhysicalDeviceExternalImageFormatInfo*)nextInfo;
+            for (auto* nextProps =
+                     (VkBaseOutStructure*)pImageFormatProperties->pNext;
+                 nextProps; nextProps = nextProps->pNext) {
+                if (nextProps->sType ==
+                    VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES) {
+                    auto* pExtImgFmtProps =
+                        (VkExternalImageFormatProperties*)nextProps;
+                    pExtImgFmtProps->externalMemoryProperties =
+                        getExternalImageProperties(pExtImgFmtInfo->handleType);
+                }
             }
-			case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT: {
-				// Under Metal, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT does not affect either memory layout
-				// or access, therefore, both identicalMemoryLayout and optimalDeviceAccess should be VK_TRUE.
-				// Also, per Vulkan spec, if identicalMemoryLayout is VK_TRUE, optimalDeviceAccess must also be VK_TRUE.
-				auto* hostImgCopyPerfQry = (VkHostImageCopyDevicePerformanceQueryEXT*)nextProps;
-				hostImgCopyPerfQry->optimalDeviceAccess = VK_TRUE;
-				hostImgCopyPerfQry->identicalMemoryLayout = VK_TRUE;
-				break;
-			}
-            default:
-                break;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO: {
+            // If the format includes a stencil component, combine any separate
+            // stencil usage with non-stencil usage.
+            if (_pixelFormats.isStencilFormat(_pixelFormats.getMTLPixelFormat(
+                    pImageFormatInfo->format))) {
+                usage |=
+                    ((VkImageStencilUsageCreateInfo*)nextInfo)->stencilUsage;
+            }
+            break;
+        }
+        default:
+            break;
         }
     }
 
-	if ( !_pixelFormats.isSupported(pImageFormatInfo->format) ) { return VK_ERROR_FORMAT_NOT_SUPPORTED; }
+    for (const auto* nextProps =
+             (VkBaseInStructure*)pImageFormatProperties->pNext;
+         nextProps; nextProps = nextProps->pNext) {
+        switch (nextProps->sType) {
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES: {
+            auto* samplerYcbcrConvProps =
+                (VkSamplerYcbcrConversionImageFormatProperties*)nextProps;
+            samplerYcbcrConvProps->combinedImageSamplerDescriptorCount =
+                std::max(_pixelFormats.getChromaSubsamplingPlaneCount(
+                             pImageFormatInfo->format),
+                         (uint8_t)1u);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT: {
+            // Under Metal, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT does not affect
+            // either memory layout or access, therefore, both
+            // identicalMemoryLayout and optimalDeviceAccess should be VK_TRUE.
+            // Also, per Vulkan spec, if identicalMemoryLayout is VK_TRUE,
+            // optimalDeviceAccess must also be VK_TRUE.
+            auto* hostImgCopyPerfQry =
+                (VkHostImageCopyDevicePerformanceQueryEXT*)nextProps;
+            hostImgCopyPerfQry->optimalDeviceAccess = VK_TRUE;
+            hostImgCopyPerfQry->identicalMemoryLayout = VK_TRUE;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	return getImageFormatProperties(pImageFormatInfo->format, pImageFormatInfo->type,
-									pImageFormatInfo->tiling, usage,
-									pImageFormatInfo->flags,
-									&pImageFormatProperties->imageFormatProperties);
+    if (!_pixelFormats.isSupported(pImageFormatInfo->format)) {
+        return VK_ERROR_FORMAT_NOT_SUPPORTED;
+    }
+
+    return getImageFormatProperties(pImageFormatInfo->format,
+                                    pImageFormatInfo->type,
+                                    pImageFormatInfo->tiling, usage,
+                                    pImageFormatInfo->flags,
+                                    &pImageFormatProperties
+                                         ->imageFormatProperties);
 }
 
-void MVKPhysicalDevice::getExternalBufferProperties(const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
-													VkExternalBufferProperties* pExternalBufferProperties) {
-	pExternalBufferProperties->externalMemoryProperties = getExternalBufferProperties(pExternalBufferInfo->handleType);
+void MVKPhysicalDevice::getExternalBufferProperties(
+    const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
+    VkExternalBufferProperties* pExternalBufferProperties) {
+    pExternalBufferProperties->externalMemoryProperties =
+        getExternalBufferProperties(pExternalBufferInfo->handleType);
 }
 
 static VkExternalMemoryProperties _emptyExtMemProps = {};
 
-VkExternalMemoryProperties& MVKPhysicalDevice::getExternalBufferProperties(VkExternalMemoryHandleTypeFlagBits handleType) {
-	switch (handleType) {
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
-			return _hostPointerExternalMemoryProperties;
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR:
-			return _mtlBufferExternalMemoryProperties;
-		default:
-			return _emptyExtMemProps;
-	}
+VkExternalMemoryProperties& MVKPhysicalDevice::getExternalBufferProperties(
+    VkExternalMemoryHandleTypeFlagBits handleType) {
+    switch (handleType) {
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
+        return _hostPointerExternalMemoryProperties;
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR:
+        return _mtlBufferExternalMemoryProperties;
+    default:
+        return _emptyExtMemProps;
+    }
 }
 
-VkExternalMemoryProperties& MVKPhysicalDevice::getExternalImageProperties(VkExternalMemoryHandleTypeFlagBits handleType) {
-	switch (handleType) {
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
-			return _hostPointerExternalMemoryProperties;
-		case VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR:
-			return _mtlTextureExternalMemoryProperties;
-		default:
-			return _emptyExtMemProps;
-	}
+VkExternalMemoryProperties& MVKPhysicalDevice::getExternalImageProperties(
+    VkExternalMemoryHandleTypeFlagBits handleType) {
+    switch (handleType) {
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
+        return _hostPointerExternalMemoryProperties;
+    case VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR:
+        return _mtlTextureExternalMemoryProperties;
+    default:
+        return _emptyExtMemProps;
+    }
 }
 
-static const VkExternalFenceProperties _emptyExtFenceProps = {VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr, 0, 0, 0};
+static const VkExternalFenceProperties _emptyExtFenceProps =
+    {VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr, 0, 0, 0};
 
-void MVKPhysicalDevice::getExternalFenceProperties(const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
-												   VkExternalFenceProperties* pExternalFenceProperties) {
-	void* next = pExternalFenceProperties->pNext;
-	*pExternalFenceProperties = _emptyExtFenceProps;
-	pExternalFenceProperties->pNext = next;
+void MVKPhysicalDevice::getExternalFenceProperties(
+    const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
+    VkExternalFenceProperties* pExternalFenceProperties) {
+    void* next = pExternalFenceProperties->pNext;
+    *pExternalFenceProperties = _emptyExtFenceProps;
+    pExternalFenceProperties->pNext = next;
 }
 
-static const VkExternalSemaphoreProperties _emptyExtSemProps = {VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr, 0, 0, 0};
+static const VkExternalSemaphoreProperties _emptyExtSemProps =
+    {VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr, 0, 0, 0};
 
-void MVKPhysicalDevice::getExternalSemaphoreProperties(const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
-													   VkExternalSemaphoreProperties* pExternalSemaphoreProperties) {
-	void* next = pExternalSemaphoreProperties->pNext;
-	*pExternalSemaphoreProperties = _emptyExtSemProps;
-	pExternalSemaphoreProperties->pNext = next;
+void MVKPhysicalDevice::getExternalSemaphoreProperties(
+    const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
+    VkExternalSemaphoreProperties* pExternalSemaphoreProperties) {
+    void* next = pExternalSemaphoreProperties->pNext;
+    *pExternalSemaphoreProperties = _emptyExtSemProps;
+    pExternalSemaphoreProperties->pNext = next;
 }
 
-VkResult MVKPhysicalDevice::getCalibrateableTimeDomains(uint32_t* pTimeDomainCount, VkTimeDomainEXT* pTimeDomains) {
-	if (!pTimeDomains) {
-		*pTimeDomainCount = kMaxTimeDomains;
-		return VK_SUCCESS;
-	}
-	// XXX CLOCK_MONOTONIC_RAW is mach_continuous_time(), but
-	// -[MTLDevice sampleTimestamps:gpuTimestamp:] returns the CPU
-	// timestamp in the mach_absolute_time() domain, which is CLOCK_UPTIME_RAW
-	// (cf. Libc/gen/clock_gettime.c).
-	static const VkTimeDomainEXT domains[] = { VK_TIME_DOMAIN_DEVICE_EXT, VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT };
-	std::copy_n(domains, min(*pTimeDomainCount, kMaxTimeDomains), pTimeDomains);
-	if (*pTimeDomainCount < kMaxTimeDomains) { return VK_INCOMPLETE; }
-	*pTimeDomainCount = kMaxTimeDomains;
-	return VK_SUCCESS;
+VkResult
+MVKPhysicalDevice::getCalibrateableTimeDomains(uint32_t* pTimeDomainCount,
+                                               VkTimeDomainEXT* pTimeDomains) {
+    if (!pTimeDomains) {
+        *pTimeDomainCount = kMaxTimeDomains;
+        return VK_SUCCESS;
+    }
+    // XXX CLOCK_MONOTONIC_RAW is mach_continuous_time(), but
+    // -[MTLDevice sampleTimestamps:gpuTimestamp:] returns the CPU
+    // timestamp in the mach_absolute_time() domain, which is CLOCK_UPTIME_RAW
+    // (cf. Libc/gen/clock_gettime.c).
+    static const VkTimeDomainEXT domains[] =
+        {VK_TIME_DOMAIN_DEVICE_EXT, VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT};
+    std::copy_n(domains, min(*pTimeDomainCount, kMaxTimeDomains), pTimeDomains);
+    if (*pTimeDomainCount < kMaxTimeDomains) {
+        return VK_INCOMPLETE;
+    }
+    *pTimeDomainCount = kMaxTimeDomains;
+    return VK_SUCCESS;
 }
-
 
 #pragma mark Surfaces
 
 VkResult MVKPhysicalDevice::getSurfaceSupport(uint32_t queueFamilyIndex,
-											  MVKSurface* surface,
-											  VkBool32* pSupported) {
+                                              MVKSurface* surface,
+                                              VkBool32* pSupported) {
     // Check whether this is a headless device
     bool isHeadless = false;
 #if MVK_MACOS
     isHeadless = _mtlDevice.isHeadless;
 #endif
-    
-	// If this device is headless, the surface must be headless.
-	*pSupported = isHeadless ? surface->isHeadless() : wasConfigurationSuccessful();
-	return *pSupported ? VK_SUCCESS : surface->getConfigurationResult();
+
+    // If this device is headless, the surface must be headless.
+    *pSupported =
+        isHeadless ? surface->isHeadless() : wasConfigurationSuccessful();
+    return *pSupported ? VK_SUCCESS : surface->getConfigurationResult();
 }
 
-VkResult MVKPhysicalDevice::getSurfaceCapabilities(VkSurfaceKHR surface,
-												   VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
-	VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo;
-	surfaceInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
-	surfaceInfo.pNext = nullptr;
-	surfaceInfo.surface = surface;
+VkResult MVKPhysicalDevice::getSurfaceCapabilities(
+    VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
+    VkPhysicalDeviceSurfaceInfo2KHR surfaceInfo;
+    surfaceInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR;
+    surfaceInfo.pNext = nullptr;
+    surfaceInfo.surface = surface;
 
-	VkSurfaceCapabilities2KHR surfaceCaps;
-	surfaceCaps.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR;
-	surfaceCaps.pNext = nullptr;
-	surfaceCaps.surfaceCapabilities = *pSurfaceCapabilities;
+    VkSurfaceCapabilities2KHR surfaceCaps;
+    surfaceCaps.sType = VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR;
+    surfaceCaps.pNext = nullptr;
+    surfaceCaps.surfaceCapabilities = *pSurfaceCapabilities;
 
-	VkResult rslt = getSurfaceCapabilities(&surfaceInfo, &surfaceCaps);
+    VkResult rslt = getSurfaceCapabilities(&surfaceInfo, &surfaceCaps);
 
-	*pSurfaceCapabilities = surfaceCaps.surfaceCapabilities;
+    *pSurfaceCapabilities = surfaceCaps.surfaceCapabilities;
 
-	return rslt;
+    return rslt;
 }
 
-VkResult MVKPhysicalDevice::getSurfaceCapabilities(	const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
-												   VkSurfaceCapabilities2KHR* pSurfaceCapabilities) {
+VkResult MVKPhysicalDevice::getSurfaceCapabilities(
+    const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+    VkSurfaceCapabilities2KHR* pSurfaceCapabilities) {
 
-	// Retrieve the present mode if it is supplied in this query.
-	VkPresentModeKHR presentMode = VK_PRESENT_MODE_MAX_ENUM_KHR;
-	for (auto* next = (const VkBaseInStructure*)pSurfaceInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT: {
-				presentMode = ((VkSurfacePresentModeEXT*)next)->presentMode;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    // Retrieve the present mode if it is supplied in this query.
+    VkPresentModeKHR presentMode = VK_PRESENT_MODE_MAX_ENUM_KHR;
+    for (auto* next = (const VkBaseInStructure*)pSurfaceInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT: {
+            presentMode = ((VkSurfacePresentModeEXT*)next)->presentMode;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	// Retrieve the scaling and present mode compatibility structs if they are supplied in this query.
-	VkSurfacePresentScalingCapabilitiesEXT* pScalingCaps = nullptr;
-	VkSurfacePresentModeCompatibilityEXT* pCompatibility = nullptr;
-	for (auto* next = (VkBaseOutStructure*)pSurfaceCapabilities->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT: {
-				pScalingCaps = (VkSurfacePresentScalingCapabilitiesEXT*)next;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT: {
-				pCompatibility = (VkSurfacePresentModeCompatibilityEXT*)next;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    // Retrieve the scaling and present mode compatibility structs if they are
+    // supplied in this query.
+    VkSurfacePresentScalingCapabilitiesEXT* pScalingCaps = nullptr;
+    VkSurfacePresentModeCompatibilityEXT* pCompatibility = nullptr;
+    for (auto* next = (VkBaseOutStructure*)pSurfaceCapabilities->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT: {
+            pScalingCaps = (VkSurfacePresentScalingCapabilitiesEXT*)next;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT: {
+            pCompatibility = (VkSurfacePresentModeCompatibilityEXT*)next;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	// The CAlayer underlying the surface must be a CAMetalLayer.
-	MVKSurface* surface = (MVKSurface*)pSurfaceInfo->surface;
-	if ( !surface->wasConfigurationSuccessful() ) { return surface->getConfigurationResult(); }
+    // The CAlayer underlying the surface must be a CAMetalLayer.
+    MVKSurface* surface = (MVKSurface*)pSurfaceInfo->surface;
+    if (!surface->wasConfigurationSuccessful()) {
+        return surface->getConfigurationResult();
+    }
 
-	VkSurfaceCapabilitiesKHR& surfCaps = pSurfaceCapabilities->surfaceCapabilities;
-	surfCaps.minImageCount = _metalFeatures.minSwapchainImageCount;
-	surfCaps.maxImageCount = _metalFeatures.maxSwapchainImageCount;
-	surfCaps.currentExtent = surface->getNaturalExtent();
-	surfCaps.minImageExtent = { 1, 1 };
-	surfCaps.maxImageExtent = { _properties.limits.maxImageDimension2D, _properties.limits.maxImageDimension2D };
-	surfCaps.maxImageArrayLayers = 1;
-	surfCaps.supportedTransforms = (VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
-	surfCaps.currentTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-	surfCaps.supportedCompositeAlpha = (VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR |
-										VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR |
-										VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR);
-	surfCaps.supportedUsageFlags = (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-									VK_IMAGE_USAGE_STORAGE_BIT |
-									VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-									VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-									VK_IMAGE_USAGE_SAMPLED_BIT);
+    VkSurfaceCapabilitiesKHR& surfCaps =
+        pSurfaceCapabilities->surfaceCapabilities;
+    surfCaps.minImageCount = _metalFeatures.minSwapchainImageCount;
+    surfCaps.maxImageCount = _metalFeatures.maxSwapchainImageCount;
+    surfCaps.currentExtent = surface->getNaturalExtent();
+    surfCaps.minImageExtent = {1, 1};
+    surfCaps.maxImageExtent = {_properties.limits.maxImageDimension2D,
+                               _properties.limits.maxImageDimension2D};
+    surfCaps.maxImageArrayLayers = 1;
+    surfCaps.supportedTransforms = (VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+    surfCaps.currentTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    surfCaps.supportedCompositeAlpha =
+        (VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR |
+         VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR |
+         VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR);
+    surfCaps.supportedUsageFlags =
+        (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT |
+         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+         VK_IMAGE_USAGE_SAMPLED_BIT);
 
-	// Swapchain-to-surface scaling capabilities.
-	if (pScalingCaps) {
-		pScalingCaps->supportedPresentScaling = (VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT |
-												 VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT |
-												 VK_PRESENT_SCALING_STRETCH_BIT_EXT);
-		pScalingCaps->supportedPresentGravityX = (VK_PRESENT_GRAVITY_MIN_BIT_EXT |
-												  VK_PRESENT_GRAVITY_MAX_BIT_EXT |
-												  VK_PRESENT_GRAVITY_CENTERED_BIT_EXT);
-		pScalingCaps->supportedPresentGravityY = (VK_PRESENT_GRAVITY_MIN_BIT_EXT |
-												  VK_PRESENT_GRAVITY_MAX_BIT_EXT |
-												  VK_PRESENT_GRAVITY_CENTERED_BIT_EXT);
-		pScalingCaps->minScaledImageExtent = surfCaps.minImageExtent;
-		pScalingCaps->maxScaledImageExtent = surfCaps.maxImageExtent;
-	}
+    // Swapchain-to-surface scaling capabilities.
+    if (pScalingCaps) {
+        pScalingCaps->supportedPresentScaling =
+            (VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT |
+             VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT |
+             VK_PRESENT_SCALING_STRETCH_BIT_EXT);
+        pScalingCaps->supportedPresentGravityX =
+            (VK_PRESENT_GRAVITY_MIN_BIT_EXT | VK_PRESENT_GRAVITY_MAX_BIT_EXT |
+             VK_PRESENT_GRAVITY_CENTERED_BIT_EXT);
+        pScalingCaps->supportedPresentGravityY =
+            (VK_PRESENT_GRAVITY_MIN_BIT_EXT | VK_PRESENT_GRAVITY_MAX_BIT_EXT |
+             VK_PRESENT_GRAVITY_CENTERED_BIT_EXT);
+        pScalingCaps->minScaledImageExtent = surfCaps.minImageExtent;
+        pScalingCaps->maxScaledImageExtent = surfCaps.maxImageExtent;
+    }
 
+    // Per spec, always include the queried present mode in returned
+    // compatibility results.
+    MVKSmallVector<VkPresentModeKHR> compatiblePresentModes;
+    if (presentMode != VK_PRESENT_MODE_MAX_ENUM_KHR) {
+        compatiblePresentModes.push_back(presentMode);
+    }
 
-	// Per spec, always include the queried present mode in returned compatibility results.
-	MVKSmallVector<VkPresentModeKHR> compatiblePresentModes;
-	if (presentMode != VK_PRESENT_MODE_MAX_ENUM_KHR) { compatiblePresentModes.push_back(presentMode); }
+    // Customize results based on the provided present mode.
+    switch (presentMode) {
+    case VK_PRESENT_MODE_FIFO_KHR:
+        // This could be dodgy, because Metal may not match the Vulkan spec's
+        // tight requirements for transitioning from FIFO to IMMEDIATE, because
+        // the change to IMMEDIATE may occur while some FIFO items are still on
+        // the GPU queue.
+        if (_metalFeatures.presentModeImmediate) {
+            compatiblePresentModes.push_back(VK_PRESENT_MODE_IMMEDIATE_KHR);
+        }
+        break;
+    case VK_PRESENT_MODE_IMMEDIATE_KHR:
+        compatiblePresentModes.push_back(VK_PRESENT_MODE_FIFO_KHR);
+        surfCaps.minImageCount =
+            surfCaps.maxImageCount; // Recommend always using max count to avoid
+                                    // visual tearing.
+        break;
+    case VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR:
+    case VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR:
+        // Although these are not advertised as supported, per spec, counts must
+        // be 1.
+        surfCaps.minImageCount = 1;
+        surfCaps.maxImageCount = 1;
+        break;
 
-	// Customize results based on the provided present mode.
-	switch (presentMode) {
-		case VK_PRESENT_MODE_FIFO_KHR:
-			// This could be dodgy, because Metal may not match the Vulkan spec's tight
-			// requirements for transitioning from FIFO to IMMEDIATE, because the change to
-			// IMMEDIATE may occur while some FIFO items are still on the GPU queue.
-			if (_metalFeatures.presentModeImmediate) {
-				compatiblePresentModes.push_back(VK_PRESENT_MODE_IMMEDIATE_KHR);
-			}
-			break;
-		case VK_PRESENT_MODE_IMMEDIATE_KHR:
-			compatiblePresentModes.push_back(VK_PRESENT_MODE_FIFO_KHR);
-			surfCaps.minImageCount = surfCaps.maxImageCount;	// Recommend always using max count to avoid visual tearing.
-			break;
-		case VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR:
-		case VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR:
-			// Although these are not advertised as supported, per spec, counts must be 1.
-			surfCaps.minImageCount = 1;
-			surfCaps.maxImageCount = 1;
-			break;
+    default:
+        break;
+    }
 
-		default:
-			break;
-	}
+    // If compatible present modes are requested, return them, otherwise return
+    // the count of them.
+    if (pCompatibility) {
+        if (pCompatibility->pPresentModes) {
+            pCompatibility->presentModeCount =
+                min(pCompatibility->presentModeCount,
+                    (uint32_t)compatiblePresentModes.size());
+            for (uint32_t pmIdx = 0; pmIdx < pCompatibility->presentModeCount;
+                 pmIdx++) {
+                pCompatibility->pPresentModes[pmIdx] =
+                    compatiblePresentModes[pmIdx];
+            }
+        } else {
+            pCompatibility->presentModeCount =
+                (uint32_t)compatiblePresentModes.size();
+        }
+    }
 
-	// If compatible present modes are requested, return them, otherwise return the count of them.
-	if (pCompatibility) {
-		if (pCompatibility->pPresentModes) {
-			pCompatibility->presentModeCount = min(pCompatibility->presentModeCount, (uint32_t)compatiblePresentModes.size());
-			for (uint32_t pmIdx = 0; pmIdx < pCompatibility->presentModeCount; pmIdx++) {
-				pCompatibility->pPresentModes[pmIdx] = compatiblePresentModes[pmIdx];
-			}
-		} else {
-			pCompatibility->presentModeCount = (uint32_t)compatiblePresentModes.size();
-		}
-	}
-
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
-											  uint32_t* pCount,
-											  VkSurfaceFormatKHR* pSurfaceFormats) {
+VkResult
+MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface, uint32_t* pCount,
+                                     VkSurfaceFormatKHR* pSurfaceFormats) {
 
-	if ( !surface->wasConfigurationSuccessful() ) { return surface->getConfigurationResult(); }
+    if (!surface->wasConfigurationSuccessful()) {
+        return surface->getConfigurationResult();
+    }
 
-#define addSurfFmt(MTL_FMT) \
-	do { \
-		if (_pixelFormats.isSupported(MTLPixelFormat ##MTL_FMT)) { \
-			VkFormat vkFmt = _pixelFormats.getVkFormat(MTLPixelFormat ##MTL_FMT); \
-			if (vkFmt) { vkFormats.push_back(vkFmt); } \
-		} \
-	} while(false)
+#define addSurfFmt(MTL_FMT)                                                    \
+    do {                                                                       \
+        if (_pixelFormats.isSupported(MTLPixelFormat##MTL_FMT)) {              \
+            VkFormat vkFmt =                                                   \
+                _pixelFormats.getVkFormat(MTLPixelFormat##MTL_FMT);            \
+            if (vkFmt) {                                                       \
+                vkFormats.push_back(vkFmt);                                    \
+            }                                                                  \
+        }                                                                      \
+    } while (false)
 
-	MVKSmallVector<VkFormat, 16> vkFormats;
-	addSurfFmt(BGRA8Unorm);
-	addSurfFmt(BGRA8Unorm_sRGB);
-	addSurfFmt(RGBA16Float);
-	addSurfFmt(RGB10A2Unorm);
-	addSurfFmt(BGR10A2Unorm);
+    MVKSmallVector<VkFormat, 16> vkFormats;
+    addSurfFmt(BGRA8Unorm);
+    addSurfFmt(BGRA8Unorm_sRGB);
+    addSurfFmt(RGBA16Float);
+    addSurfFmt(RGB10A2Unorm);
+    addSurfFmt(BGR10A2Unorm);
 #if MVK_APPLE_SILICON && !MVK_OS_SIMULATOR
-	addSurfFmt(BGRA10_XR);
-	addSurfFmt(BGRA10_XR_sRGB);
-	addSurfFmt(BGR10_XR);
-	addSurfFmt(BGR10_XR_sRGB);
+    addSurfFmt(BGRA10_XR);
+    addSurfFmt(BGRA10_XR_sRGB);
+    addSurfFmt(BGR10_XR);
+    addSurfFmt(BGR10_XR_sRGB);
 #endif
 
-	MVKSmallVector<VkColorSpaceKHR, 16> colorSpaces;
-	colorSpaces.push_back(VK_COLOR_SPACE_SRGB_NONLINEAR_KHR);
+    MVKSmallVector<VkColorSpaceKHR, 16> colorSpaces;
+    colorSpaces.push_back(VK_COLOR_SPACE_SRGB_NONLINEAR_KHR);
 #if MVK_MACOS
-    // 10.11 supports some but not all of the color spaces specified by VK_EXT_swapchain_colorspace.
+    // 10.11 supports some but not all of the color spaces specified by
+    // VK_EXT_swapchain_colorspace.
     colorSpaces.push_back(VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT);
     colorSpaces.push_back(VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT);
     colorSpaces.push_back(VK_COLOR_SPACE_BT709_NONLINEAR_EXT);
@@ -1651,313 +2154,363 @@ VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
 #endif
 #endif
 
-	size_t vkFmtsCnt = vkFormats.size();
-	size_t vkColSpcFmtsCnt = vkFmtsCnt * colorSpaces.size();
+    size_t vkFmtsCnt = vkFormats.size();
+    size_t vkColSpcFmtsCnt = vkFmtsCnt * colorSpaces.size();
 
-	// If properties aren't actually being requested yet, simply update the returned count
-	if ( !pSurfaceFormats ) {
-		*pCount = (uint32_t)vkColSpcFmtsCnt;
-		return VK_SUCCESS;
-	}
+    // If properties aren't actually being requested yet, simply update the
+    // returned count
+    if (!pSurfaceFormats) {
+        *pCount = (uint32_t)vkColSpcFmtsCnt;
+        return VK_SUCCESS;
+    }
 
-	// Determine how many results we'll return, and return that number
-	VkResult result = (*pCount >= vkColSpcFmtsCnt) ? VK_SUCCESS : VK_INCOMPLETE;
-	*pCount = min(*pCount, (uint32_t)vkColSpcFmtsCnt);
+    // Determine how many results we'll return, and return that number
+    VkResult result = (*pCount >= vkColSpcFmtsCnt) ? VK_SUCCESS : VK_INCOMPLETE;
+    *pCount = min(*pCount, (uint32_t)vkColSpcFmtsCnt);
 
-	// Now populate the supplied array
-	for (uint csIdx = 0, idx = 0; idx < *pCount && csIdx < colorSpaces.size(); csIdx++) {
-		for (uint fmtIdx = 0; idx < *pCount && fmtIdx < vkFmtsCnt; fmtIdx++, idx++) {
-			pSurfaceFormats[idx].format = vkFormats[fmtIdx];
-			pSurfaceFormats[idx].colorSpace = colorSpaces[csIdx];
-		}
-	}
+    // Now populate the supplied array
+    for (uint csIdx = 0, idx = 0; idx < *pCount && csIdx < colorSpaces.size();
+         csIdx++) {
+        for (uint fmtIdx = 0; idx < *pCount && fmtIdx < vkFmtsCnt;
+             fmtIdx++, idx++) {
+            pSurfaceFormats[idx].format = vkFormats[fmtIdx];
+            pSurfaceFormats[idx].colorSpace = colorSpaces[csIdx];
+        }
+    }
 
-	return result;
+    return result;
 }
 
-VkResult MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface,
-											  uint32_t* pCount,
-											  VkSurfaceFormat2KHR* pSurfaceFormats) {
-	VkResult rslt;
-	if (pSurfaceFormats) {
-		// Populate temp array of VkSurfaceFormatKHR then copy into array of VkSurfaceFormat2KHR.
-		// The value of *pCount may be reduced during call, but will always be <= size of temp array.
-		VkSurfaceFormatKHR surfFmts[*pCount];
-		rslt = getSurfaceFormats(surface, pCount, surfFmts);
-		for (uint32_t fmtIdx = 0; fmtIdx < *pCount; fmtIdx++) {
-			auto pSF = &pSurfaceFormats[fmtIdx];
-			pSF->sType = VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR;
-			pSF->pNext = nullptr;
-			pSF->surfaceFormat = surfFmts[fmtIdx];
-		}
-	} else {
-		rslt = getSurfaceFormats(surface, pCount, (VkSurfaceFormatKHR*)nullptr);
-	}
-	return rslt;
+VkResult
+MVKPhysicalDevice::getSurfaceFormats(MVKSurface* surface, uint32_t* pCount,
+                                     VkSurfaceFormat2KHR* pSurfaceFormats) {
+    VkResult rslt;
+    if (pSurfaceFormats) {
+        // Populate temp array of VkSurfaceFormatKHR then copy into array of
+        // VkSurfaceFormat2KHR. The value of *pCount may be reduced during call,
+        // but will always be <= size of temp array.
+        VkSurfaceFormatKHR surfFmts[*pCount];
+        rslt = getSurfaceFormats(surface, pCount, surfFmts);
+        for (uint32_t fmtIdx = 0; fmtIdx < *pCount; fmtIdx++) {
+            auto pSF = &pSurfaceFormats[fmtIdx];
+            pSF->sType = VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR;
+            pSF->pNext = nullptr;
+            pSF->surfaceFormat = surfFmts[fmtIdx];
+        }
+    } else {
+        rslt = getSurfaceFormats(surface, pCount, (VkSurfaceFormatKHR*)nullptr);
+    }
+    return rslt;
 }
 
-VkResult MVKPhysicalDevice::getSurfacePresentModes(MVKSurface* surface,
-												   uint32_t* pCount,
-												   VkPresentModeKHR* pPresentModes) {
+VkResult
+MVKPhysicalDevice::getSurfacePresentModes(MVKSurface* surface, uint32_t* pCount,
+                                          VkPresentModeKHR* pPresentModes) {
 
-	if ( !surface->wasConfigurationSuccessful() ) { return surface->getConfigurationResult(); }
+    if (!surface->wasConfigurationSuccessful()) {
+        return surface->getConfigurationResult();
+    }
 
-#define ADD_VK_PRESENT_MODE(VK_PM)																	\
-	do {																							\
-		if (pPresentModes && presentModesCnt < *pCount) { pPresentModes[presentModesCnt] = VK_PM; }	\
-		presentModesCnt++;																			\
-	} while(false)
+#define ADD_VK_PRESENT_MODE(VK_PM)                                             \
+    do {                                                                       \
+        if (pPresentModes && presentModesCnt < *pCount) {                      \
+            pPresentModes[presentModesCnt] = VK_PM;                            \
+        }                                                                      \
+        presentModesCnt++;                                                     \
+    } while (false)
 
-	uint32_t presentModesCnt = 0;
+    uint32_t presentModesCnt = 0;
 
-	ADD_VK_PRESENT_MODE(VK_PRESENT_MODE_FIFO_KHR);
+    ADD_VK_PRESENT_MODE(VK_PRESENT_MODE_FIFO_KHR);
 
-	if (_metalFeatures.presentModeImmediate) {
-		ADD_VK_PRESENT_MODE(VK_PRESENT_MODE_IMMEDIATE_KHR);
-	}
+    if (_metalFeatures.presentModeImmediate) {
+        ADD_VK_PRESENT_MODE(VK_PRESENT_MODE_IMMEDIATE_KHR);
+    }
 
-	if (pPresentModes && *pCount < presentModesCnt) {
-		return VK_INCOMPLETE;
-	}
+    if (pPresentModes && *pCount < presentModesCnt) {
+        return VK_INCOMPLETE;
+    }
 
-	*pCount = presentModesCnt;
-	return VK_SUCCESS;
+    *pCount = presentModesCnt;
+    return VK_SUCCESS;
 }
 
 VkResult MVKPhysicalDevice::getPresentRectangles(MVKSurface* surface,
-												 uint32_t* pRectCount,
-												 VkRect2D* pRects) {
+                                                 uint32_t* pRectCount,
+                                                 VkRect2D* pRects) {
 
-	if ( !surface->wasConfigurationSuccessful() ) { return surface->getConfigurationResult(); }
+    if (!surface->wasConfigurationSuccessful()) {
+        return surface->getConfigurationResult();
+    }
 
-	if ( !pRects ) {
-		*pRectCount = 1;
-		return VK_SUCCESS;
-	}
+    if (!pRects) {
+        *pRectCount = 1;
+        return VK_SUCCESS;
+    }
 
-	if (*pRectCount == 0) { return VK_INCOMPLETE; }
+    if (*pRectCount == 0) {
+        return VK_INCOMPLETE;
+    }
 
-	*pRectCount = 1;
+    *pRectCount = 1;
 
-	pRects[0].offset = { 0, 0 };
-	pRects[0].extent = surface->getNaturalExtent();
+    pRects[0].offset = {0, 0};
+    pRects[0].extent = surface->getNaturalExtent();
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
-
 
 #pragma mark Queues
 
-// Returns the queue families supported by this instance, lazily creating them if necessary.
-// Metal does not distinguish functionality between queues, which would normally lead us
-// to create only only one general-purpose queue family. However, Vulkan associates command
-// buffers with a queue family, whereas Metal associates command buffers with a Metal queue.
-// In order to allow a Metal command buffer to be prefilled before it is formally submitted to
-// a Vulkan queue, we need to enforce that each Vulkan queue family can have only one Metal queue.
-// In order to provide parallel queue operations, we therefore provide multiple queue families.
-// In addition, Metal queues are always general purpose, so the default behaviour is for all
-// queue families to support graphics + compute + transfer, unless the app indicates it
-// requires queue family specialization.
+// Returns the queue families supported by this instance, lazily creating them
+// if necessary. Metal does not distinguish functionality between queues, which
+// would normally lead us to create only only one general-purpose queue family.
+// However, Vulkan associates command buffers with a queue family, whereas Metal
+// associates command buffers with a Metal queue. In order to allow a Metal
+// command buffer to be prefilled before it is formally submitted to a Vulkan
+// queue, we need to enforce that each Vulkan queue family can have only one
+// Metal queue. In order to provide parallel queue operations, we therefore
+// provide multiple queue families. In addition, Metal queues are always general
+// purpose, so the default behaviour is for all queue families to support
+// graphics + compute + transfer, unless the app indicates it requires queue
+// family specialization.
 MVKArrayRef<MVKQueueFamily*> MVKPhysicalDevice::getQueueFamilies() {
-	if (_queueFamilies.empty()) {
-		VkQueueFamilyProperties qfProps;
-		bool specialize = getMVKConfig().specializedQueueFamilies;
-		uint32_t qfIdx = 0;
+    if (_queueFamilies.empty()) {
+        VkQueueFamilyProperties qfProps;
+        bool specialize = getMVKConfig().specializedQueueFamilies;
+        uint32_t qfIdx = 0;
 
-		qfProps.queueCount = kMVKQueueCountPerQueueFamily;
-		qfProps.timestampValidBits = 64;
-		qfProps.minImageTransferGranularity = { 1, 1, 1};
+        qfProps.queueCount = kMVKQueueCountPerQueueFamily;
+        qfProps.timestampValidBits = 64;
+        qfProps.minImageTransferGranularity = {1, 1, 1};
 
-		// General-purpose queue family
-		qfProps.queueFlags = (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT);
-		_queueFamilies.push_back(new MVKQueueFamily(this, qfIdx++, &qfProps));
+        // General-purpose queue family
+        qfProps.queueFlags = (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT |
+                              VK_QUEUE_TRANSFER_BIT);
+        _queueFamilies.push_back(new MVKQueueFamily(this, qfIdx++, &qfProps));
 
-		// Single queue semaphore requires using a single queue for everything
-		// So don't allow anyone to have more than one
-		if (_vkSemaphoreStyle != MVKSemaphoreStyleSingleQueue) {
-			// Dedicated graphics queue family...or another general-purpose queue family.
-			if (specialize) { qfProps.queueFlags = (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT); }
-			_queueFamilies.push_back(new MVKQueueFamily(this, qfIdx++, &qfProps));
+        // Single queue semaphore requires using a single queue for everything
+        // So don't allow anyone to have more than one
+        if (_vkSemaphoreStyle != MVKSemaphoreStyleSingleQueue) {
+            // Dedicated graphics queue family...or another general-purpose
+            // queue family.
+            if (specialize) {
+                qfProps.queueFlags =
+                    (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_TRANSFER_BIT);
+            }
+            _queueFamilies.push_back(
+                new MVKQueueFamily(this, qfIdx++, &qfProps));
 
-			// Dedicated compute queue family...or another general-purpose queue family.
-			if (specialize) { qfProps.queueFlags = (VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT); }
-			_queueFamilies.push_back(new MVKQueueFamily(this, qfIdx++, &qfProps));
+            // Dedicated compute queue family...or another general-purpose queue
+            // family.
+            if (specialize) {
+                qfProps.queueFlags =
+                    (VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT);
+            }
+            _queueFamilies.push_back(
+                new MVKQueueFamily(this, qfIdx++, &qfProps));
 
-			// Dedicated transfer queue family...or another general-purpose queue family.
-			if (specialize) { qfProps.queueFlags = VK_QUEUE_TRANSFER_BIT; }
-			_queueFamilies.push_back(new MVKQueueFamily(this, qfIdx++, &qfProps));
-		}
+            // Dedicated transfer queue family...or another general-purpose
+            // queue family.
+            if (specialize) {
+                qfProps.queueFlags = VK_QUEUE_TRANSFER_BIT;
+            }
+            _queueFamilies.push_back(
+                new MVKQueueFamily(this, qfIdx++, &qfProps));
+        }
 
-		MVKAssert(kMVKQueueFamilyCount >= _queueFamilies.size(), "Adjust value of kMVKQueueFamilyCount.");
-	}
-	return _queueFamilies.contents();
+        MVKAssert(kMVKQueueFamilyCount >= _queueFamilies.size(),
+                  "Adjust value of kMVKQueueFamilyCount.");
+    }
+    return _queueFamilies.contents();
 }
 
-VkResult MVKPhysicalDevice::getQueueFamilyProperties(uint32_t* pCount,
-													 VkQueueFamilyProperties* pQueueFamilyProperties) {
-	auto qFams = getQueueFamilies();
-	uint32_t qfCnt = uint32_t(qFams.size());
+VkResult MVKPhysicalDevice::getQueueFamilyProperties(
+    uint32_t* pCount, VkQueueFamilyProperties* pQueueFamilyProperties) {
+    auto qFams = getQueueFamilies();
+    uint32_t qfCnt = uint32_t(qFams.size());
 
-	// If properties aren't actually being requested yet, simply update the returned count
-	if ( !pQueueFamilyProperties ) {
-		*pCount = qfCnt;
-		return VK_SUCCESS;
-	}
+    // If properties aren't actually being requested yet, simply update the
+    // returned count
+    if (!pQueueFamilyProperties) {
+        *pCount = qfCnt;
+        return VK_SUCCESS;
+    }
 
-	// Determine how many families we'll return, and return that number
-	VkResult rslt = (*pCount >= qfCnt) ? VK_SUCCESS : VK_INCOMPLETE;
-	*pCount = min(*pCount, qfCnt);
+    // Determine how many families we'll return, and return that number
+    VkResult rslt = (*pCount >= qfCnt) ? VK_SUCCESS : VK_INCOMPLETE;
+    *pCount = min(*pCount, qfCnt);
 
-	// Now populate the queue families
-	if (pQueueFamilyProperties) {
-		for (uint32_t qfIdx = 0; qfIdx < *pCount; qfIdx++) {
-			qFams[qfIdx]->getProperties(&pQueueFamilyProperties[qfIdx]);
-		}
-	}
+    // Now populate the queue families
+    if (pQueueFamilyProperties) {
+        for (uint32_t qfIdx = 0; qfIdx < *pCount; qfIdx++) {
+            qFams[qfIdx]->getProperties(&pQueueFamilyProperties[qfIdx]);
+        }
+    }
 
-	return rslt;
+    return rslt;
 }
 
-VkResult MVKPhysicalDevice::getQueueFamilyProperties(uint32_t* pCount,
-													 VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
-	VkResult rslt;
-	if (pQueueFamilyProperties) {
-		// Populate temp array of VkQueueFamilyProperties then copy into array of VkQueueFamilyProperties2KHR.
-		// The value of *pCount may be reduced during call, but will always be <= size of temp array.
-		VkQueueFamilyProperties qProps[*pCount];
-		rslt = getQueueFamilyProperties(pCount, qProps);
-		for (uint32_t qpIdx = 0; qpIdx < *pCount; qpIdx++) {
-			auto pQP = &pQueueFamilyProperties[qpIdx];
-			pQP->sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR;
-			pQP->pNext = nullptr;
-			pQP->queueFamilyProperties = qProps[qpIdx];
-		}
-	} else {
-		rslt = getQueueFamilyProperties(pCount, (VkQueueFamilyProperties*)nullptr);
-	}
-	return rslt;
+VkResult MVKPhysicalDevice::getQueueFamilyProperties(
+    uint32_t* pCount, VkQueueFamilyProperties2KHR* pQueueFamilyProperties) {
+    VkResult rslt;
+    if (pQueueFamilyProperties) {
+        // Populate temp array of VkQueueFamilyProperties then copy into array
+        // of VkQueueFamilyProperties2KHR. The value of *pCount may be reduced
+        // during call, but will always be <= size of temp array.
+        VkQueueFamilyProperties qProps[*pCount];
+        rslt = getQueueFamilyProperties(pCount, qProps);
+        for (uint32_t qpIdx = 0; qpIdx < *pCount; qpIdx++) {
+            auto pQP = &pQueueFamilyProperties[qpIdx];
+            pQP->sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR;
+            pQP->pNext = nullptr;
+            pQP->queueFamilyProperties = qProps[qpIdx];
+        }
+    } else {
+        rslt =
+            getQueueFamilyProperties(pCount, (VkQueueFamilyProperties*)nullptr);
+    }
+    return rslt;
 }
 
-// If needed, update the timestamp period for this device, using a crude lowpass filter to level out
-// wild temporary changes, particularly during initial queries before much GPU activity has occurred.
-// On Apple GPUs, CPU & GPU timestamps are the same, and timestamp period never changes.
+// If needed, update the timestamp period for this device, using a crude lowpass
+// filter to level out wild temporary changes, particularly during initial
+// queries before much GPU activity has occurred. On Apple GPUs, CPU & GPU
+// timestamps are the same, and timestamp period never changes.
 void MVKPhysicalDevice::updateTimestampPeriod() {
-	if ( !_gpuCapabilities.isAppleGPU && [_mtlDevice respondsToSelector: @selector(sampleTimestamps:gpuTimestamp:)]) {
-		MTLTimestamp earlierCPUTs = _prevCPUTimestamp;
-		MTLTimestamp earlierGPUTs = _prevGPUTimestamp;
-		[_mtlDevice sampleTimestamps: &_prevCPUTimestamp gpuTimestamp: &_prevGPUTimestamp];
-		double elapsedCPUNanos = _prevCPUTimestamp - earlierCPUTs;
-		double elapsedGPUTicks = _prevGPUTimestamp - earlierGPUTs;
+    if (!_gpuCapabilities.isAppleGPU &&
+        [_mtlDevice respondsToSelector:@selector(sampleTimestamps:
+                                                     gpuTimestamp:)]) {
+        MTLTimestamp earlierCPUTs = _prevCPUTimestamp;
+        MTLTimestamp earlierGPUTs = _prevGPUTimestamp;
+        [_mtlDevice sampleTimestamps:&_prevCPUTimestamp
+                        gpuTimestamp:&_prevGPUTimestamp];
+        double elapsedCPUNanos = _prevCPUTimestamp - earlierCPUTs;
+        double elapsedGPUTicks = _prevGPUTimestamp - earlierGPUTs;
 
-		// Don't update period the first time through, or if no time elapsed.
-		if (earlierCPUTs && elapsedCPUNanos && elapsedGPUTicks) {
-			// Basic lowpass filter TPout = (1 - A)TPout + (A * TPin).
-			// The lower A is, the slower TPout will change over time.
-			auto& vkTsp = _properties.limits.timestampPeriod;
-			float a = getMVKConfig().timestampPeriodLowPassAlpha;
-			float tsPeriod = elapsedCPUNanos / elapsedGPUTicks;
-			vkTsp = ((1.0 - a) * vkTsp) + (a * tsPeriod);
-		}
-	}
+        // Don't update period the first time through, or if no time elapsed.
+        if (earlierCPUTs && elapsedCPUNanos && elapsedGPUTicks) {
+            // Basic lowpass filter TPout = (1 - A)TPout + (A * TPin).
+            // The lower A is, the slower TPout will change over time.
+            auto& vkTsp = _properties.limits.timestampPeriod;
+            float a = getMVKConfig().timestampPeriodLowPassAlpha;
+            float tsPeriod = elapsedCPUNanos / elapsedGPUTicks;
+            vkTsp = ((1.0 - a) * vkTsp) + (a * tsPeriod);
+        }
+    }
 }
-
 
 #pragma mark Memory models
 
-/** Populates the specified memory properties with the memory characteristics of this device. */
-VkResult MVKPhysicalDevice::getMemoryProperties(VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
-	*pMemoryProperties = _memoryProperties;
-	return VK_SUCCESS;
+/** Populates the specified memory properties with the memory characteristics of
+ * this device. */
+VkResult MVKPhysicalDevice::getMemoryProperties(
+    VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
+    *pMemoryProperties = _memoryProperties;
+    return VK_SUCCESS;
 }
 
-VkResult MVKPhysicalDevice::getMemoryProperties(VkPhysicalDeviceMemoryProperties2* pMemoryProperties) {
-	pMemoryProperties->sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
-	pMemoryProperties->memoryProperties = _memoryProperties;
-	for (auto* next = (VkBaseOutStructure*)pMemoryProperties->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT: {
-				auto* budgetProps = (VkPhysicalDeviceMemoryBudgetPropertiesEXT*)next;
-				mvkClear(budgetProps->heapBudget, VK_MAX_MEMORY_HEAPS);
-				mvkClear(budgetProps->heapUsage, VK_MAX_MEMORY_HEAPS);
-				if ( !_hasUnifiedMemory ) {
-					budgetProps->heapBudget[1] = (VkDeviceSize)mvkGetAvailableMemorySize();
-					budgetProps->heapUsage[1] = (VkDeviceSize)mvkGetUsedMemorySize();
-				}
-				budgetProps->heapBudget[0] = (VkDeviceSize)getRecommendedMaxWorkingSetSize();
-				auto currentAllocatedSize = (VkDeviceSize)getCurrentAllocatedSize();
-				if (budgetProps->heapUsage[1] > currentAllocatedSize) {
-					// mapped memory can't be larger than total memory, so ignore and zero-out
-					budgetProps->heapUsage[1] = 0;
-				}
-				budgetProps->heapUsage[0] = currentAllocatedSize - budgetProps->heapUsage[1];
-				break;
-			}
-			default:
-				break;
-		}
-	}
-	return VK_SUCCESS;
+VkResult MVKPhysicalDevice::getMemoryProperties(
+    VkPhysicalDeviceMemoryProperties2* pMemoryProperties) {
+    pMemoryProperties->sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+    pMemoryProperties->memoryProperties = _memoryProperties;
+    for (auto* next = (VkBaseOutStructure*)pMemoryProperties->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT: {
+            auto* budgetProps =
+                (VkPhysicalDeviceMemoryBudgetPropertiesEXT*)next;
+            mvkClear(budgetProps->heapBudget, VK_MAX_MEMORY_HEAPS);
+            mvkClear(budgetProps->heapUsage, VK_MAX_MEMORY_HEAPS);
+            if (!_hasUnifiedMemory) {
+                budgetProps->heapBudget[1] =
+                    (VkDeviceSize)mvkGetAvailableMemorySize();
+                budgetProps->heapUsage[1] =
+                    (VkDeviceSize)mvkGetUsedMemorySize();
+            }
+            budgetProps->heapBudget[0] =
+                (VkDeviceSize)getRecommendedMaxWorkingSetSize();
+            auto currentAllocatedSize = (VkDeviceSize)getCurrentAllocatedSize();
+            if (budgetProps->heapUsage[1] > currentAllocatedSize) {
+                // mapped memory can't be larger than total memory, so ignore
+                // and zero-out
+                budgetProps->heapUsage[1] = 0;
+            }
+            budgetProps->heapUsage[0] =
+                currentAllocatedSize - budgetProps->heapUsage[1];
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    return VK_SUCCESS;
 }
-
 
 #pragma mark Construction
 
-MVKPhysicalDevice::MVKPhysicalDevice(MVKInstance* mvkInstance, id<MTLDevice> mtlDevice) :
-	_mvkInstance(mvkInstance),
-	_mtlDevice([mtlDevice retain]),
-	_gpuCapabilities(mtlDevice),
-	_supportedExtensions(this, true),
-	_pixelFormats(this) {				// Set after _mtlDevice & _gpuCapabilities
+MVKPhysicalDevice::MVKPhysicalDevice(MVKInstance* mvkInstance,
+                                     id<MTLDevice> mtlDevice)
+    : _mvkInstance(mvkInstance), _mtlDevice([mtlDevice retain]),
+      _gpuCapabilities(mtlDevice), _supportedExtensions(this, true),
+      _pixelFormats(this) { // Set after _mtlDevice & _gpuCapabilities
 
-	initMTLDevice();           			// Call first.
-	initProperties();           		// Call second.
-	initMetalFeatures();        		// Call third.
-	initFeatures();             		// Call fourth.
-	initLimits();						// Call fifth.
-	initExtensions();
-	initMemoryProperties();
-	initExternalMemoryProperties();
-	initCounterSets();
-	initVkSemaphoreStyle();
-	logGPUInfo();
+    initMTLDevice();     // Call first.
+    initProperties();    // Call second.
+    initMetalFeatures(); // Call third.
+    initFeatures();      // Call fourth.
+    initLimits();        // Call fifth.
+    initExtensions();
+    initMemoryProperties();
+    initExternalMemoryProperties();
+    initCounterSets();
+    initVkSemaphoreStyle();
+    logGPUInfo();
 }
 
 void MVKPhysicalDevice::initMTLDevice() {
 #if MVK_MACOS
-	// Apple Silicon will respond false to isLowPower, but never hits it.
-	_hasUnifiedMemory = ([_mtlDevice respondsToSelector: @selector(hasUnifiedMemory)]
-						 ? _mtlDevice.hasUnifiedMemory : _mtlDevice.isLowPower);
+    // Apple Silicon will respond false to isLowPower, but never hits it.
+    _hasUnifiedMemory =
+        ([_mtlDevice respondsToSelector:@selector(hasUnifiedMemory)]
+             ? _mtlDevice.hasUnifiedMemory
+             : _mtlDevice.isLowPower);
 
 #if MVK_XCODE_14_3 && !MVK_MACCAT
-	if ([_mtlDevice respondsToSelector: @selector(setShouldMaximizeConcurrentCompilation:)]) {
-		[_mtlDevice setShouldMaximizeConcurrentCompilation: getMVKConfig().shouldMaximizeConcurrentCompilation];
-		MVKLogInfoIf(getMVKConfig().debugMode, "maximumConcurrentCompilationTaskCount %lu", _mtlDevice.maximumConcurrentCompilationTaskCount);
-	}
+    if ([_mtlDevice respondsToSelector:@selector
+                    (setShouldMaximizeConcurrentCompilation:)]) {
+        [_mtlDevice setShouldMaximizeConcurrentCompilation:
+                        getMVKConfig().shouldMaximizeConcurrentCompilation];
+        MVKLogInfoIf(getMVKConfig().debugMode,
+                     "maximumConcurrentCompilationTaskCount %lu",
+                     _mtlDevice.maximumConcurrentCompilationTaskCount);
+    }
 #endif
 
-#endif  // MVK_MACOS
+#endif // MVK_MACOS
 }
 
 // Initializes the physical device properties (except limits).
 void MVKPhysicalDevice::initProperties() {
-	mvkClear(&_properties);	// Start with everything cleared
+    mvkClear(&_properties); // Start with everything cleared
 
-	_properties.apiVersion = getMVKConfig().apiVersionToAdvertise;
-	_properties.driverVersion = MVK_VERSION;
+    _properties.apiVersion = getMVKConfig().apiVersionToAdvertise;
+    _properties.driverVersion = MVK_VERSION;
 
-	initGPUInfoProperties();
-	initPipelineCacheUUID();
+    initGPUInfoProperties();
+    initPipelineCacheUUID();
 }
 
 // Initializes the Metal-specific physical device features of this instance.
 void MVKPhysicalDevice::initMetalFeatures() {
 
-	// Start with all Metal features cleared
-	mvkClear(&_metalFeatures);
+    // Start with all Metal features cleared
+    mvkClear(&_metalFeatures);
 
-	_metalFeatures.hostMemoryPageSize = mvkGetHostMemoryPageSize();
+    _metalFeatures.hostMemoryPageSize = mvkGetHostMemoryPageSize();
 
-	_metalFeatures.maxPerStageBufferCount = 31;
+    _metalFeatures.maxPerStageBufferCount = 31;
     _metalFeatures.maxMTLBufferSize = (256 * MEBI);
     _metalFeatures.dynamicMTLBufferSize = 0;
     _metalFeatures.maxPerStageDynamicMTLBufferCount = 0;
@@ -1965,388 +2518,420 @@ void MVKPhysicalDevice::initMetalFeatures() {
     _metalFeatures.maxPerStageSamplerCount = 16;
     _metalFeatures.maxQueryBufferSize = (64 * KIBI);
 
-	_metalFeatures.pushConstantSizeAlignment = 16;     // Min float4 alignment for typical uniform structs.
+    _metalFeatures.pushConstantSizeAlignment =
+        16; // Min float4 alignment for typical uniform structs.
 
-	_metalFeatures.maxTextureLayers = (2 * KIBI);
+    _metalFeatures.maxTextureLayers = (2 * KIBI);
 
-	_metalFeatures.ioSurfaces = MVK_SUPPORT_IOSURFACE_BOOL;
+    _metalFeatures.ioSurfaces = MVK_SUPPORT_IOSURFACE_BOOL;
 
-	// Metal supports 2 or 3 concurrent CAMetalLayer drawables.
-	_metalFeatures.minSwapchainImageCount = kMVKMinSwapchainImageCount;
-	_metalFeatures.maxSwapchainImageCount = kMVKMaxSwapchainImageCount;
+    // Metal supports 2 or 3 concurrent CAMetalLayer drawables.
+    _metalFeatures.minSwapchainImageCount = kMVKMinSwapchainImageCount;
+    _metalFeatures.maxSwapchainImageCount = kMVKMaxSwapchainImageCount;
 
-	_metalFeatures.maxPerStageStorageTextureCount = 8;
+    _metalFeatures.maxPerStageStorageTextureCount = 8;
 
-	_metalFeatures.vertexStrideAlignment = supportsMTLGPUFamily(Apple5) ? 1 : 4;
+    _metalFeatures.vertexStrideAlignment = supportsMTLGPUFamily(Apple5) ? 1 : 4;
 
 #if MVK_XCODE_15
-	// Dynamic vertex stride needs to have everything aligned - compiled with support for vertex stride calls, and supported by both runtime OS and GPU.
-	_metalFeatures.dynamicVertexStride = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2));
+    // Dynamic vertex stride needs to have everything aligned - compiled with
+    // support for vertex stride calls, and supported by both runtime OS and
+    // GPU.
+    _metalFeatures.dynamicVertexStride =
+        mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) &&
+        (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2));
 
-	_metalFeatures.nativeTextureAtomics = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Metal3) || supportsMTLGPUFamily(Apple6) || supportsMTLGPUFamily(Mac2));
+    _metalFeatures.nativeTextureAtomics =
+        mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) &&
+        (supportsMTLGPUFamily(Metal3) || supportsMTLGPUFamily(Apple6) ||
+         supportsMTLGPUFamily(Mac2));
 #endif
 
-	// GPU-specific features
-	switch (_properties.vendorID) {
-		case kAMDVendorId:
-			_metalFeatures.clearColorFloatRounding = MVK_FLOAT_ROUNDING_DOWN;
-			break;
-		case kAppleVendorId:
-			// TODO: Other GPUs?
-			if (!mvkOSVersionIsAtLeast(14.0, 17.0, 1.0)) {
-				_metalFeatures.needsSampleDrefLodArrayWorkaround = true;
-			}
-			_metalFeatures.needsCubeGradWorkaround = true;
-			// fallthrough
-		case kIntelVendorId:
-		case kNVVendorId:
-		default:
-			_metalFeatures.clearColorFloatRounding = MVK_FLOAT_ROUNDING_NEAREST;
-			break;
-	}
+    // GPU-specific features
+    switch (_properties.vendorID) {
+    case kAMDVendorId:
+        _metalFeatures.clearColorFloatRounding = MVK_FLOAT_ROUNDING_DOWN;
+        break;
+    case kAppleVendorId:
+        // TODO: Other GPUs?
+        if (!mvkOSVersionIsAtLeast(14.0, 17.0, 1.0)) {
+            _metalFeatures.needsSampleDrefLodArrayWorkaround = true;
+        }
+        _metalFeatures.needsCubeGradWorkaround = true;
+        // fallthrough
+    case kIntelVendorId:
+    case kNVVendorId:
+    default:
+        _metalFeatures.clearColorFloatRounding = MVK_FLOAT_ROUNDING_NEAREST;
+        break;
+    }
 
 #if MVK_TVOS
-	_metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
+    _metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
     _metalFeatures.mtlBufferAlignment = 64;
-	_metalFeatures.mtlCopyBufferAlignment = 1;
+    _metalFeatures.mtlCopyBufferAlignment = 1;
     _metalFeatures.texelBuffers = true;
-	_metalFeatures.maxTextureDimension = (8 * KIBI);
+    _metalFeatures.maxTextureDimension = (8 * KIBI);
     _metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
     _metalFeatures.sharedLinearTextures = true;
-    _metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
-	_metalFeatures.renderLinearTextures = true;
-	_metalFeatures.tileBasedDeferredRendering = true;
-	_metalFeatures.shaderSpecialization = true;
-	_metalFeatures.stencilViews = true;
-	_metalFeatures.fences = true;
-	_metalFeatures.deferredStoreActions = true;
-	_metalFeatures.renderWithoutAttachments = true;
-	_metalFeatures.argumentBuffers = true;
-	_metalFeatures.events = true;
-	_metalFeatures.textureBuffers = true;
+    _metalFeatures.maxPerStageDynamicMTLBufferCount =
+        _metalFeatures.maxPerStageBufferCount;
+    _metalFeatures.renderLinearTextures = true;
+    _metalFeatures.tileBasedDeferredRendering = true;
+    _metalFeatures.shaderSpecialization = true;
+    _metalFeatures.stencilViews = true;
+    _metalFeatures.fences = true;
+    _metalFeatures.deferredStoreActions = true;
+    _metalFeatures.renderWithoutAttachments = true;
+    _metalFeatures.argumentBuffers = true;
+    _metalFeatures.events = true;
+    _metalFeatures.textureBuffers = true;
 
-	if (supportsMTLGPUFamily(Apple3)) {
-		_metalFeatures.indirectDrawing = true;
-		_metalFeatures.baseVertexInstanceDrawing = true;
-		_metalFeatures.combinedStoreResolveAction = true;
-		_metalFeatures.mtlBufferAlignment = 16;     // Min float4 alignment for typical vertex buffers. MTLBuffer may go down to 4 bytes for other data.
-		_metalFeatures.maxTextureDimension = (16 * KIBI);
-		_metalFeatures.depthSampleCompare = true;
-		_metalFeatures.arrayOfTextures = true;
-		_metalFeatures.arrayOfSamplers = true;
-		_metalFeatures.depthResolve = true;
-	}
+    if (supportsMTLGPUFamily(Apple3)) {
+        _metalFeatures.indirectDrawing = true;
+        _metalFeatures.baseVertexInstanceDrawing = true;
+        _metalFeatures.combinedStoreResolveAction = true;
+        _metalFeatures.mtlBufferAlignment =
+            16; // Min float4 alignment for typical vertex buffers. MTLBuffer
+                // may go down to 4 bytes for other data.
+        _metalFeatures.maxTextureDimension = (16 * KIBI);
+        _metalFeatures.depthSampleCompare = true;
+        _metalFeatures.arrayOfTextures = true;
+        _metalFeatures.arrayOfSamplers = true;
+        _metalFeatures.depthResolve = true;
+    }
 
-	if ( mvkOSVersionIsAtLeast(12.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
-	}
+    if (mvkOSVersionIsAtLeast(12.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
+    }
 
-	if ( mvkOSVersionIsAtLeast(13.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
-		_metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
-		_metalFeatures.nativeTextureSwizzle = true;
-		if (supportsMTLGPUFamily(Apple3)) {
-			_metalFeatures.native3DCompressedTextures = true;
-		}
-		if (supportsMTLGPUFamily(Apple4)) {
-			_metalFeatures.quadPermute = true;
-		}
-	}
+    if (mvkOSVersionIsAtLeast(13.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
+        _metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
+        _metalFeatures.nativeTextureSwizzle = true;
+        if (supportsMTLGPUFamily(Apple3)) {
+            _metalFeatures.native3DCompressedTextures = true;
+        }
+        if (supportsMTLGPUFamily(Apple4)) {
+            _metalFeatures.quadPermute = true;
+        }
+    }
 
-	if (supportsMTLGPUFamily(Apple4)) {
-		_metalFeatures.maxPerStageTextureCount = 96;
-	} else {
-		_metalFeatures.maxPerStageTextureCount = 31;
-	}
+    if (supportsMTLGPUFamily(Apple4)) {
+        _metalFeatures.maxPerStageTextureCount = 96;
+    } else {
+        _metalFeatures.maxPerStageTextureCount = 31;
+    }
 
 #if MVK_XCODE_12
-	if ( mvkOSVersionIsAtLeast(14.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
-	}
+    if (mvkOSVersionIsAtLeast(14.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
+    }
 #endif
 #if MVK_XCODE_13
-	if ( mvkOSVersionIsAtLeast(15.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
-	}
+    if (mvkOSVersionIsAtLeast(15.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
+    }
 #endif
 #if MVK_XCODE_14
-	if ( mvkOSVersionIsAtLeast(16.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
-	}
+    if (mvkOSVersionIsAtLeast(16.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
+    }
 #endif
 
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(17.0) ) {
+    if (mvkOSVersionIsAtLeast(17.0)) {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
     }
 #endif
 
 #if MVK_XCODE_16
-	if ( mvkOSVersionIsAtLeast(18.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
-	}
+    if (mvkOSVersionIsAtLeast(18.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
+    }
 #endif
 
 #endif
 
 #if MVK_IOS
-	_metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
+    _metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
     _metalFeatures.mtlBufferAlignment = 64;
-	_metalFeatures.mtlCopyBufferAlignment = 1;
+    _metalFeatures.mtlCopyBufferAlignment = 1;
     _metalFeatures.texelBuffers = true;
-	_metalFeatures.maxTextureDimension = (4 * KIBI);
+    _metalFeatures.maxTextureDimension = (4 * KIBI);
     _metalFeatures.sharedLinearTextures = true;
-	_metalFeatures.renderLinearTextures = true;
-	_metalFeatures.tileBasedDeferredRendering = true;
-	_metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
-	_metalFeatures.maxTextureDimension = (8 * KIBI);
-	_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
-	_metalFeatures.shaderSpecialization = true;
-	_metalFeatures.stencilViews = true;
-	_metalFeatures.fences = true;
-	_metalFeatures.deferredStoreActions = true;
-	_metalFeatures.renderWithoutAttachments = true;
-	_metalFeatures.argumentBuffers = true;
-	_metalFeatures.events = true;
-	_metalFeatures.textureBuffers = true;
+    _metalFeatures.renderLinearTextures = true;
+    _metalFeatures.tileBasedDeferredRendering = true;
+    _metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
+    _metalFeatures.maxTextureDimension = (8 * KIBI);
+    _metalFeatures.maxPerStageDynamicMTLBufferCount =
+        _metalFeatures.maxPerStageBufferCount;
+    _metalFeatures.shaderSpecialization = true;
+    _metalFeatures.stencilViews = true;
+    _metalFeatures.fences = true;
+    _metalFeatures.deferredStoreActions = true;
+    _metalFeatures.renderWithoutAttachments = true;
+    _metalFeatures.argumentBuffers = true;
+    _metalFeatures.events = true;
+    _metalFeatures.textureBuffers = true;
 
-	if (supportsMTLGPUFamily(Apple3)) {
-		_metalFeatures.indirectDrawing = true;
-		_metalFeatures.baseVertexInstanceDrawing = true;
-		_metalFeatures.combinedStoreResolveAction = true;
-		_metalFeatures.mtlBufferAlignment = 16;     // Min float4 alignment for typical vertex buffers. MTLBuffer may go down to 4 bytes for other data.
-		_metalFeatures.maxTextureDimension = (16 * KIBI);
-		_metalFeatures.depthSampleCompare = true;
-		_metalFeatures.depthResolve = true;
-	}
+    if (supportsMTLGPUFamily(Apple3)) {
+        _metalFeatures.indirectDrawing = true;
+        _metalFeatures.baseVertexInstanceDrawing = true;
+        _metalFeatures.combinedStoreResolveAction = true;
+        _metalFeatures.mtlBufferAlignment =
+            16; // Min float4 alignment for typical vertex buffers. MTLBuffer
+                // may go down to 4 bytes for other data.
+        _metalFeatures.maxTextureDimension = (16 * KIBI);
+        _metalFeatures.depthSampleCompare = true;
+        _metalFeatures.depthResolve = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple3)) {
-		_metalFeatures.arrayOfTextures = true;
-	}
-	if (supportsMTLGPUFamily(Apple3)) {
-		_metalFeatures.arrayOfSamplers = true;
-	}
+    if (supportsMTLGPUFamily(Apple3)) {
+        _metalFeatures.arrayOfTextures = true;
+    }
+    if (supportsMTLGPUFamily(Apple3)) {
+        _metalFeatures.arrayOfSamplers = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple4)) {
-		_metalFeatures.postDepthCoverage = true;
-		_metalFeatures.nonUniformThreadgroups = true;
-	}
+    if (supportsMTLGPUFamily(Apple4)) {
+        _metalFeatures.postDepthCoverage = true;
+        _metalFeatures.nonUniformThreadgroups = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple5)) {
-		_metalFeatures.layeredRendering = true;
-		_metalFeatures.stencilFeedback = true;
-		_metalFeatures.indirectTessellationDrawing = true;
-		_metalFeatures.stencilResolve = true;
-	}
+    if (supportsMTLGPUFamily(Apple5)) {
+        _metalFeatures.layeredRendering = true;
+        _metalFeatures.stencilFeedback = true;
+        _metalFeatures.indirectTessellationDrawing = true;
+        _metalFeatures.stencilResolve = true;
+    }
 
-	if ( mvkOSVersionIsAtLeast(12.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
-	}
+    if (mvkOSVersionIsAtLeast(12.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
+    }
 
-	if ( mvkOSVersionIsAtLeast(13.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
-		_metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
-		_metalFeatures.nativeTextureSwizzle = true;
+    if (mvkOSVersionIsAtLeast(13.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
+        _metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
+        _metalFeatures.nativeTextureSwizzle = true;
 
-		if (supportsMTLGPUFamily(Apple3)) {
-			_metalFeatures.native3DCompressedTextures = true;
-		}
-		if (supportsMTLGPUFamily(Apple4)) {
-			_metalFeatures.quadPermute = true;
-		}
-		if (supportsMTLGPUFamily(Apple6) ) {
-			_metalFeatures.astcHDRTextures = true;
-			_metalFeatures.simdPermute = true;
-		}
-	}
+        if (supportsMTLGPUFamily(Apple3)) {
+            _metalFeatures.native3DCompressedTextures = true;
+        }
+        if (supportsMTLGPUFamily(Apple4)) {
+            _metalFeatures.quadPermute = true;
+        }
+        if (supportsMTLGPUFamily(Apple6)) {
+            _metalFeatures.astcHDRTextures = true;
+            _metalFeatures.simdPermute = true;
+        }
+    }
 
-	if (supportsMTLGPUFamily(Apple4)) {
-		_metalFeatures.maxPerStageTextureCount = 96;
-	} else {
-		_metalFeatures.maxPerStageTextureCount = 31;
-	}
+    if (supportsMTLGPUFamily(Apple4)) {
+        _metalFeatures.maxPerStageTextureCount = 96;
+    } else {
+        _metalFeatures.maxPerStageTextureCount = 31;
+    }
 
 #if MVK_XCODE_12
-	if ( mvkOSVersionIsAtLeast(14.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
+    if (mvkOSVersionIsAtLeast(14.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
         _metalFeatures.multisampleArrayTextures = true;
-		if ( supportsMTLGPUFamily(Apple7) ) {
-			_metalFeatures.maxQueryBufferSize = (256 * KIBI);
-			_metalFeatures.multisampleLayeredRendering = _metalFeatures.layeredRendering;
-			_metalFeatures.samplerClampToBorder = true;
-			_metalFeatures.samplerMirrorClampToEdge = true;
-			_metalFeatures.simdReduction = true;
-		}
-	}
+        if (supportsMTLGPUFamily(Apple7)) {
+            _metalFeatures.maxQueryBufferSize = (256 * KIBI);
+            _metalFeatures.multisampleLayeredRendering =
+                _metalFeatures.layeredRendering;
+            _metalFeatures.samplerClampToBorder = true;
+            _metalFeatures.samplerMirrorClampToEdge = true;
+            _metalFeatures.simdReduction = true;
+        }
+    }
 #endif
 #if MVK_XCODE_13
-	if ( mvkOSVersionIsAtLeast(15.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
-	}
+    if (mvkOSVersionIsAtLeast(15.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
+    }
 #endif
 #if MVK_XCODE_14
-	if ( mvkOSVersionIsAtLeast(16.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
-	}
+    if (mvkOSVersionIsAtLeast(16.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
+    }
 #endif
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(17.0) ) {
+    if (mvkOSVersionIsAtLeast(17.0)) {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
     }
 #endif
 #if MVK_XCODE_16
-	if ( mvkOSVersionIsAtLeast(18.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
-	}
+    if (mvkOSVersionIsAtLeast(18.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
+    }
 #endif
 
 #endif
 
 #if MVK_MACOS
-	_metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
+    _metalFeatures.mslVersionEnum = MTLLanguageVersion2_0;
     _metalFeatures.maxPerStageTextureCount = 128;
     _metalFeatures.mtlBufferAlignment = 256;
-	_metalFeatures.mtlCopyBufferAlignment = 4;
-	_metalFeatures.baseVertexInstanceDrawing = true;
-	_metalFeatures.layeredRendering = true;
-	_metalFeatures.maxTextureDimension = (16 * KIBI);
-	_metalFeatures.depthSampleCompare = true;
-	_metalFeatures.samplerMirrorClampToEdge = true;
-	_metalFeatures.indirectDrawing = true;
-	_metalFeatures.indirectTessellationDrawing = true;
-	_metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
-	_metalFeatures.shaderSpecialization = true;
-	_metalFeatures.stencilViews = true;
-	_metalFeatures.samplerClampToBorder = true;
-	_metalFeatures.combinedStoreResolveAction = true;
-	_metalFeatures.deferredStoreActions = true;
-	_metalFeatures.maxMTLBufferSize = (1 * GIBI);
-	_metalFeatures.maxPerStageDynamicMTLBufferCount = 14;
-	_metalFeatures.texelBuffers = true;
-	_metalFeatures.arrayOfTextures = true;
-	_metalFeatures.arrayOfSamplers = true;
-	_metalFeatures.presentModeImmediate = true;
-	_metalFeatures.fences = true;
-	_metalFeatures.nonUniformThreadgroups = true;
-	_metalFeatures.argumentBuffers = true;
-	_metalFeatures.multisampleArrayTextures = true;
-	_metalFeatures.events = true;
-	_metalFeatures.textureBuffers = true;
+    _metalFeatures.mtlCopyBufferAlignment = 4;
+    _metalFeatures.baseVertexInstanceDrawing = true;
+    _metalFeatures.layeredRendering = true;
+    _metalFeatures.maxTextureDimension = (16 * KIBI);
+    _metalFeatures.depthSampleCompare = true;
+    _metalFeatures.samplerMirrorClampToEdge = true;
+    _metalFeatures.indirectDrawing = true;
+    _metalFeatures.indirectTessellationDrawing = true;
+    _metalFeatures.dynamicMTLBufferSize = (4 * KIBI);
+    _metalFeatures.shaderSpecialization = true;
+    _metalFeatures.stencilViews = true;
+    _metalFeatures.samplerClampToBorder = true;
+    _metalFeatures.combinedStoreResolveAction = true;
+    _metalFeatures.deferredStoreActions = true;
+    _metalFeatures.maxMTLBufferSize = (1 * GIBI);
+    _metalFeatures.maxPerStageDynamicMTLBufferCount = 14;
+    _metalFeatures.texelBuffers = true;
+    _metalFeatures.arrayOfTextures = true;
+    _metalFeatures.arrayOfSamplers = true;
+    _metalFeatures.presentModeImmediate = true;
+    _metalFeatures.fences = true;
+    _metalFeatures.nonUniformThreadgroups = true;
+    _metalFeatures.argumentBuffers = true;
+    _metalFeatures.multisampleArrayTextures = true;
+    _metalFeatures.events = true;
+    _metalFeatures.textureBuffers = true;
 
-	if (supportsMTLGPUFamily(Mac2)) {
-		_metalFeatures.multisampleLayeredRendering = _metalFeatures.layeredRendering;
-		_metalFeatures.stencilFeedback = true;
-		_metalFeatures.depthResolve = true;
-		_metalFeatures.stencilResolve = true;
-		_metalFeatures.simdPermute = true;
-		_metalFeatures.quadPermute = true;
-		_metalFeatures.simdReduction = true;
-	}
+    if (supportsMTLGPUFamily(Mac2)) {
+        _metalFeatures.multisampleLayeredRendering =
+            _metalFeatures.layeredRendering;
+        _metalFeatures.stencilFeedback = true;
+        _metalFeatures.depthResolve = true;
+        _metalFeatures.stencilResolve = true;
+        _metalFeatures.simdPermute = true;
+        _metalFeatures.quadPermute = true;
+        _metalFeatures.simdReduction = true;
+    }
 
-	if ( mvkOSVersionIsAtLeast(10.14) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
-	}
+    if (mvkOSVersionIsAtLeast(10.14)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_1;
+    }
 
-	if ( mvkOSVersionIsAtLeast(10.15) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
-		_metalFeatures.maxQueryBufferSize = (256 * KIBI);
-		_metalFeatures.native3DCompressedTextures = true;
-        if ( mvkOSVersionIsAtLeast(mvkMakeOSVersion(10, 15, 6)) ) {
+    if (mvkOSVersionIsAtLeast(10.15)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_2;
+        _metalFeatures.maxQueryBufferSize = (256 * KIBI);
+        _metalFeatures.native3DCompressedTextures = true;
+        if (mvkOSVersionIsAtLeast(mvkMakeOSVersion(10, 15, 6))) {
             _metalFeatures.sharedLinearTextures = true;
         }
-		if (supportsMTLGPUFamily(Mac2)) {
-			_metalFeatures.nativeTextureSwizzle = true;
-			_metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
-			_metalFeatures.renderWithoutAttachments = true;
-		}
-	}
+        if (supportsMTLGPUFamily(Mac2)) {
+            _metalFeatures.nativeTextureSwizzle = true;
+            _metalFeatures.placementHeaps = getMVKConfig().useMTLHeap;
+            _metalFeatures.renderWithoutAttachments = true;
+        }
+    }
 
 #if MVK_XCODE_12
-	if ( mvkOSVersionIsAtLeast(11.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
-	}
+    if (mvkOSVersionIsAtLeast(11.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_3;
+    }
 #endif
 #if MVK_XCODE_13
-	if ( mvkOSVersionIsAtLeast(12.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
-	}
+    if (mvkOSVersionIsAtLeast(12.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
+    }
 #endif
 #if MVK_XCODE_14
-	if ( mvkOSVersionIsAtLeast(13.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
-	}
+    if (mvkOSVersionIsAtLeast(13.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
+    }
 #endif
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(14.0) ) {
+    if (mvkOSVersionIsAtLeast(14.0)) {
         _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
     }
 #endif
 #if MVK_XCODE_16
-	if ( mvkOSVersionIsAtLeast(15.0) ) {
-		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
-	}
+    if (mvkOSVersionIsAtLeast(15.0)) {
+        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
+    }
 #endif
 
-	// This is an Apple GPU--treat it accordingly.
-	if (supportsMTLGPUFamily(Apple1)) {
-		_metalFeatures.mtlCopyBufferAlignment = 1;
-		_metalFeatures.mtlBufferAlignment = 16;     // Min float4 alignment for typical vertex buffers. MTLBuffer may go down to 4 bytes for other data.
-		_metalFeatures.maxQueryBufferSize = (64 * KIBI);
-		_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
-		_metalFeatures.postDepthCoverage = true;
-		_metalFeatures.renderLinearTextures = true;
-		_metalFeatures.tileBasedDeferredRendering = true;
+    // This is an Apple GPU--treat it accordingly.
+    if (supportsMTLGPUFamily(Apple1)) {
+        _metalFeatures.mtlCopyBufferAlignment = 1;
+        _metalFeatures.mtlBufferAlignment =
+            16; // Min float4 alignment for typical vertex buffers. MTLBuffer
+                // may go down to 4 bytes for other data.
+        _metalFeatures.maxQueryBufferSize = (64 * KIBI);
+        _metalFeatures.maxPerStageDynamicMTLBufferCount =
+            _metalFeatures.maxPerStageBufferCount;
+        _metalFeatures.postDepthCoverage = true;
+        _metalFeatures.renderLinearTextures = true;
+        _metalFeatures.tileBasedDeferredRendering = true;
 
 #if MVK_XCODE_12
-		if (supportsMTLGPUFamily(Apple6)) {
-			_metalFeatures.astcHDRTextures = true;
-		}
-		if (supportsMTLGPUFamily(Apple7)) {
-			_metalFeatures.maxQueryBufferSize = (256 * KIBI);
-		}
+        if (supportsMTLGPUFamily(Apple6)) {
+            _metalFeatures.astcHDRTextures = true;
+        }
+        if (supportsMTLGPUFamily(Apple7)) {
+            _metalFeatures.maxQueryBufferSize = (256 * KIBI);
+        }
 #endif
-	}
+    }
 
-	// Don't use barriers in render passes on Apple GPUs. Apple GPUs don't support them,
-	// and in fact Metal's validation layer will complain if you try to use them.
-	// Texture barriers deprecated as of macOS 10.14.
-	_metalFeatures.memoryBarriers = !_gpuCapabilities.isAppleGPU;
+    // Don't use barriers in render passes on Apple GPUs. Apple GPUs don't
+    // support them, and in fact Metal's validation layer will complain if you
+    // try to use them. Texture barriers deprecated as of macOS 10.14.
+    _metalFeatures.memoryBarriers = !_gpuCapabilities.isAppleGPU;
 
 #endif
 
-	if ( [_mtlDevice respondsToSelector: @selector(areProgrammableSamplePositionsSupported)] ) {
-		_metalFeatures.programmableSamplePositions = _mtlDevice.areProgrammableSamplePositionsSupported;
-	}
+    if ([_mtlDevice respondsToSelector:@selector
+                    (areProgrammableSamplePositionsSupported)]) {
+        _metalFeatures.programmableSamplePositions =
+            _mtlDevice.areProgrammableSamplePositionsSupported;
+    }
 
-    if ( [_mtlDevice respondsToSelector: @selector(areRasterOrderGroupsSupported)] ) {
-        _metalFeatures.rasterOrderGroups = _mtlDevice.areRasterOrderGroupsSupported;
+    if ([_mtlDevice
+            respondsToSelector:@selector(areRasterOrderGroupsSupported)]) {
+        _metalFeatures.rasterOrderGroups =
+            _mtlDevice.areRasterOrderGroupsSupported;
     }
 #if MVK_XCODE_12
-	if ( [_mtlDevice respondsToSelector: @selector(supportsPullModelInterpolation)] ) {
-		_metalFeatures.pullModelInterpolation = _mtlDevice.supportsPullModelInterpolation;
-	}
+    if ([_mtlDevice
+            respondsToSelector:@selector(supportsPullModelInterpolation)]) {
+        _metalFeatures.pullModelInterpolation =
+            _mtlDevice.supportsPullModelInterpolation;
+    }
 #endif
 
-#if (MVK_MACOS && !MVK_MACCAT) || (MVK_MACCAT && MVK_XCODE_14) || (MVK_IOS && MVK_XCODE_12)
-	// Both current and deprecated properties are retrieved and OR'd together, due to a
-	// Metal bug that, in some environments, returned true for one and false for the other.
-	bool bcProp1 = false;
-	bool bcProp2 = false;
-	if ( [_mtlDevice respondsToSelector: @selector(supportsShaderBarycentricCoordinates)] ) {
-		bcProp1 = _mtlDevice.supportsShaderBarycentricCoordinates;
-	}
-	if ( [_mtlDevice respondsToSelector: @selector(areBarycentricCoordsSupported)] ) {
-		bcProp2 = _mtlDevice.areBarycentricCoordsSupported;
-	}
-	_metalFeatures.shaderBarycentricCoordinates = bcProp1 || bcProp2;
+#if (MVK_MACOS && !MVK_MACCAT) || (MVK_MACCAT && MVK_XCODE_14) ||              \
+    (MVK_IOS && MVK_XCODE_12)
+    // Both current and deprecated properties are retrieved and OR'd together,
+    // due to a Metal bug that, in some environments, returned true for one and
+    // false for the other.
+    bool bcProp1 = false;
+    bool bcProp2 = false;
+    if ([_mtlDevice respondsToSelector:@selector
+                    (supportsShaderBarycentricCoordinates)]) {
+        bcProp1 = _mtlDevice.supportsShaderBarycentricCoordinates;
+    }
+    if ([_mtlDevice
+            respondsToSelector:@selector(areBarycentricCoordsSupported)]) {
+        bcProp2 = _mtlDevice.areBarycentricCoordsSupported;
+    }
+    _metalFeatures.shaderBarycentricCoordinates = bcProp1 || bcProp2;
 #endif
 
-    if ( [_mtlDevice respondsToSelector: @selector(maxBufferLength)] ) {
+    if ([_mtlDevice respondsToSelector:@selector(maxBufferLength)]) {
         _metalFeatures.maxMTLBufferSize = _mtlDevice.maxBufferLength;
     }
 
-    for (uint32_t sc = VK_SAMPLE_COUNT_1_BIT; sc <= VK_SAMPLE_COUNT_64_BIT; sc <<= 1) {
-        if ([_mtlDevice supportsTextureSampleCount: mvkSampleCountFromVkSampleCountFlagBits((VkSampleCountFlagBits)sc)]) {
+    for (uint32_t sc = VK_SAMPLE_COUNT_1_BIT; sc <= VK_SAMPLE_COUNT_64_BIT;
+         sc <<= 1) {
+        if ([_mtlDevice supportsTextureSampleCount:
+                            mvkSampleCountFromVkSampleCountFlagBits(
+                                (VkSampleCountFlagBits)sc)]) {
             _metalFeatures.supportedSampleCounts |= sc;
         }
     }
@@ -2355,33 +2940,36 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #if MVK_MACOS
     if (_metalFeatures.simdPermute) {
         // Based on data from Sascha Willems' Vulkan Hardware Database.
-        // This would be a lot easier and less painful if MTLDevice had properties for this...
-        _metalFeatures.maxSubgroupSize = (_properties.vendorID == kAMDVendorId) ? 64 : 32;
+        // This would be a lot easier and less painful if MTLDevice had
+        // properties for this...
+        _metalFeatures.maxSubgroupSize =
+            (_properties.vendorID == kAMDVendorId) ? 64 : 32;
         switch (_properties.vendorID) {
-            case kIntelVendorId:
-                _metalFeatures.minSubgroupSize = 8;
-                break;
-            case kAMDVendorId:
-                switch (_properties.deviceID) {
-                    case kAMDRadeonRX5700DeviceId:
-                    case kAMDRadeonRX5500DeviceId:
-                    case kAMDRadeonRX6800DeviceId:
-                    case kAMDRadeonRX6700DeviceId:
-                    case kAMDRadeonRX6600DeviceId:
-                        _metalFeatures.minSubgroupSize = 32;
-                        break;
-                    default:
-                        _metalFeatures.minSubgroupSize = _metalFeatures.maxSubgroupSize;
-                        break;
-                }
-                break;
-            case kAppleVendorId:
-                // XXX Minimum thread execution width for Apple GPUs is unknown, but assumed to be 4. May be greater.
-                _metalFeatures.minSubgroupSize = 4;
+        case kIntelVendorId:
+            _metalFeatures.minSubgroupSize = 8;
+            break;
+        case kAMDVendorId:
+            switch (_properties.deviceID) {
+            case kAMDRadeonRX5700DeviceId:
+            case kAMDRadeonRX5500DeviceId:
+            case kAMDRadeonRX6800DeviceId:
+            case kAMDRadeonRX6700DeviceId:
+            case kAMDRadeonRX6600DeviceId:
+                _metalFeatures.minSubgroupSize = 32;
                 break;
             default:
                 _metalFeatures.minSubgroupSize = _metalFeatures.maxSubgroupSize;
                 break;
+            }
+            break;
+        case kAppleVendorId:
+            // XXX Minimum thread execution width for Apple GPUs is unknown, but
+            // assumed to be 4. May be greater.
+            _metalFeatures.minSubgroupSize = 4;
+            break;
+        default:
+            _metalFeatures.minSubgroupSize = _metalFeatures.maxSubgroupSize;
+            break;
         }
     }
 #endif
@@ -2394,124 +2982,137 @@ void MVKPhysicalDevice::initMetalFeatures() {
     }
 #endif
 
-#define setMSLVersion(maj, min)	\
-	_metalFeatures.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj, min);
+#define setMSLVersion(maj, min)                                                \
+    _metalFeatures.mslVersion =                                                \
+        SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj,     \
+                                                                      min);
 
-	switch (_metalFeatures.mslVersionEnum) {
+    switch (_metalFeatures.mslVersionEnum) {
 #if MVK_XCODE_16
-		case MTLLanguageVersion3_2:
-			setMSLVersion(3, 2);
-			break;
+    case MTLLanguageVersion3_2:
+        setMSLVersion(3, 2);
+        break;
 #endif
 #if MVK_XCODE_15
-        case MTLLanguageVersion3_1:
-            setMSLVersion(3, 1);
-            break;
+    case MTLLanguageVersion3_1:
+        setMSLVersion(3, 1);
+        break;
 #endif
 #if MVK_XCODE_14
-		case MTLLanguageVersion3_0:
-			setMSLVersion(3, 0);
-			break;
+    case MTLLanguageVersion3_0:
+        setMSLVersion(3, 0);
+        break;
 #endif
 #if MVK_XCODE_13
-		case MTLLanguageVersion2_4:
-			setMSLVersion(2, 4);
-			break;
+    case MTLLanguageVersion2_4:
+        setMSLVersion(2, 4);
+        break;
 #endif
 #if MVK_XCODE_12
-		case MTLLanguageVersion2_3:
-			setMSLVersion(2, 3);
-			break;
+    case MTLLanguageVersion2_3:
+        setMSLVersion(2, 3);
+        break;
 #endif
-		case MTLLanguageVersion2_2:
-			setMSLVersion(2, 2);
-			break;
-		case MTLLanguageVersion2_1:
-			setMSLVersion(2, 1);
-			break;
-		case MTLLanguageVersion2_0:
-			setMSLVersion(2, 0);
-			break;
-		case MTLLanguageVersion1_2:
-			setMSLVersion(1, 2);
-			break;
-		case MTLLanguageVersion1_1:
-			setMSLVersion(1, 1);
-			break;
+    case MTLLanguageVersion2_2:
+        setMSLVersion(2, 2);
+        break;
+    case MTLLanguageVersion2_1:
+        setMSLVersion(2, 1);
+        break;
+    case MTLLanguageVersion2_0:
+        setMSLVersion(2, 0);
+        break;
+    case MTLLanguageVersion1_2:
+        setMSLVersion(1, 2);
+        break;
+    case MTLLanguageVersion1_1:
+        setMSLVersion(1, 1);
+        break;
 #if MVK_IOS_OR_TVOS
-		case MTLLanguageVersion1_0:
-			setMSLVersion(1, 0);
-			break;
+    case MTLLanguageVersion1_0:
+        setMSLVersion(1, 0);
+        break;
 #endif
-	}
+    }
 
 // iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
-	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
-	_metalFeatures.nativeTextureSwizzle = false;
+    _metalFeatures.mtlBufferAlignment = 256; // Even on Apple Silicon
+    _metalFeatures.nativeTextureSwizzle = false;
 #endif
 
-	// Argument buffers
-	if ([_mtlDevice respondsToSelector: @selector(argumentBuffersSupport)]) {
-		_metalFeatures.argumentBuffersTier = _mtlDevice.argumentBuffersSupport;
-	} else {
-		_metalFeatures.argumentBuffersTier = MTLArgumentBuffersTier1;
-	}
+    // Argument buffers
+    if ([_mtlDevice respondsToSelector:@selector(argumentBuffersSupport)]) {
+        _metalFeatures.argumentBuffersTier = _mtlDevice.argumentBuffersSupport;
+    } else {
+        _metalFeatures.argumentBuffersTier = MTLArgumentBuffersTier1;
+    }
 
-	// Metal argument buffer support for descriptor sets is supported on macOS 11.0 or later,
-	// or on older versions of macOS using an Intel GPU, or on iOS & tvOS 16.0 or later (Metal 3).
-	_metalFeatures.descriptorSetArgumentBuffers = (_metalFeatures.argumentBuffers &&
-												   (mvkOSVersionIsAtLeast(11.0, 16.0, 1.0) ||
-													_properties.vendorID == kIntelVendorId));
+    // Metal argument buffer support for descriptor sets is supported on
+    // macOS 11.0 or later, or on older versions of macOS using an Intel GPU, or
+    // on iOS & tvOS 16.0 or later (Metal 3).
+    _metalFeatures.descriptorSetArgumentBuffers =
+        (_metalFeatures.argumentBuffers &&
+         (mvkOSVersionIsAtLeast(11.0, 16.0, 1.0) ||
+          _properties.vendorID == kIntelVendorId));
 
-	// Argument encoders are not needed if Metal 3 plus Tier 2 argument buffers.
+    // Argument encoders are not needed if Metal 3 plus Tier 2 argument buffers.
 #if MVK_XCODE_14
-	_metalFeatures.needsArgumentBufferEncoders = (_metalFeatures.argumentBuffers &&
-												  !(mvkOSVersionIsAtLeast(13.0, 16.0, 1.0) &&
-													supportsMTLGPUFamily(Metal3) &&
-													_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2));
+    _metalFeatures.needsArgumentBufferEncoders =
+        (_metalFeatures.argumentBuffers &&
+         !(mvkOSVersionIsAtLeast(13.0, 16.0, 1.0) &&
+           supportsMTLGPUFamily(Metal3) &&
+           _metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2));
 #else
-	_metalFeatures.needsArgumentBufferEncoders = _metalFeatures.argumentBuffers;
+    _metalFeatures.needsArgumentBufferEncoders = _metalFeatures.argumentBuffers;
 #endif
 
-	_isUsingMetalArgumentBuffers = _metalFeatures.descriptorSetArgumentBuffers && getMVKConfig().useMetalArgumentBuffers;;
+    _isUsingMetalArgumentBuffers =
+        _metalFeatures.descriptorSetArgumentBuffers &&
+        getMVKConfig().useMetalArgumentBuffers;
+    ;
 
-#define checkSupportsMTLCounterSamplingPoint(mtlSP, mvkSP)  \
-	if ([_mtlDevice respondsToSelector: @selector(supportsCounterSampling:)] &&  \
-		[_mtlDevice supportsCounterSampling: MTLCounterSamplingPointAt ##mtlSP ##Boundary]) {  \
-		_metalFeatures.counterSamplingPoints |= MVK_COUNTER_SAMPLING_AT_ ##mvkSP;  \
-	}
+#define checkSupportsMTLCounterSamplingPoint(mtlSP, mvkSP)                     \
+    if ([_mtlDevice respondsToSelector:@selector(supportsCounterSampling:)] && \
+        [_mtlDevice supportsCounterSampling:MTLCounterSamplingPointAt##mtlSP## \
+                    Boundary]) {                                               \
+        _metalFeatures.counterSamplingPoints |=                                \
+            MVK_COUNTER_SAMPLING_AT_##mvkSP;                                   \
+    }
 
 #if MVK_XCODE_12
-	checkSupportsMTLCounterSamplingPoint(Draw, DRAW);
-	checkSupportsMTLCounterSamplingPoint(Dispatch, DISPATCH);
-	checkSupportsMTLCounterSamplingPoint(Blit, BLIT);
-	checkSupportsMTLCounterSamplingPoint(Stage, PIPELINE_STAGE);
+    checkSupportsMTLCounterSamplingPoint(Draw, DRAW);
+    checkSupportsMTLCounterSamplingPoint(Dispatch, DISPATCH);
+    checkSupportsMTLCounterSamplingPoint(Blit, BLIT);
+    checkSupportsMTLCounterSamplingPoint(Stage, PIPELINE_STAGE);
 #endif
 
 #if MVK_MACOS
-	// On macOS, if we couldn't query supported sample points (on macOS 11),
-	// but the platform can support immediate-mode sample points, indicate that here.
-	if (!_metalFeatures.counterSamplingPoints && mvkOSVersionIsAtLeast(10.15) && !supportsMTLGPUFamily(Apple1)) {  \
-		_metalFeatures.counterSamplingPoints = MVK_COUNTER_SAMPLING_AT_DRAW | MVK_COUNTER_SAMPLING_AT_DISPATCH | MVK_COUNTER_SAMPLING_AT_BLIT;  \
-	}
+    // On macOS, if we couldn't query supported sample points (on macOS 11),
+    // but the platform can support immediate-mode sample points, indicate that
+    // here.
+    if (!_metalFeatures.counterSamplingPoints && mvkOSVersionIsAtLeast(10.15) &&
+        !supportsMTLGPUFamily(Apple1)) {
+        _metalFeatures.counterSamplingPoints =
+            MVK_COUNTER_SAMPLING_AT_DRAW | MVK_COUNTER_SAMPLING_AT_DISPATCH |
+            MVK_COUNTER_SAMPLING_AT_BLIT;
+    }
 #endif
-
 }
 
 // Initializes the physical device features of this instance.
 void MVKPhysicalDevice::initFeatures() {
-	mvkClear(&_features);	// Start with everything cleared
+    mvkClear(&_features); // Start with everything cleared
 
-    _features.robustBufferAccess = true;  // XXX Required by Vulkan spec
+    _features.robustBufferAccess = true; // XXX Required by Vulkan spec
     _features.fullDrawIndexUint32 = true;
     _features.independentBlend = true;
     _features.sampleRateShading = true;
-	_features.logicOp = getMVKConfig().useMetalPrivateAPI;
+    _features.logicOp = getMVKConfig().useMetalPrivateAPI;
     _features.depthBiasClamp = true;
     _features.fillModeNonSolid = true;
     _features.largePoints = true;
-	_features.wideLines = getMVKConfig().useMetalPrivateAPI;
+    _features.wideLines = getMVKConfig().useMetalPrivateAPI;
     _features.alphaToOne = true;
     _features.samplerAnisotropy = true;
     _features.shaderImageGatherExtended = true;
@@ -2524,33 +3125,39 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderInt16 = true;
     _features.multiDrawIndirect = true;
     _features.inheritedQueries = true;
-	_features.vertexPipelineStoresAndAtomics = true;
-	_features.fragmentStoresAndAtomics = true;
+    _features.vertexPipelineStoresAndAtomics = true;
+    _features.fragmentStoresAndAtomics = true;
 
-	_features.shaderSampledImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
-	_features.textureCompressionBC = _gpuCapabilities.supportsBCTextureCompression;
+    _features.shaderSampledImageArrayDynamicIndexing =
+        _metalFeatures.arrayOfTextures;
+    _features.textureCompressionBC =
+        _gpuCapabilities.supportsBCTextureCompression;
 
-	_features.drawIndirectFirstInstance = _metalFeatures.indirectDrawing && _metalFeatures.baseVertexInstanceDrawing;
+    _features.drawIndirectFirstInstance =
+        _metalFeatures.indirectDrawing &&
+        _metalFeatures.baseVertexInstanceDrawing;
 
 #if MVK_XCODE_12
-	_features.shaderInt64 = mslVersionIsAtLeast(MTLLanguageVersion2_3) && (supportsMTLGPUFamily(Apple3) || supportsMTLGPUFamily(Mac1));
+    _features.shaderInt64 =
+        mslVersionIsAtLeast(MTLLanguageVersion2_3) &&
+        (supportsMTLGPUFamily(Apple3) || supportsMTLGPUFamily(Mac1));
 #endif
 
 #if MVK_TVOS
     _features.textureCompressionETC2 = true;
     _features.textureCompressionASTC_LDR = true;
 
-	_features.dualSrcBlend = true;
-	_features.depthClamp = true;
+    _features.dualSrcBlend = true;
+    _features.depthClamp = true;
 
     if (supportsMTLGPUFamily(Apple3)) {
         _features.occlusionQueryPrecise = true;
     }
 
-	if (supportsMTLGPUFamily(Apple3)) {
-		_features.tessellationShader = true;
-		_features.shaderTessellationAndGeometryPointSize = true;
-	}
+    if (supportsMTLGPUFamily(Apple3)) {
+        _features.tessellationShader = true;
+        _features.shaderTessellationAndGeometryPointSize = true;
+    }
 #endif
 
 #if MVK_IOS
@@ -2564,73 +3171,77 @@ void MVKPhysicalDevice::initFeatures() {
         _features.occlusionQueryPrecise = true;
     }
 
-	_features.dualSrcBlend = true;
+    _features.dualSrcBlend = true;
 
-	if (supportsMTLGPUFamily(Apple2)) {
-		_features.depthClamp = true;
-	}
+    if (supportsMTLGPUFamily(Apple2)) {
+        _features.depthClamp = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple3)) {
-		_features.tessellationShader = true;
-		_features.shaderTessellationAndGeometryPointSize = true;
-	}
+    if (supportsMTLGPUFamily(Apple3)) {
+        _features.tessellationShader = true;
+        _features.shaderTessellationAndGeometryPointSize = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple4)) {
-		_features.imageCubeArray = true;
-	}
-  
-	if (supportsMTLGPUFamily(Apple5)) {
-		_features.multiViewport = true;
-	}
+    if (supportsMTLGPUFamily(Apple4)) {
+        _features.imageCubeArray = true;
+    }
 
-	if (supportsMTLGPUFamily(Apple6)) {
+    if (supportsMTLGPUFamily(Apple5)) {
+        _features.multiViewport = true;
+    }
+
+    if (supportsMTLGPUFamily(Apple6)) {
         _features.shaderResourceMinLod = true;
-	}
+    }
 #endif
 
 // iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
-	_features.depthClamp = false;
+    _features.depthClamp = false;
 #endif
 
 #if MVK_MACOS
     _features.occlusionQueryPrecise = true;
     _features.imageCubeArray = true;
     _features.depthClamp = true;
-    _features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
+    _features.shaderStorageImageArrayDynamicIndexing =
+        _metalFeatures.arrayOfTextures;
 
 #if MVK_USE_METAL_PRIVATE_API
-    if (getMVKConfig().useMetalPrivateAPI && _properties.vendorID == kAMDVendorId) {
+    if (getMVKConfig().useMetalPrivateAPI &&
+        _properties.vendorID == kAMDVendorId) {
         // Only AMD drivers have the method we need for now.
         _features.depthBounds = true;
     }
 #endif
 
-	_features.tessellationShader = true;
-	_features.dualSrcBlend = true;
-	_features.shaderTessellationAndGeometryPointSize = true;
-	_features.multiViewport = true;
+    _features.tessellationShader = true;
+    _features.dualSrcBlend = true;
+    _features.shaderTessellationAndGeometryPointSize = true;
+    _features.multiViewport = true;
 
-    if ( mvkOSVersionIsAtLeast(10.15) ) {
+    if (mvkOSVersionIsAtLeast(10.15)) {
         _features.shaderResourceMinLod = true;
     }
 
-    if ( supportsMTLGPUFamily(Apple5) ) {
+    if (supportsMTLGPUFamily(Apple5)) {
         _features.textureCompressionETC2 = true;
         _features.textureCompressionASTC_LDR = true;
     }
 #endif
 
-	// Additional non-extension Vulkan 1.2 features.
-	mvkClear(&_vulkan12FeaturesNoExt);		// Start with everything cleared
-	_vulkan12FeaturesNoExt.samplerMirrorClampToEdge = _metalFeatures.samplerMirrorClampToEdge;
-	_vulkan12FeaturesNoExt.drawIndirectCount = false;
-	_vulkan12FeaturesNoExt.descriptorIndexing = _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers;
-	_vulkan12FeaturesNoExt.samplerFilterMinmax = false;
-	_vulkan12FeaturesNoExt.shaderOutputViewportIndex = _features.multiViewport;
-	_vulkan12FeaturesNoExt.shaderOutputLayer = _metalFeatures.layeredRendering;
-	_vulkan12FeaturesNoExt.subgroupBroadcastDynamicId = _metalFeatures.simdPermute || _metalFeatures.quadPermute;
-
+    // Additional non-extension Vulkan 1.2 features.
+    mvkClear(&_vulkan12FeaturesNoExt); // Start with everything cleared
+    _vulkan12FeaturesNoExt.samplerMirrorClampToEdge =
+        _metalFeatures.samplerMirrorClampToEdge;
+    _vulkan12FeaturesNoExt.drawIndirectCount = false;
+    _vulkan12FeaturesNoExt.descriptorIndexing =
+        _metalFeatures.arrayOfTextures && _metalFeatures.arrayOfSamplers;
+    _vulkan12FeaturesNoExt.samplerFilterMinmax = false;
+    _vulkan12FeaturesNoExt.shaderOutputViewportIndex = _features.multiViewport;
+    _vulkan12FeaturesNoExt.shaderOutputLayer = _metalFeatures.layeredRendering;
+    _vulkan12FeaturesNoExt.subgroupBroadcastDynamicId =
+        _metalFeatures.simdPermute || _metalFeatures.quadPermute;
 }
 
 // Initializes the physical device property limits.
@@ -2643,165 +3254,251 @@ void MVKPhysicalDevice::initLimits() {
     if (supportsMTLGPUFamily(Apple2)) {
         _properties.limits.maxColorAttachments = kMVKMaxColorAttachmentCount;
     } else {
-        _properties.limits.maxColorAttachments = 4;		// < kMVKMaxColorAttachmentCount
+        _properties.limits.maxColorAttachments =
+            4; // < kMVKMaxColorAttachmentCount
     }
 #endif
 #if MVK_MACOS
     _properties.limits.maxColorAttachments = kMVKMaxColorAttachmentCount;
 #endif
 
-    _properties.limits.maxFragmentOutputAttachments = _properties.limits.maxColorAttachments;
-    _properties.limits.maxFragmentDualSrcAttachments = _features.dualSrcBlend ? 1 : 0;
+    _properties.limits.maxFragmentOutputAttachments =
+        _properties.limits.maxColorAttachments;
+    _properties.limits.maxFragmentDualSrcAttachments =
+        _features.dualSrcBlend ? 1 : 0;
 
-	_properties.limits.framebufferColorSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.framebufferDepthSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.framebufferStencilSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.framebufferNoAttachmentsSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.sampledImageColorSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.sampledImageIntegerSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.sampledImageDepthSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.sampledImageStencilSampleCounts = _metalFeatures.supportedSampleCounts;
-	_properties.limits.storageImageSampleCounts = VK_SAMPLE_COUNT_1_BIT;
+    _properties.limits.framebufferColorSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.framebufferDepthSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.framebufferStencilSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.framebufferNoAttachmentsSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.sampledImageColorSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.sampledImageIntegerSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.sampledImageDepthSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.sampledImageStencilSampleCounts =
+        _metalFeatures.supportedSampleCounts;
+    _properties.limits.storageImageSampleCounts = VK_SAMPLE_COUNT_1_BIT;
 
-	_properties.limits.maxSampleMaskWords = 1;
+    _properties.limits.maxSampleMaskWords = 1;
 
-	_properties.limits.maxImageDimension1D = _metalFeatures.maxTextureDimension;
-	_properties.limits.maxImageDimension2D = _metalFeatures.maxTextureDimension;
-	_properties.limits.maxImageDimensionCube = _metalFeatures.maxTextureDimension;
-	_properties.limits.maxFramebufferWidth = _metalFeatures.maxTextureDimension;
-	_properties.limits.maxFramebufferHeight = _metalFeatures.maxTextureDimension;
-	_properties.limits.maxFramebufferLayers = _metalFeatures.layeredRendering ? _metalFeatures.maxTextureLayers : 1;
+    _properties.limits.maxImageDimension1D = _metalFeatures.maxTextureDimension;
+    _properties.limits.maxImageDimension2D = _metalFeatures.maxTextureDimension;
+    _properties.limits.maxImageDimensionCube =
+        _metalFeatures.maxTextureDimension;
+    _properties.limits.maxFramebufferWidth = _metalFeatures.maxTextureDimension;
+    _properties.limits.maxFramebufferHeight =
+        _metalFeatures.maxTextureDimension;
+    _properties.limits.maxFramebufferLayers =
+        _metalFeatures.layeredRendering ? _metalFeatures.maxTextureLayers : 1;
 
-    _properties.limits.maxViewportDimensions[0] = _metalFeatures.maxTextureDimension;
-    _properties.limits.maxViewportDimensions[1] = _metalFeatures.maxTextureDimension;
-    float maxVPDim = max(_properties.limits.maxViewportDimensions[0], _properties.limits.maxViewportDimensions[1]);
+    _properties.limits.maxViewportDimensions[0] =
+        _metalFeatures.maxTextureDimension;
+    _properties.limits.maxViewportDimensions[1] =
+        _metalFeatures.maxTextureDimension;
+    float maxVPDim = max(_properties.limits.maxViewportDimensions[0],
+                         _properties.limits.maxViewportDimensions[1]);
     _properties.limits.viewportBoundsRange[0] = (-2.0 * maxVPDim);
     _properties.limits.viewportBoundsRange[1] = (2.0 * maxVPDim) - 1;
-    _properties.limits.maxViewports = _features.multiViewport ? kMVKMaxViewportScissorCount : 1;
+    _properties.limits.maxViewports =
+        _features.multiViewport ? kMVKMaxViewportScissorCount : 1;
 
-	_properties.limits.maxImageDimension3D = _metalFeatures.maxTextureLayers;
-	_properties.limits.maxImageArrayLayers = _metalFeatures.maxTextureLayers;
-	// Max sum of API and shader values. Bias not publicly supported in API, but can be applied in the shader directly.
-	// The lack of API value is covered by VkPhysicalDevicePortabilitySubsetFeaturesKHR::samplerMipLodBias.
-	// Metal does not specify a limit for the shader value, so choose something reasonable.
-	_properties.limits.maxSamplerLodBias = getMVKConfig().useMetalPrivateAPI ? 16 : 4;
-	_properties.limits.maxSamplerAnisotropy = 16;
+    _properties.limits.maxImageDimension3D = _metalFeatures.maxTextureLayers;
+    _properties.limits.maxImageArrayLayers = _metalFeatures.maxTextureLayers;
+    // Max sum of API and shader values. Bias not publicly supported in API, but
+    // can be applied in the shader directly. The lack of API value is covered
+    // by VkPhysicalDevicePortabilitySubsetFeaturesKHR::samplerMipLodBias. Metal
+    // does not specify a limit for the shader value, so choose something
+    // reasonable.
+    _properties.limits.maxSamplerLodBias =
+        getMVKConfig().useMetalPrivateAPI ? 16 : 4;
+    _properties.limits.maxSamplerAnisotropy = 16;
 
     _properties.limits.maxVertexInputAttributes = 31;
     _properties.limits.maxVertexInputBindings = 31;
 
-    _properties.limits.maxVertexInputBindingStride = supportsMTLGPUFamily(Apple2) ? kMVKUndefinedLargeUInt32 : (4 * KIBI);
-	_properties.limits.maxVertexInputAttributeOffset = _properties.limits.maxVertexInputBindingStride - 1;
+    _properties.limits.maxVertexInputBindingStride =
+        supportsMTLGPUFamily(Apple2) ? kMVKUndefinedLargeUInt32 : (4 * KIBI);
+    _properties.limits.maxVertexInputAttributeOffset =
+        _properties.limits.maxVertexInputBindingStride - 1;
 
-	_properties.limits.maxPerStageDescriptorSamplers = _metalFeatures.maxPerStageSamplerCount;
-	_properties.limits.maxPerStageDescriptorUniformBuffers = _metalFeatures.maxPerStageBufferCount;
-	_properties.limits.maxPerStageDescriptorStorageBuffers = _metalFeatures.maxPerStageBufferCount;
-	_properties.limits.maxPerStageDescriptorSampledImages = _metalFeatures.maxPerStageTextureCount;
-	_properties.limits.maxPerStageDescriptorStorageImages = _metalFeatures.maxPerStageStorageTextureCount;
-	_properties.limits.maxPerStageDescriptorInputAttachments = _metalFeatures.maxPerStageTextureCount;
+    _properties.limits.maxPerStageDescriptorSamplers =
+        _metalFeatures.maxPerStageSamplerCount;
+    _properties.limits.maxPerStageDescriptorUniformBuffers =
+        _metalFeatures.maxPerStageBufferCount;
+    _properties.limits.maxPerStageDescriptorStorageBuffers =
+        _metalFeatures.maxPerStageBufferCount;
+    _properties.limits.maxPerStageDescriptorSampledImages =
+        _metalFeatures.maxPerStageTextureCount;
+    _properties.limits.maxPerStageDescriptorStorageImages =
+        _metalFeatures.maxPerStageStorageTextureCount;
+    _properties.limits.maxPerStageDescriptorInputAttachments =
+        _metalFeatures.maxPerStageTextureCount;
 
-    _properties.limits.maxPerStageResources = (_metalFeatures.maxPerStageBufferCount + _metalFeatures.maxPerStageTextureCount);
-    _properties.limits.maxFragmentCombinedOutputResources = _properties.limits.maxPerStageResources;
+    _properties.limits.maxPerStageResources =
+        (_metalFeatures.maxPerStageBufferCount +
+         _metalFeatures.maxPerStageTextureCount);
+    _properties.limits.maxFragmentCombinedOutputResources =
+        _properties.limits.maxPerStageResources;
 
-	_properties.limits.maxDescriptorSetSamplers = (_properties.limits.maxPerStageDescriptorSamplers * 5);
-	_properties.limits.maxDescriptorSetUniformBuffers = (_properties.limits.maxPerStageDescriptorUniformBuffers * 5);
-	_properties.limits.maxDescriptorSetUniformBuffersDynamic = (_properties.limits.maxPerStageDescriptorUniformBuffers * 5);
-	_properties.limits.maxDescriptorSetStorageBuffers = (_properties.limits.maxPerStageDescriptorStorageBuffers * 5);
-	_properties.limits.maxDescriptorSetStorageBuffersDynamic = (_properties.limits.maxPerStageDescriptorStorageBuffers * 5);
-	_properties.limits.maxDescriptorSetSampledImages = (_properties.limits.maxPerStageDescriptorSampledImages * 5);
-	_properties.limits.maxDescriptorSetStorageImages = (_properties.limits.maxPerStageDescriptorStorageImages * 5);
-	_properties.limits.maxDescriptorSetInputAttachments = (_properties.limits.maxPerStageDescriptorInputAttachments * 5);
+    _properties.limits.maxDescriptorSetSamplers =
+        (_properties.limits.maxPerStageDescriptorSamplers * 5);
+    _properties.limits.maxDescriptorSetUniformBuffers =
+        (_properties.limits.maxPerStageDescriptorUniformBuffers * 5);
+    _properties.limits.maxDescriptorSetUniformBuffersDynamic =
+        (_properties.limits.maxPerStageDescriptorUniformBuffers * 5);
+    _properties.limits.maxDescriptorSetStorageBuffers =
+        (_properties.limits.maxPerStageDescriptorStorageBuffers * 5);
+    _properties.limits.maxDescriptorSetStorageBuffersDynamic =
+        (_properties.limits.maxPerStageDescriptorStorageBuffers * 5);
+    _properties.limits.maxDescriptorSetSampledImages =
+        (_properties.limits.maxPerStageDescriptorSampledImages * 5);
+    _properties.limits.maxDescriptorSetStorageImages =
+        (_properties.limits.maxPerStageDescriptorStorageImages * 5);
+    _properties.limits.maxDescriptorSetInputAttachments =
+        (_properties.limits.maxPerStageDescriptorInputAttachments * 5);
 
-	_properties.limits.maxClipDistances = 8;	// Per Apple engineers.
-	_properties.limits.maxCullDistances = 0;	// unsupported
-	_properties.limits.maxCombinedClipAndCullDistances = max(_properties.limits.maxClipDistances,
-															 _properties.limits.maxCullDistances);  // If supported, these consume the same slots.
+    _properties.limits.maxClipDistances = 8; // Per Apple engineers.
+    _properties.limits.maxCullDistances = 0; // unsupported
+    _properties.limits.maxCombinedClipAndCullDistances =
+        max(_properties.limits.maxClipDistances,
+            _properties.limits.maxCullDistances); // If supported, these consume
+                                                  // the same slots.
 
-	// Whether handled as a real texture buffer or a 2D texture, this value is likely nowhere near the size of a buffer,
-	// needs to fit in 32 bits, and some apps (I'm looking at you, CTS), assume it is low when doing 32-bit math.
-	_properties.limits.maxTexelBufferElements = _properties.limits.maxImageDimension2D * (4 * KIBI);
+    // Whether handled as a real texture buffer or a 2D texture, this value is
+    // likely nowhere near the size of a buffer, needs to fit in 32 bits, and
+    // some apps (I'm looking at you, CTS), assume it is low when doing 32-bit
+    // math.
+    _properties.limits.maxTexelBufferElements =
+        _properties.limits.maxImageDimension2D * (4 * KIBI);
 #if MVK_MACOS
-	_properties.limits.maxUniformBufferRange = (64 * KIBI);
-	if (supportsMTLGPUFamily(Apple5)) {
-		_properties.limits.maxUniformBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
-	}
+    _properties.limits.maxUniformBufferRange = (64 * KIBI);
+    if (supportsMTLGPUFamily(Apple5)) {
+        _properties.limits.maxUniformBufferRange =
+            (uint32_t)min(_metalFeatures.maxMTLBufferSize,
+                          (VkDeviceSize)std::numeric_limits<uint32_t>::max());
+    }
 #endif
 #if MVK_IOS_OR_TVOS
-	_properties.limits.maxUniformBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
+    _properties.limits.maxUniformBufferRange =
+        (uint32_t)min(_metalFeatures.maxMTLBufferSize,
+                      (VkDeviceSize)std::numeric_limits<uint32_t>::max());
 #endif
-	_properties.limits.maxStorageBufferRange = (uint32_t)min(_metalFeatures.maxMTLBufferSize, (VkDeviceSize)std::numeric_limits<uint32_t>::max());
-	_properties.limits.maxPushConstantsSize = (4 * KIBI);
+    _properties.limits.maxStorageBufferRange =
+        (uint32_t)min(_metalFeatures.maxMTLBufferSize,
+                      (VkDeviceSize)std::numeric_limits<uint32_t>::max());
+    _properties.limits.maxPushConstantsSize = (4 * KIBI);
 
-    _properties.limits.minMemoryMapAlignment = max(_metalFeatures.mtlBufferAlignment, (VkDeviceSize)64);	// Vulkan spec requires MIN of 64
-    _properties.limits.minUniformBufferOffsetAlignment = _metalFeatures.mtlBufferAlignment;
+    _properties.limits.minMemoryMapAlignment =
+        max(_metalFeatures.mtlBufferAlignment,
+            (VkDeviceSize)64); // Vulkan spec requires MIN of 64
+    _properties.limits.minUniformBufferOffsetAlignment =
+        _metalFeatures.mtlBufferAlignment;
     _properties.limits.minStorageBufferOffsetAlignment = 16;
-    _properties.limits.bufferImageGranularity = _metalFeatures.mtlBufferAlignment;
+    _properties.limits.bufferImageGranularity =
+        _metalFeatures.mtlBufferAlignment;
     _properties.limits.nonCoherentAtomSize = _metalFeatures.mtlBufferAlignment;
 
-    if ([_mtlDevice respondsToSelector: @selector(minimumLinearTextureAlignmentForPixelFormat:)]) {
-        // Figure out the greatest alignment required by all supported formats, and whether
-		// or not they only require alignment to a single texel. We'll use this information
-		// to fill out the VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT struct.
+    if ([_mtlDevice respondsToSelector:@selector
+                    (minimumLinearTextureAlignmentForPixelFormat:)]) {
+        // Figure out the greatest alignment required by all supported formats,
+        // and whether or not they only require alignment to a single texel.
+        // We'll use this information to fill out the
+        // VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT struct.
         uint32_t maxStorage = 0, maxUniform = 0;
         bool singleTexelStorage = true, singleTexelUniform = true;
-		
-		VkFormatProperties3 fmtProps = {}; // We don't initialize sType as enumerateSupportedFormats doesn't care.
-		fmtProps.bufferFeatures = VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT | VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
-		
-        _pixelFormats.enumerateSupportedFormats(fmtProps, true, [&](VkFormat vk) {
-			MTLPixelFormat mtlFmt = _pixelFormats.getMTLPixelFormat(vk);
-			if ( !mtlFmt ) { return false; }	// If format is invalid, avoid validation errors on MTLDevice format alignment calls
 
-            NSUInteger alignment;
-            if ([_mtlDevice respondsToSelector: @selector(minimumTextureBufferAlignmentForPixelFormat:)]) {
-                alignment = [_mtlDevice minimumTextureBufferAlignmentForPixelFormat: mtlFmt];
-            } else {
-                alignment = [_mtlDevice minimumLinearTextureAlignmentForPixelFormat: mtlFmt];
-            }
-            VkFormatProperties3& props = _pixelFormats.getVkFormatProperties3(vk);
-            // For uncompressed formats, this is the size of a single texel.
-            // Note that no implementations of Metal support compressed formats
-            // in a linear texture (including texture buffers). It's likely that even
-            // if they did, this would be the absolute minimum alignment.
-            uint32_t texelSize = _pixelFormats.getBytesPerBlock(vk);
-            // From the spec:
-            //   "If the size of a single texel is a multiple of three bytes, then
-            //    the size of a single component of the format is used instead."
-            if (texelSize % 3 == 0) {
-                switch (_pixelFormats.getFormatType(vk)) {
-                case kMVKFormatColorInt8:
-                case kMVKFormatColorUInt8:
-                    texelSize = 1;
-                    break;
-                case kMVKFormatColorHalf:
-                case kMVKFormatColorInt16:
-                case kMVKFormatColorUInt16:
-                    texelSize = 2;
-                    break;
-                case kMVKFormatColorFloat:
-                case kMVKFormatColorInt32:
-                case kMVKFormatColorUInt32:
-                default:
-                    texelSize = 4;
-                    break;
+        VkFormatProperties3 fmtProps =
+            {}; // We don't initialize sType as enumerateSupportedFormats
+                // doesn't care.
+        fmtProps.bufferFeatures = VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT |
+                                  VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
+
+        _pixelFormats
+            .enumerateSupportedFormats(fmtProps, true, [&](VkFormat vk) {
+                MTLPixelFormat mtlFmt = _pixelFormats.getMTLPixelFormat(vk);
+                if (!mtlFmt) {
+                    return false;
+                } // If format is invalid, avoid validation errors on MTLDevice
+                  // format alignment calls
+
+                NSUInteger alignment;
+                if ([_mtlDevice
+                        respondsToSelector:@selector
+                        (minimumTextureBufferAlignmentForPixelFormat:)]) {
+                    alignment = [_mtlDevice
+                        minimumTextureBufferAlignmentForPixelFormat:mtlFmt];
+                } else {
+                    alignment = [_mtlDevice
+                        minimumLinearTextureAlignmentForPixelFormat:mtlFmt];
                 }
-            }
-            if (mvkAreAllFlagsEnabled(props.bufferFeatures, VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT)) {
-                maxUniform = max(maxUniform, uint32_t(alignment));
-                if (alignment > texelSize) { singleTexelUniform = false; }
-            }
-            if (mvkAreAllFlagsEnabled(props.bufferFeatures, VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT)) {
-                maxStorage = max(maxStorage, uint32_t(alignment));
-                if (alignment > texelSize) { singleTexelStorage = false; }
-            }
-            return true;
-        });
-        _texelBuffAlignProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT;
-        _texelBuffAlignProperties.storageTexelBufferOffsetAlignmentBytes = maxStorage;
-        _texelBuffAlignProperties.storageTexelBufferOffsetSingleTexelAlignment = singleTexelStorage;
-        _texelBuffAlignProperties.uniformTexelBufferOffsetAlignmentBytes = maxUniform;
-        _texelBuffAlignProperties.uniformTexelBufferOffsetSingleTexelAlignment = singleTexelUniform;
-        _properties.limits.minTexelBufferOffsetAlignment = max(maxStorage, maxUniform);
+                VkFormatProperties3& props =
+                    _pixelFormats.getVkFormatProperties3(vk);
+                // For uncompressed formats, this is the size of a single texel.
+                // Note that no implementations of Metal support compressed
+                // formats in a linear texture (including texture buffers). It's
+                // likely that even if they did, this would be the absolute
+                // minimum alignment.
+                uint32_t texelSize = _pixelFormats.getBytesPerBlock(vk);
+                // From the spec:
+                //   "If the size of a single texel is a multiple of three
+                //   bytes, then
+                //    the size of a single component of the format is used
+                //    instead."
+                if (texelSize % 3 == 0) {
+                    switch (_pixelFormats.getFormatType(vk)) {
+                    case kMVKFormatColorInt8:
+                    case kMVKFormatColorUInt8:
+                        texelSize = 1;
+                        break;
+                    case kMVKFormatColorHalf:
+                    case kMVKFormatColorInt16:
+                    case kMVKFormatColorUInt16:
+                        texelSize = 2;
+                        break;
+                    case kMVKFormatColorFloat:
+                    case kMVKFormatColorInt32:
+                    case kMVKFormatColorUInt32:
+                    default:
+                        texelSize = 4;
+                        break;
+                    }
+                }
+                if (mvkAreAllFlagsEnabled(
+                        props.bufferFeatures,
+                        VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT)) {
+                    maxUniform = max(maxUniform, uint32_t(alignment));
+                    if (alignment > texelSize) {
+                        singleTexelUniform = false;
+                    }
+                }
+                if (mvkAreAllFlagsEnabled(
+                        props.bufferFeatures,
+                        VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT)) {
+                    maxStorage = max(maxStorage, uint32_t(alignment));
+                    if (alignment > texelSize) {
+                        singleTexelStorage = false;
+                    }
+                }
+                return true;
+            });
+        _texelBuffAlignProperties.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT;
+        _texelBuffAlignProperties.storageTexelBufferOffsetAlignmentBytes =
+            maxStorage;
+        _texelBuffAlignProperties.storageTexelBufferOffsetSingleTexelAlignment =
+            singleTexelStorage;
+        _texelBuffAlignProperties.uniformTexelBufferOffsetAlignmentBytes =
+            maxUniform;
+        _texelBuffAlignProperties.uniformTexelBufferOffsetSingleTexelAlignment =
+            singleTexelUniform;
+        _properties.limits.minTexelBufferOffsetAlignment =
+            max(maxStorage, maxUniform);
     } else {
 #if MVK_TVOS
         _properties.limits.minTexelBufferOffsetAlignment = 64;
@@ -2815,14 +3512,18 @@ void MVKPhysicalDevice::initLimits() {
 #endif
 #if MVK_MACOS
         _properties.limits.minTexelBufferOffsetAlignment = 256;
-		if (supportsMTLGPUFamily(Apple5)) {
-			_properties.limits.minTexelBufferOffsetAlignment = 16;
-		}
+        if (supportsMTLGPUFamily(Apple5)) {
+            _properties.limits.minTexelBufferOffsetAlignment = 16;
+        }
 #endif
-        _texelBuffAlignProperties.storageTexelBufferOffsetAlignmentBytes = _properties.limits.minTexelBufferOffsetAlignment;
-        _texelBuffAlignProperties.storageTexelBufferOffsetSingleTexelAlignment = VK_FALSE;
-        _texelBuffAlignProperties.uniformTexelBufferOffsetAlignmentBytes = _properties.limits.minTexelBufferOffsetAlignment;
-        _texelBuffAlignProperties.uniformTexelBufferOffsetSingleTexelAlignment = VK_FALSE;
+        _texelBuffAlignProperties.storageTexelBufferOffsetAlignmentBytes =
+            _properties.limits.minTexelBufferOffsetAlignment;
+        _texelBuffAlignProperties.storageTexelBufferOffsetSingleTexelAlignment =
+            VK_FALSE;
+        _texelBuffAlignProperties.uniformTexelBufferOffsetAlignmentBytes =
+            _properties.limits.minTexelBufferOffsetAlignment;
+        _texelBuffAlignProperties.uniformTexelBufferOffsetSingleTexelAlignment =
+            VK_FALSE;
     }
 
 #if MVK_TVOS
@@ -2868,24 +3569,34 @@ void MVKPhysicalDevice::initLimits() {
 #if MVK_MACOS
     _properties.limits.maxFragmentInputComponents = 124;
     _properties.limits.optimalBufferCopyOffsetAlignment = 256;
-	if (supportsMTLGPUFamily(Apple5)) {
-		_properties.limits.optimalBufferCopyOffsetAlignment = 16;
-	}
+    if (supportsMTLGPUFamily(Apple5)) {
+        _properties.limits.optimalBufferCopyOffsetAlignment = 16;
+    }
 
-	_properties.limits.maxTessellationGenerationLevel = 64;
-	_properties.limits.maxTessellationPatchSize = 32;
+    _properties.limits.maxTessellationGenerationLevel = 64;
+    _properties.limits.maxTessellationPatchSize = 32;
 #endif
 
-    _properties.limits.maxVertexOutputComponents = _properties.limits.maxFragmentInputComponents;
+    _properties.limits.maxVertexOutputComponents =
+        _properties.limits.maxFragmentInputComponents;
 
     if (_features.tessellationShader) {
-        _properties.limits.maxTessellationControlPerVertexInputComponents = _properties.limits.maxVertexOutputComponents;
-        _properties.limits.maxTessellationControlPerVertexOutputComponents = _properties.limits.maxTessellationControlPerVertexInputComponents;
+        _properties.limits.maxTessellationControlPerVertexInputComponents =
+            _properties.limits.maxVertexOutputComponents;
+        _properties.limits.maxTessellationControlPerVertexOutputComponents =
+            _properties.limits.maxTessellationControlPerVertexInputComponents;
         // Reserve a few for the tessellation levels.
-        _properties.limits.maxTessellationControlPerPatchOutputComponents = std::max(_properties.limits.maxFragmentInputComponents - 8, 120u);
-        _properties.limits.maxTessellationControlTotalOutputComponents = _properties.limits.maxTessellationPatchSize * _properties.limits.maxTessellationControlPerVertexOutputComponents + _properties.limits.maxTessellationControlPerPatchOutputComponents;
-        _properties.limits.maxTessellationEvaluationInputComponents = _properties.limits.maxTessellationControlPerVertexInputComponents;
-        _properties.limits.maxTessellationEvaluationOutputComponents = _properties.limits.maxTessellationEvaluationInputComponents;
+        _properties.limits.maxTessellationControlPerPatchOutputComponents =
+            std::max(_properties.limits.maxFragmentInputComponents - 8, 120u);
+        _properties.limits.maxTessellationControlTotalOutputComponents =
+            _properties.limits.maxTessellationPatchSize *
+                _properties.limits
+                    .maxTessellationControlPerVertexOutputComponents +
+            _properties.limits.maxTessellationControlPerPatchOutputComponents;
+        _properties.limits.maxTessellationEvaluationInputComponents =
+            _properties.limits.maxTessellationControlPerVertexInputComponents;
+        _properties.limits.maxTessellationEvaluationOutputComponents =
+            _properties.limits.maxTessellationEvaluationInputComponents;
     } else {
         _properties.limits.maxTessellationControlPerVertexInputComponents = 0;
         _properties.limits.maxTessellationControlPerVertexOutputComponents = 0;
@@ -2897,26 +3608,27 @@ void MVKPhysicalDevice::initLimits() {
 
     _properties.limits.optimalBufferCopyRowPitchAlignment = 1;
 
-	_properties.limits.timestampComputeAndGraphics = VK_TRUE;
+    _properties.limits.timestampComputeAndGraphics = VK_TRUE;
 
-	// On non-Apple GPU's, this can vary over time, and is calculated based on actual GPU activity.
-	_properties.limits.timestampPeriod = 1.0;
-	updateTimestampPeriod();
+    // On non-Apple GPU's, this can vary over time, and is calculated based on
+    // actual GPU activity.
+    _properties.limits.timestampPeriod = 1.0;
+    updateTimestampPeriod();
 
     _properties.limits.pointSizeRange[0] = 1;
-	switch (_properties.vendorID) {
-		case kAppleVendorId:
-			_properties.limits.pointSizeRange[1] = 511;
-			break;
-		case kIntelVendorId:
-			_properties.limits.pointSizeRange[1] = 256;
-			break;
-		case kAMDVendorId:
-		case kNVVendorId:
-		default:
-			_properties.limits.pointSizeRange[1] = 64;
-			break;
-	}
+    switch (_properties.vendorID) {
+    case kAppleVendorId:
+        _properties.limits.pointSizeRange[1] = 511;
+        break;
+    case kIntelVendorId:
+        _properties.limits.pointSizeRange[1] = 256;
+        break;
+    case kAMDVendorId:
+    case kNVVendorId:
+    default:
+        _properties.limits.pointSizeRange[1] = 64;
+        break;
+    }
 
     _properties.limits.pointSizeGranularity = 1;
     _properties.limits.lineWidthRange[0] = 1;
@@ -2924,57 +3636,61 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.lineWidthGranularity = _features.wideLines ? 0.125f : 0;
 
     _properties.limits.standardSampleLocations = VK_TRUE;
-    _properties.limits.strictLines = _properties.vendorID == kIntelVendorId || _properties.vendorID == kNVVendorId;
+    _properties.limits.strictLines = _properties.vendorID == kIntelVendorId ||
+                                     _properties.vendorID == kNVVendorId;
 
-	VkExtent3D wgSize = mvkVkExtent3DFromMTLSize(_mtlDevice.maxThreadsPerThreadgroup);
-	_properties.limits.maxComputeWorkGroupSize[0] = wgSize.width;
-	_properties.limits.maxComputeWorkGroupSize[1] = wgSize.height;
-	_properties.limits.maxComputeWorkGroupSize[2] = wgSize.depth;
-	_properties.limits.maxComputeWorkGroupInvocations = max({wgSize.width, wgSize.height, wgSize.depth});
+    VkExtent3D wgSize =
+        mvkVkExtent3DFromMTLSize(_mtlDevice.maxThreadsPerThreadgroup);
+    _properties.limits.maxComputeWorkGroupSize[0] = wgSize.width;
+    _properties.limits.maxComputeWorkGroupSize[1] = wgSize.height;
+    _properties.limits.maxComputeWorkGroupSize[2] = wgSize.depth;
+    _properties.limits.maxComputeWorkGroupInvocations =
+        max({wgSize.width, wgSize.height, wgSize.depth});
 
-	if ( [_mtlDevice respondsToSelector: @selector(maxThreadgroupMemoryLength)] ) {
-		_properties.limits.maxComputeSharedMemorySize = (uint32_t)_mtlDevice.maxThreadgroupMemoryLength;
-	} else {
+    if ([_mtlDevice respondsToSelector:@selector(maxThreadgroupMemoryLength)]) {
+        _properties.limits.maxComputeSharedMemorySize =
+            (uint32_t)_mtlDevice.maxThreadgroupMemoryLength;
+    } else {
 #if MVK_TVOS
-		if (supportsMTLGPUFamily(Apple3)) {
-			_properties.limits.maxComputeSharedMemorySize = (16 * KIBI);
-		} else {
-			_properties.limits.maxComputeSharedMemorySize = ((16 * KIBI) - 32);
-		}
+        if (supportsMTLGPUFamily(Apple3)) {
+            _properties.limits.maxComputeSharedMemorySize = (16 * KIBI);
+        } else {
+            _properties.limits.maxComputeSharedMemorySize = ((16 * KIBI) - 32);
+        }
 #endif
 #if MVK_IOS
-		if (supportsMTLGPUFamily(Apple4)) {
-			_properties.limits.maxComputeSharedMemorySize = (32 * KIBI);
-		} else if (supportsMTLGPUFamily(Apple3)) {
-			_properties.limits.maxComputeSharedMemorySize = (16 * KIBI);
-		} else {
-			_properties.limits.maxComputeSharedMemorySize = ((16 * KIBI) - 32);
-		}
+        if (supportsMTLGPUFamily(Apple4)) {
+            _properties.limits.maxComputeSharedMemorySize = (32 * KIBI);
+        } else if (supportsMTLGPUFamily(Apple3)) {
+            _properties.limits.maxComputeSharedMemorySize = (16 * KIBI);
+        } else {
+            _properties.limits.maxComputeSharedMemorySize = ((16 * KIBI) - 32);
+        }
 #endif
 #if MVK_MACOS
-		_properties.limits.maxComputeSharedMemorySize = (32 * KIBI);
+        _properties.limits.maxComputeSharedMemorySize = (32 * KIBI);
 #endif
-	}
+    }
 
     _properties.limits.minTexelOffset = -8;
     _properties.limits.maxTexelOffset = 7;
     _properties.limits.minTexelGatherOffset = _properties.limits.minTexelOffset;
     _properties.limits.maxTexelGatherOffset = _properties.limits.maxTexelOffset;
 
-
-    // Features with no specific limits - default to effectively unlimited int values
+    // Features with no specific limits - default to effectively unlimited int
+    // values
 
     _properties.limits.maxMemoryAllocationCount = kMVKUndefinedLargeUInt32;
-	_properties.limits.maxSamplerAllocationCount = getMaxSamplerCount();
+    _properties.limits.maxSamplerAllocationCount = getMaxSamplerCount();
     _properties.limits.maxBoundDescriptorSets = kMVKMaxDescriptorSetCount;
 
     _properties.limits.maxComputeWorkGroupCount[0] = kMVKUndefinedLargeUInt32;
     _properties.limits.maxComputeWorkGroupCount[1] = kMVKUndefinedLargeUInt32;
     _properties.limits.maxComputeWorkGroupCount[2] = kMVKUndefinedLargeUInt32;
 
-    _properties.limits.maxDrawIndexedIndexValue = numeric_limits<uint32_t>::max();
+    _properties.limits.maxDrawIndexedIndexValue =
+        numeric_limits<uint32_t>::max();
     _properties.limits.maxDrawIndirectCount = kMVKUndefinedLargeUInt32;
-
 
     // Features with unknown limits - default to Vulkan required limits
 
@@ -2989,7 +3705,6 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.maxInterpolationOffset = 0.5;
     _properties.limits.subPixelInterpolationOffsetBits = 4;
 
-
     // Unsupported features - set to zeros generally
 
     _properties.limits.sparseAddressSpaceSize = 0;
@@ -3003,133 +3718,159 @@ void MVKPhysicalDevice::initLimits() {
 
 #if MVK_MACOS
 
-static uint32_t mvkGetEntryProperty(io_registry_entry_t entry, CFStringRef propertyName) {
+static uint32_t mvkGetEntryProperty(io_registry_entry_t entry,
+                                    CFStringRef propertyName) {
 
-	uint32_t value = 0;
+    uint32_t value = 0;
 
-	CFTypeRef cfProp = IORegistryEntrySearchCFProperty(entry,
-													   kIOServicePlane,
-													   propertyName,
-													   kCFAllocatorDefault,
-													   kIORegistryIterateRecursively |
-													   kIORegistryIterateParents);
-	if (cfProp) {
-		const uint32_t* pValue = reinterpret_cast<const uint32_t*>(CFDataGetBytePtr((CFDataRef)cfProp));
-		if (pValue) { value = *pValue; }
-		CFRelease(cfProp);
-	}
+    CFTypeRef cfProp =
+        IORegistryEntrySearchCFProperty(entry, kIOServicePlane, propertyName,
+                                        kCFAllocatorDefault,
+                                        kIORegistryIterateRecursively |
+                                            kIORegistryIterateParents);
+    if (cfProp) {
+        const uint32_t* pValue = reinterpret_cast<const uint32_t*>(
+            CFDataGetBytePtr((CFDataRef)cfProp));
+        if (pValue) {
+            value = *pValue;
+        }
+        CFRelease(cfProp);
+    }
 
-	return value;
+    return value;
 }
 
 void MVKPhysicalDevice::initGPUInfoProperties() {
-	_properties.deviceType = _hasUnifiedMemory ? VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU : VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
-	strlcpy(_properties.deviceName, _mtlDevice.name.UTF8String, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+    _properties.deviceType = _hasUnifiedMemory
+                                 ? VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
+                                 : VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
+    strlcpy(_properties.deviceName, _mtlDevice.name.UTF8String,
+            VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 
-	// For Apple Silicon, the Device ID is determined by the highest
-	// GPU capability, which is a combination of OS version and GPU type.
-	// We determine Apple Silicon directly from the GPU, instead
-	// of from the build, in case we are running Rosetta2.
-	if (_gpuCapabilities.isAppleGPU) {
-		_properties.vendorID = kAppleVendorId;
-		_properties.deviceID = getHighestGPUCapability();
-		return;
-	}
+    // For Apple Silicon, the Device ID is determined by the highest
+    // GPU capability, which is a combination of OS version and GPU type.
+    // We determine Apple Silicon directly from the GPU, instead
+    // of from the build, in case we are running Rosetta2.
+    if (_gpuCapabilities.isAppleGPU) {
+        _properties.vendorID = kAppleVendorId;
+        _properties.deviceID = getHighestGPUCapability();
+        return;
+    }
 
-	// If the device has an associated registry ID, we can use that to get the associated IOKit node.
-	// The match dictionary is consumed by IOServiceGetMatchingServices and does not need to be released.
-	bool isFound = false;
-	io_registry_entry_t entry;
-	uint64_t regID = mvkGetRegistryID(_mtlDevice);
-	if (regID) {
-		entry = IOServiceGetMatchingService(MACH_PORT_NULL, IORegistryEntryIDMatching(regID));
-		if (entry) {
-			// That returned the IOGraphicsAccelerator nub. Its parent, then, is the actual PCI device.
-			io_registry_entry_t parent;
-			if (IORegistryEntryGetParentEntry(entry, kIOServicePlane, &parent) == kIOReturnSuccess) {
-				isFound = true;
-				_properties.vendorID = mvkGetEntryProperty(parent, CFSTR("vendor-id"));
-				_properties.deviceID = mvkGetEntryProperty(parent, CFSTR("device-id"));
-				IOObjectRelease(parent);
-			}
-			IOObjectRelease(entry);
-		}
-	}
-	// Iterate all GPU's, looking for a match.
-	// The match dictionary is consumed by IOServiceGetMatchingServices and does not need to be released.
-	io_iterator_t entryIterator;
-	if (!isFound && IOServiceGetMatchingServices(MACH_PORT_NULL,
-												 IOServiceMatching("IOPCIDevice"),
-												 &entryIterator) == kIOReturnSuccess) {
-		while ( !isFound && (entry = IOIteratorNext(entryIterator)) ) {
-			if (mvkGetEntryProperty(entry, CFSTR("class-code")) == 0x30000) {	// 0x30000 : DISPLAY_VGA
+    // If the device has an associated registry ID, we can use that to get the
+    // associated IOKit node. The match dictionary is consumed by
+    // IOServiceGetMatchingServices and does not need to be released.
+    bool isFound = false;
+    io_registry_entry_t entry;
+    uint64_t regID = mvkGetRegistryID(_mtlDevice);
+    if (regID) {
+        entry = IOServiceGetMatchingService(MACH_PORT_NULL,
+                                            IORegistryEntryIDMatching(regID));
+        if (entry) {
+            // That returned the IOGraphicsAccelerator nub. Its parent, then, is
+            // the actual PCI device.
+            io_registry_entry_t parent;
+            if (IORegistryEntryGetParentEntry(entry, kIOServicePlane,
+                                              &parent) == kIOReturnSuccess) {
+                isFound = true;
+                _properties.vendorID =
+                    mvkGetEntryProperty(parent, CFSTR("vendor-id"));
+                _properties.deviceID =
+                    mvkGetEntryProperty(parent, CFSTR("device-id"));
+                IOObjectRelease(parent);
+            }
+            IOObjectRelease(entry);
+        }
+    }
+    // Iterate all GPU's, looking for a match.
+    // The match dictionary is consumed by IOServiceGetMatchingServices and does
+    // not need to be released.
+    io_iterator_t entryIterator;
+    if (!isFound &&
+        IOServiceGetMatchingServices(MACH_PORT_NULL,
+                                     IOServiceMatching("IOPCIDevice"),
+                                     &entryIterator) == kIOReturnSuccess) {
+        while (!isFound && (entry = IOIteratorNext(entryIterator))) {
+            if (mvkGetEntryProperty(entry, CFSTR("class-code")) ==
+                0x30000) { // 0x30000 : DISPLAY_VGA
 
-				// The Intel GPU will always be marked as integrated.
-				// Return on a match of either Intel && unified memory, or non-Intel and non-unified memory.
-				uint32_t vendorID = mvkGetEntryProperty(entry, CFSTR("vendor-id"));
-				if ( (vendorID == kIntelVendorId) == _hasUnifiedMemory) {
-					isFound = true;
-					_properties.vendorID = vendorID;
-					_properties.deviceID = mvkGetEntryProperty(entry, CFSTR("device-id"));
-				}
-			}
-		}
-		IOObjectRelease(entryIterator);
-	}
+                // The Intel GPU will always be marked as integrated.
+                // Return on a match of either Intel && unified memory, or
+                // non-Intel and non-unified memory.
+                uint32_t vendorID =
+                    mvkGetEntryProperty(entry, CFSTR("vendor-id"));
+                if ((vendorID == kIntelVendorId) == _hasUnifiedMemory) {
+                    isFound = true;
+                    _properties.vendorID = vendorID;
+                    _properties.deviceID =
+                        mvkGetEntryProperty(entry, CFSTR("device-id"));
+                }
+            }
+        }
+        IOObjectRelease(entryIterator);
+    }
 }
 
-#endif	//MVK_MACOS
+#endif // MVK_MACOS
 
 #if !MVK_MACOS
 // For Apple Silicon, the Device ID is determined by the highest
 // GPU capability, which is a combination of OS version and GPU type.
 void MVKPhysicalDevice::initGPUInfoProperties() {
-	_properties.vendorID = kAppleVendorId;
-	_properties.deviceID = getHighestGPUCapability();
-	_properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
-	strlcpy(_properties.deviceName, _mtlDevice.name.UTF8String, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+    _properties.vendorID = kAppleVendorId;
+    _properties.deviceID = getHighestGPUCapability();
+    _properties.deviceType = VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    strlcpy(_properties.deviceName, _mtlDevice.name.UTF8String,
+            VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 }
-#endif	//!MVK_MACOS
+#endif //! MVK_MACOS
 
 // Since this is a uint8_t array, use Big-Endian byte ordering,
 // so a hex dump of the array is human readable in its parts.
 void MVKPhysicalDevice::initPipelineCacheUUID() {
 
-	// Clear the UUID
-	mvkClear(&_properties.pipelineCacheUUID, VK_UUID_SIZE);
+    // Clear the UUID
+    mvkClear(&_properties.pipelineCacheUUID, VK_UUID_SIZE);
 
-	size_t uuidComponentOffset = 0;
+    size_t uuidComponentOffset = 0;
 
-	// First 4 bytes contains MoltenVK revision.
-	// This is captured either as the MoltenVK Git revision, or if that's not available, as the MoltenVK version.
-	uint32_t mvkRev = getMoltenVKGitRevision();
-	if ( !mvkRev ) { mvkRev = MVK_VERSION; }
-	*(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] = NSSwapHostIntToBig(mvkRev);
-	uuidComponentOffset += sizeof(mvkRev);
+    // First 4 bytes contains MoltenVK revision.
+    // This is captured either as the MoltenVK Git revision, or if that's not
+    // available, as the MoltenVK version.
+    uint32_t mvkRev = getMoltenVKGitRevision();
+    if (!mvkRev) {
+        mvkRev = MVK_VERSION;
+    }
+    *(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] =
+        NSSwapHostIntToBig(mvkRev);
+    uuidComponentOffset += sizeof(mvkRev);
 
-	// Next 4 bytes contains highest GPU capability supported by this device
-	uint32_t gpuCap = getHighestGPUCapability();
-	*(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] = NSSwapHostIntToBig(gpuCap);
-	uuidComponentOffset += sizeof(gpuCap);
+    // Next 4 bytes contains highest GPU capability supported by this device
+    uint32_t gpuCap = getHighestGPUCapability();
+    *(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] =
+        NSSwapHostIntToBig(gpuCap);
+    uuidComponentOffset += sizeof(gpuCap);
 
-	// Next 4 bytes contains flags based on enabled Metal features that
-	// might affect the contents of the pipeline cache (mostly MSL content).
-	uint32_t mtlFeatures = 0;
-	mtlFeatures |= _isUsingMetalArgumentBuffers << 0;
-	*(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] = NSSwapHostIntToBig(mtlFeatures);
-	uuidComponentOffset += sizeof(mtlFeatures);
+    // Next 4 bytes contains flags based on enabled Metal features that
+    // might affect the contents of the pipeline cache (mostly MSL content).
+    uint32_t mtlFeatures = 0;
+    mtlFeatures |= _isUsingMetalArgumentBuffers << 0;
+    *(uint32_t*)&_properties.pipelineCacheUUID[uuidComponentOffset] =
+        NSSwapHostIntToBig(mtlFeatures);
+    uuidComponentOffset += sizeof(mtlFeatures);
 }
 
 // Combine OS major (8 bits), OS minor (8 bits), Mac GPU family (8 bits), and
-// Apple GPU family (8 bits) into one 32-bit value summarizing highest GPU capability.
+// Apple GPU family (8 bits) into one 32-bit value summarizing highest GPU
+// capability.
 uint32_t MVKPhysicalDevice::getHighestGPUCapability() {
-	float fosMaj;
-	float fosMin = modf(mvkOSVersion(), &fosMaj);
-	uint8_t osMaj = (uint8_t)fosMaj;
-	uint8_t osMin = (uint8_t)(fosMin * 100);
-	uint8_t gpuM = _gpuCapabilities.getHighestMacGPU();
-	uint8_t gpuA = _gpuCapabilities.getHighestAppleGPU();
-	return (osMaj << 24) + (osMin << 16) + (gpuM << 8) + gpuA;
+    float fosMaj;
+    float fosMin = modf(mvkOSVersion(), &fosMaj);
+    uint8_t osMaj = (uint8_t)fosMaj;
+    uint8_t osMin = (uint8_t)(fosMin * 100);
+    uint8_t gpuM = _gpuCapabilities.getHighestMacGPU();
+    uint8_t gpuA = _gpuCapabilities.getHighestAppleGPU();
+    return (osMaj << 24) + (osMin << 16) + (gpuM << 8) + gpuA;
 }
 
 // Retrieve the SPIRV-Cross Git revision hash from a derived header file,
@@ -3140,669 +3881,790 @@ uint32_t MVKPhysicalDevice::getMoltenVKGitRevision() {
 
 #include "mvkGitRevDerived.h"
 
-	static const string revStr(mvkRevString, 0, 8);		// We just need the first 8 chars
-	static const string lut("0123456789ABCDEF");
+    static const string revStr(mvkRevString, 0,
+                               8); // We just need the first 8 chars
+    static const string lut("0123456789ABCDEF");
 
-	uint32_t revVal = 0;
-	for (char c : revStr) {
-		size_t cVal = lut.find(toupper(c));
-		if (cVal != string::npos) {
-			revVal <<= 4;
-			revVal += cVal;
-		}
-	}
-	return revVal;
+    uint32_t revVal = 0;
+    for (char c : revStr) {
+        size_t cVal = lut.find(toupper(c));
+        if (cVal != string::npos) {
+            revVal <<= 4;
+            revVal += cVal;
+        }
+    }
+    return revVal;
 }
 
-void MVKPhysicalDevice::setMemoryHeap(uint32_t heapIndex, VkDeviceSize heapSize, VkMemoryHeapFlags heapFlags) {
-	_memoryProperties.memoryHeaps[heapIndex].size = heapSize;
-	_memoryProperties.memoryHeaps[heapIndex].flags = heapFlags;
+void MVKPhysicalDevice::setMemoryHeap(uint32_t heapIndex, VkDeviceSize heapSize,
+                                      VkMemoryHeapFlags heapFlags) {
+    _memoryProperties.memoryHeaps[heapIndex].size = heapSize;
+    _memoryProperties.memoryHeaps[heapIndex].flags = heapFlags;
 }
 
-void MVKPhysicalDevice::setMemoryType(uint32_t typeIndex, uint32_t heapIndex, VkMemoryPropertyFlags propertyFlags) {
-	_memoryProperties.memoryTypes[typeIndex].heapIndex = heapIndex;
-	_memoryProperties.memoryTypes[typeIndex].propertyFlags = propertyFlags;
+void MVKPhysicalDevice::setMemoryType(uint32_t typeIndex, uint32_t heapIndex,
+                                      VkMemoryPropertyFlags propertyFlags) {
+    _memoryProperties.memoryTypes[typeIndex].heapIndex = heapIndex;
+    _memoryProperties.memoryTypes[typeIndex].propertyFlags = propertyFlags;
 }
 
 void MVKPhysicalDevice::initMemoryProperties() {
 
-	mvkClear(&_memoryProperties);	// Start with everything cleared
+    mvkClear(&_memoryProperties); // Start with everything cleared
 
-	// Main heap
-	uint32_t mainHeapIdx = 0;
-	setMemoryHeap(mainHeapIdx, getVRAMSize(), VK_MEMORY_HEAP_DEVICE_LOCAL_BIT);
+    // Main heap
+    uint32_t mainHeapIdx = 0;
+    setMemoryHeap(mainHeapIdx, getVRAMSize(), VK_MEMORY_HEAP_DEVICE_LOCAL_BIT);
 
-	// Optional second heap for shared memory
-	uint32_t sharedHeapIdx;
-	VkMemoryPropertyFlags sharedTypePropFlags;
-	if (_hasUnifiedMemory) {
-		// Shared memory goes in the single main heap in unified memory, and per Vulkan spec must be marked local
-		sharedHeapIdx = mainHeapIdx;
-		sharedTypePropFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-	} else {
-		// Define a second heap to mark the shared memory as non-local
-		sharedHeapIdx = mainHeapIdx + 1;
-		setMemoryHeap(sharedHeapIdx, mvkGetSystemMemorySize(), 0);
-		sharedTypePropFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
-	}
+    // Optional second heap for shared memory
+    uint32_t sharedHeapIdx;
+    VkMemoryPropertyFlags sharedTypePropFlags;
+    if (_hasUnifiedMemory) {
+        // Shared memory goes in the single main heap in unified memory, and per
+        // Vulkan spec must be marked local
+        sharedHeapIdx = mainHeapIdx;
+        sharedTypePropFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED |
+                              VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    } else {
+        // Define a second heap to mark the shared memory as non-local
+        sharedHeapIdx = mainHeapIdx + 1;
+        setMemoryHeap(sharedHeapIdx, mvkGetSystemMemorySize(), 0);
+        sharedTypePropFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
+    }
 
-	_memoryProperties.memoryHeapCount = sharedHeapIdx + 1;
+    _memoryProperties.memoryHeapCount = sharedHeapIdx + 1;
 
-	// Memory types
-	uint32_t typeIdx = 0;
+    // Memory types
+    uint32_t typeIdx = 0;
 
-	// Private storage
-	uint32_t privateBit = 1 << typeIdx;
-	setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_PRIVATE);
-	typeIdx++;
+    // Private storage
+    uint32_t privateBit = 1 << typeIdx;
+    setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_PRIVATE);
+    typeIdx++;
 
-	// Shared storage
-	uint32_t sharedBit = 1 << typeIdx;
-	setMemoryType(typeIdx, sharedHeapIdx, sharedTypePropFlags);
-	typeIdx++;
+    // Shared storage
+    uint32_t sharedBit = 1 << typeIdx;
+    setMemoryType(typeIdx, sharedHeapIdx, sharedTypePropFlags);
+    typeIdx++;
 
-	// Managed storage. On all Apple Silicon, use Shared instead.
-	uint32_t managedBit = 0;
+    // Managed storage. On all Apple Silicon, use Shared instead.
+    uint32_t managedBit = 0;
 #if MVK_MACOS
-	if ( !_gpuCapabilities.isAppleGPU ) {
-		managedBit = 1 << typeIdx;
-		setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MANAGED);
-		typeIdx++;
-	}
+    if (!_gpuCapabilities.isAppleGPU) {
+        managedBit = 1 << typeIdx;
+        setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MANAGED);
+        typeIdx++;
+    }
 #endif
 
-	// Memoryless storage
-	uint32_t memlessBit = 0;
+    // Memoryless storage
+    uint32_t memlessBit = 0;
 #if MVK_MACOS
-	if (supportsMTLGPUFamily(Apple5)) {
-		memlessBit = 1 << typeIdx;
-		setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
-		typeIdx++;
-	}
+    if (supportsMTLGPUFamily(Apple5)) {
+        memlessBit = 1 << typeIdx;
+        setMemoryType(typeIdx, mainHeapIdx,
+                      MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
+        typeIdx++;
+    }
 #endif
 #if MVK_IOS
-	memlessBit = 1 << typeIdx;
-	setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
-	typeIdx++;
+    memlessBit = 1 << typeIdx;
+    setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
+    typeIdx++;
 #endif
 #if MVK_TVOS
-	memlessBit = 1 << typeIdx;
-	setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
-	typeIdx++;
+    memlessBit = 1 << typeIdx;
+    setMemoryType(typeIdx, mainHeapIdx, MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS);
+    typeIdx++;
 #endif
 
-	_memoryProperties.memoryTypeCount = typeIdx;
+    _memoryProperties.memoryTypeCount = typeIdx;
 
-	_privateMemoryTypes			= privateBit | memlessBit;
-	_hostVisibleMemoryTypes		= sharedBit | managedBit;
-	_hostCoherentMemoryTypes 	= sharedBit;
-	_lazilyAllocatedMemoryTypes	= memlessBit;
-	_allMemoryTypes				= privateBit | sharedBit | managedBit | memlessBit;
+    _privateMemoryTypes = privateBit | memlessBit;
+    _hostVisibleMemoryTypes = sharedBit | managedBit;
+    _hostCoherentMemoryTypes = sharedBit;
+    _lazilyAllocatedMemoryTypes = memlessBit;
+    _allMemoryTypes = privateBit | sharedBit | managedBit | memlessBit;
 }
 
-MVK_PUBLIC_SYMBOL MTLStorageMode MVKPhysicalDevice::getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags) {
+MVK_PUBLIC_SYMBOL MTLStorageMode
+MVKPhysicalDevice::getMTLStorageModeFromVkMemoryPropertyFlags(
+    VkMemoryPropertyFlags vkFlags) {
 
-	// If not visible to the host, use Private, or Memoryless if available and lazily allocated.
-	if ( !mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ) {
+    // If not visible to the host, use Private, or Memoryless if available and
+    // lazily allocated.
+    if (!mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
 #if MVK_APPLE_SILICON
-		if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
-			return MTLStorageModeMemoryless;
-		}
+        if (mvkAreAllFlagsEnabled(vkFlags,
+                                  VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
+            return MTLStorageModeMemoryless;
+        }
 #endif
-		return MTLStorageModePrivate;
-	}
+        return MTLStorageModePrivate;
+    }
 
-	// If visible to the host and coherent: Shared
-	if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-		return MTLStorageModeShared;
-	}
+    // If visible to the host and coherent: Shared
+    if (mvkAreAllFlagsEnabled(vkFlags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+        return MTLStorageModeShared;
+    }
 
-	// If visible to the host, but not coherent: Shared on Apple Silicon, Managed on other GPUs.
+    // If visible to the host, but not coherent: Shared on Apple Silicon,
+    // Managed on other GPUs.
 #if MVK_MACOS
-	return _gpuCapabilities.isAppleGPU ? MTLStorageModeShared : MTLStorageModeManaged;
+    return _gpuCapabilities.isAppleGPU ? MTLStorageModeShared
+                                       : MTLStorageModeManaged;
 #else
-	return MTLStorageModeShared;
+    return MTLStorageModeShared;
 #endif
 }
 
 uint64_t MVKPhysicalDevice::getVRAMSize() {
-	if (_hasUnifiedMemory) {
-		return mvkGetSystemMemorySize();
-	} else {
-		// There's actually no way to query the total physical VRAM on the device in Metal.
-		// Just default to using the recommended max working set size (i.e. the budget).
-		return getRecommendedMaxWorkingSetSize();
-	}
+    if (_hasUnifiedMemory) {
+        return mvkGetSystemMemorySize();
+    } else {
+        // There's actually no way to query the total physical VRAM on the
+        // device in Metal. Just default to using the recommended max working
+        // set size (i.e. the budget).
+        return getRecommendedMaxWorkingSetSize();
+    }
 }
 
-// If possible, retrieve from the MTLDevice, otherwise from available memory size, or a fixed conservative estimate.
+// If possible, retrieve from the MTLDevice, otherwise from available memory
+// size, or a fixed conservative estimate.
 uint64_t MVKPhysicalDevice::getRecommendedMaxWorkingSetSize() {
 #if MVK_XCODE_15 || MVK_MACOS
-	if ( [_mtlDevice respondsToSelector: @selector(recommendedMaxWorkingSetSize)]) {
-		return _mtlDevice.recommendedMaxWorkingSetSize;
-	}
+    if ([_mtlDevice
+            respondsToSelector:@selector(recommendedMaxWorkingSetSize)]) {
+        return _mtlDevice.recommendedMaxWorkingSetSize;
+    }
 #endif
-	uint64_t freeMem = mvkGetAvailableMemorySize();
-	return freeMem ? freeMem : 256 * MEBI;
+    uint64_t freeMem = mvkGetAvailableMemorySize();
+    return freeMem ? freeMem : 256 * MEBI;
 }
 
-// If possible, retrieve from the MTLDevice, otherwise use the current memory used by this process.
+// If possible, retrieve from the MTLDevice, otherwise use the current memory
+// used by this process.
 size_t MVKPhysicalDevice::getCurrentAllocatedSize() {
-	if ( [_mtlDevice respondsToSelector: @selector(currentAllocatedSize)] ) {
-		return _mtlDevice.currentAllocatedSize;
-	}
-	return mvkGetUsedMemorySize();
+    if ([_mtlDevice respondsToSelector:@selector(currentAllocatedSize)]) {
+        return _mtlDevice.currentAllocatedSize;
+    }
+    return mvkGetUsedMemorySize();
 }
 
-// When using argument buffers, Metal imposes a hard limit on the number of MTLSamplerState
-// objects that can be created within the app. When not using argument buffers, no such
-// limit is imposed. This has been verified with testing up to 1M MTLSamplerStates.
+// When using argument buffers, Metal imposes a hard limit on the number of
+// MTLSamplerState objects that can be created within the app. When not using
+// argument buffers, no such limit is imposed. This has been verified with
+// testing up to 1M MTLSamplerStates.
 uint32_t MVKPhysicalDevice::getMaxSamplerCount() {
-	if (_isUsingMetalArgumentBuffers) {
-		return ([_mtlDevice respondsToSelector: @selector(maxArgumentBufferSamplerCount)]
-				? (uint32_t)_mtlDevice.maxArgumentBufferSamplerCount : 1024);
-	} else {
-		return 1e6;
-	}
+    if (_isUsingMetalArgumentBuffers) {
+        return ([_mtlDevice
+                    respondsToSelector:@selector(maxArgumentBufferSamplerCount)]
+                    ? (uint32_t)_mtlDevice.maxArgumentBufferSamplerCount
+                    : 1024);
+    } else {
+        return 1e6;
+    }
 }
 
 // Vulkan imposes a minimum maximum of 1024 descriptors per set.
 uint32_t MVKPhysicalDevice::getMaxPerSetDescriptorCount() {
-	return max(4 * (_metalFeatures.maxPerStageBufferCount +
-					_metalFeatures.maxPerStageTextureCount +
-					_metalFeatures.maxPerStageSamplerCount), 1024u);
+    return max(4 * (_metalFeatures.maxPerStageBufferCount +
+                    _metalFeatures.maxPerStageTextureCount +
+                    _metalFeatures.maxPerStageSamplerCount),
+               1024u);
 }
 
 void MVKPhysicalDevice::initExternalMemoryProperties() {
 
-	// Common
-	_hostPointerExternalMemoryProperties.externalMemoryFeatures = VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
-	_hostPointerExternalMemoryProperties.exportFromImportedHandleTypes = 0;
-	_hostPointerExternalMemoryProperties.compatibleHandleTypes = (VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT |
-																  VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT);
+    // Common
+    _hostPointerExternalMemoryProperties.externalMemoryFeatures =
+        VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
+    _hostPointerExternalMemoryProperties.exportFromImportedHandleTypes = 0;
+    _hostPointerExternalMemoryProperties.compatibleHandleTypes =
+        (VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT |
+         VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT);
 
-	// Buffers
-	_mtlBufferExternalMemoryProperties.externalMemoryFeatures = (VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT |
-																 VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
-	_mtlBufferExternalMemoryProperties.exportFromImportedHandleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR;
-	_mtlBufferExternalMemoryProperties.compatibleHandleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR;
+    // Buffers
+    _mtlBufferExternalMemoryProperties.externalMemoryFeatures =
+        (VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT |
+         VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
+    _mtlBufferExternalMemoryProperties.exportFromImportedHandleTypes =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR;
+    _mtlBufferExternalMemoryProperties.compatibleHandleTypes =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR;
 
-	// Images
-	_mtlTextureExternalMemoryProperties.externalMemoryFeatures = (VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT |
-																  VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT |
-																  VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
-	_mtlTextureExternalMemoryProperties.exportFromImportedHandleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR;
-	_mtlTextureExternalMemoryProperties.compatibleHandleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR;
+    // Images
+    _mtlTextureExternalMemoryProperties.externalMemoryFeatures =
+        (VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT |
+         VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT |
+         VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+    _mtlTextureExternalMemoryProperties.exportFromImportedHandleTypes =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR;
+    _mtlTextureExternalMemoryProperties.compatibleHandleTypes =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR;
 }
 
 void MVKPhysicalDevice::initExtensions() {
-	MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_supportedExtensions;
-	pWritableExtns->disableAllButEnabledDeviceExtensions();
+    MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_supportedExtensions;
+    pWritableExtns->disableAllButEnabledDeviceExtensions();
 
-	if (!_metalFeatures.samplerMirrorClampToEdge) {
-		pWritableExtns->vk_KHR_sampler_mirror_clamp_to_edge.enabled = false;
-	}
-	if (!_metalFeatures.programmableSamplePositions) {
-		pWritableExtns->vk_EXT_sample_locations.enabled = false;
-	}
-	if (!_metalFeatures.rasterOrderGroups) {
-		pWritableExtns->vk_EXT_fragment_shader_interlock.enabled = false;
-	}
-	if (!_metalFeatures.postDepthCoverage) {
-		pWritableExtns->vk_EXT_post_depth_coverage.enabled = false;
-	}
-	if (!_metalFeatures.stencilFeedback) {
-		pWritableExtns->vk_EXT_shader_stencil_export.enabled = false;
-	}
-	if (!_metalFeatures.astcHDRTextures) {
-		pWritableExtns->vk_EXT_texture_compression_astc_hdr.enabled = false;
-	}
-	if (!_metalFeatures.simdPermute && !_metalFeatures.quadPermute) {
-		pWritableExtns->vk_KHR_shader_subgroup_extended_types.enabled = false;
-		pWritableExtns->vk_EXT_shader_subgroup_ballot.enabled = false;
-		pWritableExtns->vk_EXT_shader_subgroup_vote.enabled = false;
-	}
-	if (!_metalFeatures.shaderBarycentricCoordinates) {
-		pWritableExtns->vk_KHR_fragment_shader_barycentric.enabled = false;
-		pWritableExtns->vk_NV_fragment_shader_barycentric.enabled = false;
-	}
-	if (!_metalFeatures.arrayOfTextures || !_metalFeatures.arrayOfSamplers) {
-		pWritableExtns->vk_EXT_descriptor_indexing.enabled = false;
-	}
-    
+    if (!_metalFeatures.samplerMirrorClampToEdge) {
+        pWritableExtns->vk_KHR_sampler_mirror_clamp_to_edge.enabled = false;
+    }
+    if (!_metalFeatures.programmableSamplePositions) {
+        pWritableExtns->vk_EXT_sample_locations.enabled = false;
+    }
+    if (!_metalFeatures.rasterOrderGroups) {
+        pWritableExtns->vk_EXT_fragment_shader_interlock.enabled = false;
+    }
+    if (!_metalFeatures.postDepthCoverage) {
+        pWritableExtns->vk_EXT_post_depth_coverage.enabled = false;
+    }
+    if (!_metalFeatures.stencilFeedback) {
+        pWritableExtns->vk_EXT_shader_stencil_export.enabled = false;
+    }
+    if (!_metalFeatures.astcHDRTextures) {
+        pWritableExtns->vk_EXT_texture_compression_astc_hdr.enabled = false;
+    }
+    if (!_metalFeatures.simdPermute && !_metalFeatures.quadPermute) {
+        pWritableExtns->vk_KHR_shader_subgroup_extended_types.enabled = false;
+        pWritableExtns->vk_EXT_shader_subgroup_ballot.enabled = false;
+        pWritableExtns->vk_EXT_shader_subgroup_vote.enabled = false;
+    }
+    if (!_metalFeatures.shaderBarycentricCoordinates) {
+        pWritableExtns->vk_KHR_fragment_shader_barycentric.enabled = false;
+        pWritableExtns->vk_NV_fragment_shader_barycentric.enabled = false;
+    }
+    if (!_metalFeatures.arrayOfTextures || !_metalFeatures.arrayOfSamplers) {
+        pWritableExtns->vk_EXT_descriptor_indexing.enabled = false;
+    }
+
     // The relevant functions are not available if not built with Xcode 14.
 #if MVK_XCODE_14
-    // gpuAddress requires Tier2 argument buffer support (per feedback from Apple engineers).
+    // gpuAddress requires Tier2 argument buffer support (per feedback from
+    // Apple engineers).
     if (_metalFeatures.argumentBuffersTier < MTLArgumentBuffersTier2) {
-		pWritableExtns->vk_KHR_buffer_device_address.enabled = false;
-		pWritableExtns->vk_EXT_buffer_device_address.enabled = false;
-	}
+        pWritableExtns->vk_KHR_buffer_device_address.enabled = false;
+        pWritableExtns->vk_EXT_buffer_device_address.enabled = false;
+    }
 #else
     pWritableExtns->vk_KHR_buffer_device_address.enabled = false;
     pWritableExtns->vk_EXT_buffer_device_address.enabled = false;
 #endif
 
 #if MVK_MACOS
-	if (!supportsMTLGPUFamily(Apple5)) {
-		pWritableExtns->vk_AMD_shader_image_load_store_lod.enabled = false;
-		pWritableExtns->vk_IMG_format_pvrtc.enabled = false;
-	}
+    if (!supportsMTLGPUFamily(Apple5)) {
+        pWritableExtns->vk_AMD_shader_image_load_store_lod.enabled = false;
+        pWritableExtns->vk_IMG_format_pvrtc.enabled = false;
+    }
 #endif
 }
 
 void MVKPhysicalDevice::initCounterSets() {
-	_timestampMTLCounterSet = nil;
-	@autoreleasepool {
-		if (_metalFeatures.counterSamplingPoints) {
-			NSArray<id<MTLCounterSet>>* counterSets = _mtlDevice.counterSets;
+    _timestampMTLCounterSet = nil;
+    @autoreleasepool {
+        if (_metalFeatures.counterSamplingPoints) {
+            NSArray<id<MTLCounterSet>>* counterSets = _mtlDevice.counterSets;
 
-			if (needsCounterSetRetained()) { [counterSets retain]; }
+            if (needsCounterSetRetained()) {
+                [counterSets retain];
+            }
 
-			for (id<MTLCounterSet> cs in counterSets){
-				NSString* csName = cs.name;
-				if ( [csName caseInsensitiveCompare: MTLCommonCounterSetTimestamp] == NSOrderedSame) {
-					NSArray<id<MTLCounter>>* countersInSet = cs.counters;
-					for(id<MTLCounter> ctr in countersInSet) {
-						if ( [ctr.name caseInsensitiveCompare: MTLCommonCounterTimestamp] == NSOrderedSame) {
-							_timestampMTLCounterSet = [cs retain];		// retained
-							break;
-						}
-					}
-					break;
-				}
-			}
-		}
-	}
+            for (id<MTLCounterSet> cs in counterSets) {
+                NSString* csName = cs.name;
+                if ([csName
+                        caseInsensitiveCompare:MTLCommonCounterSetTimestamp] ==
+                    NSOrderedSame) {
+                    NSArray<id<MTLCounter>>* countersInSet = cs.counters;
+                    for (id<MTLCounter> ctr in countersInSet) {
+                        if ([ctr.name caseInsensitiveCompare:
+                                          MTLCommonCounterTimestamp] ==
+                            NSOrderedSame) {
+                            _timestampMTLCounterSet = [cs retain]; // retained
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
 }
 
-// Determine whether Vulkan semaphores should use a MTLEvent, CPU callbacks, or should limit
-// Vulkan to a single queue and use Metal's implicit guarantees that all operations submitted
-// to a queue will give the same result as if they had been run in submission order.
-// MTLEvents for semaphores are preferred, but can sometimes prove troublesome on some platforms,
-// and so may be disabled on those platforms, unless explicitly requested. If MTLEvents are
-// unusable, 
+// Determine whether Vulkan semaphores should use a MTLEvent, CPU callbacks, or
+// should limit Vulkan to a single queue and use Metal's implicit guarantees
+// that all operations submitted to a queue will give the same result as if they
+// had been run in submission order. MTLEvents for semaphores are preferred, but
+// can sometimes prove troublesome on some platforms, and so may be disabled on
+// those platforms, unless explicitly requested. If MTLEvents are unusable,
 void MVKPhysicalDevice::initVkSemaphoreStyle() {
 
-	// Default to single queue if other options unavailable.
-	_vkSemaphoreStyle = MVKSemaphoreStyleSingleQueue;
+    // Default to single queue if other options unavailable.
+    _vkSemaphoreStyle = MVKSemaphoreStyleSingleQueue;
 
-	switch (getMVKConfig().semaphoreSupportStyle) {
-		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS_WHERE_SAFE: {
-			bool isNVIDIA = _properties.vendorID == kNVVendorId;
-			bool isRosetta2 = _gpuCapabilities.isAppleGPU && !MVK_APPLE_SILICON;
-			if (_metalFeatures.events && !(isRosetta2 || isNVIDIA)) { _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent; }
-			break;
-		}
-		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS:
-			if (_metalFeatures.events) { _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent; }
-			break;
-		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK:
-			_vkSemaphoreStyle = MVKSemaphoreStyleUseEmulation;
-			break;
-		case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE:
-		default:
-			break;
-	}
+    switch (getMVKConfig().semaphoreSupportStyle) {
+    case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS_WHERE_SAFE: {
+        bool isNVIDIA = _properties.vendorID == kNVVendorId;
+        bool isRosetta2 = _gpuCapabilities.isAppleGPU && !MVK_APPLE_SILICON;
+        if (_metalFeatures.events && !(isRosetta2 || isNVIDIA)) {
+            _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent;
+        }
+        break;
+    }
+    case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS:
+        if (_metalFeatures.events) {
+            _vkSemaphoreStyle = MVKSemaphoreStyleUseMTLEvent;
+        }
+        break;
+    case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_CALLBACK:
+        _vkSemaphoreStyle = MVKSemaphoreStyleUseEmulation;
+        break;
+    case MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE:
+    default:
+        break;
+    }
 }
 
-// Workaround for a bug in Intel Iris Plus Graphics driver where the counterSets array is
-// not properly retained internally, and becomes a zombie when counterSets is called more
-// than once, which occurs when an app creates more than one VkInstance. This workaround
-// will cause a very small memory leak on systems that do not have this bug, so we apply
-// the workaround only when absolutely needed for specific devices. The list of deviceIDs
-// is sourced from the list of Intel Iris Plus Graphics Gen11 tier G7 devices found here:
+// Workaround for a bug in Intel Iris Plus Graphics driver where the counterSets
+// array is not properly retained internally, and becomes a zombie when
+// counterSets is called more than once, which occurs when an app creates more
+// than one VkInstance. This workaround will cause a very small memory leak on
+// systems that do not have this bug, so we apply the workaround only when
+// absolutely needed for specific devices. The list of deviceIDs is sourced from
+// the list of Intel Iris Plus Graphics Gen11 tier G7 devices found here:
 // https://en.wikipedia.org/wiki/List_of_Intel_graphics_processing_units#Gen11
 bool MVKPhysicalDevice::needsCounterSetRetained() {
 
-	if (_properties.vendorID != kIntelVendorId) { return false; }
+    if (_properties.vendorID != kIntelVendorId) {
+        return false;
+    }
 
-	switch (_properties.deviceID) {
-		case 0x8a51:
-		case 0x8a52:
-		case 0x8a53:
-		case 0x8a5a:
-		case 0x8a5c:
-			return true;
-		default:
-			return false;
-	}
+    switch (_properties.deviceID) {
+    case 0x8a51:
+    case 0x8a52:
+    case 0x8a53:
+    case 0x8a5a:
+    case 0x8a5c:
+        return true;
+    default:
+        return false;
+    }
 }
 
 void MVKPhysicalDevice::logGPUInfo() {
-	string logMsg = "GPU device:";
-	logMsg += "\n\tmodel: %s";
-	logMsg += "\n\ttype: %s";
-	logMsg += "\n\tvendorID: %#06x";
-	logMsg += "\n\tdeviceID: %#06x";
-	logMsg += "\n\tpipelineCacheUUID: %s";
-	logMsg += "\n\tGPU memory available: %llu MB";
-	logMsg += "\n\tGPU memory used: %llu MB";
-	logMsg += "\n\tMetal Shading Language %s";
-	logMsg += "\n\tsupports the following GPU Features:";
+    string logMsg = "GPU device:";
+    logMsg += "\n\tmodel: %s";
+    logMsg += "\n\ttype: %s";
+    logMsg += "\n\tvendorID: %#06x";
+    logMsg += "\n\tdeviceID: %#06x";
+    logMsg += "\n\tpipelineCacheUUID: %s";
+    logMsg += "\n\tGPU memory available: %llu MB";
+    logMsg += "\n\tGPU memory used: %llu MB";
+    logMsg += "\n\tMetal Shading Language %s";
+    logMsg += "\n\tsupports the following GPU Features:";
 
 #if MVK_XCODE_14
-	if (supportsMTLGPUFamily(Metal3)) { logMsg += "\n\t\tGPU Family Metal 3"; }
+    if (supportsMTLGPUFamily(Metal3)) {
+        logMsg += "\n\t\tGPU Family Metal 3";
+    }
 #endif
 #if MVK_XCODE_15 && (MVK_IOS || MVK_MACOS)
-	if (supportsMTLGPUFamily(Apple9)) { logMsg += "\n\t\tGPU Family Apple 9"; } else
+    if (supportsMTLGPUFamily(Apple9)) {
+        logMsg += "\n\t\tGPU Family Apple 9";
+    } else
 #endif
 #if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
-	if (supportsMTLGPUFamily(Apple8)) { logMsg += "\n\t\tGPU Family Apple 8"; } else
+        if (supportsMTLGPUFamily(Apple8)) {
+        logMsg += "\n\t\tGPU Family Apple 8";
+    } else
 #endif
 #if (MVK_IOS || MVK_MACOS) && MVK_XCODE_12
-	if (supportsMTLGPUFamily(Apple7)) { logMsg += "\n\t\tGPU Family Apple 7"; } else
+        if (supportsMTLGPUFamily(Apple7)) {
+        logMsg += "\n\t\tGPU Family Apple 7";
+    } else
 #endif
 #if MVK_IOS || (MVK_MACOS && MVK_XCODE_12)
-	if (supportsMTLGPUFamily(Apple6)) { logMsg += "\n\t\tGPU Family Apple 6"; } else
+        if (supportsMTLGPUFamily(Apple6)) {
+        logMsg += "\n\t\tGPU Family Apple 6";
+    } else
 #endif
-	if (supportsMTLGPUFamily(Apple5)) { logMsg += "\n\t\tGPU Family Apple 5"; } else
-	if (supportsMTLGPUFamily(Apple4)) { logMsg += "\n\t\tGPU Family Apple 4"; } else
-	if (supportsMTLGPUFamily(Apple3)) { logMsg += "\n\t\tGPU Family Apple 3"; } else
-	if (supportsMTLGPUFamily(Apple2)) { logMsg += "\n\t\tGPU Family Apple 2"; } else
-	if (supportsMTLGPUFamily(Apple1)) { logMsg += "\n\t\tGPU Family Apple 1"; }
+        if (supportsMTLGPUFamily(Apple5)) {
+        logMsg += "\n\t\tGPU Family Apple 5";
+    } else if (supportsMTLGPUFamily(Apple4)) {
+        logMsg += "\n\t\tGPU Family Apple 4";
+    } else if (supportsMTLGPUFamily(Apple3)) {
+        logMsg += "\n\t\tGPU Family Apple 3";
+    } else if (supportsMTLGPUFamily(Apple2)) {
+        logMsg += "\n\t\tGPU Family Apple 2";
+    } else if (supportsMTLGPUFamily(Apple1)) {
+        logMsg += "\n\t\tGPU Family Apple 1";
+    }
 
-	if (supportsMTLGPUFamily(Mac2)) { logMsg += "\n\t\tGPU Family Mac 2"; } else
-	if (supportsMTLGPUFamily(Mac1)) { logMsg += "\n\t\tGPU Family Mac 1"; }
+    if (supportsMTLGPUFamily(Mac2)) {
+        logMsg += "\n\t\tGPU Family Mac 2";
+    } else if (supportsMTLGPUFamily(Mac1)) {
+        logMsg += "\n\t\tGPU Family Mac 1";
+    }
 
-	logMsg += "\n\t\tRead-Write Texture Tier ";
-	logMsg += ([_mtlDevice respondsToSelector: @selector(readWriteTextureSupport)] &&
-			   _mtlDevice.readWriteTextureSupport == MTLReadWriteTextureTier2) ? "2" : "1";
+    logMsg += "\n\t\tRead-Write Texture Tier ";
+    logMsg +=
+        ([_mtlDevice respondsToSelector:@selector(readWriteTextureSupport)] &&
+         _mtlDevice.readWriteTextureSupport == MTLReadWriteTextureTier2)
+            ? "2"
+            : "1";
 
-	string devTypeStr;
-	switch (_properties.deviceType) {
-		case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-			devTypeStr = "Discrete";
-			break;
-		case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-			devTypeStr = "Integrated";
-			break;
-		case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
-			devTypeStr = "Virtual";
-			break;
-		case VK_PHYSICAL_DEVICE_TYPE_CPU:
-			devTypeStr = "CPU Emulation";
-			break;
-		default:
-			devTypeStr = "Unknown";
-			break;
-	}
+    string devTypeStr;
+    switch (_properties.deviceType) {
+    case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+        devTypeStr = "Discrete";
+        break;
+    case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+        devTypeStr = "Integrated";
+        break;
+    case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+        devTypeStr = "Virtual";
+        break;
+    case VK_PHYSICAL_DEVICE_TYPE_CPU:
+        devTypeStr = "CPU Emulation";
+        break;
+    default:
+        devTypeStr = "Unknown";
+        break;
+    }
 
-	NSUUID* nsUUID = [[NSUUID alloc] initWithUUIDBytes: _properties.pipelineCacheUUID];		// temp retain
-	MVKLogInfo(logMsg.c_str(), getName(), devTypeStr.c_str(),
-             _properties.vendorID, _properties.deviceID, nsUUID.UUIDString.UTF8String,
-             getRecommendedMaxWorkingSetSize() / MEBI, getCurrentAllocatedSize() / MEBI,
-             mvk::SPIRVToMSLConversionOptions::printMSLVersion(_metalFeatures.mslVersion).c_str());
-	[nsUUID release];																		// temp release
+    NSUUID* nsUUID = [[NSUUID alloc]
+        initWithUUIDBytes:_properties.pipelineCacheUUID]; // temp retain
+    MVKLogInfo(logMsg.c_str(), getName(), devTypeStr.c_str(),
+               _properties.vendorID, _properties.deviceID,
+               nsUUID.UUIDString.UTF8String,
+               getRecommendedMaxWorkingSetSize() / MEBI,
+               getCurrentAllocatedSize() / MEBI,
+               mvk::SPIRVToMSLConversionOptions::printMSLVersion(
+                   _metalFeatures.mslVersion)
+                   .c_str());
+    [nsUUID release]; // temp release
 }
 
 MVKPhysicalDevice::~MVKPhysicalDevice() {
-	mvkDestroyContainerContents(_queueFamilies);
-	[_timestampMTLCounterSet release];
+    mvkDestroyContainerContents(_queueFamilies);
+    [_timestampMTLCounterSet release];
 
-	uint64_t memUsed = getCurrentAllocatedSize();	// Retrieve before releasing MTLDevice
-	[_mtlDevice release];
+    uint64_t memUsed =
+        getCurrentAllocatedSize(); // Retrieve before releasing MTLDevice
+    [_mtlDevice release];
 
-	MVKLogInfo("Destroyed VkPhysicalDevice for GPU %s with %llu MB of GPU memory still allocated.", getName(), memUsed / MEBI);
+    MVKLogInfo("Destroyed VkPhysicalDevice for GPU %s with %llu MB of GPU "
+               "memory still allocated.",
+               getName(), memUsed / MEBI);
 }
-
 
 #pragma mark -
 #pragma mark MVKDevice
 
 // Returns core device commands and enabled extension device commands.
 PFN_vkVoidFunction MVKDevice::getProcAddr(const char* pName) {
-	MVKInstance* pMVKInst = _physicalDevice->_mvkInstance;
-	MVKEntryPoint* pMVKPA = pMVKInst->getEntryPoint(pName);
-	uint32_t apiVersion = pMVKInst->_appInfo.apiVersion;
+    MVKInstance* pMVKInst = _physicalDevice->_mvkInstance;
+    MVKEntryPoint* pMVKPA = pMVKInst->getEntryPoint(pName);
+    uint32_t apiVersion = pMVKInst->_appInfo.apiVersion;
 
-	bool isSupported = (pMVKPA &&																			// Command exists and...
-						pMVKPA->isDevice &&																	// ...is a device command and...
-						pMVKPA->isEnabled(apiVersion, _enabledExtensions, &pMVKInst->_enabledExtensions));	// ...is a core or enabled extension command.
+    bool isSupported =
+        (pMVKPA &&           // Command exists and...
+         pMVKPA->isDevice && // ...is a device command and...
+         pMVKPA
+             ->isEnabled(apiVersion, _enabledExtensions,
+                         &pMVKInst
+                              ->_enabledExtensions)); // ...is a core or enabled
+                                                      // extension command.
 
-	return isSupported ? pMVKPA->functionPointer : nullptr;
+    return isSupported ? pMVKPA->functionPointer : nullptr;
 }
 
 MVKQueue* MVKDevice::getQueue(uint32_t queueFamilyIndex, uint32_t queueIndex) {
-	return _queuesByQueueFamilyIndex[queueFamilyIndex][queueIndex];
+    return _queuesByQueueFamilyIndex[queueFamilyIndex][queueIndex];
 }
 
 MVKQueue* MVKDevice::getQueue(const VkDeviceQueueInfo2* queueInfo) {
-	return _queuesByQueueFamilyIndex[queueInfo->queueFamilyIndex][queueInfo->queueIndex];
+    return _queuesByQueueFamilyIndex[queueInfo->queueFamilyIndex]
+                                    [queueInfo->queueIndex];
 }
 
 MVKQueue* MVKDevice::getAnyQueue() {
-	for (auto& queues : _queuesByQueueFamilyIndex) {
-		for (MVKQueue* q : queues) {
-			if (q) { return q; };
-		}
-	}
-	return nullptr;
+    for (auto& queues : _queuesByQueueFamilyIndex) {
+        for (MVKQueue* q : queues) {
+            if (q) {
+                return q;
+            };
+        }
+    }
+    return nullptr;
 }
 
 VkResult MVKDevice::waitIdle() {
-	VkResult rslt = VK_SUCCESS;
-	for (auto& queues : _queuesByQueueFamilyIndex) {
-		for (MVKQueue* q : queues) {
-			if ((rslt = q->waitIdle(kMVKCommandUseDeviceWaitIdle)) != VK_SUCCESS) { return rslt; }
-		}
-	}
-	return VK_SUCCESS;
+    VkResult rslt = VK_SUCCESS;
+    for (auto& queues : _queuesByQueueFamilyIndex) {
+        for (MVKQueue* q : queues) {
+            if ((rslt = q->waitIdle(kMVKCommandUseDeviceWaitIdle)) !=
+                VK_SUCCESS) {
+                return rslt;
+            }
+        }
+    }
+    return VK_SUCCESS;
 }
 
 VkResult MVKDevice::markLost(bool alsoMarkPhysicalDevice) {
-	lock_guard<mutex> lock(_sem4Lock);
+    lock_guard<mutex> lock(_sem4Lock);
 
-	setConfigurationResult(VK_ERROR_DEVICE_LOST);
-	if (alsoMarkPhysicalDevice) { _physicalDevice->setConfigurationResult(VK_ERROR_DEVICE_LOST); }
+    setConfigurationResult(VK_ERROR_DEVICE_LOST);
+    if (alsoMarkPhysicalDevice) {
+        _physicalDevice->setConfigurationResult(VK_ERROR_DEVICE_LOST);
+    }
 
-	for (auto* sem4 : _awaitingSemaphores) {
-		sem4->release();
-	}
-	for (auto& sem4AndValue : _awaitingTimelineSem4s) {
-		VkSemaphoreSignalInfo signalInfo;
-		signalInfo.value = sem4AndValue.second;
-		sem4AndValue.first->signal(&signalInfo);
-	}
-	_awaitingSemaphores.clear();
-	_awaitingTimelineSem4s.clear();
+    for (auto* sem4 : _awaitingSemaphores) {
+        sem4->release();
+    }
+    for (auto& sem4AndValue : _awaitingTimelineSem4s) {
+        VkSemaphoreSignalInfo signalInfo;
+        signalInfo.value = sem4AndValue.second;
+        sem4AndValue.first->signal(&signalInfo);
+    }
+    _awaitingSemaphores.clear();
+    _awaitingTimelineSem4s.clear();
 
-	return getConfigurationResult();
+    return getConfigurationResult();
 }
 
-void MVKDevice::getDescriptorSetLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-											  VkDescriptorSetLayoutSupport* pSupport) {
-	// According to the Vulkan spec:
-	//   "If the descriptor set layout satisfies the VkPhysicalDeviceMaintenance3Properties::maxPerSetDescriptors
-	//   limit, this command is guaranteed to return VK_TRUE in VkDescriptorSetLayout::supported...
-	//   "This command does not consider other limits such as maxPerStageDescriptor*..."
-	uint32_t descriptorCount = 0;
-	for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
-		descriptorCount += pCreateInfo->pBindings[i].descriptorCount;
-	}
-	pSupport->supported = (descriptorCount < _physicalDevice->getMaxPerSetDescriptorCount());
+void MVKDevice::getDescriptorSetLayoutSupport(
+    const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+    VkDescriptorSetLayoutSupport* pSupport) {
+    // According to the Vulkan spec:
+    //   "If the descriptor set layout satisfies the
+    //   VkPhysicalDeviceMaintenance3Properties::maxPerSetDescriptors limit,
+    //   this command is guaranteed to return VK_TRUE in
+    //   VkDescriptorSetLayout::supported... "This command does not consider
+    //   other limits such as maxPerStageDescriptor*..."
+    uint32_t descriptorCount = 0;
+    for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
+        descriptorCount += pCreateInfo->pBindings[i].descriptorCount;
+    }
+    pSupport->supported =
+        (descriptorCount < _physicalDevice->getMaxPerSetDescriptorCount());
 
-	// Check whether the layout has a variable-count descriptor, and if so, whether we can support it.
-	for (auto* next = (VkBaseOutStructure*)pSupport->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT: {
-				auto* pVarDescSetCountSupport = (VkDescriptorSetVariableDescriptorCountLayoutSupport*)next;
-				getDescriptorVariableDescriptorCountLayoutSupport(pCreateInfo, pSupport, pVarDescSetCountSupport);
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    // Check whether the layout has a variable-count descriptor, and if so,
+    // whether we can support it.
+    for (auto* next = (VkBaseOutStructure*)pSupport->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT: {
+            auto* pVarDescSetCountSupport =
+                (VkDescriptorSetVariableDescriptorCountLayoutSupport*)next;
+            getDescriptorVariableDescriptorCountLayoutSupport(
+                pCreateInfo, pSupport, pVarDescSetCountSupport);
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
-// Check whether the layout has a variable-count descriptor, and if so, whether we can support it.
-void MVKDevice::getDescriptorVariableDescriptorCountLayoutSupport(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-																  VkDescriptorSetLayoutSupport* pSupport,
-																  VkDescriptorSetVariableDescriptorCountLayoutSupport* pVarDescSetCountSupport) {
-	// Assume we don't need this, then set appropriately if we do.
-	pVarDescSetCountSupport->maxVariableDescriptorCount = 0;
+// Check whether the layout has a variable-count descriptor, and if so, whether
+// we can support it.
+void MVKDevice::getDescriptorVariableDescriptorCountLayoutSupport(
+    const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+    VkDescriptorSetLayoutSupport* pSupport,
+    VkDescriptorSetVariableDescriptorCountLayoutSupport*
+        pVarDescSetCountSupport) {
+    // Assume we don't need this, then set appropriately if we do.
+    pVarDescSetCountSupport->maxVariableDescriptorCount = 0;
 
-	// Look for a variable length descriptor and remember its index.
-	int32_t varBindingIdx = -1;
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO: {
-				auto* pDescSetLayoutBindingFlags = (VkDescriptorSetLayoutBindingFlagsCreateInfo*)next;
-				for (uint32_t bindIdx = 0; bindIdx < pDescSetLayoutBindingFlags->bindingCount; bindIdx++) {
-					if (mvkIsAnyFlagEnabled(pDescSetLayoutBindingFlags->pBindingFlags[bindIdx], VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT)) {
-						varBindingIdx = bindIdx;
-						break;
-					}
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    // Look for a variable length descriptor and remember its index.
+    int32_t varBindingIdx = -1;
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO: {
+            auto* pDescSetLayoutBindingFlags =
+                (VkDescriptorSetLayoutBindingFlagsCreateInfo*)next;
+            for (uint32_t bindIdx = 0;
+                 bindIdx < pDescSetLayoutBindingFlags->bindingCount;
+                 bindIdx++) {
+                if (mvkIsAnyFlagEnabled(
+                        pDescSetLayoutBindingFlags->pBindingFlags[bindIdx],
+                        VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT)) {
+                    varBindingIdx = bindIdx;
+                    break;
+                }
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	// If no variable length descriptor is found, we can skip the rest.
-	if (varBindingIdx < 0) { return; }
+    // If no variable length descriptor is found, we can skip the rest.
+    if (varBindingIdx < 0) {
+        return;
+    }
 
-	// Device does not support variable descriptor counts but it has been requested.
-	if ( !_enabledDescriptorIndexingFeatures.descriptorBindingVariableDescriptorCount ) {
-		pSupport->supported = false;
-		return;
-	}
+    // Device does not support variable descriptor counts but it has been
+    // requested.
+    if (!_enabledDescriptorIndexingFeatures
+             .descriptorBindingVariableDescriptorCount) {
+        pSupport->supported = false;
+        return;
+    }
 
-	uint32_t mtlBuffCnt = 0;
-	uint32_t mtlTexCnt = 0;
-	uint32_t mtlSampCnt = 0;
-	uint32_t requestedCount = 0;
-	uint32_t maxVarDescCount = 0;
+    uint32_t mtlBuffCnt = 0;
+    uint32_t mtlTexCnt = 0;
+    uint32_t mtlSampCnt = 0;
+    uint32_t requestedCount = 0;
+    uint32_t maxVarDescCount = 0;
 
-	// Determine the number of descriptors available for use by the variable descriptor by
-	// accumulating the number of resources accumulated by other descriptors and subtracting
-	// that from the device's per-stage max counts. This is not perfect because it does not
-	// take into consideration other descriptor sets in the pipeline layout, but we can't
-	// anticipate that here. The variable descriptor must have the highest binding number,
-	// but it may not be the last descriptor in the array. The handling here accommodates that.
-	for (uint32_t bindIdx = 0; bindIdx < pCreateInfo->bindingCount; bindIdx++) {
-		auto* pBind = &pCreateInfo->pBindings[bindIdx];
-		if (bindIdx == varBindingIdx) {
-			requestedCount = std::max(pBind->descriptorCount, 1u);
-		} else {
-			auto& mtlFeats = _physicalDevice->_metalFeatures;
-			switch (pBind->descriptorType) {
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-				case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-				case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-					mtlBuffCnt += pBind->descriptorCount;
-					maxVarDescCount = mtlFeats.maxPerStageBufferCount - mtlBuffCnt;
-					break;
-				case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-					maxVarDescCount = (uint32_t)min<VkDeviceSize>(mtlFeats.maxMTLBufferSize, numeric_limits<uint32_t>::max());
-					break;
-				case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-				case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-				case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-					mtlTexCnt += pBind->descriptorCount;
-					maxVarDescCount = mtlFeats.maxPerStageTextureCount - mtlTexCnt;
-					break;
-				case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-				case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-					mtlTexCnt += pBind->descriptorCount;
-					if (_physicalDevice->_metalFeatures.nativeTextureAtomics) {
-						mtlBuffCnt += pBind->descriptorCount;
-					}
-					maxVarDescCount = min(mtlFeats.maxPerStageTextureCount - mtlTexCnt,
-										  mtlFeats.maxPerStageBufferCount - mtlBuffCnt);
-					break;
-				case VK_DESCRIPTOR_TYPE_SAMPLER:
-					mtlSampCnt += pBind->descriptorCount;
-					maxVarDescCount = mtlFeats.maxPerStageSamplerCount - mtlSampCnt;
-					break;
-				case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-					mtlTexCnt += pBind->descriptorCount;
-					mtlSampCnt += pBind->descriptorCount;
-					maxVarDescCount = min(mtlFeats.maxPerStageTextureCount - mtlTexCnt,
-										  mtlFeats.maxPerStageSamplerCount - mtlSampCnt);
-					break;
-				default:
-					break;
-			}
-		}
-	}
+    // Determine the number of descriptors available for use by the variable
+    // descriptor by accumulating the number of resources accumulated by other
+    // descriptors and subtracting that from the device's per-stage max counts.
+    // This is not perfect because it does not take into consideration other
+    // descriptor sets in the pipeline layout, but we can't anticipate that
+    // here. The variable descriptor must have the highest binding number, but
+    // it may not be the last descriptor in the array. The handling here
+    // accommodates that.
+    for (uint32_t bindIdx = 0; bindIdx < pCreateInfo->bindingCount; bindIdx++) {
+        auto* pBind = &pCreateInfo->pBindings[bindIdx];
+        if (bindIdx == varBindingIdx) {
+            requestedCount = std::max(pBind->descriptorCount, 1u);
+        } else {
+            auto& mtlFeats = _physicalDevice->_metalFeatures;
+            switch (pBind->descriptorType) {
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                mtlBuffCnt += pBind->descriptorCount;
+                maxVarDescCount = mtlFeats.maxPerStageBufferCount - mtlBuffCnt;
+                break;
+            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+                maxVarDescCount = (uint32_t)
+                    min<VkDeviceSize>(mtlFeats.maxMTLBufferSize,
+                                      numeric_limits<uint32_t>::max());
+                break;
+            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                mtlTexCnt += pBind->descriptorCount;
+                maxVarDescCount = mtlFeats.maxPerStageTextureCount - mtlTexCnt;
+                break;
+            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                mtlTexCnt += pBind->descriptorCount;
+                if (_physicalDevice->_metalFeatures.nativeTextureAtomics) {
+                    mtlBuffCnt += pBind->descriptorCount;
+                }
+                maxVarDescCount =
+                    min(mtlFeats.maxPerStageTextureCount - mtlTexCnt,
+                        mtlFeats.maxPerStageBufferCount - mtlBuffCnt);
+                break;
+            case VK_DESCRIPTOR_TYPE_SAMPLER:
+                mtlSampCnt += pBind->descriptorCount;
+                maxVarDescCount = mtlFeats.maxPerStageSamplerCount - mtlSampCnt;
+                break;
+            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                mtlTexCnt += pBind->descriptorCount;
+                mtlSampCnt += pBind->descriptorCount;
+                maxVarDescCount =
+                    min(mtlFeats.maxPerStageTextureCount - mtlTexCnt,
+                        mtlFeats.maxPerStageSamplerCount - mtlSampCnt);
+                break;
+            default:
+                break;
+            }
+        }
+    }
 
-	// If there is enough room for the requested size, indicate the amount available,
-	// otherwise indicate that the requested size cannot be supported.
-	if (requestedCount < maxVarDescCount) {
-		pVarDescSetCountSupport->maxVariableDescriptorCount = maxVarDescCount;
-	} else {
-		pSupport->supported = false;
-	}
+    // If there is enough room for the requested size, indicate the amount
+    // available, otherwise indicate that the requested size cannot be
+    // supported.
+    if (requestedCount < maxVarDescCount) {
+        pVarDescSetCountSupport->maxVariableDescriptorCount = maxVarDescCount;
+    } else {
+        pSupport->supported = false;
+    }
 }
 
-VkResult MVKDevice::getDeviceGroupPresentCapabilities(VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities) {
-	mvkClear(pDeviceGroupPresentCapabilities->presentMask, VK_MAX_DEVICE_GROUP_SIZE);
-	pDeviceGroupPresentCapabilities->presentMask[0] = 0x1;
+VkResult MVKDevice::getDeviceGroupPresentCapabilities(
+    VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities) {
+    mvkClear(pDeviceGroupPresentCapabilities->presentMask,
+             VK_MAX_DEVICE_GROUP_SIZE);
+    pDeviceGroupPresentCapabilities->presentMask[0] = 0x1;
 
-	pDeviceGroupPresentCapabilities->modes = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
+    pDeviceGroupPresentCapabilities->modes =
+        VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-VkResult MVKDevice::getDeviceGroupSurfacePresentModes(MVKSurface* surface, VkDeviceGroupPresentModeFlagsKHR* pModes) {
-	*pModes = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
-	return VK_SUCCESS;
+VkResult MVKDevice::getDeviceGroupSurfacePresentModes(
+    MVKSurface* surface, VkDeviceGroupPresentModeFlagsKHR* pModes) {
+    *pModes = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
+    return VK_SUCCESS;
 }
 
-void MVKDevice::getPeerMemoryFeatures(uint32_t heapIndex, uint32_t localDevice, uint32_t remoteDevice, VkPeerMemoryFeatureFlags* pPeerMemoryFeatures) {
-	*pPeerMemoryFeatures = VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT | VK_PEER_MEMORY_FEATURE_COPY_DST_BIT;
+void MVKDevice::getPeerMemoryFeatures(
+    uint32_t heapIndex, uint32_t localDevice, uint32_t remoteDevice,
+    VkPeerMemoryFeatureFlags* pPeerMemoryFeatures) {
+    *pPeerMemoryFeatures = VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT |
+                           VK_PEER_MEMORY_FEATURE_COPY_DST_BIT;
 }
 
-VkResult MVKDevice::getMemoryHostPointerProperties(VkExternalMemoryHandleTypeFlagBits handleType,
-												   const void* pHostPointer,
-												   VkMemoryHostPointerPropertiesEXT* pMemHostPtrProps) {
-	if (pMemHostPtrProps) {
-		switch (handleType) {
-			case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
-			case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
-				pMemHostPtrProps->memoryTypeBits = _physicalDevice->getHostVisibleMemoryTypes();
-				break;
-			default:
-				pMemHostPtrProps->memoryTypeBits = 0;
-				break;
-		}
-	}
-	return VK_SUCCESS;
+VkResult MVKDevice::getMemoryHostPointerProperties(
+    VkExternalMemoryHandleTypeFlagBits handleType, const void* pHostPointer,
+    VkMemoryHostPointerPropertiesEXT* pMemHostPtrProps) {
+    if (pMemHostPtrProps) {
+        switch (handleType) {
+        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
+        case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
+            pMemHostPtrProps->memoryTypeBits =
+                _physicalDevice->getHostVisibleMemoryTypes();
+            break;
+        default:
+            pMemHostPtrProps->memoryTypeBits = 0;
+            break;
+        }
+    }
+    return VK_SUCCESS;
 }
 
-void MVKDevice::getCalibratedTimestamps(uint32_t timestampCount,
-										const VkCalibratedTimestampInfoEXT* pTimestampInfos,
-										uint64_t* pTimestamps,
-										uint64_t* pMaxDeviation) {
-	MTLTimestamp cpuStamp, gpuStamp;
-	uint64_t cpuStart, cpuEnd;
+void MVKDevice::getCalibratedTimestamps(
+    uint32_t timestampCount,
+    const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps,
+    uint64_t* pMaxDeviation) {
+    MTLTimestamp cpuStamp, gpuStamp;
+    uint64_t cpuStart, cpuEnd;
 
-	cpuStart = mvkGetContinuousNanoseconds();
-	[_physicalDevice->_mtlDevice sampleTimestamps: &cpuStamp gpuTimestamp: &gpuStamp];
-	// Sample again to calculate the maximum deviation. Note that the
-	// -[MTLDevice sampleTimestamps:gpuTimestamp:] method guarantees that CPU
-	// timestamps are in nanoseconds. We don't want to call the method again,
-	// because that could result in an expensive syscall to query the GPU time-
-	// stamp.
-	cpuEnd = mvkGetContinuousNanoseconds();
-	for (uint32_t tsIdx = 0; tsIdx < timestampCount; ++tsIdx) {
-		switch (pTimestampInfos[tsIdx].timeDomain) {
-			case VK_TIME_DOMAIN_DEVICE_EXT:
-				pTimestamps[tsIdx] = gpuStamp;
-				break;
-			// XXX Should be VK_TIME_DOMAIN_CLOCK_UPTIME_RAW_EXT
-			case VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT:
-				pTimestamps[tsIdx] = cpuStart;
-				break;
-			default:
-				continue;
-		}
-	}
-	*pMaxDeviation = cpuEnd - cpuStart;
+    cpuStart = mvkGetContinuousNanoseconds();
+    [_physicalDevice->_mtlDevice sampleTimestamps:&cpuStamp
+                                     gpuTimestamp:&gpuStamp];
+    // Sample again to calculate the maximum deviation. Note that the
+    // -[MTLDevice sampleTimestamps:gpuTimestamp:] method guarantees that CPU
+    // timestamps are in nanoseconds. We don't want to call the method again,
+    // because that could result in an expensive syscall to query the GPU time-
+    // stamp.
+    cpuEnd = mvkGetContinuousNanoseconds();
+    for (uint32_t tsIdx = 0; tsIdx < timestampCount; ++tsIdx) {
+        switch (pTimestampInfos[tsIdx].timeDomain) {
+        case VK_TIME_DOMAIN_DEVICE_EXT:
+            pTimestamps[tsIdx] = gpuStamp;
+            break;
+        // XXX Should be VK_TIME_DOMAIN_CLOCK_UPTIME_RAW_EXT
+        case VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT:
+            pTimestamps[tsIdx] = cpuStart;
+            break;
+        default:
+            continue;
+        }
+    }
+    *pMaxDeviation = cpuEnd - cpuStart;
 }
 
 #pragma mark Object lifecycle
@@ -3810,780 +4672,973 @@ void MVKDevice::getCalibratedTimestamps(uint32_t timestampCount,
 uint32_t MVKDevice::getVulkanMemoryTypeIndex(MTLStorageMode mtlStorageMode) {
     VkMemoryPropertyFlags vkMemFlags;
     switch (mtlStorageMode) {
-        case MTLStorageModePrivate:
-            vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_PRIVATE;
-            break;
-        case MTLStorageModeShared:
-            vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
-            break;
+    case MTLStorageModePrivate:
+        vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_PRIVATE;
+        break;
+    case MTLStorageModeShared:
+        vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
+        break;
 #if MVK_MACOS
-        case MTLStorageModeManaged:
-            vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_MANAGED;
-            break;
+    case MTLStorageModeManaged:
+        vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_MANAGED;
+        break;
 #endif
 #if MVK_APPLE_SILICON
-        case MTLStorageModeMemoryless:
-            vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS;
-            break;
+    case MTLStorageModeMemoryless:
+        vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_MEMORYLESS;
+        break;
 #endif
-        default:
-            vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
-            break;
+    default:
+        vkMemFlags = MVK_VK_MEMORY_TYPE_METAL_SHARED;
+        break;
     }
 
-	auto& memProps = _physicalDevice->_memoryProperties;
+    auto& memProps = _physicalDevice->_memoryProperties;
     for (uint32_t mtIdx = 0; mtIdx < memProps.memoryTypeCount; mtIdx++) {
-        if (memProps.memoryTypes[mtIdx].propertyFlags == vkMemFlags) { return mtIdx; }
+        if (memProps.memoryTypes[mtIdx].propertyFlags == vkMemFlags) {
+            return mtIdx;
+        }
     }
-    MVKAssert(false, "Could not find memory type corresponding to VkMemoryPropertyFlags %d", vkMemFlags);
+    MVKAssert(false,
+              "Could not find memory type corresponding to "
+              "VkMemoryPropertyFlags %d",
+              vkMemFlags);
     return 0;
 }
 
 MVKBuffer* MVKDevice::createBuffer(const VkBufferCreateInfo* pCreateInfo,
-								   const VkAllocationCallbacks* pAllocator) {
+                                   const VkAllocationCallbacks* pAllocator) {
     return addBuffer(new MVKBuffer(this, pCreateInfo));
 }
 
 void MVKDevice::destroyBuffer(MVKBuffer* mvkBuff,
-							  const VkAllocationCallbacks* pAllocator) {
-	if ( !mvkBuff ) { return; }
-	removeBuffer(mvkBuff);
-	mvkBuff->destroy();
+                              const VkAllocationCallbacks* pAllocator) {
+    if (!mvkBuff) {
+        return;
+    }
+    removeBuffer(mvkBuff);
+    mvkBuff->destroy();
 }
 
-MVKBufferView* MVKDevice::createBufferView(const VkBufferViewCreateInfo* pCreateInfo,
-                                           const VkAllocationCallbacks* pAllocator) {
+MVKBufferView*
+MVKDevice::createBufferView(const VkBufferViewCreateInfo* pCreateInfo,
+                            const VkAllocationCallbacks* pAllocator) {
     return new MVKBufferView(this, pCreateInfo);
 }
 
 void MVKDevice::destroyBufferView(MVKBufferView* mvkBuffView,
                                   const VkAllocationCallbacks* pAllocator) {
-	if (mvkBuffView) { mvkBuffView->destroy(); }
+    if (mvkBuffView) {
+        mvkBuffView->destroy();
+    }
 }
 
 MVKImage* MVKDevice::createImage(const VkImageCreateInfo* pCreateInfo,
-								 const VkAllocationCallbacks* pAllocator) {
-	// If there's a VkImageSwapchainCreateInfoKHR, then we need to create a swapchain image.
-	const VkImageSwapchainCreateInfoKHR* swapchainInfo = nullptr;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-		case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
-			swapchainInfo = (const VkImageSwapchainCreateInfoKHR*)next;
-			break;
-		default:
-			break;
-		}
-	}
-    MVKImage* mvkImg = (swapchainInfo)
-        ? new MVKPeerSwapchainImage(this, pCreateInfo, (MVKSwapchain*)swapchainInfo->swapchain, uint32_t(-1))
-        : new MVKImage(this, pCreateInfo);
-	return addImage(mvkImg);
+                                 const VkAllocationCallbacks* pAllocator) {
+    // If there's a VkImageSwapchainCreateInfoKHR, then we need to create a
+    // swapchain image.
+    const VkImageSwapchainCreateInfoKHR* swapchainInfo = nullptr;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
+            swapchainInfo = (const VkImageSwapchainCreateInfoKHR*)next;
+            break;
+        default:
+            break;
+        }
+    }
+    MVKImage* mvkImg =
+        (swapchainInfo)
+            ? new MVKPeerSwapchainImage(this, pCreateInfo,
+                                        (MVKSwapchain*)swapchainInfo->swapchain,
+                                        uint32_t(-1))
+            : new MVKImage(this, pCreateInfo);
+    return addImage(mvkImg);
 }
 
 void MVKDevice::destroyImage(MVKImage* mvkImg,
-							 const VkAllocationCallbacks* pAllocator) {
-	if ( !mvkImg ) { return; }
-	removeImage(mvkImg);
-	mvkImg->destroy();
+                             const VkAllocationCallbacks* pAllocator) {
+    if (!mvkImg) {
+        return;
+    }
+    removeImage(mvkImg);
+    mvkImg->destroy();
 }
 
-MVKImageView* MVKDevice::createImageView(const VkImageViewCreateInfo* pCreateInfo,
-										 const VkAllocationCallbacks* pAllocator) {
-	return new MVKImageView(this, pCreateInfo);
+MVKImageView*
+MVKDevice::createImageView(const VkImageViewCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    return new MVKImageView(this, pCreateInfo);
 }
 
 void MVKDevice::destroyImageView(MVKImageView* mvkImgView,
-								 const VkAllocationCallbacks* pAllocator) {
-	if (mvkImgView) { mvkImgView->destroy(); }
+                                 const VkAllocationCallbacks* pAllocator) {
+    if (mvkImgView) {
+        mvkImgView->destroy();
+    }
 }
 
-MVKSwapchain* MVKDevice::createSwapchain(const VkSwapchainCreateInfoKHR* pCreateInfo,
-										 const VkAllocationCallbacks* pAllocator) {
-	return new MVKSwapchain(this, pCreateInfo);
+MVKSwapchain*
+MVKDevice::createSwapchain(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    return new MVKSwapchain(this, pCreateInfo);
 }
 
 void MVKDevice::destroySwapchain(MVKSwapchain* mvkSwpChn,
-								 const VkAllocationCallbacks* pAllocator) {
-	if (mvkSwpChn) { mvkSwpChn->destroy(); }
+                                 const VkAllocationCallbacks* pAllocator) {
+    if (mvkSwpChn) {
+        mvkSwpChn->destroy();
+    }
 }
 
-MVKPresentableSwapchainImage* MVKDevice::createPresentableSwapchainImage(const VkImageCreateInfo* pCreateInfo,
-																		 MVKSwapchain* swapchain,
-																		 uint32_t swapchainIndex,
-																		 const VkAllocationCallbacks* pAllocator) {
-	auto* pImg = new MVKPresentableSwapchainImage(this, pCreateInfo, swapchain, swapchainIndex);
-	addImage(pImg);
-	return pImg;
+MVKPresentableSwapchainImage* MVKDevice::createPresentableSwapchainImage(
+    const VkImageCreateInfo* pCreateInfo, MVKSwapchain* swapchain,
+    uint32_t swapchainIndex, const VkAllocationCallbacks* pAllocator) {
+    auto* pImg = new MVKPresentableSwapchainImage(this, pCreateInfo, swapchain,
+                                                  swapchainIndex);
+    addImage(pImg);
+    return pImg;
 }
 
-void MVKDevice::destroyPresentableSwapchainImage(MVKPresentableSwapchainImage* mvkImg,
-												 const VkAllocationCallbacks* pAllocator) {
-	if ( !mvkImg ) { return; }
-	removeImage(mvkImg);
-	mvkImg->destroy();
+void MVKDevice::destroyPresentableSwapchainImage(
+    MVKPresentableSwapchainImage* mvkImg,
+    const VkAllocationCallbacks* pAllocator) {
+    if (!mvkImg) {
+        return;
+    }
+    removeImage(mvkImg);
+    mvkImg->destroy();
 }
 
 MVKFence* MVKDevice::createFence(const VkFenceCreateInfo* pCreateInfo,
-								 const VkAllocationCallbacks* pAllocator) {
-	return new MVKFence(this, pCreateInfo);
+                                 const VkAllocationCallbacks* pAllocator) {
+    return new MVKFence(this, pCreateInfo);
 }
 
 void MVKDevice::destroyFence(MVKFence* mvkFence,
-							 const VkAllocationCallbacks* pAllocator) {
-	if (mvkFence) { mvkFence->destroy(); }
+                             const VkAllocationCallbacks* pAllocator) {
+    if (mvkFence) {
+        mvkFence->destroy();
+    }
 }
 
-MVKSemaphore* MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInfo,
-										 const VkAllocationCallbacks* pAllocator) {
-	const VkSemaphoreTypeCreateInfo* pTypeCreateInfo = nullptr;
-	const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
-	const VkImportMetalSharedEventInfoEXT* pImportInfo = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
-				pTypeCreateInfo = (VkSemaphoreTypeCreateInfo*)next;
-				break;
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
-				pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
-				break;
-			case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
-				pImportInfo = (VkImportMetalSharedEventInfoEXT*)next;
-				break;
-			default:
-				break;
-		}
-	}
+MVKSemaphore*
+MVKDevice::createSemaphore(const VkSemaphoreCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    const VkSemaphoreTypeCreateInfo* pTypeCreateInfo = nullptr;
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
+    const VkImportMetalSharedEventInfoEXT* pImportInfo = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
+            pTypeCreateInfo = (VkSemaphoreTypeCreateInfo*)next;
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
+            pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
+            pImportInfo = (VkImportMetalSharedEventInfoEXT*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	if (pTypeCreateInfo && pTypeCreateInfo->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE) {
-		if (_physicalDevice->_metalFeatures.events) {
-			return new MVKTimelineSemaphoreMTLEvent(this, pCreateInfo, pTypeCreateInfo, pExportInfo, pImportInfo);
-		} else {
-			return new MVKTimelineSemaphoreEmulated(this, pCreateInfo, pTypeCreateInfo, pExportInfo, pImportInfo);
-		}
-	} else {
-		switch (_physicalDevice->_vkSemaphoreStyle) {
-			case MVKSemaphoreStyleUseMTLEvent:  return new MVKSemaphoreMTLEvent(this, pCreateInfo, pExportInfo, pImportInfo);
-			case MVKSemaphoreStyleUseEmulation: return new MVKSemaphoreEmulated(this, pCreateInfo, pExportInfo, pImportInfo);
-			case MVKSemaphoreStyleSingleQueue:  return new MVKSemaphoreSingleQueue(this, pCreateInfo, pExportInfo, pImportInfo);
-		}
-	}
+    if (pTypeCreateInfo &&
+        pTypeCreateInfo->semaphoreType == VK_SEMAPHORE_TYPE_TIMELINE) {
+        if (_physicalDevice->_metalFeatures.events) {
+            return new MVKTimelineSemaphoreMTLEvent(this, pCreateInfo,
+                                                    pTypeCreateInfo,
+                                                    pExportInfo, pImportInfo);
+        } else {
+            return new MVKTimelineSemaphoreEmulated(this, pCreateInfo,
+                                                    pTypeCreateInfo,
+                                                    pExportInfo, pImportInfo);
+        }
+    } else {
+        switch (_physicalDevice->_vkSemaphoreStyle) {
+        case MVKSemaphoreStyleUseMTLEvent:
+            return new MVKSemaphoreMTLEvent(this, pCreateInfo, pExportInfo,
+                                            pImportInfo);
+        case MVKSemaphoreStyleUseEmulation:
+            return new MVKSemaphoreEmulated(this, pCreateInfo, pExportInfo,
+                                            pImportInfo);
+        case MVKSemaphoreStyleSingleQueue:
+            return new MVKSemaphoreSingleQueue(this, pCreateInfo, pExportInfo,
+                                               pImportInfo);
+        }
+    }
 }
 
 void MVKDevice::destroySemaphore(MVKSemaphore* mvkSem4,
-								 const VkAllocationCallbacks* pAllocator) {
-	if (mvkSem4) { mvkSem4->destroy(); }
+                                 const VkAllocationCallbacks* pAllocator) {
+    if (mvkSem4) {
+        mvkSem4->destroy();
+    }
 }
 
-MVKDeferredOperation* MVKDevice::createDeferredOperation(const VkAllocationCallbacks* pAllocator) {
+MVKDeferredOperation*
+MVKDevice::createDeferredOperation(const VkAllocationCallbacks* pAllocator) {
     return new MVKDeferredOperation(this);
 }
 
-void MVKDevice::destroyDeferredOperation(MVKDeferredOperation* mvkDeferredOperation,
-                                         const VkAllocationCallbacks* pAllocator) {
-    if(mvkDeferredOperation) { mvkDeferredOperation->destroy(); }
+void MVKDevice::destroyDeferredOperation(
+    MVKDeferredOperation* mvkDeferredOperation,
+    const VkAllocationCallbacks* pAllocator) {
+    if (mvkDeferredOperation) {
+        mvkDeferredOperation->destroy();
+    }
 }
 
 MVKEvent* MVKDevice::createEvent(const VkEventCreateInfo* pCreateInfo,
-								 const VkAllocationCallbacks* pAllocator) {
-	const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
-	const VkImportMetalSharedEventInfoEXT* pImportInfo = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
-				pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
-				break;
-			case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
-				pImportInfo = (VkImportMetalSharedEventInfoEXT*)next;
-				break;
-			default:
-				break;
-		}
-	}
+                                 const VkAllocationCallbacks* pAllocator) {
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
+    const VkImportMetalSharedEventInfoEXT* pImportInfo = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
+            pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
+            pImportInfo = (VkImportMetalSharedEventInfoEXT*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	if (_physicalDevice->_metalFeatures.events) {
-		return new MVKEventNative(this, pCreateInfo, pExportInfo, pImportInfo);
-	} else {
-		return new MVKEventEmulated(this, pCreateInfo, pExportInfo, pImportInfo);
-	}
+    if (_physicalDevice->_metalFeatures.events) {
+        return new MVKEventNative(this, pCreateInfo, pExportInfo, pImportInfo);
+    } else {
+        return new MVKEventEmulated(this, pCreateInfo, pExportInfo,
+                                    pImportInfo);
+    }
 }
 
-void MVKDevice::destroyEvent(MVKEvent* mvkEvent, const VkAllocationCallbacks* pAllocator) {
-	if (mvkEvent) { mvkEvent->destroy(); }
+void MVKDevice::destroyEvent(MVKEvent* mvkEvent,
+                             const VkAllocationCallbacks* pAllocator) {
+    if (mvkEvent) {
+        mvkEvent->destroy();
+    }
 }
 
-MVKQueryPool* MVKDevice::createQueryPool(const VkQueryPoolCreateInfo* pCreateInfo,
-										 const VkAllocationCallbacks* pAllocator) {
-	switch (pCreateInfo->queryType) {
-        case VK_QUERY_TYPE_OCCLUSION:
-            return new MVKOcclusionQueryPool(this, pCreateInfo);
-		case VK_QUERY_TYPE_TIMESTAMP:
-			return new MVKTimestampQueryPool(this, pCreateInfo);
-		case VK_QUERY_TYPE_PIPELINE_STATISTICS:
-			return new MVKPipelineStatisticsQueryPool(this, pCreateInfo);
-		default:
-            return new MVKUnsupportedQueryPool(this, pCreateInfo);
-	}
+MVKQueryPool*
+MVKDevice::createQueryPool(const VkQueryPoolCreateInfo* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    switch (pCreateInfo->queryType) {
+    case VK_QUERY_TYPE_OCCLUSION:
+        return new MVKOcclusionQueryPool(this, pCreateInfo);
+    case VK_QUERY_TYPE_TIMESTAMP:
+        return new MVKTimestampQueryPool(this, pCreateInfo);
+    case VK_QUERY_TYPE_PIPELINE_STATISTICS:
+        return new MVKPipelineStatisticsQueryPool(this, pCreateInfo);
+    default:
+        return new MVKUnsupportedQueryPool(this, pCreateInfo);
+    }
 }
 
 void MVKDevice::destroyQueryPool(MVKQueryPool* mvkQP,
-								 const VkAllocationCallbacks* pAllocator) {
-	if (mvkQP) { mvkQP->destroy(); }
+                                 const VkAllocationCallbacks* pAllocator) {
+    if (mvkQP) {
+        mvkQP->destroy();
+    }
 }
 
-MVKShaderModule* MVKDevice::createShaderModule(const VkShaderModuleCreateInfo* pCreateInfo,
-											   const VkAllocationCallbacks* pAllocator) {
-	return new MVKShaderModule(this, pCreateInfo);
+MVKShaderModule*
+MVKDevice::createShaderModule(const VkShaderModuleCreateInfo* pCreateInfo,
+                              const VkAllocationCallbacks* pAllocator) {
+    return new MVKShaderModule(this, pCreateInfo);
 }
 
 void MVKDevice::destroyShaderModule(MVKShaderModule* mvkShdrMod,
-									const VkAllocationCallbacks* pAllocator) {
-	if (mvkShdrMod) { mvkShdrMod->destroy(); }
+                                    const VkAllocationCallbacks* pAllocator) {
+    if (mvkShdrMod) {
+        mvkShdrMod->destroy();
+    }
 }
 
-MVKPipelineCache* MVKDevice::createPipelineCache(const VkPipelineCacheCreateInfo* pCreateInfo,
-												 const VkAllocationCallbacks* pAllocator) {
-	return new MVKPipelineCache(this, pCreateInfo);
+MVKPipelineCache*
+MVKDevice::createPipelineCache(const VkPipelineCacheCreateInfo* pCreateInfo,
+                               const VkAllocationCallbacks* pAllocator) {
+    return new MVKPipelineCache(this, pCreateInfo);
 }
 
 void MVKDevice::destroyPipelineCache(MVKPipelineCache* mvkPLC,
-									 const VkAllocationCallbacks* pAllocator) {
-	if (mvkPLC) { mvkPLC->destroy(); }
+                                     const VkAllocationCallbacks* pAllocator) {
+    if (mvkPLC) {
+        mvkPLC->destroy();
+    }
 }
 
-MVKPipelineLayout* MVKDevice::createPipelineLayout(const VkPipelineLayoutCreateInfo* pCreateInfo,
-												   const VkAllocationCallbacks* pAllocator) {
-	return new MVKPipelineLayout(this, pCreateInfo);
+MVKPipelineLayout*
+MVKDevice::createPipelineLayout(const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                const VkAllocationCallbacks* pAllocator) {
+    return new MVKPipelineLayout(this, pCreateInfo);
 }
 
 void MVKDevice::destroyPipelineLayout(MVKPipelineLayout* mvkPLL,
-									  const VkAllocationCallbacks* pAllocator) {
-	if (mvkPLL) { mvkPLL->destroy(); }
+                                      const VkAllocationCallbacks* pAllocator) {
+    if (mvkPLL) {
+        mvkPLL->destroy();
+    }
 }
 
-template<typename PipelineType, typename PipelineInfoType>
+template <typename PipelineType, typename PipelineInfoType>
 VkResult MVKDevice::createPipelines(VkPipelineCache pipelineCache,
                                     uint32_t count,
                                     const PipelineInfoType* pCreateInfos,
                                     const VkAllocationCallbacks* pAllocator,
                                     VkPipeline* pPipelines) {
-	bool ignoreFurtherPipelines = false;
+    bool ignoreFurtherPipelines = false;
     VkResult rslt = VK_SUCCESS;
     MVKPipelineCache* mvkPLC = (MVKPipelineCache*)pipelineCache;
 
-	@autoreleasepool {
-		for (uint32_t plIdx = 0; plIdx < count; plIdx++) {
+    @autoreleasepool {
+        for (uint32_t plIdx = 0; plIdx < count; plIdx++) {
 
-			// Ensure all slots are purposefully set.
-			pPipelines[plIdx] = VK_NULL_HANDLE;
-			if (ignoreFurtherPipelines) { continue; }
+            // Ensure all slots are purposefully set.
+            pPipelines[plIdx] = VK_NULL_HANDLE;
+            if (ignoreFurtherPipelines) {
+                continue;
+            }
 
-			const PipelineInfoType* pCreateInfo = &pCreateInfos[plIdx];
+            const PipelineInfoType* pCreateInfo = &pCreateInfos[plIdx];
 
-			// See if this pipeline has a parent. This can come either directly
-			// via basePipelineHandle or indirectly via basePipelineIndex.
-			MVKPipeline* parentPL = VK_NULL_HANDLE;
-			if ( mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_PIPELINE_CREATE_DERIVATIVE_BIT) ) {
-				VkPipeline vkParentPL = pCreateInfo->basePipelineHandle;
-				int32_t parentPLIdx = pCreateInfo->basePipelineIndex;
-				if ( !vkParentPL && (parentPLIdx >= 0)) { vkParentPL = pPipelines[parentPLIdx]; }
-				parentPL = vkParentPL ? (MVKPipeline*)vkParentPL : VK_NULL_HANDLE;
-			}
+            // See if this pipeline has a parent. This can come either directly
+            // via basePipelineHandle or indirectly via basePipelineIndex.
+            MVKPipeline* parentPL = VK_NULL_HANDLE;
+            if (mvkAreAllFlagsEnabled(pCreateInfo->flags,
+                                      VK_PIPELINE_CREATE_DERIVATIVE_BIT)) {
+                VkPipeline vkParentPL = pCreateInfo->basePipelineHandle;
+                int32_t parentPLIdx = pCreateInfo->basePipelineIndex;
+                if (!vkParentPL && (parentPLIdx >= 0)) {
+                    vkParentPL = pPipelines[parentPLIdx];
+                }
+                parentPL =
+                    vkParentPL ? (MVKPipeline*)vkParentPL : VK_NULL_HANDLE;
+            }
 
-			// Create the pipeline and if creation was successful, insert the new pipeline in the return array.
-			MVKPipeline* mvkPL = new PipelineType(this, mvkPLC, parentPL, pCreateInfo);
-			VkResult plRslt = mvkPL->getConfigurationResult();
-			if (plRslt == VK_SUCCESS) {
-				pPipelines[plIdx] = (VkPipeline)mvkPL;
-			} else {
-				// If creation was unsuccessful, destroy the broken pipeline, change the result
-				// code of this function, and if the VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT
-				// flag is set, don't build any further pipelines.
-				mvkPL->destroy();
-				if (rslt == VK_SUCCESS) { rslt = plRslt; }
-				ignoreFurtherPipelines = (_enabledPipelineCreationCacheControlFeatures.pipelineCreationCacheControl &&
-										  mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT));
-			}
-		}
-	}
+            // Create the pipeline and if creation was successful, insert the
+            // new pipeline in the return array.
+            MVKPipeline* mvkPL =
+                new PipelineType(this, mvkPLC, parentPL, pCreateInfo);
+            VkResult plRslt = mvkPL->getConfigurationResult();
+            if (plRslt == VK_SUCCESS) {
+                pPipelines[plIdx] = (VkPipeline)mvkPL;
+            } else {
+                // If creation was unsuccessful, destroy the broken pipeline,
+                // change the result code of this function, and if the
+                // VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT flag is set,
+                // don't build any further pipelines.
+                mvkPL->destroy();
+                if (rslt == VK_SUCCESS) {
+                    rslt = plRslt;
+                }
+                ignoreFurtherPipelines =
+                    (_enabledPipelineCreationCacheControlFeatures
+                         .pipelineCreationCacheControl &&
+                     mvkIsAnyFlagEnabled(
+                         pCreateInfo->flags,
+                         VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT));
+            }
+        }
+    }
 
     return rslt;
 }
 
-// Create concrete implementations of the two variations of the mvkCreatePipelines() function
-// that we will be using. This is required since the template definition is located in this
-// implementation file instead of in the header file. This is a realistic approach if the
-// universe of possible template implementation variations is small and known in advance.
-template VkResult MVKDevice::createPipelines<MVKGraphicsPipeline, VkGraphicsPipelineCreateInfo>(VkPipelineCache pipelineCache,
-                                                                                                uint32_t count,
-                                                                                                const VkGraphicsPipelineCreateInfo* pCreateInfos,
-                                                                                                const VkAllocationCallbacks* pAllocator,
-                                                                                                VkPipeline* pPipelines);
+// Create concrete implementations of the two variations of the
+// mvkCreatePipelines() function that we will be using. This is required since
+// the template definition is located in this implementation file instead of in
+// the header file. This is a realistic approach if the universe of possible
+// template implementation variations is small and known in advance.
+template VkResult
+MVKDevice::createPipelines<MVKGraphicsPipeline, VkGraphicsPipelineCreateInfo>(
+    VkPipelineCache pipelineCache, uint32_t count,
+    const VkGraphicsPipelineCreateInfo* pCreateInfos,
+    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
 
-template VkResult MVKDevice::createPipelines<MVKComputePipeline, VkComputePipelineCreateInfo>(VkPipelineCache pipelineCache,
-                                                                                              uint32_t count,
-                                                                                              const VkComputePipelineCreateInfo* pCreateInfos,
-                                                                                              const VkAllocationCallbacks* pAllocator,
-                                                                                              VkPipeline* pPipelines);
+template VkResult
+MVKDevice::createPipelines<MVKComputePipeline, VkComputePipelineCreateInfo>(
+    VkPipelineCache pipelineCache, uint32_t count,
+    const VkComputePipelineCreateInfo* pCreateInfos,
+    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines);
 
 void MVKDevice::destroyPipeline(MVKPipeline* mvkPL,
                                 const VkAllocationCallbacks* pAllocator) {
-	if (mvkPL) { mvkPL->destroy(); }
+    if (mvkPL) {
+        mvkPL->destroy();
+    }
 }
 
 MVKSampler* MVKDevice::createSampler(const VkSamplerCreateInfo* pCreateInfo,
-									 const VkAllocationCallbacks* pAllocator) {
-	return new MVKSampler(this, pCreateInfo);
+                                     const VkAllocationCallbacks* pAllocator) {
+    return new MVKSampler(this, pCreateInfo);
 }
 
 void MVKDevice::destroySampler(MVKSampler* mvkSamp,
-							   const VkAllocationCallbacks* pAllocator) {
-	if (mvkSamp) { mvkSamp->destroy(); }
+                               const VkAllocationCallbacks* pAllocator) {
+    if (mvkSamp) {
+        mvkSamp->destroy();
+    }
 }
 
-MVKSamplerYcbcrConversion* MVKDevice::createSamplerYcbcrConversion(const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
-																   const VkAllocationCallbacks* pAllocator) {
-	return new MVKSamplerYcbcrConversion(this, pCreateInfo);
+MVKSamplerYcbcrConversion* MVKDevice::createSamplerYcbcrConversion(
+    const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator) {
+    return new MVKSamplerYcbcrConversion(this, pCreateInfo);
 }
 
-void MVKDevice::destroySamplerYcbcrConversion(MVKSamplerYcbcrConversion* mvkSampConv,
-											  const VkAllocationCallbacks* pAllocator) {
-	mvkSampConv->destroy();
+void MVKDevice::destroySamplerYcbcrConversion(
+    MVKSamplerYcbcrConversion* mvkSampConv,
+    const VkAllocationCallbacks* pAllocator) {
+    mvkSampConv->destroy();
 }
 
-MVKDescriptorSetLayout* MVKDevice::createDescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
-															 const VkAllocationCallbacks* pAllocator) {
-	return new MVKDescriptorSetLayout(this, pCreateInfo);
+MVKDescriptorSetLayout* MVKDevice::createDescriptorSetLayout(
+    const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator) {
+    return new MVKDescriptorSetLayout(this, pCreateInfo);
 }
 
-void MVKDevice::destroyDescriptorSetLayout(MVKDescriptorSetLayout* mvkDSL,
-										   const VkAllocationCallbacks* pAllocator) {
-	if (mvkDSL) { mvkDSL->destroy(); }
+void MVKDevice::destroyDescriptorSetLayout(
+    MVKDescriptorSetLayout* mvkDSL, const VkAllocationCallbacks* pAllocator) {
+    if (mvkDSL) {
+        mvkDSL->destroy();
+    }
 }
 
-MVKDescriptorPool* MVKDevice::createDescriptorPool(const VkDescriptorPoolCreateInfo* pCreateInfo,
-												   const VkAllocationCallbacks* pAllocator) {
-	return new MVKDescriptorPool(this, pCreateInfo);
+MVKDescriptorPool*
+MVKDevice::createDescriptorPool(const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                const VkAllocationCallbacks* pAllocator) {
+    return new MVKDescriptorPool(this, pCreateInfo);
 }
 
 void MVKDevice::destroyDescriptorPool(MVKDescriptorPool* mvkDP,
-									  const VkAllocationCallbacks* pAllocator) {
-	if (mvkDP) { mvkDP->destroy(); }
+                                      const VkAllocationCallbacks* pAllocator) {
+    if (mvkDP) {
+        mvkDP->destroy();
+    }
 }
 
 MVKDescriptorUpdateTemplate* MVKDevice::createDescriptorUpdateTemplate(
-	const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-	const VkAllocationCallbacks* pAllocator) {
-	return new MVKDescriptorUpdateTemplate(this, pCreateInfo);
+    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator) {
+    return new MVKDescriptorUpdateTemplate(this, pCreateInfo);
 }
 
-void MVKDevice::destroyDescriptorUpdateTemplate(MVKDescriptorUpdateTemplate* mvkDUT,
-												const VkAllocationCallbacks* pAllocator) {
-	if (mvkDUT) { mvkDUT->destroy(); }
+void MVKDevice::destroyDescriptorUpdateTemplate(
+    MVKDescriptorUpdateTemplate* mvkDUT,
+    const VkAllocationCallbacks* pAllocator) {
+    if (mvkDUT) {
+        mvkDUT->destroy();
+    }
 }
 
-MVKFramebuffer* MVKDevice::createFramebuffer(const VkFramebufferCreateInfo* pCreateInfo,
-											 const VkAllocationCallbacks* pAllocator) {
-	return new MVKFramebuffer(this, pCreateInfo);
+MVKFramebuffer*
+MVKDevice::createFramebuffer(const VkFramebufferCreateInfo* pCreateInfo,
+                             const VkAllocationCallbacks* pAllocator) {
+    return new MVKFramebuffer(this, pCreateInfo);
 }
 
-MVKFramebuffer* MVKDevice::createFramebuffer(const VkRenderingInfo* pRenderingInfo,
-											 const VkAllocationCallbacks* pAllocator) {
-	return new MVKFramebuffer(this, pRenderingInfo);
+MVKFramebuffer*
+MVKDevice::createFramebuffer(const VkRenderingInfo* pRenderingInfo,
+                             const VkAllocationCallbacks* pAllocator) {
+    return new MVKFramebuffer(this, pRenderingInfo);
 }
 
 void MVKDevice::destroyFramebuffer(MVKFramebuffer* mvkFB,
-								   const VkAllocationCallbacks* pAllocator) {
-	if (mvkFB) { mvkFB->destroy(); }
+                                   const VkAllocationCallbacks* pAllocator) {
+    if (mvkFB) {
+        mvkFB->destroy();
+    }
 }
 
-MVKRenderPass* MVKDevice::createRenderPass(const VkRenderPassCreateInfo* pCreateInfo,
-										   const VkAllocationCallbacks* pAllocator) {
-	return new MVKRenderPass(this, pCreateInfo);
+MVKRenderPass*
+MVKDevice::createRenderPass(const VkRenderPassCreateInfo* pCreateInfo,
+                            const VkAllocationCallbacks* pAllocator) {
+    return new MVKRenderPass(this, pCreateInfo);
 }
 
-MVKRenderPass* MVKDevice::createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
-										   const VkAllocationCallbacks* pAllocator) {
-	return new MVKRenderPass(this, pCreateInfo);
+MVKRenderPass*
+MVKDevice::createRenderPass(const VkRenderPassCreateInfo2* pCreateInfo,
+                            const VkAllocationCallbacks* pAllocator) {
+    return new MVKRenderPass(this, pCreateInfo);
 }
 
-MVKRenderPass* MVKDevice::createRenderPass(const VkRenderingInfo* pRenderingInfo,
-										   const VkAllocationCallbacks* pAllocator) {
-	return new MVKRenderPass(this, pRenderingInfo);
+MVKRenderPass*
+MVKDevice::createRenderPass(const VkRenderingInfo* pRenderingInfo,
+                            const VkAllocationCallbacks* pAllocator) {
+    return new MVKRenderPass(this, pRenderingInfo);
 }
 
 void MVKDevice::destroyRenderPass(MVKRenderPass* mvkRP,
-								  const VkAllocationCallbacks* pAllocator) {
-	if (mvkRP) { mvkRP->destroy(); }
+                                  const VkAllocationCallbacks* pAllocator) {
+    if (mvkRP) {
+        mvkRP->destroy();
+    }
 }
 
-MVKCommandPool* MVKDevice::createCommandPool(const VkCommandPoolCreateInfo* pCreateInfo,
-											const VkAllocationCallbacks* pAllocator) {
-	return new MVKCommandPool(this, pCreateInfo, getMVKConfig().useCommandPooling);
+MVKCommandPool*
+MVKDevice::createCommandPool(const VkCommandPoolCreateInfo* pCreateInfo,
+                             const VkAllocationCallbacks* pAllocator) {
+    return new MVKCommandPool(this, pCreateInfo,
+                              getMVKConfig().useCommandPooling);
 }
 
 void MVKDevice::destroyCommandPool(MVKCommandPool* mvkCmdPool,
-								   const VkAllocationCallbacks* pAllocator) {
-	if (mvkCmdPool) { mvkCmdPool->destroy(); }
+                                   const VkAllocationCallbacks* pAllocator) {
+    if (mvkCmdPool) {
+        mvkCmdPool->destroy();
+    }
 }
 
-MVKDeviceMemory* MVKDevice::allocateMemory(const VkMemoryAllocateInfo* pAllocateInfo,
-										   const VkAllocationCallbacks* pAllocator) {
-	return new MVKDeviceMemory(this, pAllocateInfo, pAllocator);
+MVKDeviceMemory*
+MVKDevice::allocateMemory(const VkMemoryAllocateInfo* pAllocateInfo,
+                          const VkAllocationCallbacks* pAllocator) {
+    return new MVKDeviceMemory(this, pAllocateInfo, pAllocator);
 }
 
 void MVKDevice::freeMemory(MVKDeviceMemory* mvkDevMem,
-						   const VkAllocationCallbacks* pAllocator) {
-	if (mvkDevMem) { mvkDevMem->destroy(); }
+                           const VkAllocationCallbacks* pAllocator) {
+    if (mvkDevMem) {
+        mvkDevMem->destroy();
+    }
 }
 
-// Look for an available pre-reserved private data slot and return its address if found.
-// Otherwise create a new instance and return it.
-VkResult MVKDevice::createPrivateDataSlot(const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
-										  const VkAllocationCallbacks* pAllocator,
-										  VkPrivateDataSlotEXT* pPrivateDataSlot) {
-	MVKPrivateDataSlot* mvkPDS = nullptr;
+// Look for an available pre-reserved private data slot and return its address
+// if found. Otherwise create a new instance and return it.
+VkResult MVKDevice::createPrivateDataSlot(
+    const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator,
+    VkPrivateDataSlotEXT* pPrivateDataSlot) {
+    MVKPrivateDataSlot* mvkPDS = nullptr;
 
-	size_t slotCnt = _privateDataSlots.size();
-	for (size_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
-		if ( _privateDataSlotsAvailability[slotIdx] ) {
-			_privateDataSlotsAvailability[slotIdx] = false;
-			mvkPDS = _privateDataSlots[slotIdx];
-			break;
-		}
-	}
+    size_t slotCnt = _privateDataSlots.size();
+    for (size_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
+        if (_privateDataSlotsAvailability[slotIdx]) {
+            _privateDataSlotsAvailability[slotIdx] = false;
+            mvkPDS = _privateDataSlots[slotIdx];
+            break;
+        }
+    }
 
-	if ( !mvkPDS ) { mvkPDS = new MVKPrivateDataSlot(this); }
+    if (!mvkPDS) {
+        mvkPDS = new MVKPrivateDataSlot(this);
+    }
 
-	*pPrivateDataSlot = (VkPrivateDataSlotEXT)mvkPDS;
-	return VK_SUCCESS;
+    *pPrivateDataSlot = (VkPrivateDataSlotEXT)mvkPDS;
+    return VK_SUCCESS;
 }
 
-// If the private data slot is one of the pre-reserved slots, clear it and mark it as available.
-// Otherwise destroy it.
-void MVKDevice::destroyPrivateDataSlot(VkPrivateDataSlotEXT privateDataSlot,
-									   const VkAllocationCallbacks* pAllocator) {
+// If the private data slot is one of the pre-reserved slots, clear it and mark
+// it as available. Otherwise destroy it.
+void MVKDevice::destroyPrivateDataSlot(
+    VkPrivateDataSlotEXT privateDataSlot,
+    const VkAllocationCallbacks* pAllocator) {
 
-	MVKPrivateDataSlot* mvkPDS = (MVKPrivateDataSlot*)privateDataSlot;
+    MVKPrivateDataSlot* mvkPDS = (MVKPrivateDataSlot*)privateDataSlot;
 
-	size_t slotCnt = _privateDataSlots.size();
-	for (size_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
-		if (mvkPDS == _privateDataSlots[slotIdx]) {
-			mvkPDS->clearData();
-			_privateDataSlotsAvailability[slotIdx] = true;
-			return;
-		}
-	}
+    size_t slotCnt = _privateDataSlots.size();
+    for (size_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
+        if (mvkPDS == _privateDataSlots[slotIdx]) {
+            mvkPDS->clearData();
+            _privateDataSlotsAvailability[slotIdx] = true;
+            return;
+        }
+    }
 
-	mvkPDS->destroy();
+    mvkPDS->destroy();
 }
 
 #pragma mark Operations
 
-// If the underlying MTLBuffer is referenced in a shader only via its gpuAddress,
-// the GPU might not be aware that the MTLBuffer needs to be made resident.
-// Track the buffer as needing to be made resident if a shader is bound that uses
-// PhysicalStorageBufferAddresses to access the contents of the underlying MTLBuffer.
+// If the underlying MTLBuffer is referenced in a shader only via its
+// gpuAddress, the GPU might not be aware that the MTLBuffer needs to be made
+// resident. Track the buffer as needing to be made resident if a shader is
+// bound that uses PhysicalStorageBufferAddresses to access the contents of the
+// underlying MTLBuffer.
 MVKBuffer* MVKDevice::addBuffer(MVKBuffer* mvkBuff) {
-	if ( !mvkBuff ) { return mvkBuff; }
+    if (!mvkBuff) {
+        return mvkBuff;
+    }
 
-	lock_guard<mutex> lock(_rezLock);
-	_resources.push_back(mvkBuff);
-	if (mvkIsAnyFlagEnabled(mvkBuff->getUsage(), VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)) {
-		_gpuAddressableBuffers.push_back(mvkBuff);
-	}
-	return mvkBuff;
+    lock_guard<mutex> lock(_rezLock);
+    _resources.push_back(mvkBuff);
+    if (mvkIsAnyFlagEnabled(mvkBuff->getUsage(),
+                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)) {
+        _gpuAddressableBuffers.push_back(mvkBuff);
+    }
+    return mvkBuff;
 }
 
 MVKBuffer* MVKDevice::removeBuffer(MVKBuffer* mvkBuff) {
-	if ( !mvkBuff ) { return mvkBuff; }
+    if (!mvkBuff) {
+        return mvkBuff;
+    }
 
-	lock_guard<mutex> lock(_rezLock);
-	mvkRemoveFirstOccurance(_resources, mvkBuff);
-	if (mvkIsAnyFlagEnabled(mvkBuff->getUsage(), VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)) {
-		mvkRemoveFirstOccurance(_gpuAddressableBuffers, mvkBuff);
-	}
-	return mvkBuff;
+    lock_guard<mutex> lock(_rezLock);
+    mvkRemoveFirstOccurance(_resources, mvkBuff);
+    if (mvkIsAnyFlagEnabled(mvkBuff->getUsage(),
+                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT)) {
+        mvkRemoveFirstOccurance(_gpuAddressableBuffers, mvkBuff);
+    }
+    return mvkBuff;
 }
 
-void MVKDevice::encodeGPUAddressableBuffers(MVKResourcesCommandEncoderState* rezEncState, MVKShaderStage stage) {
-	MTLResourceUsage mtlUsage = MTLResourceUsageRead | MTLResourceUsageWrite;
-	MTLRenderStages mtlRendStage = (stage == kMVKShaderStageFragment) ? MTLRenderStageFragment : MTLRenderStageVertex;
+void MVKDevice::encodeGPUAddressableBuffers(
+    MVKResourcesCommandEncoderState* rezEncState, MVKShaderStage stage) {
+    MTLResourceUsage mtlUsage = MTLResourceUsageRead | MTLResourceUsageWrite;
+    MTLRenderStages mtlRendStage = (stage == kMVKShaderStageFragment)
+                                       ? MTLRenderStageFragment
+                                       : MTLRenderStageVertex;
 
-	lock_guard<mutex> lock(_rezLock);
-	for (auto& buff : _gpuAddressableBuffers) {
-		rezEncState->encodeResourceUsage(stage, buff->getMTLBuffer(), mtlUsage, mtlRendStage);
-	}
+    lock_guard<mutex> lock(_rezLock);
+    for (auto& buff : _gpuAddressableBuffers) {
+        rezEncState->encodeResourceUsage(stage, buff->getMTLBuffer(), mtlUsage,
+                                         mtlRendStage);
+    }
 }
 
 MVKImage* MVKDevice::addImage(MVKImage* mvkImg) {
-	if ( !mvkImg ) { return mvkImg; }
+    if (!mvkImg) {
+        return mvkImg;
+    }
 
-	lock_guard<mutex> lock(_rezLock);
-	for (auto& mb : mvkImg->_memoryBindings) {
-		_resources.push_back(mb);
-	}
-	return mvkImg;
+    lock_guard<mutex> lock(_rezLock);
+    for (auto& mb : mvkImg->_memoryBindings) {
+        _resources.push_back(mb);
+    }
+    return mvkImg;
 }
 
 MVKImage* MVKDevice::removeImage(MVKImage* mvkImg) {
-	if ( !mvkImg ) { return mvkImg; }
+    if (!mvkImg) {
+        return mvkImg;
+    }
 
-	lock_guard<mutex> lock(_rezLock);
-	for (auto& mb : mvkImg->_memoryBindings) {
-		mvkRemoveFirstOccurance(_resources, mb);
-	}
-	return mvkImg;
+    lock_guard<mutex> lock(_rezLock);
+    for (auto& mb : mvkImg->_memoryBindings) {
+        mvkRemoveFirstOccurance(_resources, mb);
+    }
+    return mvkImg;
 }
 
 void MVKDevice::addSemaphore(MVKSemaphoreImpl* sem4) {
-	lock_guard<mutex> lock(_sem4Lock);
-	_awaitingSemaphores.push_back(sem4);
+    lock_guard<mutex> lock(_sem4Lock);
+    _awaitingSemaphores.push_back(sem4);
 }
 
 void MVKDevice::removeSemaphore(MVKSemaphoreImpl* sem4) {
-	lock_guard<mutex> lock(_sem4Lock);
-	mvkRemoveFirstOccurance(_awaitingSemaphores, sem4);
+    lock_guard<mutex> lock(_sem4Lock);
+    mvkRemoveFirstOccurance(_awaitingSemaphores, sem4);
 }
 
-void MVKDevice::addTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value) {
-	lock_guard<mutex> lock(_sem4Lock);
-	_awaitingTimelineSem4s.emplace_back(sem4, value);
+void MVKDevice::addTimelineSemaphore(MVKTimelineSemaphore* sem4,
+                                     uint64_t value) {
+    lock_guard<mutex> lock(_sem4Lock);
+    _awaitingTimelineSem4s.emplace_back(sem4, value);
 }
 
-void MVKDevice::removeTimelineSemaphore(MVKTimelineSemaphore* sem4, uint64_t value) {
-	lock_guard<mutex> lock(_sem4Lock);
-	mvkRemoveFirstOccurance(_awaitingTimelineSem4s, make_pair(sem4, value));
+void MVKDevice::removeTimelineSemaphore(MVKTimelineSemaphore* sem4,
+                                        uint64_t value) {
+    lock_guard<mutex> lock(_sem4Lock);
+    mvkRemoveFirstOccurance(_awaitingTimelineSem4s, make_pair(sem4, value));
 }
 
 void MVKDevice::applyMemoryBarrier(MVKPipelineBarrier& barrier,
-								   MVKCommandEncoder* cmdEncoder,
-								   MVKCommandUse cmdUse) {
-	if (!mvkIsAnyFlagEnabled(barrier.dstStageMask, VK_PIPELINE_STAGE_HOST_BIT) ||
-		!mvkIsAnyFlagEnabled(barrier.dstAccessMask, VK_ACCESS_HOST_READ_BIT) ) { return; }
-	lock_guard<mutex> lock(_rezLock);
-	for (auto& rez : _resources) {
-		rez->applyMemoryBarrier(barrier, cmdEncoder, cmdUse);
-	}
+                                   MVKCommandEncoder* cmdEncoder,
+                                   MVKCommandUse cmdUse) {
+    if (!mvkIsAnyFlagEnabled(barrier.dstStageMask,
+                             VK_PIPELINE_STAGE_HOST_BIT) ||
+        !mvkIsAnyFlagEnabled(barrier.dstAccessMask, VK_ACCESS_HOST_READ_BIT)) {
+        return;
+    }
+    lock_guard<mutex> lock(_rezLock);
+    for (auto& rez : _resources) {
+        rez->applyMemoryBarrier(barrier, cmdEncoder, cmdUse);
+    }
 }
 
-void MVKDevice::updateActivityPerformance(MVKPerformanceTracker& activity, double currentValue) {
-	lock_guard<mutex> lock(_perfLock);
+void MVKDevice::updateActivityPerformance(MVKPerformanceTracker& activity,
+                                          double currentValue) {
+    lock_guard<mutex> lock(_perfLock);
 
-	activity.previous = activity.latest;
-	activity.latest = currentValue;
-	activity.minimum = ((activity.minimum == 0.0)
-								? currentValue :
-								min(currentValue, activity.minimum));
-	activity.maximum = max(currentValue, activity.maximum);
-	double total = (activity.average * activity.count++) + currentValue;
-	activity.average = total / activity.count;
+    activity.previous = activity.latest;
+    activity.latest = currentValue;
+    activity.minimum =
+        ((activity.minimum == 0.0) ? currentValue
+                                   : min(currentValue, activity.minimum));
+    activity.maximum = max(currentValue, activity.maximum);
+    double total = (activity.average * activity.count++) + currentValue;
+    activity.average = total / activity.count;
 
-	if (_isPerformanceTracking && getMVKConfig().activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_IMMEDIATE) {
-		logActivityInline(activity, _performanceStats);
-	}
+    if (_isPerformanceTracking &&
+        getMVKConfig().activityPerformanceLoggingStyle ==
+            MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_IMMEDIATE) {
+        logActivityInline(activity, _performanceStats);
+    }
 }
 
-void MVKDevice::logActivityInline(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats) {
-	if (getActivityPerformanceValueType(activity, _performanceStats) == MVKActivityPerformanceValueTypeByteCount) {
-		logActivityByteCount(activity, _performanceStats, true);
-	} else {
-		logActivityDuration(activity, _performanceStats, true);
-	}
+void MVKDevice::logActivityInline(MVKPerformanceTracker& activity,
+                                  MVKPerformanceStatistics& perfStats) {
+    if (getActivityPerformanceValueType(activity, _performanceStats) ==
+        MVKActivityPerformanceValueTypeByteCount) {
+        logActivityByteCount(activity, _performanceStats, true);
+    } else {
+        logActivityDuration(activity, _performanceStats, true);
+    }
 }
-void MVKDevice::logActivityDuration(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats, bool isInline) {
-	const char* fmt = (isInline
-					   ? "%s performance avg: %.3f ms, latest: %.3f ms, prev: %.3f ms, min: %.3f ms, max: %.3f ms, count: %d"
-					   : "  %-45s avg: %.3f ms, latest: %.3f ms, prev: %.3f ms, min: %.3f ms, max: %.3f ms, count: %d");
-	MVKLogInfo(fmt,
-			   getActivityPerformanceDescription(activity, perfStats),
-			   activity.average,
-			   activity.latest,
-			   activity.previous,
-			   activity.minimum,
-			   activity.maximum,
-			   activity.count);
+void MVKDevice::logActivityDuration(MVKPerformanceTracker& activity,
+                                    MVKPerformanceStatistics& perfStats,
+                                    bool isInline) {
+    const char* fmt =
+        (isInline ? "%s performance avg: %.3f ms, latest: %.3f ms, prev: %.3f "
+                    "ms, min: %.3f ms, max: %.3f ms, count: %d"
+                  : "  %-45s avg: %.3f ms, latest: %.3f ms, prev: %.3f ms, "
+                    "min: %.3f ms, max: %.3f ms, count: %d");
+    MVKLogInfo(fmt, getActivityPerformanceDescription(activity, perfStats),
+               activity.average, activity.latest, activity.previous,
+               activity.minimum, activity.maximum, activity.count);
 }
 
-void MVKDevice::logActivityByteCount(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats, bool isInline) {
-	const char* fmt = (isInline
-					   ? "%s avg: %5llu MB, latest: %5llu MB, prev: %5llu MB, min: %5llu MB, max: %5llu MB, count: %d"
-					   : "  %-45s avg: %5llu MB, latest: %5llu MB, prev: %5llu MB, min: %5llu MB, max: %5llu MB, count: %d");
-	MVKLogInfo(fmt,
-			   getActivityPerformanceDescription(activity, perfStats),
-			   uint64_t(activity.average) / KIBI,
-			   uint64_t(activity.latest) / KIBI,
-			   uint64_t(activity.previous) / KIBI,
-			   uint64_t(activity.minimum) / KIBI,
-			   uint64_t(activity.maximum) / KIBI,
-			   activity.count);
+void MVKDevice::logActivityByteCount(MVKPerformanceTracker& activity,
+                                     MVKPerformanceStatistics& perfStats,
+                                     bool isInline) {
+    const char* fmt =
+        (isInline ? "%s avg: %5llu MB, latest: %5llu MB, prev: %5llu MB, min: "
+                    "%5llu MB, max: %5llu MB, count: %d"
+                  : "  %-45s avg: %5llu MB, latest: %5llu MB, prev: %5llu MB, "
+                    "min: %5llu MB, max: %5llu MB, count: %d");
+    MVKLogInfo(fmt, getActivityPerformanceDescription(activity, perfStats),
+               uint64_t(activity.average) / KIBI,
+               uint64_t(activity.latest) / KIBI,
+               uint64_t(activity.previous) / KIBI,
+               uint64_t(activity.minimum) / KIBI,
+               uint64_t(activity.maximum) / KIBI, activity.count);
 }
 
 void MVKDevice::logPerformanceSummary() {
 
-	// Get a copy to minimize time under lock
-	MVKPerformanceStatistics perfStats;
-	getPerformanceStatistics(&perfStats);
+    // Get a copy to minimize time under lock
+    MVKPerformanceStatistics perfStats;
+    getPerformanceStatistics(&perfStats);
 
-#define logDuration(s)   logActivityDuration(perfStats.s, perfStats)
-#define logByteCount(s)  logActivityByteCount(perfStats.s, perfStats)
+#define logDuration(s) logActivityDuration(perfStats.s, perfStats)
+#define logByteCount(s) logActivityByteCount(perfStats.s, perfStats)
 
-	logDuration(queue.frameInterval);
-	logDuration(queue.retrieveMTLCommandBuffer);
-	logDuration(queue.commandBufferEncoding);
-	logDuration(queue.submitCommandBuffers);
-	logDuration(queue.mtlCommandBufferExecution);
-	logDuration(queue.retrieveCAMetalDrawable);
-	logDuration(queue.presentSwapchains);
-	logDuration(shaderCompilation.hashShaderCode);
-	logDuration(shaderCompilation.spirvToMSL);
-	logDuration(shaderCompilation.mslCompile);
-	logDuration(shaderCompilation.mslLoad);
-	logDuration(shaderCompilation.mslCompress);
-	logDuration(shaderCompilation.mslDecompress);
-	logDuration(shaderCompilation.shaderLibraryFromCache);
-	logDuration(shaderCompilation.functionRetrieval);
-	logDuration(shaderCompilation.functionSpecialization);
-	logDuration(shaderCompilation.pipelineCompile);
-	logDuration(pipelineCache.sizePipelineCache);
-	logDuration(pipelineCache.readPipelineCache);
-	logDuration(pipelineCache.writePipelineCache);
-	logByteCount(device.gpuMemoryAllocated);
+    logDuration(queue.frameInterval);
+    logDuration(queue.retrieveMTLCommandBuffer);
+    logDuration(queue.commandBufferEncoding);
+    logDuration(queue.submitCommandBuffers);
+    logDuration(queue.mtlCommandBufferExecution);
+    logDuration(queue.retrieveCAMetalDrawable);
+    logDuration(queue.presentSwapchains);
+    logDuration(shaderCompilation.hashShaderCode);
+    logDuration(shaderCompilation.spirvToMSL);
+    logDuration(shaderCompilation.mslCompile);
+    logDuration(shaderCompilation.mslLoad);
+    logDuration(shaderCompilation.mslCompress);
+    logDuration(shaderCompilation.mslDecompress);
+    logDuration(shaderCompilation.shaderLibraryFromCache);
+    logDuration(shaderCompilation.functionRetrieval);
+    logDuration(shaderCompilation.functionSpecialization);
+    logDuration(shaderCompilation.pipelineCompile);
+    logDuration(pipelineCache.sizePipelineCache);
+    logDuration(pipelineCache.readPipelineCache);
+    logDuration(pipelineCache.writePipelineCache);
+    logByteCount(device.gpuMemoryAllocated);
 #undef logDuration
 #undef logByteCount
 }
 
-const char* MVKDevice::getActivityPerformanceDescription(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats) {
-#define ifActivityReturnName(s, n)  if (&activity == &perfStats.s) return n
-	ifActivityReturnName(shaderCompilation.hashShaderCode,         "Hash shader SPIR-V code");
-	ifActivityReturnName(shaderCompilation.spirvToMSL,             "Convert SPIR-V to MSL source code");
-	ifActivityReturnName(shaderCompilation.mslCompile,             "Compile MSL into a MTLLibrary");
-	ifActivityReturnName(shaderCompilation.mslLoad,                "Load pre-compiled MSL into a MTLLibrary");
-	ifActivityReturnName(shaderCompilation.mslCompress,            "Compress MSL after compiling a MTLLibrary");
-	ifActivityReturnName(shaderCompilation.mslDecompress,          "Decompress MSL for pipeline cache write");
-	ifActivityReturnName(shaderCompilation.shaderLibraryFromCache, "Retrieve shader library from the cache");
-	ifActivityReturnName(shaderCompilation.functionRetrieval,      "Retrieve a MTLFunction from a MTLLibrary");
-	ifActivityReturnName(shaderCompilation.functionSpecialization, "Specialize a retrieved MTLFunction");
-	ifActivityReturnName(shaderCompilation.pipelineCompile,        "Compile MTLFunctions into a pipeline");
-	ifActivityReturnName(pipelineCache.sizePipelineCache,          "Calculate pipeline cache size");
-	ifActivityReturnName(pipelineCache.readPipelineCache,          "Read MSL from pipeline cache");
-	ifActivityReturnName(pipelineCache.writePipelineCache,         "Write MSL to pipeline cache");
-	ifActivityReturnName(queue.retrieveMTLCommandBuffer,           "Retrieve a MTLCommandBuffer");
-	ifActivityReturnName(queue.commandBufferEncoding,              "Encode VkCommandBuffer to MTLCommandBuffer");
-	ifActivityReturnName(queue.submitCommandBuffers,               "vkQueueSubmit() encoding to MTLCommandBuffers");
-	ifActivityReturnName(queue.mtlCommandBufferExecution,          "Execute a MTLCommandBuffer on GPU");
-	ifActivityReturnName(queue.retrieveCAMetalDrawable,            "Retrieve a CAMetalDrawable");
-	ifActivityReturnName(queue.presentSwapchains,                  "Present swapchains in on GPU");
-	ifActivityReturnName(queue.frameInterval,                      "Frame interval");
-	ifActivityReturnName(device.gpuMemoryAllocated,                "GPU memory allocated");
-	return                                                         "Unknown performance activity";
+const char* MVKDevice::getActivityPerformanceDescription(
+    MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats) {
+#define ifActivityReturnName(s, n)                                             \
+    if (&activity == &perfStats.s) return n
+    ifActivityReturnName(shaderCompilation.hashShaderCode,
+                         "Hash shader SPIR-V code");
+    ifActivityReturnName(shaderCompilation.spirvToMSL,
+                         "Convert SPIR-V to MSL source code");
+    ifActivityReturnName(shaderCompilation.mslCompile,
+                         "Compile MSL into a MTLLibrary");
+    ifActivityReturnName(shaderCompilation.mslLoad,
+                         "Load pre-compiled MSL into a MTLLibrary");
+    ifActivityReturnName(shaderCompilation.mslCompress,
+                         "Compress MSL after compiling a MTLLibrary");
+    ifActivityReturnName(shaderCompilation.mslDecompress,
+                         "Decompress MSL for pipeline cache write");
+    ifActivityReturnName(shaderCompilation.shaderLibraryFromCache,
+                         "Retrieve shader library from the cache");
+    ifActivityReturnName(shaderCompilation.functionRetrieval,
+                         "Retrieve a MTLFunction from a MTLLibrary");
+    ifActivityReturnName(shaderCompilation.functionSpecialization,
+                         "Specialize a retrieved MTLFunction");
+    ifActivityReturnName(shaderCompilation.pipelineCompile,
+                         "Compile MTLFunctions into a pipeline");
+    ifActivityReturnName(pipelineCache.sizePipelineCache,
+                         "Calculate pipeline cache size");
+    ifActivityReturnName(pipelineCache.readPipelineCache,
+                         "Read MSL from pipeline cache");
+    ifActivityReturnName(pipelineCache.writePipelineCache,
+                         "Write MSL to pipeline cache");
+    ifActivityReturnName(queue.retrieveMTLCommandBuffer,
+                         "Retrieve a MTLCommandBuffer");
+    ifActivityReturnName(queue.commandBufferEncoding,
+                         "Encode VkCommandBuffer to MTLCommandBuffer");
+    ifActivityReturnName(queue.submitCommandBuffers,
+                         "vkQueueSubmit() encoding to MTLCommandBuffers");
+    ifActivityReturnName(queue.mtlCommandBufferExecution,
+                         "Execute a MTLCommandBuffer on GPU");
+    ifActivityReturnName(queue.retrieveCAMetalDrawable,
+                         "Retrieve a CAMetalDrawable");
+    ifActivityReturnName(queue.presentSwapchains,
+                         "Present swapchains in on GPU");
+    ifActivityReturnName(queue.frameInterval, "Frame interval");
+    ifActivityReturnName(device.gpuMemoryAllocated, "GPU memory allocated");
+    return "Unknown performance activity";
 #undef ifActivityReturnName
 }
 
-MVKActivityPerformanceValueType MVKDevice::getActivityPerformanceValueType(MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats) {
-	if (&activity == &perfStats.device.gpuMemoryAllocated) return MVKActivityPerformanceValueTypeByteCount;
-	return MVKActivityPerformanceValueTypeDuration;
+MVKActivityPerformanceValueType MVKDevice::getActivityPerformanceValueType(
+    MVKPerformanceTracker& activity, MVKPerformanceStatistics& perfStats) {
+    if (&activity == &perfStats.device.gpuMemoryAllocated)
+        return MVKActivityPerformanceValueTypeByteCount;
+    return MVKActivityPerformanceValueTypeDuration;
 }
 
 void MVKDevice::getPerformanceStatistics(MVKPerformanceStatistics* pPerf) {
-	if (_isPerformanceTracking) {
-		updateActivityPerformance(_performanceStats.device.gpuMemoryAllocated,
-								  double(_physicalDevice->getCurrentAllocatedSize() / KIBI));
-	}
-	lock_guard<mutex> lock(_perfLock);
-    if (pPerf) { *pPerf = _performanceStats; }
+    if (_isPerformanceTracking) {
+        updateActivityPerformance(_performanceStats.device.gpuMemoryAllocated,
+                                  double(_physicalDevice
+                                             ->getCurrentAllocatedSize() /
+                                         KIBI));
+    }
+    lock_guard<mutex> lock(_perfLock);
+    if (pPerf) {
+        *pPerf = _performanceStats;
+    }
 }
 
-VkResult MVKDevice::invalidateMappedMemoryRanges(uint32_t memRangeCount, const VkMappedMemoryRange* pMemRanges) {
-	@autoreleasepool {
-		VkResult rslt = VK_SUCCESS;
-		MVKMTLBlitEncoder mvkBlitEnc;
-		for (uint32_t i = 0; i < memRangeCount; i++) {
-			const VkMappedMemoryRange* pMem = &pMemRanges[i];
-			MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
-			VkResult r = mvkMem->pullFromDevice(pMem->offset, pMem->size, &mvkBlitEnc);
-			if (rslt == VK_SUCCESS) { rslt = r; }
-		}
-		if (mvkBlitEnc.mtlBlitEncoder) { [mvkBlitEnc.mtlBlitEncoder endEncoding]; }
-		if (mvkBlitEnc.mtlCmdBuffer) {
-			[mvkBlitEnc.mtlCmdBuffer commit];
-			[mvkBlitEnc.mtlCmdBuffer waitUntilCompleted];
-		}
-		return rslt;
-	}
+VkResult
+MVKDevice::invalidateMappedMemoryRanges(uint32_t memRangeCount,
+                                        const VkMappedMemoryRange* pMemRanges) {
+    @autoreleasepool {
+        VkResult rslt = VK_SUCCESS;
+        MVKMTLBlitEncoder mvkBlitEnc;
+        for (uint32_t i = 0; i < memRangeCount; i++) {
+            const VkMappedMemoryRange* pMem = &pMemRanges[i];
+            MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMem->memory;
+            VkResult r =
+                mvkMem->pullFromDevice(pMem->offset, pMem->size, &mvkBlitEnc);
+            if (rslt == VK_SUCCESS) {
+                rslt = r;
+            }
+        }
+        if (mvkBlitEnc.mtlBlitEncoder) {
+            [mvkBlitEnc.mtlBlitEncoder endEncoding];
+        }
+        if (mvkBlitEnc.mtlCmdBuffer) {
+            [mvkBlitEnc.mtlCmdBuffer commit];
+            [mvkBlitEnc.mtlCmdBuffer waitUntilCompleted];
+        }
+        return rslt;
+    }
 }
 
 uint32_t MVKDevice::getMultiviewMetalPassCount(uint32_t viewMask) const {
-	if ( !viewMask ) { return 0; }
-	if ( !_physicalDevice->canUseInstancingForMultiview() ) {
-		// If we can't use instanced drawing for this, we'll have to unroll the render pass.
-		return __builtin_popcount(viewMask);
-	}
-	uint32_t mask = viewMask;
-	uint32_t count;
-	// Step through each clump until there are no more clumps. I'll know this has
-	// happened when the mask becomes 0, since mvkGetNextViewMaskGroup() clears each group of bits
-	// as it finds them, and returns the remainder of the mask.
-	for (count = 0; mask != 0; ++count) {
-		mask = mvkGetNextViewMaskGroup(mask, nullptr, nullptr);
-	}
-	return count;
+    if (!viewMask) {
+        return 0;
+    }
+    if (!_physicalDevice->canUseInstancingForMultiview()) {
+        // If we can't use instanced drawing for this, we'll have to unroll the
+        // render pass.
+        return __builtin_popcount(viewMask);
+    }
+    uint32_t mask = viewMask;
+    uint32_t count;
+    // Step through each clump until there are no more clumps. I'll know this
+    // has happened when the mask becomes 0, since mvkGetNextViewMaskGroup()
+    // clears each group of bits as it finds them, and returns the remainder of
+    // the mask.
+    for (count = 0; mask != 0; ++count) {
+        mask = mvkGetNextViewMaskGroup(mask, nullptr, nullptr);
+    }
+    return count;
 }
 
-uint32_t MVKDevice::getFirstViewIndexInMetalPass(uint32_t viewMask, uint32_t passIdx) const {
-	if ( !viewMask ) { return 0; }
-	assert(passIdx < getMultiviewMetalPassCount(viewMask));
-	uint32_t mask = viewMask;
-	uint32_t startView = 0, viewCount = 0;
-	if ( !_physicalDevice->canUseInstancingForMultiview() ) {
-		while (mask != 0) {
-			mask = mvkGetNextViewMaskGroup(mask, &startView, &viewCount);
-			while (passIdx-- > 0 && viewCount-- > 0) {
-				startView++;
-			}
-		}
-	} else {
-		for (uint32_t i = 0; i <= passIdx; ++i) {
-			mask = mvkGetNextViewMaskGroup(mask, &startView, nullptr);
-		}
-	}
-	return startView;
+uint32_t MVKDevice::getFirstViewIndexInMetalPass(uint32_t viewMask,
+                                                 uint32_t passIdx) const {
+    if (!viewMask) {
+        return 0;
+    }
+    assert(passIdx < getMultiviewMetalPassCount(viewMask));
+    uint32_t mask = viewMask;
+    uint32_t startView = 0, viewCount = 0;
+    if (!_physicalDevice->canUseInstancingForMultiview()) {
+        while (mask != 0) {
+            mask = mvkGetNextViewMaskGroup(mask, &startView, &viewCount);
+            while (passIdx-- > 0 && viewCount-- > 0) {
+                startView++;
+            }
+        }
+    } else {
+        for (uint32_t i = 0; i <= passIdx; ++i) {
+            mask = mvkGetNextViewMaskGroup(mask, &startView, nullptr);
+        }
+    }
+    return startView;
 }
 
-uint32_t MVKDevice::getViewCountInMetalPass(uint32_t viewMask, uint32_t passIdx) const {
-	if ( !viewMask ) { return 0; }
-	assert(passIdx < getMultiviewMetalPassCount(viewMask));
-	if ( !_physicalDevice->canUseInstancingForMultiview() ) {
-		return 1;
-	}
-	uint32_t mask = viewMask;
-	uint32_t viewCount = 0;
-	for (uint32_t i = 0; i <= passIdx; ++i) {
-		mask = mvkGetNextViewMaskGroup(mask, nullptr, &viewCount);
-	}
-	return viewCount;
+uint32_t MVKDevice::getViewCountInMetalPass(uint32_t viewMask,
+                                            uint32_t passIdx) const {
+    if (!viewMask) {
+        return 0;
+    }
+    assert(passIdx < getMultiviewMetalPassCount(viewMask));
+    if (!_physicalDevice->canUseInstancingForMultiview()) {
+        return 1;
+    }
+    uint32_t mask = viewMask;
+    uint32_t viewCount = 0;
+    for (uint32_t i = 0; i <= passIdx; ++i) {
+        mask = mvkGetNextViewMaskGroup(mask, nullptr, &viewCount);
+    }
+    return viewCount;
 }
-
 
 #pragma mark Metal
 
-uint32_t MVKDevice::getMetalBufferIndexForVertexAttributeBinding(uint32_t binding) {
-	return ((_physicalDevice->_metalFeatures.maxPerStageBufferCount - 1) - binding);
+uint32_t
+MVKDevice::getMetalBufferIndexForVertexAttributeBinding(uint32_t binding) {
+    return ((_physicalDevice->_metalFeatures.maxPerStageBufferCount - 1) -
+            binding);
 }
 
-VkDeviceSize MVKDevice::getVkFormatTexelBufferAlignment(VkFormat format, MVKBaseObject* mvkObj) {
-	VkDeviceSize deviceAlignment = 0;
-	id<MTLDevice> mtlDev = _physicalDevice->_mtlDevice;
-	MVKPixelFormats* mvkPixFmts = &_physicalDevice->_pixelFormats;
-	if ([mtlDev respondsToSelector: @selector(minimumLinearTextureAlignmentForPixelFormat:)]) {
-		MTLPixelFormat mtlPixFmt = mvkPixFmts->getMTLPixelFormat(format);
-		if (mvkPixFmts->getChromaSubsamplingPlaneCount(format) >= 2) {
-			// Use plane 1 to get the alignment requirements. In a 2-plane format, this will
-			// typically have stricter alignment requirements due to it being a 2-component format.
-			mtlPixFmt = mvkPixFmts->getChromaSubsamplingPlaneMTLPixelFormat(format, 1);
-		}
-		deviceAlignment = [mtlDev minimumLinearTextureAlignmentForPixelFormat: mtlPixFmt];
-	}
-	return deviceAlignment ? deviceAlignment : _physicalDevice->_properties.limits.minTexelBufferOffsetAlignment;
+VkDeviceSize MVKDevice::getVkFormatTexelBufferAlignment(VkFormat format,
+                                                        MVKBaseObject* mvkObj) {
+    VkDeviceSize deviceAlignment = 0;
+    id<MTLDevice> mtlDev = _physicalDevice->_mtlDevice;
+    MVKPixelFormats* mvkPixFmts = &_physicalDevice->_pixelFormats;
+    if ([mtlDev respondsToSelector:@selector
+                (minimumLinearTextureAlignmentForPixelFormat:)]) {
+        MTLPixelFormat mtlPixFmt = mvkPixFmts->getMTLPixelFormat(format);
+        if (mvkPixFmts->getChromaSubsamplingPlaneCount(format) >= 2) {
+            // Use plane 1 to get the alignment requirements. In a 2-plane
+            // format, this will typically have stricter alignment requirements
+            // due to it being a 2-component format.
+            mtlPixFmt =
+                mvkPixFmts->getChromaSubsamplingPlaneMTLPixelFormat(format, 1);
+        }
+        deviceAlignment =
+            [mtlDev minimumLinearTextureAlignmentForPixelFormat:mtlPixFmt];
+    }
+    return deviceAlignment ? deviceAlignment
+                           : _physicalDevice->_properties.limits
+                                 .minTexelBufferOffsetAlignment;
 }
 
 id<MTLBuffer> MVKDevice::getGlobalVisibilityResultMTLBuffer() {
@@ -4596,666 +5651,815 @@ uint32_t MVKDevice::expandVisibilityResultMTLBuffer(uint32_t queryCount) {
 
     // Ensure we don't overflow the maximum number of queries
     _globalVisibilityQueryCount += queryCount;
-    VkDeviceSize reqBuffLen = (VkDeviceSize)_globalVisibilityQueryCount * kMVKQuerySlotSizeInBytes;
-    VkDeviceSize maxBuffLen = _physicalDevice->_metalFeatures.maxQueryBufferSize;
+    VkDeviceSize reqBuffLen =
+        (VkDeviceSize)_globalVisibilityQueryCount * kMVKQuerySlotSizeInBytes;
+    VkDeviceSize maxBuffLen =
+        _physicalDevice->_metalFeatures.maxQueryBufferSize;
     VkDeviceSize newBuffLen = min(reqBuffLen, maxBuffLen);
-    _globalVisibilityQueryCount = uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes);
+    _globalVisibilityQueryCount =
+        uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes);
 
     if (reqBuffLen > maxBuffLen) {
-        reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkCreateQueryPool(): A maximum of %d total queries are available on this device in its current configuration. See the API notes for the MVKConfiguration.supportLargeQueryPools configuration parameter for more info.", _globalVisibilityQueryCount);
+        reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                    "vkCreateQueryPool(): A maximum of %d total queries are "
+                    "available on this device in its current "
+                    "configuration. See the API notes for the "
+                    "MVKConfiguration.supportLargeQueryPools configuration "
+                    "parameter for more info.",
+                    _globalVisibilityQueryCount);
     }
 
-    NSUInteger mtlBuffLen = mvkAlignByteCount(newBuffLen, _physicalDevice->_metalFeatures.mtlBufferAlignment);
-    MTLResourceOptions mtlBuffOpts = MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache;
+    NSUInteger mtlBuffLen =
+        mvkAlignByteCount(newBuffLen,
+                          _physicalDevice->_metalFeatures.mtlBufferAlignment);
+    MTLResourceOptions mtlBuffOpts =
+        MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache;
     [_globalVisibilityResultMTLBuffer release];
-    _globalVisibilityResultMTLBuffer = [_physicalDevice->_mtlDevice newBufferWithLength: mtlBuffLen options: mtlBuffOpts];     // retained
+    _globalVisibilityResultMTLBuffer = [_physicalDevice->_mtlDevice
+        newBufferWithLength:mtlBuffLen
+                    options:mtlBuffOpts]; // retained
 
-    return _globalVisibilityQueryCount - queryCount;     // Might be lower than requested if an overflow occurred
+    return _globalVisibilityQueryCount -
+           queryCount; // Might be lower than requested if an overflow occurred
 }
 
 id<MTLSamplerState> MVKDevice::getDefaultMTLSamplerState() {
-	if ( !_defaultMTLSamplerState ) {
+    if (!_defaultMTLSamplerState) {
 
-		// Lock and check again in case another thread has created the sampler.
-		lock_guard<mutex> lock(_rezLock);
-		if ( !_defaultMTLSamplerState ) {
-			@autoreleasepool {
-				MTLSamplerDescriptor* mtlSampDesc = [[MTLSamplerDescriptor new] autorelease];
-				mtlSampDesc.supportArgumentBuffers = _physicalDevice->_isUsingMetalArgumentBuffers;
-				_defaultMTLSamplerState = [_physicalDevice->_mtlDevice newSamplerStateWithDescriptor: mtlSampDesc];	// retained
-			}
-		}
-	}
-	return _defaultMTLSamplerState;
+        // Lock and check again in case another thread has created the sampler.
+        lock_guard<mutex> lock(_rezLock);
+        if (!_defaultMTLSamplerState) {
+            @autoreleasepool {
+                MTLSamplerDescriptor* mtlSampDesc =
+                    [[MTLSamplerDescriptor new] autorelease];
+                mtlSampDesc.supportArgumentBuffers =
+                    _physicalDevice->_isUsingMetalArgumentBuffers;
+                _defaultMTLSamplerState = [_physicalDevice->_mtlDevice
+                    newSamplerStateWithDescriptor:mtlSampDesc]; // retained
+            }
+        }
+    }
+    return _defaultMTLSamplerState;
 }
 
 id<MTLBuffer> MVKDevice::getDummyBlitMTLBuffer() {
-	if ( !_dummyBlitMTLBuffer ) {
+    if (!_dummyBlitMTLBuffer) {
 
-		// Lock and check again in case another thread has created the buffer.
-		lock_guard<mutex> lock(_rezLock);
-		if ( !_dummyBlitMTLBuffer ) {
-			@autoreleasepool {
-				_dummyBlitMTLBuffer = [_physicalDevice->_mtlDevice newBufferWithLength: 1 options: MTLResourceStorageModePrivate];
-			}
-		}
-	}
-	return _dummyBlitMTLBuffer;
+        // Lock and check again in case another thread has created the buffer.
+        lock_guard<mutex> lock(_rezLock);
+        if (!_dummyBlitMTLBuffer) {
+            @autoreleasepool {
+                _dummyBlitMTLBuffer = [_physicalDevice->_mtlDevice
+                    newBufferWithLength:1
+                                options:MTLResourceStorageModePrivate];
+            }
+        }
+    }
+    return _dummyBlitMTLBuffer;
 }
 
-MTLCompileOptions* MVKDevice::getMTLCompileOptions(bool requestFastMath, bool preserveInvariance) {
-	MTLCompileOptions* mtlCompOpt = [MTLCompileOptions new];
-	mtlCompOpt.languageVersion = _physicalDevice->_metalFeatures.mslVersionEnum;
-	mtlCompOpt.fastMathEnabled = (getMVKConfig().fastMathEnabled == MVK_CONFIG_FAST_MATH_ALWAYS ||
-								  (getMVKConfig().fastMathEnabled == MVK_CONFIG_FAST_MATH_ON_DEMAND && requestFastMath));
+MTLCompileOptions* MVKDevice::getMTLCompileOptions(bool requestFastMath,
+                                                   bool preserveInvariance) {
+    MTLCompileOptions* mtlCompOpt = [MTLCompileOptions new];
+    mtlCompOpt.languageVersion = _physicalDevice->_metalFeatures.mslVersionEnum;
+    mtlCompOpt.fastMathEnabled =
+        (getMVKConfig().fastMathEnabled == MVK_CONFIG_FAST_MATH_ALWAYS ||
+         (getMVKConfig().fastMathEnabled == MVK_CONFIG_FAST_MATH_ON_DEMAND &&
+          requestFastMath));
 #if MVK_XCODE_12
-	if ([mtlCompOpt respondsToSelector: @selector(setPreserveInvariance:)]) {
-		[mtlCompOpt setPreserveInvariance: preserveInvariance];
-	}
+    if ([mtlCompOpt respondsToSelector:@selector(setPreserveInvariance:)]) {
+        [mtlCompOpt setPreserveInvariance:preserveInvariance];
+    }
 #endif
-	return [mtlCompOpt autorelease];
+    return [mtlCompOpt autorelease];
 }
 
-// Can't use prefilled Metal command buffers if any of the resource descriptors can be updated after binding.
+// Can't use prefilled Metal command buffers if any of the resource descriptors
+// can be updated after binding.
 bool MVKDevice::shouldPrefillMTLCommandBuffers() {
-	return (getMVKConfig().prefillMetalCommandBuffers &&
-			!(_enabledDescriptorIndexingFeatures.descriptorBindingUniformBufferUpdateAfterBind ||
-			  _enabledDescriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind ||
-			  _enabledDescriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind ||
-			  _enabledDescriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind ||
-			  _enabledDescriptorIndexingFeatures.descriptorBindingUniformTexelBufferUpdateAfterBind ||
-			  _enabledDescriptorIndexingFeatures.descriptorBindingStorageTexelBufferUpdateAfterBind ||
-			  _enabledInlineUniformBlockFeatures.descriptorBindingInlineUniformBlockUpdateAfterBind));
+    return (getMVKConfig().prefillMetalCommandBuffers &&
+            !(_enabledDescriptorIndexingFeatures
+                  .descriptorBindingUniformBufferUpdateAfterBind ||
+              _enabledDescriptorIndexingFeatures
+                  .descriptorBindingSampledImageUpdateAfterBind ||
+              _enabledDescriptorIndexingFeatures
+                  .descriptorBindingStorageImageUpdateAfterBind ||
+              _enabledDescriptorIndexingFeatures
+                  .descriptorBindingStorageBufferUpdateAfterBind ||
+              _enabledDescriptorIndexingFeatures
+                  .descriptorBindingUniformTexelBufferUpdateAfterBind ||
+              _enabledDescriptorIndexingFeatures
+                  .descriptorBindingStorageTexelBufferUpdateAfterBind ||
+              _enabledInlineUniformBlockFeatures
+                  .descriptorBindingInlineUniformBlockUpdateAfterBind));
 }
 
-void MVKDevice::startAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope, id mtlCaptureObject) {
+void MVKDevice::startAutoGPUCapture(
+    MVKConfigAutoGPUCaptureScope autoGPUCaptureScope, id mtlCaptureObject) {
 
-	if (_isCurrentlyAutoGPUCapturing || (getMVKConfig().autoGPUCaptureScope != autoGPUCaptureScope)) { return; }
+    if (_isCurrentlyAutoGPUCapturing ||
+        (getMVKConfig().autoGPUCaptureScope != autoGPUCaptureScope)) {
+        return;
+    }
 
-	if (autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND && !readGPUCapturePipe()) return;
+    if (autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND &&
+        !readGPUCapturePipe())
+        return;
 
-	_isCurrentlyAutoGPUCapturing = true;
+    _isCurrentlyAutoGPUCapturing = true;
 
-	@autoreleasepool {
-		MTLCaptureManager *captureMgr = [MTLCaptureManager sharedCaptureManager];
+    @autoreleasepool {
+        MTLCaptureManager* captureMgr =
+            [MTLCaptureManager sharedCaptureManager];
 
-		// Before macOS 10.15 and iOS 13.0, captureDesc will just be nil
-		MTLCaptureDescriptor *captureDesc = [[MTLCaptureDescriptor new] autorelease];
-		captureDesc.captureObject = mtlCaptureObject;
-		captureDesc.destination = MTLCaptureDestinationDeveloperTools;
+        // Before macOS 10.15 and iOS 13.0, captureDesc will just be nil
+        MTLCaptureDescriptor* captureDesc =
+            [[MTLCaptureDescriptor new] autorelease];
+        captureDesc.captureObject = mtlCaptureObject;
+        captureDesc.destination = MTLCaptureDestinationDeveloperTools;
 
-		const char* filePath = getMVKConfig().autoGPUCaptureOutputFilepath;
-		if (strlen(filePath)) {
-			if ([captureMgr respondsToSelector: @selector(supportsDestination:)] &&
-				[captureMgr supportsDestination: MTLCaptureDestinationGPUTraceDocument] ) {
+        const char* filePath = getMVKConfig().autoGPUCaptureOutputFilepath;
+        if (strlen(filePath)) {
+            if ([captureMgr
+                    respondsToSelector:@selector(supportsDestination:)] &&
+                [captureMgr supportsDestination:
+                                MTLCaptureDestinationGPUTraceDocument]) {
 
-				NSString* expandedFilePath = [[NSString stringWithUTF8String: filePath] stringByExpandingTildeInPath];
-				MVKLogInfo("Capturing GPU trace to file %s.", expandedFilePath.UTF8String);
+                NSString* expandedFilePath =
+                    [[NSString stringWithUTF8String:filePath]
+                        stringByExpandingTildeInPath];
+                MVKLogInfo("Capturing GPU trace to file %s.",
+                           expandedFilePath.UTF8String);
 
-				captureDesc.destination = MTLCaptureDestinationGPUTraceDocument;
-				captureDesc.outputURL = [NSURL fileURLWithPath: expandedFilePath];
+                captureDesc.destination = MTLCaptureDestinationGPUTraceDocument;
+                captureDesc.outputURL =
+                    [NSURL fileURLWithPath:expandedFilePath];
 
-			} else {
-				reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Capturing GPU traces to a file requires macOS 10.15 or iOS 13.0 and GPU capturing to be enabled. Falling back to Xcode GPU capture.");
-			}
-		} else {
-			MVKLogInfo("Capturing GPU trace to Xcode.");
-		}
+            } else {
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "Capturing GPU traces to a file requires macOS "
+                            "10.15 or iOS 13.0 and GPU capturing to be "
+                            "enabled. Falling back to Xcode GPU capture.");
+            }
+        } else {
+            MVKLogInfo("Capturing GPU trace to Xcode.");
+        }
 
-		// Suppress deprecation warnings for startCaptureWithXXX: on MacCatalyst.
-#		pragma clang diagnostic push
-#		pragma clang diagnostic ignored "-Wdeprecated-declarations"
-		if ([captureMgr respondsToSelector: @selector(startCaptureWithDescriptor:error:)] ) {
-			NSError *err = nil;
-			if ( ![captureMgr startCaptureWithDescriptor: captureDesc error: &err] ) {
-				reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to automatically start GPU capture session (Error code %li): %s", (long)err.code, err.localizedDescription.UTF8String);
-			}
-		} else if ([mtlCaptureObject conformsToProtocol:@protocol(MTLCommandQueue)]) {
-			[captureMgr startCaptureWithCommandQueue: mtlCaptureObject];
-		} else if ([mtlCaptureObject conformsToProtocol:@protocol(MTLDevice)]) {
-			[captureMgr startCaptureWithDevice: mtlCaptureObject];
-		}
-#		pragma clang diagnostic pop
-	}
+        // Suppress deprecation warnings for startCaptureWithXXX: on
+        // MacCatalyst.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        if ([captureMgr respondsToSelector:@selector
+                        (startCaptureWithDescriptor:error:)]) {
+            NSError* err = nil;
+            if (![captureMgr startCaptureWithDescriptor:captureDesc
+                                                  error:&err]) {
+                reportError(VK_ERROR_INITIALIZATION_FAILED,
+                            "Failed to automatically start GPU capture session "
+                            "(Error code %li): %s",
+                            (long)err.code,
+                            err.localizedDescription.UTF8String);
+            }
+        } else if ([mtlCaptureObject
+                       conformsToProtocol:@protocol(MTLCommandQueue)]) {
+            [captureMgr startCaptureWithCommandQueue:mtlCaptureObject];
+        } else if ([mtlCaptureObject conformsToProtocol:@protocol(MTLDevice)]) {
+            [captureMgr startCaptureWithDevice:mtlCaptureObject];
+        }
+#pragma clang diagnostic pop
+    }
 }
 
-void MVKDevice::stopAutoGPUCapture(MVKConfigAutoGPUCaptureScope autoGPUCaptureScope) {
-	if (_isCurrentlyAutoGPUCapturing && getMVKConfig().autoGPUCaptureScope == autoGPUCaptureScope) {
-		if (autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND && readGPUCapturePipe()) return;
-		[[MTLCaptureManager sharedCaptureManager] stopCapture];
-		_isCurrentlyAutoGPUCapturing = false;
-	}
+void MVKDevice::stopAutoGPUCapture(
+    MVKConfigAutoGPUCaptureScope autoGPUCaptureScope) {
+    if (_isCurrentlyAutoGPUCapturing &&
+        getMVKConfig().autoGPUCaptureScope == autoGPUCaptureScope) {
+        if (autoGPUCaptureScope ==
+                MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND &&
+            readGPUCapturePipe())
+            return;
+        [[MTLCaptureManager sharedCaptureManager] stopCapture];
+        _isCurrentlyAutoGPUCapturing = false;
+    }
 }
 
-void MVKDevice::getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) {
-	for (auto* next = (VkBaseOutStructure*)pMetalObjectsInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT: {
-				auto* pDvcInfo = (VkExportMetalDeviceInfoEXT*)next;
-				pDvcInfo->mtlDevice = _physicalDevice->_mtlDevice;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT: {
-				auto* pQInfo = (VkExportMetalCommandQueueInfoEXT*)next;
-				MVKQueue* mvkQ = MVKQueue::getMVKQueue(pQInfo->queue);
-				pQInfo->mtlCommandQueue = mvkQ->getMTLCommandQueue();
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
-				auto* pBuffInfo = (VkExportMetalBufferInfoEXT*)next;
-				auto* mvkDevMem = (MVKDeviceMemory*)pBuffInfo->memory;
-				pBuffInfo->mtlBuffer = mvkDevMem->getMTLBuffer();
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
-				auto* pImgInfo = (VkExportMetalTextureInfoEXT*)next;
-				uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(pImgInfo->plane);
-				auto* mvkImg = (MVKImage*)pImgInfo->image;
-				auto* mvkImgView = (MVKImageView*)pImgInfo->imageView;
-				auto* mvkBuffView = (MVKBufferView*)pImgInfo->bufferView;
-				if (mvkImg) {
-					pImgInfo->mtlTexture = mvkImg->getMTLTexture(planeIndex);
-				} else if (mvkImgView) {
-					pImgInfo->mtlTexture = mvkImgView->getMTLTexture(planeIndex);
-				} else {
-					pImgInfo->mtlTexture = mvkBuffView->getMTLTexture();
-				}
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
-				auto* pIOSurfInfo = (VkExportMetalIOSurfaceInfoEXT*)next;
-				auto* mvkImg = (MVKImage*)pIOSurfInfo->image;
-				pIOSurfInfo->ioSurface = mvkImg->getIOSurface();
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
-				auto* pShEvtInfo = (VkExportMetalSharedEventInfoEXT*)next;
-				auto* mvkSem4 = (MVKSemaphore*)pShEvtInfo->semaphore;
-				auto* mvkEvt = (MVKEvent*)pShEvtInfo->event;
-				if (mvkSem4) {
-					pShEvtInfo->mtlSharedEvent = mvkSem4->getMTLSharedEvent();
-				} else if (mvkEvt) {
-					pShEvtInfo->mtlSharedEvent = mvkEvt->getMTLSharedEvent();
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
+void MVKDevice::getMetalObjects(
+    VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) {
+    for (auto* next = (VkBaseOutStructure*)pMetalObjectsInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT: {
+            auto* pDvcInfo = (VkExportMetalDeviceInfoEXT*)next;
+            pDvcInfo->mtlDevice = _physicalDevice->_mtlDevice;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT: {
+            auto* pQInfo = (VkExportMetalCommandQueueInfoEXT*)next;
+            MVKQueue* mvkQ = MVKQueue::getMVKQueue(pQInfo->queue);
+            pQInfo->mtlCommandQueue = mvkQ->getMTLCommandQueue();
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
+            auto* pBuffInfo = (VkExportMetalBufferInfoEXT*)next;
+            auto* mvkDevMem = (MVKDeviceMemory*)pBuffInfo->memory;
+            pBuffInfo->mtlBuffer = mvkDevMem->getMTLBuffer();
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
+            auto* pImgInfo = (VkExportMetalTextureInfoEXT*)next;
+            uint8_t planeIndex =
+                MVKImage::getPlaneFromVkImageAspectFlags(pImgInfo->plane);
+            auto* mvkImg = (MVKImage*)pImgInfo->image;
+            auto* mvkImgView = (MVKImageView*)pImgInfo->imageView;
+            auto* mvkBuffView = (MVKBufferView*)pImgInfo->bufferView;
+            if (mvkImg) {
+                pImgInfo->mtlTexture = mvkImg->getMTLTexture(planeIndex);
+            } else if (mvkImgView) {
+                pImgInfo->mtlTexture = mvkImgView->getMTLTexture(planeIndex);
+            } else {
+                pImgInfo->mtlTexture = mvkBuffView->getMTLTexture();
+            }
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
+            auto* pIOSurfInfo = (VkExportMetalIOSurfaceInfoEXT*)next;
+            auto* mvkImg = (MVKImage*)pIOSurfInfo->image;
+            pIOSurfInfo->ioSurface = mvkImg->getIOSurface();
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
+            auto* pShEvtInfo = (VkExportMetalSharedEventInfoEXT*)next;
+            auto* mvkSem4 = (MVKSemaphore*)pShEvtInfo->semaphore;
+            auto* mvkEvt = (MVKEvent*)pShEvtInfo->event;
+            if (mvkSem4) {
+                pShEvtInfo->mtlSharedEvent = mvkSem4->getMTLSharedEvent();
+            } else if (mvkEvt) {
+                pShEvtInfo->mtlSharedEvent = mvkEvt->getMTLSharedEvent();
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
-
 
 #pragma mark Construction
 
-MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo) : _enabledExtensions(this) {
+MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice,
+                     const VkDeviceCreateInfo* pCreateInfo)
+    : _enabledExtensions(this) {
 
-	// If the physical device is lost, bail.
-	// Must have initialized everything accessed in destructor to null.
-	if (physicalDevice->getConfigurationResult() != VK_SUCCESS) {
-		setConfigurationResult(physicalDevice->getConfigurationResult());
-		return;
-	}
+    // If the physical device is lost, bail.
+    // Must have initialized everything accessed in destructor to null.
+    if (physicalDevice->getConfigurationResult() != VK_SUCCESS) {
+        setConfigurationResult(physicalDevice->getConfigurationResult());
+        return;
+    }
 
-	initPhysicalDevice(physicalDevice, pCreateInfo);
-	initPerformanceTracking();
-	enableExtensions(pCreateInfo);
-	enableFeatures(pCreateInfo);
-	initQueues(pCreateInfo);
-	reservePrivateData(pCreateInfo);
+    initPhysicalDevice(physicalDevice, pCreateInfo);
+    initPerformanceTracking();
+    enableExtensions(pCreateInfo);
+    enableFeatures(pCreateInfo);
+    initQueues(pCreateInfo);
+    reservePrivateData(pCreateInfo);
 
 #if MVK_MACOS
-	// After enableExtensions
-	// If the VK_KHR_swapchain extension is enabled, we expect to render to the screen.
-	// In a multi-GPU system, if we are using the high-power GPU and want the window system
-	// to also use that GPU to avoid copying content between GPUs, force the window system
-	// to use the high-power GPU by calling the MTLCreateSystemDefaultDevice() function.
-	id<MTLDevice> mtlDev = _physicalDevice->_mtlDevice;
-	if (_enabledExtensions.vk_KHR_swapchain.enabled && getMVKConfig().switchSystemGPU &&
-		!(mtlDev.isLowPower || mtlDev.isHeadless) ) {
-			MTLCreateSystemDefaultDevice();
-	}
+    // After enableExtensions
+    // If the VK_KHR_swapchain extension is enabled, we expect to render to the
+    // screen. In a multi-GPU system, if we are using the high-power GPU and
+    // want the window system to also use that GPU to avoid copying content
+    // between GPUs, force the window system to use the high-power GPU by
+    // calling the MTLCreateSystemDefaultDevice() function.
+    id<MTLDevice> mtlDev = _physicalDevice->_mtlDevice;
+    if (_enabledExtensions.vk_KHR_swapchain.enabled &&
+        getMVKConfig().switchSystemGPU &&
+        !(mtlDev.isLowPower || mtlDev.isHeadless)) {
+        MTLCreateSystemDefaultDevice();
+    }
 #endif
 
-	MVKLogInfo("Descriptor sets binding resources using %s.",
-			   _physicalDevice->_isUsingMetalArgumentBuffers ? (_physicalDevice->_metalFeatures.needsArgumentBufferEncoders
-																? "Metal argument buffers" : "Metal3 argument buffers") : "discrete resource indexes");
+    MVKLogInfo("Descriptor sets binding resources using %s.",
+               _physicalDevice->_isUsingMetalArgumentBuffers
+                   ? (_physicalDevice->_metalFeatures
+                              .needsArgumentBufferEncoders
+                          ? "Metal argument buffers"
+                          : "Metal3 argument buffers")
+                   : "discrete resource indexes");
 
-	_commandResourceFactory = new MVKCommandResourceFactory(this);
+    _commandResourceFactory = new MVKCommandResourceFactory(this);
 
-	startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE, _physicalDevice->_mtlDevice);
+    startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE,
+                        _physicalDevice->_mtlDevice);
 
-	if (getMVKConfig().autoGPUCaptureScope == MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND) {
-		for (int tries = 0; tries < 3; ++tries) {
-			char pipeName[] = "/tmp/MoltenVKCapturePipe-XXXXXXXXXX";
+    if (getMVKConfig().autoGPUCaptureScope ==
+        MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND) {
+        for (int tries = 0; tries < 3; ++tries) {
+            char pipeName[] = "/tmp/MoltenVKCapturePipe-XXXXXXXXXX";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			mktemp(pipeName);
+            mktemp(pipeName);
 #pragma clang diagnostic pop
 
-			if (mkfifo(pipeName, 0600) < 0) {
-				if (errno == EEXIST) continue; // Name collision, retry.
-				reportMessage(MVK_CONFIG_LOG_LEVEL_ERROR, "Could not create named pipe for signaling GPU capture: %s\n", strerror(errno));
-			} else {
-				_capturePipeFileName = std::string(pipeName);
-				_capturePipeFileDesc = open(pipeName, O_RDONLY | O_NONBLOCK);
-				if (_capturePipeFileDesc < 0) {
-					reportMessage(MVK_CONFIG_LOG_LEVEL_ERROR, "Could not open named pipe for signaling GPU capture at path %s: %s\n", pipeName, strerror(errno));
-				}
-			}
+            if (mkfifo(pipeName, 0600) < 0) {
+                if (errno == EEXIST) continue; // Name collision, retry.
+                reportMessage(MVK_CONFIG_LOG_LEVEL_ERROR,
+                              "Could not create named pipe for signaling GPU "
+                              "capture: %s\n",
+                              strerror(errno));
+            } else {
+                _capturePipeFileName = std::string(pipeName);
+                _capturePipeFileDesc = open(pipeName, O_RDONLY | O_NONBLOCK);
+                if (_capturePipeFileDesc < 0) {
+                    reportMessage(MVK_CONFIG_LOG_LEVEL_ERROR,
+                                  "Could not open named pipe for signaling GPU "
+                                  "capture at path %s: %s\n",
+                                  pipeName, strerror(errno));
+                }
+            }
 
-			break;
-		}
-	}
+            break;
+        }
+    }
 
-	MVKLogInfo("Created VkDevice to run on GPU %s with the following %d Vulkan extensions enabled:%s",
-			   getName(), _enabledExtensions.getEnabledCount(), _enabledExtensions.enabledNamesString("\n\t", true).c_str());
+    MVKLogInfo("Created VkDevice to run on GPU %s with the following %d Vulkan "
+               "extensions enabled:%s",
+               getName(), _enabledExtensions.getEnabledCount(),
+               _enabledExtensions.enabledNamesString("\n\t", true).c_str());
 }
 
 // Perf stats that last the duration of the app process.
 static MVKPerformanceStatistics _processPerformanceStats = {};
 
 void MVKDevice::initPerformanceTracking() {
-	_isPerformanceTracking = getMVKConfig().performanceTracking;
-	_performanceStats = _processPerformanceStats;
+    _isPerformanceTracking = getMVKConfig().performanceTracking;
+    _performanceStats = _processPerformanceStats;
 }
 
-void MVKDevice::initPhysicalDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo* pCreateInfo) {
+void MVKDevice::initPhysicalDevice(MVKPhysicalDevice* physicalDevice,
+                                   const VkDeviceCreateInfo* pCreateInfo) {
 
-	const VkDeviceGroupDeviceCreateInfo* pGroupCreateInfo = nullptr;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-		case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
-			pGroupCreateInfo = (const VkDeviceGroupDeviceCreateInfo*)next;
-			break;
-		default:
-			break;
-		}
-	}
+    const VkDeviceGroupDeviceCreateInfo* pGroupCreateInfo = nullptr;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
+            pGroupCreateInfo = (const VkDeviceGroupDeviceCreateInfo*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	// If I was given physical devices for a grouped device, use them.
-	// At this time, we only support device groups consisting of a single member,
-	// so this is sufficient for now.
-	if (pGroupCreateInfo && pGroupCreateInfo->physicalDeviceCount)
-		_physicalDevice = MVKPhysicalDevice::getMVKPhysicalDevice(pGroupCreateInfo->pPhysicalDevices[0]);
-	else
-		_physicalDevice = physicalDevice;
+    // If I was given physical devices for a grouped device, use them.
+    // At this time, we only support device groups consisting of a single
+    // member, so this is sufficient for now.
+    if (pGroupCreateInfo && pGroupCreateInfo->physicalDeviceCount)
+        _physicalDevice = MVKPhysicalDevice::getMVKPhysicalDevice(
+            pGroupCreateInfo->pPhysicalDevices[0]);
+    else
+        _physicalDevice = physicalDevice;
 
-	switch (_physicalDevice->_vkSemaphoreStyle) {
-		case MVKSemaphoreStyleUseMTLEvent:
-			MVKLogInfo("Vulkan semaphores using MTLEvent.");
-			break;
-		case MVKSemaphoreStyleUseEmulation:
-			MVKLogInfo("Vulkan semaphores using CPU callbacks upon GPU submission completion.");
-			break;
-		case MVKSemaphoreStyleSingleQueue:
-			MVKLogInfo("Vulkan semaphores using Metal implicit guarantees within a single queue.");
-			break;
-	}
+    switch (_physicalDevice->_vkSemaphoreStyle) {
+    case MVKSemaphoreStyleUseMTLEvent:
+        MVKLogInfo("Vulkan semaphores using MTLEvent.");
+        break;
+    case MVKSemaphoreStyleUseEmulation:
+        MVKLogInfo("Vulkan semaphores using CPU callbacks upon GPU submission "
+                   "completion.");
+        break;
+    case MVKSemaphoreStyleSingleQueue:
+        MVKLogInfo("Vulkan semaphores using Metal implicit guarantees within a "
+                   "single queue.");
+        break;
+    }
 }
 
 void MVKDevice::enableFeatures(const VkDeviceCreateInfo* pCreateInfo) {
-	VkStructureType sType;
-	VkBaseInStructure* pPrevStruct = nullptr;
+    VkStructureType sType;
+    VkBaseInStructure* pPrevStruct = nullptr;
 
-	// Clear and set the sType of each VkDevice enabled feature iVar (_enabledXXXFeatures),
-	// and create a chain of identical structs that will be sent to the MVKPhysicalDevice
-	// to query which features are supported.
-#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
-	sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES; \
-	mvkClear(&_enabled##structName##Features); \
-	_enabled##structName##Features.sType = sType; \
-	VkPhysicalDevice##structName##Features pd##structName##Features; \
-	pd##structName##Features.sType = sType; \
-	pd##structName##Features.pNext = pPrevStruct; \
-	pPrevStruct = (VkBaseInStructure*)&pd##structName##Features;
+    // Clear and set the sType of each VkDevice enabled feature iVar
+    // (_enabledXXXFeatures), and create a chain of identical structs that will
+    // be sent to the MVKPhysicalDevice to query which features are supported.
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount)                    \
+    sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES;           \
+    mvkClear(&_enabled##structName##Features);                                 \
+    _enabled##structName##Features.sType = sType;                              \
+    VkPhysicalDevice##structName##Features pd##structName##Features;           \
+    pd##structName##Features.sType = sType;                                    \
+    pd##structName##Features.pNext = pPrevStruct;                              \
+    pPrevStruct = (VkBaseInStructure*)&pd##structName##Features;
 
-#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
-	sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES_##extnSfx; \
-	mvkClear(&_enabled##structName##Features); \
-	_enabled##structName##Features.sType = sType; \
-	VkPhysicalDevice##structName##Features##extnSfx pd##structName##Features; \
-	pd##structName##Features.sType = sType; \
-	pd##structName##Features.pNext = pPrevStruct; \
-	pPrevStruct = (VkBaseInStructure*)&pd##structName##Features;
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount)      \
+    sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES_##extnSfx; \
+    mvkClear(&_enabled##structName##Features);                                 \
+    _enabled##structName##Features.sType = sType;                              \
+    VkPhysicalDevice##structName##Features##extnSfx pd##structName##Features;  \
+    pd##structName##Features.sType = sType;                                    \
+    pd##structName##Features.pNext = pPrevStruct;                              \
+    pPrevStruct = (VkBaseInStructure*)&pd##structName##Features;
 
 #include "MVKDeviceFeatureStructs.def"
 
-	mvkClear(&_enabledVulkan12FeaturesNoExt);
+    mvkClear(&_enabledVulkan12FeaturesNoExt);
 
-	sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-	mvkClear(&_enabledFeatures);
-	VkPhysicalDeviceFeatures2 pdFeats2;
-	pdFeats2.sType = sType;
-	pdFeats2.pNext = pPrevStruct;
+    sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    mvkClear(&_enabledFeatures);
+    VkPhysicalDeviceFeatures2 pdFeats2;
+    pdFeats2.sType = sType;
+    pdFeats2.pNext = pPrevStruct;
 
-	_physicalDevice->getFeatures(&pdFeats2);
+    _physicalDevice->getFeatures(&pdFeats2);
 
-	//Enable device features based on requested and available features,
-	// including extended features that are requested in the pNext chain.
-	if (pCreateInfo->pEnabledFeatures) {
-		enableFeatures(pCreateInfo->pEnabledFeatures,
-					   &_enabledFeatures.robustBufferAccess,
-					   &pCreateInfo->pEnabledFeatures->robustBufferAccess,
-					   &pdFeats2.features.robustBufferAccess, 55);
-	}
+    // Enable device features based on requested and available features,
+    //  including extended features that are requested in the pNext chain.
+    if (pCreateInfo->pEnabledFeatures) {
+        enableFeatures(pCreateInfo->pEnabledFeatures,
+                       &_enabledFeatures.robustBufferAccess,
+                       &pCreateInfo->pEnabledFeatures->robustBufferAccess,
+                       &pdFeats2.features.robustBufferAccess, 55);
+    }
 
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch ((uint32_t)next->sType) {
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2: {
-				auto* requestedFeatures = (VkPhysicalDeviceFeatures2*)next;
-				enableFeatures(requestedFeatures,
-							   &_enabledFeatures.robustBufferAccess,
-							   &requestedFeatures->features.robustBufferAccess,
-							   &pdFeats2.features.robustBufferAccess, 55);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
-				auto* requestedFeatures = (VkPhysicalDeviceVulkan11Features*)next;
-				enableFeatures(requestedFeatures,
-							   &_enabled16BitStorageFeatures.storageBuffer16BitAccess,
-							   &requestedFeatures->storageBuffer16BitAccess,
-							   &pd16BitStorageFeatures.storageBuffer16BitAccess, 4);
-				enableFeatures(requestedFeatures,
-							   &_enabledMultiviewFeatures.multiview,
-							   &requestedFeatures->multiview,
-							   &pdMultiviewFeatures.multiview, 3);
-				enableFeatures(requestedFeatures,
-							   &_enabledVariablePointerFeatures.variablePointersStorageBuffer,
-							   &requestedFeatures->variablePointersStorageBuffer,
-							   &pdVariablePointerFeatures.variablePointersStorageBuffer, 2);
-				enableFeatures(requestedFeatures,
-							   &_enabledProtectedMemoryFeatures.protectedMemory,
-							   &requestedFeatures->protectedMemory,
-							   &pdProtectedMemoryFeatures.protectedMemory, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledSamplerYcbcrConversionFeatures.samplerYcbcrConversion,
-							   &requestedFeatures->samplerYcbcrConversion,
-							   &pdSamplerYcbcrConversionFeatures.samplerYcbcrConversion, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledShaderDrawParametersFeatures.shaderDrawParameters,
-							   &requestedFeatures->shaderDrawParameters,
-							   &pdShaderDrawParametersFeatures.shaderDrawParameters, 1);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
-				auto& pdvulkan12FeaturesNoExt = _physicalDevice->_vulkan12FeaturesNoExt;
-				auto* requestedFeatures = (VkPhysicalDeviceVulkan12Features*)next;
-				enableFeatures(requestedFeatures,
-							   &_enabledVulkan12FeaturesNoExt.samplerMirrorClampToEdge,
-							   &requestedFeatures->samplerMirrorClampToEdge,
-							   &pdvulkan12FeaturesNoExt.samplerMirrorClampToEdge, 2);
-				enableFeatures(requestedFeatures,
-							   &_enabled8BitStorageFeatures.storageBuffer8BitAccess,
-							   &requestedFeatures->storageBuffer8BitAccess,
-							   &pd8BitStorageFeatures.storageBuffer8BitAccess, 3);
-				enableFeatures(requestedFeatures,
-							   &_enabledShaderAtomicInt64Features.shaderBufferInt64Atomics,
-							   &requestedFeatures->shaderBufferInt64Atomics,
-							   &pdShaderAtomicInt64Features.shaderBufferInt64Atomics, 2);
-				enableFeatures(requestedFeatures,
-							   &_enabledShaderFloat16Int8Features.shaderFloat16,
-							   &requestedFeatures->shaderFloat16,
-							   &pdShaderFloat16Int8Features.shaderFloat16, 2);
-				enableFeatures(requestedFeatures,
-							   &_enabledVulkan12FeaturesNoExt.descriptorIndexing,
-							   &requestedFeatures->descriptorIndexing,
-							   &pdvulkan12FeaturesNoExt.descriptorIndexing, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing,
-							   &requestedFeatures->shaderInputAttachmentArrayDynamicIndexing,
-							   &pdDescriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing, 20);
-				enableFeatures(requestedFeatures,
-							   &_enabledVulkan12FeaturesNoExt.samplerFilterMinmax,
-							   &requestedFeatures->samplerFilterMinmax,
-							   &pdvulkan12FeaturesNoExt.samplerFilterMinmax, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledScalarBlockLayoutFeatures.scalarBlockLayout,
-							   &requestedFeatures->scalarBlockLayout,
-							   &pdScalarBlockLayoutFeatures.scalarBlockLayout, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledImagelessFramebufferFeatures.imagelessFramebuffer,
-							   &requestedFeatures->imagelessFramebuffer,
-							   &pdImagelessFramebufferFeatures.imagelessFramebuffer, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledUniformBufferStandardLayoutFeatures.uniformBufferStandardLayout,
-							   &requestedFeatures->uniformBufferStandardLayout,
-							   &pdUniformBufferStandardLayoutFeatures.uniformBufferStandardLayout, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledShaderSubgroupExtendedTypesFeatures.shaderSubgroupExtendedTypes,
-							   &requestedFeatures->shaderSubgroupExtendedTypes,
-							   &pdShaderSubgroupExtendedTypesFeatures.shaderSubgroupExtendedTypes, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledSeparateDepthStencilLayoutsFeatures.separateDepthStencilLayouts,
-							   &requestedFeatures->separateDepthStencilLayouts,
-							   &pdSeparateDepthStencilLayoutsFeatures.separateDepthStencilLayouts, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledHostQueryResetFeatures.hostQueryReset,
-							   &requestedFeatures->hostQueryReset,
-							   &pdHostQueryResetFeatures.hostQueryReset, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledTimelineSemaphoreFeatures.timelineSemaphore,
-							   &requestedFeatures->timelineSemaphore,
-							   &pdTimelineSemaphoreFeatures.timelineSemaphore, 1);
-				enableFeatures(requestedFeatures,
-							   &_enabledBufferDeviceAddressFeatures.bufferDeviceAddress,
-							   &requestedFeatures->bufferDeviceAddress,
-							   &pdBufferDeviceAddressFeatures.bufferDeviceAddress, 3);
-				enableFeatures(requestedFeatures,
-							   &_enabledVulkanMemoryModelFeatures.vulkanMemoryModel,
-							   &requestedFeatures->vulkanMemoryModel,
-							   &pdVulkanMemoryModelFeatures.vulkanMemoryModel, 3);
-				enableFeatures(requestedFeatures,
-							   &_enabledVulkan12FeaturesNoExt.shaderOutputViewportIndex,
-							   &requestedFeatures->shaderOutputViewportIndex,
-							   &pdvulkan12FeaturesNoExt.shaderOutputViewportIndex, 3);
-				break;
-			}
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch ((uint32_t)next->sType) {
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2: {
+            auto* requestedFeatures = (VkPhysicalDeviceFeatures2*)next;
+            enableFeatures(requestedFeatures,
+                           &_enabledFeatures.robustBufferAccess,
+                           &requestedFeatures->features.robustBufferAccess,
+                           &pdFeats2.features.robustBufferAccess, 55);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
+            auto* requestedFeatures = (VkPhysicalDeviceVulkan11Features*)next;
+            enableFeatures(requestedFeatures,
+                           &_enabled16BitStorageFeatures
+                                .storageBuffer16BitAccess,
+                           &requestedFeatures->storageBuffer16BitAccess,
+                           &pd16BitStorageFeatures.storageBuffer16BitAccess, 4);
+            enableFeatures(requestedFeatures,
+                           &_enabledMultiviewFeatures.multiview,
+                           &requestedFeatures->multiview,
+                           &pdMultiviewFeatures.multiview, 3);
+            enableFeatures(requestedFeatures,
+                           &_enabledVariablePointerFeatures
+                                .variablePointersStorageBuffer,
+                           &requestedFeatures->variablePointersStorageBuffer,
+                           &pdVariablePointerFeatures
+                                .variablePointersStorageBuffer,
+                           2);
+            enableFeatures(requestedFeatures,
+                           &_enabledProtectedMemoryFeatures.protectedMemory,
+                           &requestedFeatures->protectedMemory,
+                           &pdProtectedMemoryFeatures.protectedMemory, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledSamplerYcbcrConversionFeatures
+                                .samplerYcbcrConversion,
+                           &requestedFeatures->samplerYcbcrConversion,
+                           &pdSamplerYcbcrConversionFeatures
+                                .samplerYcbcrConversion,
+                           1);
+            enableFeatures(requestedFeatures,
+                           &_enabledShaderDrawParametersFeatures
+                                .shaderDrawParameters,
+                           &requestedFeatures->shaderDrawParameters,
+                           &pdShaderDrawParametersFeatures.shaderDrawParameters,
+                           1);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
+            auto& pdvulkan12FeaturesNoExt =
+                _physicalDevice->_vulkan12FeaturesNoExt;
+            auto* requestedFeatures = (VkPhysicalDeviceVulkan12Features*)next;
+            enableFeatures(requestedFeatures,
+                           &_enabledVulkan12FeaturesNoExt
+                                .samplerMirrorClampToEdge,
+                           &requestedFeatures->samplerMirrorClampToEdge,
+                           &pdvulkan12FeaturesNoExt.samplerMirrorClampToEdge,
+                           2);
+            enableFeatures(requestedFeatures,
+                           &_enabled8BitStorageFeatures.storageBuffer8BitAccess,
+                           &requestedFeatures->storageBuffer8BitAccess,
+                           &pd8BitStorageFeatures.storageBuffer8BitAccess, 3);
+            enableFeatures(requestedFeatures,
+                           &_enabledShaderAtomicInt64Features
+                                .shaderBufferInt64Atomics,
+                           &requestedFeatures->shaderBufferInt64Atomics,
+                           &pdShaderAtomicInt64Features
+                                .shaderBufferInt64Atomics,
+                           2);
+            enableFeatures(requestedFeatures,
+                           &_enabledShaderFloat16Int8Features.shaderFloat16,
+                           &requestedFeatures->shaderFloat16,
+                           &pdShaderFloat16Int8Features.shaderFloat16, 2);
+            enableFeatures(requestedFeatures,
+                           &_enabledVulkan12FeaturesNoExt.descriptorIndexing,
+                           &requestedFeatures->descriptorIndexing,
+                           &pdvulkan12FeaturesNoExt.descriptorIndexing, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledDescriptorIndexingFeatures
+                                .shaderInputAttachmentArrayDynamicIndexing,
+                           &requestedFeatures
+                                ->shaderInputAttachmentArrayDynamicIndexing,
+                           &pdDescriptorIndexingFeatures
+                                .shaderInputAttachmentArrayDynamicIndexing,
+                           20);
+            enableFeatures(requestedFeatures,
+                           &_enabledVulkan12FeaturesNoExt.samplerFilterMinmax,
+                           &requestedFeatures->samplerFilterMinmax,
+                           &pdvulkan12FeaturesNoExt.samplerFilterMinmax, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledScalarBlockLayoutFeatures.scalarBlockLayout,
+                           &requestedFeatures->scalarBlockLayout,
+                           &pdScalarBlockLayoutFeatures.scalarBlockLayout, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledImagelessFramebufferFeatures
+                                .imagelessFramebuffer,
+                           &requestedFeatures->imagelessFramebuffer,
+                           &pdImagelessFramebufferFeatures.imagelessFramebuffer,
+                           1);
+            enableFeatures(requestedFeatures,
+                           &_enabledUniformBufferStandardLayoutFeatures
+                                .uniformBufferStandardLayout,
+                           &requestedFeatures->uniformBufferStandardLayout,
+                           &pdUniformBufferStandardLayoutFeatures
+                                .uniformBufferStandardLayout,
+                           1);
+            enableFeatures(requestedFeatures,
+                           &_enabledShaderSubgroupExtendedTypesFeatures
+                                .shaderSubgroupExtendedTypes,
+                           &requestedFeatures->shaderSubgroupExtendedTypes,
+                           &pdShaderSubgroupExtendedTypesFeatures
+                                .shaderSubgroupExtendedTypes,
+                           1);
+            enableFeatures(requestedFeatures,
+                           &_enabledSeparateDepthStencilLayoutsFeatures
+                                .separateDepthStencilLayouts,
+                           &requestedFeatures->separateDepthStencilLayouts,
+                           &pdSeparateDepthStencilLayoutsFeatures
+                                .separateDepthStencilLayouts,
+                           1);
+            enableFeatures(requestedFeatures,
+                           &_enabledHostQueryResetFeatures.hostQueryReset,
+                           &requestedFeatures->hostQueryReset,
+                           &pdHostQueryResetFeatures.hostQueryReset, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledTimelineSemaphoreFeatures.timelineSemaphore,
+                           &requestedFeatures->timelineSemaphore,
+                           &pdTimelineSemaphoreFeatures.timelineSemaphore, 1);
+            enableFeatures(requestedFeatures,
+                           &_enabledBufferDeviceAddressFeatures
+                                .bufferDeviceAddress,
+                           &requestedFeatures->bufferDeviceAddress,
+                           &pdBufferDeviceAddressFeatures.bufferDeviceAddress,
+                           3);
+            enableFeatures(requestedFeatures,
+                           &_enabledVulkanMemoryModelFeatures.vulkanMemoryModel,
+                           &requestedFeatures->vulkanMemoryModel,
+                           &pdVulkanMemoryModelFeatures.vulkanMemoryModel, 3);
+            enableFeatures(requestedFeatures,
+                           &_enabledVulkan12FeaturesNoExt
+                                .shaderOutputViewportIndex,
+                           &requestedFeatures->shaderOutputViewportIndex,
+                           &pdvulkan12FeaturesNoExt.shaderOutputViewportIndex,
+                           3);
+            break;
+        }
 
-#define MVK_DEVICE_FEATURE(structName, enumName, flagCount) \
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES: { \
-				enableFeatures(&_enabled##structName##Features, \
-							   (VkPhysicalDevice##structName##Features*)next, \
-							   &pd##structName##Features, \
-							   flagCount); \
-				break; \
-			}
-#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount) \
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES_##extnSfx: { \
-				enableFeatures(&_enabled##structName##Features, \
-							   (VkPhysicalDevice##structName##Features##extnSfx*)next, \
-							   &pd##structName##Features, \
-							   flagCount); \
-				break; \
-			}
+#define MVK_DEVICE_FEATURE(structName, enumName, flagCount)                    \
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES: {            \
+        enableFeatures(&_enabled##structName##Features,                        \
+                       (VkPhysicalDevice##structName##Features*)next,          \
+                       &pd##structName##Features, flagCount);                  \
+        break;                                                                 \
+    }
+#define MVK_DEVICE_FEATURE_EXTN(structName, enumName, extnSfx, flagCount)      \
+    case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_##enumName##_FEATURES_##extnSfx: {  \
+        enableFeatures(&_enabled##structName##Features,                        \
+                       (VkPhysicalDevice##structName##Features##extnSfx*)next, \
+                       &pd##structName##Features, flagCount);                  \
+        break;                                                                 \
+    }
 #include "MVKDeviceFeatureStructs.def"
 
-			default:
-				break;
-		}
-	}
+        default:
+            break;
+        }
+    }
 }
 
-template<typename S>
-void MVKDevice::enableFeatures(S* pEnabled, const S* pRequested, const S* pAvailable, uint32_t count) {
-	enableFeatures(pRequested,
-				   (VkBool32*)mvkGetAddressOfFirstMember(pEnabled),
-				   (VkBool32*)mvkGetAddressOfFirstMember(pRequested),
-				   (VkBool32*)mvkGetAddressOfFirstMember(pAvailable),
-				   count);
+template <typename S>
+void MVKDevice::enableFeatures(S* pEnabled, const S* pRequested,
+                               const S* pAvailable, uint32_t count) {
+    enableFeatures(pRequested, (VkBool32*)mvkGetAddressOfFirstMember(pEnabled),
+                   (VkBool32*)mvkGetAddressOfFirstMember(pRequested),
+                   (VkBool32*)mvkGetAddressOfFirstMember(pAvailable), count);
 }
 
-template<typename S>
-void MVKDevice::enableFeatures(S* pRequested, VkBool32* pEnabledBools, const VkBool32* pRequestedBools, const VkBool32* pAvailableBools, uint32_t count) {
-	for (uint32_t i = 0; i < count; i++) {
-		pEnabledBools[i] = pRequestedBools[i] && pAvailableBools[i];
-		if (pRequestedBools[i] && !pAvailableBools[i]) {
-			uintptr_t mbrOffset = (uintptr_t)&pRequestedBools[i] - (uintptr_t)mvkGetAddressOfFirstMember(pRequested);
-			size_t mbrIdxOrd = (mbrOffset / sizeof(VkBool32)) + 1;
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateDevice(): Requested physical device feature specified by the %zu%s flag in %s is not available on this device.", mbrIdxOrd, mvk::getOrdinalSuffix(mbrIdxOrd), mvk::getTypeName(pRequested).c_str()));
-		}
-	}
+template <typename S>
+void MVKDevice::enableFeatures(S* pRequested, VkBool32* pEnabledBools,
+                               const VkBool32* pRequestedBools,
+                               const VkBool32* pAvailableBools,
+                               uint32_t count) {
+    for (uint32_t i = 0; i < count; i++) {
+        pEnabledBools[i] = pRequestedBools[i] && pAvailableBools[i];
+        if (pRequestedBools[i] && !pAvailableBools[i]) {
+            uintptr_t mbrOffset =
+                (uintptr_t)&pRequestedBools[i] -
+                (uintptr_t)mvkGetAddressOfFirstMember(pRequested);
+            size_t mbrIdxOrd = (mbrOffset / sizeof(VkBool32)) + 1;
+            setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "vkCreateDevice(): Requested physical device "
+                            "feature specified by the "
+                            "%zu%s flag in %s is not available on this device.",
+                            mbrIdxOrd, mvk::getOrdinalSuffix(mbrIdxOrd),
+                            mvk::getTypeName(pRequested).c_str()));
+        }
+    }
 }
 
 void MVKDevice::enableExtensions(const VkDeviceCreateInfo* pCreateInfo) {
-	setConfigurationResult(_enabledExtensions.enable(pCreateInfo->enabledExtensionCount,
-													 pCreateInfo->ppEnabledExtensionNames,
-													 &_physicalDevice->_supportedExtensions));
+    setConfigurationResult(
+        _enabledExtensions.enable(pCreateInfo->enabledExtensionCount,
+                                  pCreateInfo->ppEnabledExtensionNames,
+                                  &_physicalDevice->_supportedExtensions));
 }
 
 // Create the command queues
 void MVKDevice::initQueues(const VkDeviceCreateInfo* pCreateInfo) {
-	auto qFams = _physicalDevice->getQueueFamilies();
-	uint32_t qrCnt = pCreateInfo->queueCreateInfoCount;
-	for (uint32_t qrIdx = 0; qrIdx < qrCnt; qrIdx++) {
-		const VkDeviceQueueCreateInfo* pQFInfo = &pCreateInfo->pQueueCreateInfos[qrIdx];
-		uint32_t qfIdx = pQFInfo->queueFamilyIndex;
-		MVKQueueFamily* qFam = qFams[qfIdx];
-		VkQueueFamilyProperties qfProps;
-		qFam->getProperties(&qfProps);
+    auto qFams = _physicalDevice->getQueueFamilies();
+    uint32_t qrCnt = pCreateInfo->queueCreateInfoCount;
+    for (uint32_t qrIdx = 0; qrIdx < qrCnt; qrIdx++) {
+        const VkDeviceQueueCreateInfo* pQFInfo =
+            &pCreateInfo->pQueueCreateInfos[qrIdx];
+        uint32_t qfIdx = pQFInfo->queueFamilyIndex;
+        MVKQueueFamily* qFam = qFams[qfIdx];
+        VkQueueFamilyProperties qfProps;
+        qFam->getProperties(&qfProps);
 
-		// Ensure an entry for this queue family exists
-		uint32_t qfCntMin = qfIdx + 1;
-		if (_queuesByQueueFamilyIndex.size() < qfCntMin) {
-			_queuesByQueueFamilyIndex.resize(qfCntMin);
-		}
-		auto& queues = _queuesByQueueFamilyIndex[qfIdx];
-		uint32_t qCnt = min(pQFInfo->queueCount, qfProps.queueCount);
-		for (uint32_t qIdx = 0; qIdx < qCnt; qIdx++) {
-			queues.push_back(new MVKQueue(this, qFam, qIdx, pQFInfo->pQueuePriorities[qIdx]));
-		}
-	}
+        // Ensure an entry for this queue family exists
+        uint32_t qfCntMin = qfIdx + 1;
+        if (_queuesByQueueFamilyIndex.size() < qfCntMin) {
+            _queuesByQueueFamilyIndex.resize(qfCntMin);
+        }
+        auto& queues = _queuesByQueueFamilyIndex[qfIdx];
+        uint32_t qCnt = min(pQFInfo->queueCount, qfProps.queueCount);
+        for (uint32_t qIdx = 0; qIdx < qCnt; qIdx++) {
+            queues.push_back(new MVKQueue(this, qFam, qIdx,
+                                          pQFInfo->pQueuePriorities[qIdx]));
+        }
+    }
 }
 
 void MVKDevice::reservePrivateData(const VkDeviceCreateInfo* pCreateInfo) {
-	size_t slotCnt = 0;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO_EXT: {
-				auto* pPDCreateInfo = (const VkDevicePrivateDataCreateInfoEXT*)next;
-				slotCnt += pPDCreateInfo->privateDataSlotRequestCount;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    size_t slotCnt = 0;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO_EXT: {
+            auto* pPDCreateInfo = (const VkDevicePrivateDataCreateInfoEXT*)next;
+            slotCnt += pPDCreateInfo->privateDataSlotRequestCount;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	_privateDataSlots.reserve(slotCnt);
-	_privateDataSlotsAvailability.reserve(slotCnt);
-	for (uint32_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
-		_privateDataSlots.push_back(new MVKPrivateDataSlot(this));
-		_privateDataSlotsAvailability.push_back(true);
-	}
+    _privateDataSlots.reserve(slotCnt);
+    _privateDataSlotsAvailability.reserve(slotCnt);
+    for (uint32_t slotIdx = 0; slotIdx < slotCnt; slotIdx++) {
+        _privateDataSlots.push_back(new MVKPrivateDataSlot(this));
+        _privateDataSlotsAvailability.push_back(true);
+    }
 }
 
 MVKDevice::~MVKDevice() {
-	if (_isPerformanceTracking) {
-		auto perfLogStyle = getMVKConfig().activityPerformanceLoggingStyle;
-		if (perfLogStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_DEVICE_LIFETIME) {
-			MVKLogInfo("Device activity performance summary:");
-			logPerformanceSummary();
-		} else if (perfLogStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_DEVICE_LIFETIME_ACCUMULATE) {
-			MVKLogInfo("Process activity performance summary:");
-			logPerformanceSummary();
-			_processPerformanceStats = _performanceStats;
-		}
-	}
+    if (_isPerformanceTracking) {
+        auto perfLogStyle = getMVKConfig().activityPerformanceLoggingStyle;
+        if (perfLogStyle ==
+            MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_DEVICE_LIFETIME) {
+            MVKLogInfo("Device activity performance summary:");
+            logPerformanceSummary();
+        } else if (
+            perfLogStyle ==
+            MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_DEVICE_LIFETIME_ACCUMULATE) {
+            MVKLogInfo("Process activity performance summary:");
+            logPerformanceSummary();
+            _processPerformanceStats = _performanceStats;
+        }
+    }
 
-	for (auto& queues : _queuesByQueueFamilyIndex) {
-		mvkDestroyContainerContents(queues);
-	}
+    for (auto& queues : _queuesByQueueFamilyIndex) {
+        mvkDestroyContainerContents(queues);
+    }
 
-	if (_commandResourceFactory) { _commandResourceFactory->destroy(); }
+    if (_commandResourceFactory) {
+        _commandResourceFactory->destroy();
+    }
 
     [_globalVisibilityResultMTLBuffer release];
-	[_defaultMTLSamplerState release];
-	[_dummyBlitMTLBuffer release];
+    [_defaultMTLSamplerState release];
+    [_dummyBlitMTLBuffer release];
 
-	stopAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE);
+    stopAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE);
 
-	if (!_capturePipeFileName.empty()) { unlink(_capturePipeFileName.c_str()); }
+    if (!_capturePipeFileName.empty()) {
+        unlink(_capturePipeFileName.c_str());
+    }
 
-	mvkDestroyContainerContents(_privateDataSlots);
+    mvkDestroyContainerContents(_privateDataSlots);
 
-	MVKLogInfo("Destroyed VkDevice on GPU %s with %d Vulkan extensions enabled.",
-			   getName(), _enabledExtensions.getEnabledCount());
+    MVKLogInfo("Destroyed VkDevice on GPU %s with %d Vulkan extensions "
+               "enabled.",
+               getName(), _enabledExtensions.getEnabledCount());
 }
-
 
 #pragma mark -
 #pragma mark Support functions
 
 NSArray<id<MTLDevice>>* mvkGetAvailableMTLDevicesArray(MVKInstance* instance) {
-	NSMutableArray* mtlDevs = [NSMutableArray array];	// autoreleased
+    NSMutableArray* mtlDevs = [NSMutableArray array]; // autoreleased
 
 #if MVK_MACOS
-	NSArray* rawMTLDevs = [MTLCopyAllDevices() autorelease];
-	bool forceLowPower = mvkGetMVKConfig(instance).forceLowPowerGPU;
+    NSArray* rawMTLDevs = [MTLCopyAllDevices() autorelease];
+    bool forceLowPower = mvkGetMVKConfig(instance).forceLowPowerGPU;
 
-	// Populate the array of appropriate MTLDevices
-	for (id<MTLDevice> md in rawMTLDevs) {
-		if ( !forceLowPower || md.isLowPower ) { [mtlDevs addObject: md]; }
-	}
+    // Populate the array of appropriate MTLDevices
+    for (id<MTLDevice> md in rawMTLDevs) {
+        if (!forceLowPower || md.isLowPower) {
+            [mtlDevs addObject:md];
+        }
+    }
 
-	// Sort by power
-	[mtlDevs sortUsingComparator: ^(id<MTLDevice> md1, id<MTLDevice> md2) {
-		BOOL md1IsLP = md1.isLowPower;
-		BOOL md2IsLP = md2.isLowPower;
+    // Sort by power
+    [mtlDevs sortUsingComparator:^(id<MTLDevice> md1, id<MTLDevice> md2) {
+      BOOL md1IsLP = md1.isLowPower;
+      BOOL md2IsLP = md2.isLowPower;
 
-		if (md1IsLP == md2IsLP) {
-			// If one device is headless and the other one is not, select the
-			// one that is not headless first.
-			BOOL md1IsHeadless = md1.isHeadless;
-			BOOL md2IsHeadless = md2.isHeadless;
-			if (md1IsHeadless == md2IsHeadless ) {
-				return NSOrderedSame;
-			}
-			return md2IsHeadless ? NSOrderedAscending : NSOrderedDescending;
-		}
+      if (md1IsLP == md2IsLP) {
+          // If one device is headless and the other one is not, select the
+          // one that is not headless first.
+          BOOL md1IsHeadless = md1.isHeadless;
+          BOOL md2IsHeadless = md2.isHeadless;
+          if (md1IsHeadless == md2IsHeadless) {
+              return NSOrderedSame;
+          }
+          return md2IsHeadless ? NSOrderedAscending : NSOrderedDescending;
+      }
 
-		return md2IsLP ? NSOrderedAscending : NSOrderedDescending;
-	}];
+      return md2IsLP ? NSOrderedAscending : NSOrderedDescending;
+    }];
 
-	// If the survey found at least one device, return the array.
-	if (mtlDevs.count) { return mtlDevs; }
+    // If the survey found at least one device, return the array.
+    if (mtlDevs.count) {
+        return mtlDevs;
+    }
 
-#endif	// MVK_MACOS
+#endif // MVK_MACOS
 
-	// For other OS's, or for macOS if the survey returned empty, use the default device.
-	id<MTLDevice> md = [MTLCreateSystemDefaultDevice() autorelease];
-	if (md) { [mtlDevs addObject: md]; }
+    // For other OS's, or for macOS if the survey returned empty, use the
+    // default device.
+    id<MTLDevice> md = [MTLCreateSystemDefaultDevice() autorelease];
+    if (md) {
+        [mtlDevs addObject:md];
+    }
 
-	return mtlDevs;		// retained
+    return mtlDevs; // retained
 }
 
 uint64_t mvkGetRegistryID(id<MTLDevice> mtlDevice) {
-	return [mtlDevice respondsToSelector: @selector(registryID)] ? mtlDevice.registryID : 0;
+    return [mtlDevice respondsToSelector:@selector(registryID)]
+               ? mtlDevice.registryID
+               : 0;
 }
 
 uint64_t mvkGetLocationID(id<MTLDevice> mtlDevice) {
-	uint64_t hash = 0;
+    uint64_t hash = 0;
 
 #if MVK_MACOS && !MVK_MACCAT
-	// All of these device properties were added at the same time,
-	// so only need to check for the presence of one of them.
-	if ([mtlDevice respondsToSelector: @selector(location)]) {
-		uint64_t val;
+    // All of these device properties were added at the same time,
+    // so only need to check for the presence of one of them.
+    if ([mtlDevice respondsToSelector:@selector(location)]) {
+        uint64_t val;
 
-		val = mtlDevice.location;
-		hash = mvkHash(&val, 1, hash);
+        val = mtlDevice.location;
+        hash = mvkHash(&val, 1, hash);
 
-		val = mtlDevice.locationNumber;
-		hash = mvkHash(&val, 1, hash);
+        val = mtlDevice.locationNumber;
+        hash = mvkHash(&val, 1, hash);
 
-		val = mtlDevice.peerGroupID;
-		hash = mvkHash(&val, 1, hash);
+        val = mtlDevice.peerGroupID;
+        hash = mvkHash(&val, 1, hash);
 
-		val = mtlDevice.peerIndex;
-		hash = mvkHash(&val, 1, hash);
-	}
+        val = mtlDevice.peerIndex;
+        hash = mvkHash(&val, 1, hash);
+    }
 #endif
 
-	return hash;
+    return hash;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,41 +26,49 @@
 
 class MVKImageMemoryBinding;
 
-// TODO: These are inoperable placeholders until VK_KHR_external_memory_metal defines them properly
-static const VkExternalMemoryHandleTypeFlagBits VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR = VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
-static const VkExternalMemoryHandleTypeFlagBits VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR = VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
-
+// TODO: These are inoperable placeholders until VK_KHR_external_memory_metal
+// defines them properly
+static const VkExternalMemoryHandleTypeFlagBits
+    VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
+static const VkExternalMemoryHandleTypeFlagBits
+    VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR =
+        VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
 
 #pragma mark MVKDeviceMemory
 
 typedef struct MVKMappedMemoryRange {
-	VkDeviceSize offset = 0;
-	VkDeviceSize size = 0;
+    VkDeviceSize offset = 0;
+    VkDeviceSize size = 0;
 } MVKMappedMemoryRange;
-
 
 /** Represents a Vulkan device-space memory allocation. */
 class MVKDeviceMemory : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DEVICE_MEMORY;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEVICE_MEMORY; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT; }
-
-	/** Returns whether the memory is accessible from the host. */
+    /** Returns whether the memory is accessible from the host. */
     inline bool isMemoryHostAccessible() {
 #if MVK_APPLE_SILICON
-        if (_mtlStorageMode == MTLStorageModeMemoryless)
-            return false;
+        if (_mtlStorageMode == MTLStorageModeMemoryless) return false;
 #endif
         return (_mtlStorageMode != MTLStorageModePrivate);
     }
 
-	/** Returns whether the memory is automatically coherent between device and host. */
-    inline bool isMemoryHostCoherent() { return (_mtlStorageMode == MTLStorageModeShared); }
+    /** Returns whether the memory is automatically coherent between device and
+     * host. */
+    inline bool isMemoryHostCoherent() {
+        return (_mtlStorageMode == MTLStorageModeShared);
+    }
 
     /** Returns whether this is a dedicated allocation. */
     inline bool isDedicatedAllocation() { return _isDedicated; }
@@ -68,109 +76,113 @@ public:
     /** Returns the memory already committed by this instance. */
     inline VkDeviceSize getDeviceMemoryCommitment() { return _allocationSize; }
 
-	/**
-	 * Returns the host memory address of this memory, or NULL if the memory has not been
-	 * mapped yet, or is marked as device-only and cannot be mapped to a host address.
-	 */
-	inline void* getHostMemoryAddress() { return _pMemory; }
+    /**
+     * Returns the host memory address of this memory, or NULL if the memory has
+     * not been mapped yet, or is marked as device-only and cannot be mapped to
+     * a host address.
+     */
+    inline void* getHostMemoryAddress() { return _pMemory; }
 
-	/**
-	 * Maps the memory address at the specified offset from the start of this memory allocation,
-	 * and returns the address in the specified data reference.
-	 */
-	VkResult map(const VkMemoryMapInfoKHR* mapInfo, void** ppData);
-	
-	/** Unmaps a previously mapped memory range. */
-	VkResult unmap(const VkMemoryUnmapInfoKHR* unmapInfo);
+    /**
+     * Maps the memory address at the specified offset from the start of this
+     * memory allocation, and returns the address in the specified data
+     * reference.
+     */
+    VkResult map(const VkMemoryMapInfoKHR* mapInfo, void** ppData);
 
-	/**
-	 * If this device memory is currently mapped to host memory, returns the range within
-	 * this device memory that is currently mapped to host memory, or returns {0,0} if
-	 * this device memory is not currently mapped to host memory.
-	 */
-	inline const MVKMappedMemoryRange& getMappedRange() { return _mappedRange; }
+    /** Unmaps a previously mapped memory range. */
+    VkResult unmap(const VkMemoryUnmapInfoKHR* unmapInfo);
 
-	/** Returns whether this device memory is currently mapped to host memory. */
-	bool isMapped() { return _mappedRange.size > 0; }
+    /**
+     * If this device memory is currently mapped to host memory, returns the
+     * range within this device memory that is currently mapped to host memory,
+     * or returns {0,0} if this device memory is not currently mapped to host
+     * memory.
+     */
+    inline const MVKMappedMemoryRange& getMappedRange() { return _mappedRange; }
 
-	/** If this memory is host-visible, the specified memory range is flushed to the device. */
-	VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
+    /** Returns whether this device memory is currently mapped to host memory.
+     */
+    bool isMapped() { return _mappedRange.size > 0; }
 
-	/**
-	 * If this memory is host-visible, pulls the specified memory range from the device.
-	 *
-	 * If pBlitEnc is not null, it points to a holder for a MTLBlitCommandEncoder and its
-	 * associated MTLCommandBuffer. If this instance has a MTLBuffer using managed memory,
-	 * this function may call synchronizeResource: on the MTLBlitCommandEncoder to
-	 * synchronize the GPU contents to the CPU. If the contents of the pBlitEnc do not
-	 * include a MTLBlitCommandEncoder and MTLCommandBuffer, this function will create
-	 * them and populate the contents into the MVKMTLBlitEncoder struct.
-	 */
-	VkResult pullFromDevice(VkDeviceSize offset,
-							VkDeviceSize size,
-							MVKMTLBlitEncoder* pBlitEnc = nullptr);
+    /** If this memory is host-visible, the specified memory range is flushed to
+     * the device. */
+    VkResult flushToDevice(VkDeviceSize offset, VkDeviceSize size);
 
+    /**
+     * If this memory is host-visible, pulls the specified memory range from the
+     * device.
+     *
+     * If pBlitEnc is not null, it points to a holder for a
+     * MTLBlitCommandEncoder and its associated MTLCommandBuffer. If this
+     * instance has a MTLBuffer using managed memory, this function may call
+     * synchronizeResource: on the MTLBlitCommandEncoder to synchronize the GPU
+     * contents to the CPU. If the contents of the pBlitEnc do not include a
+     * MTLBlitCommandEncoder and MTLCommandBuffer, this function will create
+     * them and populate the contents into the MVKMTLBlitEncoder struct.
+     */
+    VkResult pullFromDevice(VkDeviceSize offset, VkDeviceSize size,
+                            MVKMTLBlitEncoder* pBlitEnc = nullptr);
 
 #pragma mark Metal
 
-	/** Returns the Metal buffer underlying this memory allocation. */
-	inline id<MTLBuffer> getMTLBuffer() { return _mtlBuffer; }
+    /** Returns the Metal buffer underlying this memory allocation. */
+    inline id<MTLBuffer> getMTLBuffer() { return _mtlBuffer; }
 
-	/** Returns the Metal heap underlying this memory allocation. */
-	inline id<MTLHeap> getMTLHeap() { return _mtlHeap; }
+    /** Returns the Metal heap underlying this memory allocation. */
+    inline id<MTLHeap> getMTLHeap() { return _mtlHeap; }
 
-	/** Returns the Metal storage mode used by this memory allocation. */
-	inline MTLStorageMode getMTLStorageMode() { return _mtlStorageMode; }
+    /** Returns the Metal storage mode used by this memory allocation. */
+    inline MTLStorageMode getMTLStorageMode() { return _mtlStorageMode; }
 
-	/** Returns the Metal CPU cache mode used by this memory allocation. */
-	inline MTLCPUCacheMode getMTLCPUCacheMode() { return _mtlCPUCacheMode; }
+    /** Returns the Metal CPU cache mode used by this memory allocation. */
+    inline MTLCPUCacheMode getMTLCPUCacheMode() { return _mtlCPUCacheMode; }
 
-	/** Returns the Metal resource options used by this memory allocation. */
-	inline MTLResourceOptions getMTLResourceOptions() { return mvkMTLResourceOptions(_mtlStorageMode, _mtlCPUCacheMode); }
-
+    /** Returns the Metal resource options used by this memory allocation. */
+    inline MTLResourceOptions getMTLResourceOptions() {
+        return mvkMTLResourceOptions(_mtlStorageMode, _mtlCPUCacheMode);
+    }
 
 #pragma mark Construction
 
-	/** Constructs an instance for the specified device. */
-	MVKDeviceMemory(MVKDevice* device,
-					const VkMemoryAllocateInfo* pAllocateInfo,
-					const VkAllocationCallbacks* pAllocator);
+    /** Constructs an instance for the specified device. */
+    MVKDeviceMemory(MVKDevice* device,
+                    const VkMemoryAllocateInfo* pAllocateInfo,
+                    const VkAllocationCallbacks* pAllocator);
 
     ~MVKDeviceMemory() override;
 
-protected:
-	friend class MVKBuffer;
+  protected:
+    friend class MVKBuffer;
     friend class MVKImageMemoryBinding;
     friend class MVKImagePlane;
 
-	void propagateDebugName() override;
-	VkDeviceSize adjustMemorySize(VkDeviceSize size, VkDeviceSize offset);
-	VkResult addBuffer(MVKBuffer* mvkBuff);
-	void removeBuffer(MVKBuffer* mvkBuff);
-	VkResult addImageMemoryBinding(MVKImageMemoryBinding* mvkImg);
-	void removeImageMemoryBinding(MVKImageMemoryBinding* mvkImg);
-	bool ensureMTLHeap();
-	bool ensureMTLBuffer();
-	bool ensureHostMemory();
-	void freeHostMemory();
-	MVKResource* getDedicatedResource();
-	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
+    void propagateDebugName() override;
+    VkDeviceSize adjustMemorySize(VkDeviceSize size, VkDeviceSize offset);
+    VkResult addBuffer(MVKBuffer* mvkBuff);
+    void removeBuffer(MVKBuffer* mvkBuff);
+    VkResult addImageMemoryBinding(MVKImageMemoryBinding* mvkImg);
+    void removeImageMemoryBinding(MVKImageMemoryBinding* mvkImg);
+    bool ensureMTLHeap();
+    bool ensureMTLBuffer();
+    bool ensureHostMemory();
+    void freeHostMemory();
+    MVKResource* getDedicatedResource();
+    void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
 
-	MVKSmallVector<MVKBuffer*, 4> _buffers;
-	MVKSmallVector<MVKImageMemoryBinding*, 4> _imageMemoryBindings;
-	std::mutex _rezLock;
+    MVKSmallVector<MVKBuffer*, 4> _buffers;
+    MVKSmallVector<MVKImageMemoryBinding*, 4> _imageMemoryBindings;
+    std::mutex _rezLock;
     VkDeviceSize _allocationSize = 0;
-	MVKMappedMemoryRange _mappedRange;
-	id<MTLBuffer> _mtlBuffer = nil;
-	id<MTLHeap> _mtlHeap = nil;
-	void* _pMemory = nullptr;
-	void* _pHostMemory = nullptr;
-	VkMemoryPropertyFlags _vkMemPropFlags;
-	VkMemoryAllocateFlags _vkMemAllocFlags;
-	MTLStorageMode _mtlStorageMode;
-	MTLCPUCacheMode _mtlCPUCacheMode;
-	bool _isDedicated = false;
-	bool _isHostMemImported = false;
-
+    MVKMappedMemoryRange _mappedRange;
+    id<MTLBuffer> _mtlBuffer = nil;
+    id<MTLHeap> _mtlHeap = nil;
+    void* _pMemory = nullptr;
+    void* _pHostMemory = nullptr;
+    VkMemoryPropertyFlags _vkMemPropFlags;
+    VkMemoryAllocateFlags _vkMemAllocFlags;
+    MTLStorageMode _mtlStorageMode;
+    MTLCPUCacheMode _mtlCPUCacheMode;
+    bool _isDedicated = false;
+    bool _isHostMemImported = false;
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,409 +27,577 @@
 
 using namespace std;
 
-
 #pragma mark MVKDeviceMemory
 
 void MVKDeviceMemory::propagateDebugName() {
-	setMetalObjectLabel(_mtlHeap, _debugName);
-	setMetalObjectLabel(_mtlBuffer, _debugName);
+    setMetalObjectLabel(_mtlHeap, _debugName);
+    setMetalObjectLabel(_mtlBuffer, _debugName);
 }
 
-VkResult MVKDeviceMemory::map(const VkMemoryMapInfoKHR* pMemoryMapInfo, void** ppData) {
-	if ( !isMemoryHostAccessible() ) {
-		return reportError(VK_ERROR_MEMORY_MAP_FAILED, "Private GPU-only memory cannot be mapped to host memory.");
-	}
+VkResult MVKDeviceMemory::map(const VkMemoryMapInfoKHR* pMemoryMapInfo,
+                              void** ppData) {
+    if (!isMemoryHostAccessible()) {
+        return reportError(VK_ERROR_MEMORY_MAP_FAILED,
+                           "Private GPU-only memory cannot be mapped to host "
+                           "memory.");
+    }
 
-	if (isMapped()) {
-		return reportError(VK_ERROR_MEMORY_MAP_FAILED, "Memory is already mapped. Call vkUnmapMemory() first.");
-	}
+    if (isMapped()) {
+        return reportError(VK_ERROR_MEMORY_MAP_FAILED,
+                           "Memory is already mapped. Call vkUnmapMemory() "
+                           "first.");
+    }
 
-	if ( !ensureMTLBuffer() && !ensureHostMemory() ) {
-		return reportError(VK_ERROR_OUT_OF_HOST_MEMORY, "Could not allocate %llu bytes of host-accessible device memory.", _allocationSize);
-	}
+    if (!ensureMTLBuffer() && !ensureHostMemory()) {
+        return reportError(VK_ERROR_OUT_OF_HOST_MEMORY,
+                           "Could not allocate %llu bytes of host-accessible "
+                           "device memory.",
+                           _allocationSize);
+    }
 
-	_mappedRange.offset = pMemoryMapInfo->offset;
-	_mappedRange.size = adjustMemorySize(pMemoryMapInfo->size, pMemoryMapInfo->offset);
+    _mappedRange.offset = pMemoryMapInfo->offset;
+    _mappedRange.size =
+        adjustMemorySize(pMemoryMapInfo->size, pMemoryMapInfo->offset);
 
-	*ppData = (void*)((uintptr_t)_pMemory + pMemoryMapInfo->offset);
+    *ppData = (void*)((uintptr_t)_pMemory + pMemoryMapInfo->offset);
 
-	// Coherent memory does not require flushing by app, so we must flush now
-	// to support Metal textures that actually reside in non-coherent memory.
-	if (mvkIsAnyFlagEnabled(_vkMemPropFlags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-		pullFromDevice(pMemoryMapInfo->offset, pMemoryMapInfo->size);
-	}
+    // Coherent memory does not require flushing by app, so we must flush now
+    // to support Metal textures that actually reside in non-coherent memory.
+    if (mvkIsAnyFlagEnabled(_vkMemPropFlags,
+                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+        pullFromDevice(pMemoryMapInfo->offset, pMemoryMapInfo->size);
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 VkResult MVKDeviceMemory::unmap(const VkMemoryUnmapInfoKHR* pUnmapMemoryInfo) {
-	if ( !isMapped() ) {
-		return reportError(VK_ERROR_MEMORY_MAP_FAILED, "Memory is not mapped. Call vkMapMemory() first.");
-	}
+    if (!isMapped()) {
+        return reportError(VK_ERROR_MEMORY_MAP_FAILED,
+                           "Memory is not mapped. Call vkMapMemory() first.");
+    }
 
-	// Coherent memory does not require flushing by app, so we must flush now
-	// to support Metal textures that actually reside in non-coherent memory.
-	if (mvkIsAnyFlagEnabled(_vkMemPropFlags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
-		flushToDevice(_mappedRange.offset, _mappedRange.size);
-	}
+    // Coherent memory does not require flushing by app, so we must flush now
+    // to support Metal textures that actually reside in non-coherent memory.
+    if (mvkIsAnyFlagEnabled(_vkMemPropFlags,
+                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+        flushToDevice(_mappedRange.offset, _mappedRange.size);
+    }
 
-	_mappedRange.offset = 0;
-	_mappedRange.size = 0;
+    _mappedRange.offset = 0;
+    _mappedRange.size = 0;
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-VkResult MVKDeviceMemory::flushToDevice(VkDeviceSize offset, VkDeviceSize size) {
-	VkDeviceSize memSize = adjustMemorySize(size, offset);
-	if (memSize == 0 || !isMemoryHostAccessible()) { return VK_SUCCESS; }
-
-#if MVK_MACOS
-	if ( !isUnifiedMemoryGPU() && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {
-		[_mtlBuffer didModifyRange: NSMakeRange(offset, memSize)];
-	}
-#endif
-
-	// If we have an MTLHeap object, there's no need to sync memory manually between resources and the buffer.
-	if ( !_mtlHeap ) {
-		lock_guard<mutex> lock(_rezLock);
-		for (auto& img : _imageMemoryBindings) { img->flushToDevice(offset, memSize); }
-		for (auto& buf : _buffers) { buf->flushToDevice(offset, memSize); }
-	}
-
-	return VK_SUCCESS;
-}
-
-VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset,
-										 VkDeviceSize size,
-										 MVKMTLBlitEncoder* pBlitEnc) {
+VkResult MVKDeviceMemory::flushToDevice(VkDeviceSize offset,
+                                        VkDeviceSize size) {
     VkDeviceSize memSize = adjustMemorySize(size, offset);
-	if (memSize == 0 || !isMemoryHostAccessible()) { return VK_SUCCESS; }
+    if (memSize == 0 || !isMemoryHostAccessible()) {
+        return VK_SUCCESS;
+    }
 
 #if MVK_MACOS
-	if ( !isUnifiedMemoryGPU() && pBlitEnc && _mtlBuffer && _mtlStorageMode == MTLStorageModeManaged) {
-		if ( !pBlitEnc->mtlCmdBuffer) { pBlitEnc->mtlCmdBuffer = _device->getAnyQueue()->getMTLCommandBuffer(kMVKCommandUseInvalidateMappedMemoryRanges); }
-		if ( !pBlitEnc->mtlBlitEncoder) { pBlitEnc->mtlBlitEncoder = [pBlitEnc->mtlCmdBuffer blitCommandEncoder]; }
-		[pBlitEnc->mtlBlitEncoder synchronizeResource: _mtlBuffer];
-	}
+    if (!isUnifiedMemoryGPU() && _mtlBuffer &&
+        _mtlStorageMode == MTLStorageModeManaged) {
+        [_mtlBuffer didModifyRange:NSMakeRange(offset, memSize)];
+    }
 #endif
 
-	// If we have an MTLHeap object, there's no need to sync memory manually between resources and the buffer.
-	if ( !_mtlHeap ) {
-		lock_guard<mutex> lock(_rezLock);
-        for (auto& img : _imageMemoryBindings) { img->pullFromDevice(offset, memSize); }
-        for (auto& buf : _buffers) { buf->pullFromDevice(offset, memSize); }
-	}
+    // If we have an MTLHeap object, there's no need to sync memory manually
+    // between resources and the buffer.
+    if (!_mtlHeap) {
+        lock_guard<mutex> lock(_rezLock);
+        for (auto& img : _imageMemoryBindings) {
+            img->flushToDevice(offset, memSize);
+        }
+        for (auto& buf : _buffers) {
+            buf->flushToDevice(offset, memSize);
+        }
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-// If the size parameter is the special constant VK_WHOLE_SIZE, returns the size of memory
-// between offset and the end of the buffer, otherwise simply returns size.
-VkDeviceSize MVKDeviceMemory::adjustMemorySize(VkDeviceSize size, VkDeviceSize offset) {
-	return (size == VK_WHOLE_SIZE) ? (_allocationSize - offset) : size;
+VkResult MVKDeviceMemory::pullFromDevice(VkDeviceSize offset, VkDeviceSize size,
+                                         MVKMTLBlitEncoder* pBlitEnc) {
+    VkDeviceSize memSize = adjustMemorySize(size, offset);
+    if (memSize == 0 || !isMemoryHostAccessible()) {
+        return VK_SUCCESS;
+    }
+
+#if MVK_MACOS
+    if (!isUnifiedMemoryGPU() && pBlitEnc && _mtlBuffer &&
+        _mtlStorageMode == MTLStorageModeManaged) {
+        if (!pBlitEnc->mtlCmdBuffer) {
+            pBlitEnc->mtlCmdBuffer =
+                _device->getAnyQueue()->getMTLCommandBuffer(
+                    kMVKCommandUseInvalidateMappedMemoryRanges);
+        }
+        if (!pBlitEnc->mtlBlitEncoder) {
+            pBlitEnc->mtlBlitEncoder =
+                [pBlitEnc->mtlCmdBuffer blitCommandEncoder];
+        }
+        [pBlitEnc->mtlBlitEncoder synchronizeResource:_mtlBuffer];
+    }
+#endif
+
+    // If we have an MTLHeap object, there's no need to sync memory manually
+    // between resources and the buffer.
+    if (!_mtlHeap) {
+        lock_guard<mutex> lock(_rezLock);
+        for (auto& img : _imageMemoryBindings) {
+            img->pullFromDevice(offset, memSize);
+        }
+        for (auto& buf : _buffers) {
+            buf->pullFromDevice(offset, memSize);
+        }
+    }
+
+    return VK_SUCCESS;
+}
+
+// If the size parameter is the special constant VK_WHOLE_SIZE, returns the size
+// of memory between offset and the end of the buffer, otherwise simply returns
+// size.
+VkDeviceSize MVKDeviceMemory::adjustMemorySize(VkDeviceSize size,
+                                               VkDeviceSize offset) {
+    return (size == VK_WHOLE_SIZE) ? (_allocationSize - offset) : size;
 }
 
 VkResult MVKDeviceMemory::addBuffer(MVKBuffer* mvkBuff) {
-	lock_guard<mutex> lock(_rezLock);
+    lock_guard<mutex> lock(_rezLock);
 
-	// If a dedicated alloc, ensure this buffer is the one and only buffer
-	// I am dedicated to.
-	if (_isDedicated && (_buffers.empty() || _buffers[0] != mvkBuff) ) {
-		return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "Could not bind VkBuffer %p to a VkDeviceMemory dedicated to resource %p. A dedicated allocation may only be used with the resource it was dedicated to.", mvkBuff, getDedicatedResource() );
-	}
+    // If a dedicated alloc, ensure this buffer is the one and only buffer
+    // I am dedicated to.
+    if (_isDedicated && (_buffers.empty() || _buffers[0] != mvkBuff)) {
+        return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                           "Could not bind VkBuffer %p to a VkDeviceMemory "
+                           "dedicated to resource %p. A dedicated "
+                           "allocation may only be used with the resource it "
+                           "was dedicated to.",
+                           mvkBuff, getDedicatedResource());
+    }
 
-	if (!ensureMTLBuffer() ) {
-		return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "Could not bind a VkBuffer to a VkDeviceMemory of size %llu bytes. The maximum memory-aligned size of a VkDeviceMemory that supports a VkBuffer is %llu bytes.", _allocationSize, getMetalFeatures().maxMTLBufferSize);
-	}
+    if (!ensureMTLBuffer()) {
+        return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                           "Could not bind a VkBuffer to a VkDeviceMemory of "
+                           "size %llu bytes. The maximum "
+                           "memory-aligned size of a VkDeviceMemory that "
+                           "supports a VkBuffer is %llu bytes.",
+                           _allocationSize,
+                           getMetalFeatures().maxMTLBufferSize);
+    }
 
-	// In the dedicated case, we already saved the buffer we're going to use.
-	if (!_isDedicated) { _buffers.push_back(mvkBuff); }
+    // In the dedicated case, we already saved the buffer we're going to use.
+    if (!_isDedicated) {
+        _buffers.push_back(mvkBuff);
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 void MVKDeviceMemory::removeBuffer(MVKBuffer* mvkBuff) {
-	lock_guard<mutex> lock(_rezLock);
-	mvkRemoveAllOccurances(_buffers, mvkBuff);
+    lock_guard<mutex> lock(_rezLock);
+    mvkRemoveAllOccurances(_buffers, mvkBuff);
 }
 
 VkResult MVKDeviceMemory::addImageMemoryBinding(MVKImageMemoryBinding* mvkImg) {
-	lock_guard<mutex> lock(_rezLock);
+    lock_guard<mutex> lock(_rezLock);
 
-	// If a dedicated alloc, ensure this image is the one and only image
-	// I am dedicated to. If my image is aliasable, though, allow other aliasable
-	// images to bind to me.
-	if (_isDedicated && (_imageMemoryBindings.empty() || !(mvkContains(_imageMemoryBindings, mvkImg) || (_imageMemoryBindings[0]->_image->getIsAliasable() && mvkImg->_image->getIsAliasable()))) ) {
-		return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "Could not bind VkImage %p to a VkDeviceMemory dedicated to resource %p. A dedicated allocation may only be used with the resource it was dedicated to.", mvkImg, getDedicatedResource() );
-	}
+    // If a dedicated alloc, ensure this image is the one and only image
+    // I am dedicated to. If my image is aliasable, though, allow other
+    // aliasable images to bind to me.
+    if (_isDedicated && (_imageMemoryBindings.empty() ||
+                         !(mvkContains(_imageMemoryBindings, mvkImg) ||
+                           (_imageMemoryBindings[0]->_image->getIsAliasable() &&
+                            mvkImg->_image->getIsAliasable())))) {
+        return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                           "Could not bind VkImage %p to a VkDeviceMemory "
+                           "dedicated to resource %p. A dedicated "
+                           "allocation may only be used with the resource it "
+                           "was dedicated to.",
+                           mvkImg, getDedicatedResource());
+    }
 
-	if (!_isDedicated) { _imageMemoryBindings.push_back(mvkImg); }
+    if (!_isDedicated) {
+        _imageMemoryBindings.push_back(mvkImg);
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 void MVKDeviceMemory::removeImageMemoryBinding(MVKImageMemoryBinding* mvkImg) {
-	lock_guard<mutex> lock(_rezLock);
-	mvkRemoveAllOccurances(_imageMemoryBindings, mvkImg);
+    lock_guard<mutex> lock(_rezLock);
+    mvkRemoveAllOccurances(_imageMemoryBindings, mvkImg);
 }
 
 // Ensures that this instance is backed by a MTLHeap object,
 // creating the MTLHeap if needed, and returns whether it was successful.
 bool MVKDeviceMemory::ensureMTLHeap() {
 
-	if (_mtlHeap) { return true; }
+    if (_mtlHeap) {
+        return true;
+    }
 
-	// Can't create a MTLHeap on imported memory
-	if (_isHostMemImported) { return true; }
+    // Can't create a MTLHeap on imported memory
+    if (_isHostMemImported) {
+        return true;
+    }
 
-	// Don't bother if we don't have placement heaps.
-	if (!getMetalFeatures().placementHeaps) { return true; }
+    // Don't bother if we don't have placement heaps.
+    if (!getMetalFeatures().placementHeaps) {
+        return true;
+    }
 
-	// Can't create MTLHeaps of zero size.
-	if (_allocationSize == 0) { return true; }
+    // Can't create MTLHeaps of zero size.
+    if (_allocationSize == 0) {
+        return true;
+    }
 
 #if MVK_MACOS
-	// MTLHeaps on macOS must use private storage for now.
-	if (_mtlStorageMode != MTLStorageModePrivate) { return true; }
+    // MTLHeaps on macOS must use private storage for now.
+    if (_mtlStorageMode != MTLStorageModePrivate) {
+        return true;
+    }
 #endif
 #if MVK_IOS
-	// MTLHeaps on iOS must use private or shared storage for now.
-	if ( !(_mtlStorageMode == MTLStorageModePrivate ||
-		   _mtlStorageMode == MTLStorageModeShared) ) { return true; }
+    // MTLHeaps on iOS must use private or shared storage for now.
+    if (!(_mtlStorageMode == MTLStorageModePrivate ||
+          _mtlStorageMode == MTLStorageModeShared)) {
+        return true;
+    }
 #endif
 
-	MTLHeapDescriptor* heapDesc = [MTLHeapDescriptor new];
-	heapDesc.type = MTLHeapTypePlacement;
-	heapDesc.storageMode = _mtlStorageMode;
-	heapDesc.cpuCacheMode = _mtlCPUCacheMode;
-	// For now, use tracked resources. Later, we should probably default
-	// to untracked, since Vulkan uses explicit barriers anyway.
-	heapDesc.hazardTrackingMode = MTLHazardTrackingModeTracked;
-	heapDesc.size = _allocationSize;
-	_mtlHeap = [getMTLDevice() newHeapWithDescriptor: heapDesc];	// retained
-	[heapDesc release];
-	if (!_mtlHeap) { return false; }
+    MTLHeapDescriptor* heapDesc = [MTLHeapDescriptor new];
+    heapDesc.type = MTLHeapTypePlacement;
+    heapDesc.storageMode = _mtlStorageMode;
+    heapDesc.cpuCacheMode = _mtlCPUCacheMode;
+    // For now, use tracked resources. Later, we should probably default
+    // to untracked, since Vulkan uses explicit barriers anyway.
+    heapDesc.hazardTrackingMode = MTLHazardTrackingModeTracked;
+    heapDesc.size = _allocationSize;
+    _mtlHeap = [getMTLDevice() newHeapWithDescriptor:heapDesc]; // retained
+    [heapDesc release];
+    if (!_mtlHeap) {
+        return false;
+    }
 
-	propagateDebugName();
+    propagateDebugName();
 
-	return true;
+    return true;
 }
 
 // Ensures that this instance is backed by a MTLBuffer object,
 // creating the MTLBuffer if needed, and returns whether it was successful.
 bool MVKDeviceMemory::ensureMTLBuffer() {
 
-	if (_mtlBuffer) { return true; }
+    if (_mtlBuffer) {
+        return true;
+    }
 
-	NSUInteger memLen = mvkAlignByteCount(_allocationSize, getMetalFeatures().mtlBufferAlignment);
+    NSUInteger memLen =
+        mvkAlignByteCount(_allocationSize,
+                          getMetalFeatures().mtlBufferAlignment);
 
-	if (memLen > getMetalFeatures().maxMTLBufferSize) { return false; }
+    if (memLen > getMetalFeatures().maxMTLBufferSize) {
+        return false;
+    }
 
-	// If host memory was already allocated, it is copied into the new MTLBuffer, and then released.
-	if (_mtlHeap) {
-		_mtlBuffer = [_mtlHeap newBufferWithLength: memLen options: getMTLResourceOptions() offset: 0];	// retained
-		if (_pHostMemory) {
-			memcpy(_mtlBuffer.contents, _pHostMemory, memLen);
-			freeHostMemory();
-		}
-		[_mtlBuffer makeAliasable];
-	} else if (_pHostMemory) {
-		auto rezOpts = getMTLResourceOptions();
-		if (_isHostMemImported) {
-			_mtlBuffer = [getMTLDevice() newBufferWithBytesNoCopy: _pHostMemory length: memLen options: rezOpts deallocator: nil];	// retained
-		} else {
-			_mtlBuffer = [getMTLDevice() newBufferWithBytes: _pHostMemory length: memLen options: rezOpts];     // retained
-		}
-		freeHostMemory();
-	} else {
-		_mtlBuffer = [getMTLDevice() newBufferWithLength: memLen options: getMTLResourceOptions()];     // retained
-	}
-	if (!_mtlBuffer) { return false; }
-	_pMemory = isMemoryHostAccessible() ? _mtlBuffer.contents : nullptr;
+    // If host memory was already allocated, it is copied into the new
+    // MTLBuffer, and then released.
+    if (_mtlHeap) {
+        _mtlBuffer = [_mtlHeap newBufferWithLength:memLen
+                                           options:getMTLResourceOptions()
+                                            offset:0]; // retained
+        if (_pHostMemory) {
+            memcpy(_mtlBuffer.contents, _pHostMemory, memLen);
+            freeHostMemory();
+        }
+        [_mtlBuffer makeAliasable];
+    } else if (_pHostMemory) {
+        auto rezOpts = getMTLResourceOptions();
+        if (_isHostMemImported) {
+            _mtlBuffer =
+                [getMTLDevice() newBufferWithBytesNoCopy:_pHostMemory
+                                                  length:memLen
+                                                 options:rezOpts
+                                             deallocator:nil]; // retained
+        } else {
+            _mtlBuffer =
+                [getMTLDevice() newBufferWithBytes:_pHostMemory
+                                            length:memLen
+                                           options:rezOpts]; // retained
+        }
+        freeHostMemory();
+    } else {
+        _mtlBuffer = [getMTLDevice()
+            newBufferWithLength:memLen
+                        options:getMTLResourceOptions()]; // retained
+    }
+    if (!_mtlBuffer) {
+        return false;
+    }
+    _pMemory = isMemoryHostAccessible() ? _mtlBuffer.contents : nullptr;
 
-	propagateDebugName();
+    propagateDebugName();
 
-	return true;
+    return true;
 }
 
 // Ensures that host-accessible memory is available, allocating it if necessary.
 bool MVKDeviceMemory::ensureHostMemory() {
 
-	if (_pMemory) { return true; }
+    if (_pMemory) {
+        return true;
+    }
 
-	if ( !_pHostMemory) {
-		size_t memAlign = getMetalFeatures().mtlBufferAlignment;
-		NSUInteger memLen = mvkAlignByteCount(_allocationSize, memAlign);
-		int err = posix_memalign(&_pHostMemory, memAlign, memLen);
-		if (err) { return false; }
-	}
+    if (!_pHostMemory) {
+        size_t memAlign = getMetalFeatures().mtlBufferAlignment;
+        NSUInteger memLen = mvkAlignByteCount(_allocationSize, memAlign);
+        int err = posix_memalign(&_pHostMemory, memAlign, memLen);
+        if (err) {
+            return false;
+        }
+    }
 
-	_pMemory = _pHostMemory;
+    _pMemory = _pHostMemory;
 
-	return true;
+    return true;
 }
 
 void MVKDeviceMemory::freeHostMemory() {
-	if ( !_isHostMemImported ) { free(_pHostMemory); }
-	_pHostMemory = nullptr;
+    if (!_isHostMemImported) {
+        free(_pHostMemory);
+    }
+    _pHostMemory = nullptr;
 }
 
 MVKResource* MVKDeviceMemory::getDedicatedResource() {
-	MVKAssert(_isDedicated, "This method should only be called on dedicated allocations!");
-	return _buffers.empty() ? (MVKResource*)_imageMemoryBindings[0] : (MVKResource*)_buffers[0];
+    MVKAssert(_isDedicated,
+              "This method should only be called on dedicated allocations!");
+    return _buffers.empty() ? (MVKResource*)_imageMemoryBindings[0]
+                            : (MVKResource*)_buffers[0];
 }
 
 MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
-								 const VkMemoryAllocateInfo* pAllocateInfo,
-								 const VkAllocationCallbacks* pAllocator) : MVKVulkanAPIDeviceObject(device) {
-	// Set Metal memory parameters
-	_vkMemAllocFlags = 0;
-	_vkMemPropFlags = getDeviceMemoryProperties().memoryTypes[pAllocateInfo->memoryTypeIndex].propertyFlags;
-	_mtlStorageMode = getPhysicalDevice()->getMTLStorageModeFromVkMemoryPropertyFlags(_vkMemPropFlags);
-	_mtlCPUCacheMode = mvkMTLCPUCacheModeFromVkMemoryPropertyFlags(_vkMemPropFlags);
+                                 const VkMemoryAllocateInfo* pAllocateInfo,
+                                 const VkAllocationCallbacks* pAllocator)
+    : MVKVulkanAPIDeviceObject(device) {
+    // Set Metal memory parameters
+    _vkMemAllocFlags = 0;
+    _vkMemPropFlags = getDeviceMemoryProperties()
+                          .memoryTypes[pAllocateInfo->memoryTypeIndex]
+                          .propertyFlags;
+    _mtlStorageMode =
+        getPhysicalDevice()->getMTLStorageModeFromVkMemoryPropertyFlags(
+            _vkMemPropFlags);
+    _mtlCPUCacheMode =
+        mvkMTLCPUCacheModeFromVkMemoryPropertyFlags(_vkMemPropFlags);
 
-	_allocationSize = pAllocateInfo->allocationSize;
+    _allocationSize = pAllocateInfo->allocationSize;
 
-	bool willExportMTLBuffer = false;
-	VkImage dedicatedImage = VK_NULL_HANDLE;
-	VkBuffer dedicatedBuffer = VK_NULL_HANDLE;
-	VkExternalMemoryHandleTypeFlags handleTypes = 0;
-	for (const auto* next = (const VkBaseInStructure*)pAllocateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO: {
-				auto* pDedicatedInfo = (VkMemoryDedicatedAllocateInfo*)next;
-				dedicatedImage = pDedicatedInfo->image;
-				dedicatedBuffer = pDedicatedInfo->buffer;
-				_isDedicated = dedicatedImage || dedicatedBuffer;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT: {
-				auto* pMemHostPtrInfo = (VkImportMemoryHostPointerInfoEXT*)next;
-				if (mvkIsAnyFlagEnabled(_vkMemPropFlags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
-					switch (pMemHostPtrInfo->handleType) {
-						case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
-						case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
-							_pHostMemory = pMemHostPtrInfo->pHostPointer;
-							_isHostMemImported = true;
-							break;
-						default:
-							break;
-					}
-				} else {
-					setConfigurationResult(reportError(VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR, "vkAllocateMemory(): Imported memory must be host-visible."));
-				}
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO: {
-				auto* pExpMemInfo = (VkExportMemoryAllocateInfo*)next;
-				handleTypes = pExpMemInfo->handleTypes;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMPORT_METAL_BUFFER_INFO_EXT: {
-				// Setting Metal objects directly will override Vulkan settings.
-				// It is responsibility of app to ensure these are consistent. Not doing so results in undefined behavior.
-				const auto* pMTLBuffInfo = (VkImportMetalBufferInfoEXT*)next;
-				[_mtlBuffer release];							// guard against dups
-				_mtlBuffer = [pMTLBuffInfo->mtlBuffer retain];	// retained
-				_mtlStorageMode = _mtlBuffer.storageMode;
-				_mtlCPUCacheMode = _mtlBuffer.cpuCacheMode;
-				_allocationSize = _mtlBuffer.length;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT: {
-				const auto* pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
-				willExportMTLBuffer = pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT;
-			}
-			case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO: {
-				auto* pMemAllocFlagsInfo = (VkMemoryAllocateFlagsInfo*)next;
-				_vkMemAllocFlags = pMemAllocFlagsInfo->flags;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    bool willExportMTLBuffer = false;
+    VkImage dedicatedImage = VK_NULL_HANDLE;
+    VkBuffer dedicatedBuffer = VK_NULL_HANDLE;
+    VkExternalMemoryHandleTypeFlags handleTypes = 0;
+    for (const auto* next = (const VkBaseInStructure*)pAllocateInfo->pNext;
+         next; next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO: {
+            auto* pDedicatedInfo = (VkMemoryDedicatedAllocateInfo*)next;
+            dedicatedImage = pDedicatedInfo->image;
+            dedicatedBuffer = pDedicatedInfo->buffer;
+            _isDedicated = dedicatedImage || dedicatedBuffer;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT: {
+            auto* pMemHostPtrInfo = (VkImportMemoryHostPointerInfoEXT*)next;
+            if (mvkIsAnyFlagEnabled(_vkMemPropFlags,
+                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+                switch (pMemHostPtrInfo->handleType) {
+                case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT:
+                case VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT:
+                    _pHostMemory = pMemHostPtrInfo->pHostPointer;
+                    _isHostMemImported = true;
+                    break;
+                default:
+                    break;
+                }
+            } else {
+                setConfigurationResult(
+                    reportError(VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR,
+                                "vkAllocateMemory(): Imported memory must be "
+                                "host-visible."));
+            }
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO: {
+            auto* pExpMemInfo = (VkExportMemoryAllocateInfo*)next;
+            handleTypes = pExpMemInfo->handleTypes;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_BUFFER_INFO_EXT: {
+            // Setting Metal objects directly will override Vulkan settings.
+            // It is responsibility of app to ensure these are consistent. Not
+            // doing so results in undefined behavior.
+            const auto* pMTLBuffInfo = (VkImportMetalBufferInfoEXT*)next;
+            [_mtlBuffer release];                          // guard against dups
+            _mtlBuffer = [pMTLBuffInfo->mtlBuffer retain]; // retained
+            _mtlStorageMode = _mtlBuffer.storageMode;
+            _mtlCPUCacheMode = _mtlBuffer.cpuCacheMode;
+            _allocationSize = _mtlBuffer.length;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT: {
+            const auto* pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
+            willExportMTLBuffer =
+                pExportInfo->exportObjectType ==
+                VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT;
+        }
+        case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO: {
+            auto* pMemAllocFlagsInfo = (VkMemoryAllocateFlagsInfo*)next;
+            _vkMemAllocFlags = pMemAllocFlagsInfo->flags;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	initExternalMemory(handleTypes);	// After setting _isDedicated
+    initExternalMemory(handleTypes); // After setting _isDedicated
 
-	// "Dedicated" means this memory can only be used for this image or buffer.
-	if (dedicatedImage) {
+    // "Dedicated" means this memory can only be used for this image or buffer.
+    if (dedicatedImage) {
 #if MVK_MACOS
-		if (isMemoryHostCoherent() ) {
-			if (!((MVKImage*)dedicatedImage)->_isLinear) {
-				setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Host-coherent VkDeviceMemory objects cannot be associated with optimal-tiling images."));
-			} else {
-				if (!getMetalFeatures().sharedLinearTextures) {
-					// Need to use the managed mode for images.
-					_mtlStorageMode = MTLStorageModeManaged;
-				}
-				// Nonetheless, we need a buffer to be able to map the memory at will.
-				if (!ensureMTLBuffer() ) {
-					setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Could not allocate a host-coherent VkDeviceMemory of size %llu bytes. The maximum memory-aligned size of a host-coherent VkDeviceMemory is %llu bytes.", _allocationSize, getMetalFeatures().maxMTLBufferSize));
-				}
-			}
-		}
+        if (isMemoryHostCoherent()) {
+            if (!((MVKImage*)dedicatedImage)->_isLinear) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                                "vkAllocateMemory(): Host-coherent "
+                                "VkDeviceMemory objects cannot be "
+                                "associated with optimal-tiling images."));
+            } else {
+                if (!getMetalFeatures().sharedLinearTextures) {
+                    // Need to use the managed mode for images.
+                    _mtlStorageMode = MTLStorageModeManaged;
+                }
+                // Nonetheless, we need a buffer to be able to map the memory at
+                // will.
+                if (!ensureMTLBuffer()) {
+                    setConfigurationResult(reportError(
+                        VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                        "vkAllocateMemory(): Could not allocate a "
+                        "host-coherent "
+                        "VkDeviceMemory of size %llu bytes. The maximum "
+                        "memory-aligned "
+                        "size of a host-coherent VkDeviceMemory is %llu bytes.",
+                        _allocationSize, getMetalFeatures().maxMTLBufferSize));
+                }
+            }
+        }
 #endif
-        for (auto& memoryBinding : ((MVKImage*)dedicatedImage)->_memoryBindings) {
+        for (auto& memoryBinding :
+             ((MVKImage*)dedicatedImage)->_memoryBindings) {
             _imageMemoryBindings.push_back(memoryBinding);
         }
-		return;
-	}
+        return;
+    }
 
-	if (dedicatedBuffer) {
-		_buffers.push_back((MVKBuffer*)dedicatedBuffer);
-	}
+    if (dedicatedBuffer) {
+        _buffers.push_back((MVKBuffer*)dedicatedBuffer);
+    }
 
-	// If we can, create a MTLHeap. This should happen before creating the buffer, allowing us to map its contents.
-	if ( !_isDedicated ) {
-		if (!ensureMTLHeap()) {
-			setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Could not allocate VkDeviceMemory of size %llu bytes.", _allocationSize));
-			return;
-		}
-	}
+    // If we can, create a MTLHeap. This should happen before creating the
+    // buffer, allowing us to map its contents.
+    if (!_isDedicated) {
+        if (!ensureMTLHeap()) {
+            setConfigurationResult(
+                reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                            "vkAllocateMemory(): Could not allocate "
+                            "VkDeviceMemory of size %llu bytes.",
+                            _allocationSize));
+            return;
+        }
+    }
 
-	// If memory needs to be coherent it must reside in a MTLBuffer, since an open-ended map() must work.
-	// If memory was imported, a MTLBuffer must be created on it.
-	// Or if a MTLBuffer will be exported, ensure it exists.
-	if ((isMemoryHostCoherent() || _isHostMemImported || willExportMTLBuffer) && !ensureMTLBuffer() ) {
-		setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Could not allocate a host-coherent or exportable VkDeviceMemory of size %llu bytes. The maximum memory-aligned size of a host-coherent VkDeviceMemory is %llu bytes.", _allocationSize, getMetalFeatures().maxMTLBufferSize));
-	}
+    // If memory needs to be coherent it must reside in a MTLBuffer, since an
+    // open-ended map() must work. If memory was imported, a MTLBuffer must be
+    // created on it. Or if a MTLBuffer will be exported, ensure it exists.
+    if ((isMemoryHostCoherent() || _isHostMemImported || willExportMTLBuffer) &&
+        !ensureMTLBuffer()) {
+        setConfigurationResult(
+            reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                        "vkAllocateMemory(): Could not allocate a "
+                        "host-coherent or exportable VkDeviceMemory of size "
+                        "%llu bytes. The maximum memory-aligned size of a "
+                        "host-coherent VkDeviceMemory is %llu bytes.",
+                        _allocationSize, getMetalFeatures().maxMTLBufferSize));
+    }
 }
 
-void MVKDeviceMemory::initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes) {
-	if ( !handleTypes ) { return; }
-	
-	if ( !mvkIsOnlyAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR | VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkAllocateMemory(): Only external memory handle types VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR or VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR are supported."));
-	}
+void MVKDeviceMemory::initExternalMemory(
+    VkExternalMemoryHandleTypeFlags handleTypes) {
+    if (!handleTypes) {
+        return;
+    }
 
-	bool requiresDedicated = false;
-	if (mvkIsAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
-		auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
-		requiresDedicated = requiresDedicated || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
-	}
-	if (mvkIsAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
-		auto& xmProps = getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
-		requiresDedicated = requiresDedicated || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
-	}
-	if (requiresDedicated && !_isDedicated) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkAllocateMemory(): External memory requires a dedicated VkBuffer or VkImage."));
-	}
+    if (!mvkIsOnlyAnyFlagEnabled(
+            handleTypes,
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR |
+                VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "vkAllocateMemory(): Only external memory handle types "
+                        "VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR or "
+                        "VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR are "
+                        "supported."));
+    }
+
+    bool requiresDedicated = false;
+    if (mvkIsAnyFlagEnabled(handleTypes,
+                            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR)) {
+        auto& xmProps = getPhysicalDevice()->getExternalBufferProperties(
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_KHR);
+        requiresDedicated =
+            requiresDedicated ||
+            mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures,
+                                VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+    }
+    if (mvkIsAnyFlagEnabled(
+            handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
+        auto& xmProps = getPhysicalDevice()->getExternalImageProperties(
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
+        requiresDedicated =
+            requiresDedicated ||
+            mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures,
+                                VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+    }
+    if (requiresDedicated && !_isDedicated) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "vkAllocateMemory(): External memory requires a "
+                        "dedicated VkBuffer or VkImage."));
+    }
 }
 
 MVKDeviceMemory::~MVKDeviceMemory() {
     // Unbind any resources that are using me. Iterate a copy of the collection,
     // to allow the resource to callback to remove itself from the collection.
     auto buffCopies = _buffers;
-    for (auto& buf : buffCopies) { buf->bindDeviceMemory(nullptr, 0); }
-	auto imgCopies = _imageMemoryBindings;
-	for (auto& img : imgCopies) { img->bindDeviceMemory(nullptr, 0); }
+    for (auto& buf : buffCopies) {
+        buf->bindDeviceMemory(nullptr, 0);
+    }
+    auto imgCopies = _imageMemoryBindings;
+    for (auto& img : imgCopies) {
+        img->bindDeviceMemory(nullptr, 0);
+    }
 
-	[_mtlBuffer release];
-	_mtlBuffer = nil;
+    [_mtlBuffer release];
+    _mtlBuffer = nil;
 
-	[_mtlHeap release];
-	_mtlHeap = nil;
+    [_mtlHeap release];
+    _mtlHeap = nil;
 
-	freeHostMemory();
+    freeHostMemory();
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,49 +25,55 @@
 
 class MVKRenderSubpass;
 
-
 #pragma mark MVKFramebuffer
 
 /** Represents a Vulkan framebuffer. */
 class MVKFramebuffer : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_FRAMEBUFFER;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_FRAMEBUFFER; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT; }
+    /** Returns the dimensions of this framebuffer. */
+    VkExtent2D getExtent2D() { return _extent; }
 
-	/** Returns the dimensions of this framebuffer. */
-	VkExtent2D getExtent2D() { return _extent; }
+    /** Returns the layers covered by this framebuffer. */
+    uint32_t getLayerCount() { return _layerCount; }
 
-	/** Returns the layers covered by this framebuffer. */
-	uint32_t getLayerCount() { return _layerCount; }
+    /** Returns the attachments.  */
+    MVKArrayRef<MVKImageView*> getAttachments() {
+        return _attachments.contents();
+    }
 
-	/** Returns the attachments.  */
-	MVKArrayRef<MVKImageView*> getAttachments() { return _attachments.contents(); }
-
-	/**
-	 * Returns a MTLTexture for use as a dummy texture when a render subpass,
-	 * that is compatible with the specified subpass, has no attachments.
-	 */
-	id<MTLTexture> getDummyAttachmentMTLTexture(MVKRenderSubpass* subpass, uint32_t passIdx);
+    /**
+     * Returns a MTLTexture for use as a dummy texture when a render subpass,
+     * that is compatible with the specified subpass, has no attachments.
+     */
+    id<MTLTexture> getDummyAttachmentMTLTexture(MVKRenderSubpass* subpass,
+                                                uint32_t passIdx);
 
 #pragma mark Construction
 
-	MVKFramebuffer(MVKDevice* device, const VkFramebufferCreateInfo* pCreateInfo);
+    MVKFramebuffer(MVKDevice* device,
+                   const VkFramebufferCreateInfo* pCreateInfo);
 
-	MVKFramebuffer(MVKDevice* device, const VkRenderingInfo* pRenderingInfo);
+    MVKFramebuffer(MVKDevice* device, const VkRenderingInfo* pRenderingInfo);
 
-	~MVKFramebuffer() override;
+    ~MVKFramebuffer() override;
 
-protected:
-	void propagateDebugName() override {}
+  protected:
+    void propagateDebugName() override {}
 
-	MVKSmallVector<MVKImageView*, 4> _attachments;
-	id<MTLTexture> _mtlDummyTex = nil;
-	std::mutex _lock;
-	VkExtent2D _extent;
-	uint32_t _layerCount;
+    MVKSmallVector<MVKImageView*, 4> _attachments;
+    id<MTLTexture> _mtlDummyTex = nil;
+    std::mutex _lock;
+    VkExtent2D _extent;
+    uint32_t _layerCount;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,94 +21,114 @@
 
 using namespace std;
 
-
 #pragma mark MVKFramebuffer
 
-id<MTLTexture> MVKFramebuffer::getDummyAttachmentMTLTexture(MVKRenderSubpass* subpass, uint32_t passIdx) {
-	if (_mtlDummyTex) { return _mtlDummyTex; }
+id<MTLTexture>
+MVKFramebuffer::getDummyAttachmentMTLTexture(MVKRenderSubpass* subpass,
+                                             uint32_t passIdx) {
+    if (_mtlDummyTex) {
+        return _mtlDummyTex;
+    }
 
-	// Lock and check again in case another thread has created the texture.
-	lock_guard<mutex> lock(_lock);
-	if (_mtlDummyTex) { return _mtlDummyTex; }
+    // Lock and check again in case another thread has created the texture.
+    lock_guard<mutex> lock(_lock);
+    if (_mtlDummyTex) {
+        return _mtlDummyTex;
+    }
 
-	VkExtent2D fbExtent = getExtent2D();
-	uint32_t fbLayerCount = getLayerCount();
-	uint32_t sampleCount = mvkSampleCountFromVkSampleCountFlagBits(subpass->getDefaultSampleCount());
-	MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: MTLPixelFormatR8Unorm width: fbExtent.width height: fbExtent.height mipmapped: NO];
-	if (subpass->isMultiview()) {
+    VkExtent2D fbExtent = getExtent2D();
+    uint32_t fbLayerCount = getLayerCount();
+    uint32_t sampleCount = mvkSampleCountFromVkSampleCountFlagBits(
+        subpass->getDefaultSampleCount());
+    MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor
+        texture2DDescriptorWithPixelFormat:MTLPixelFormatR8Unorm
+                                     width:fbExtent.width
+                                    height:fbExtent.height
+                                 mipmapped:NO];
+    if (subpass->isMultiview()) {
 #if MVK_MACOS_OR_IOS
-		if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
-			mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
-			mtlTexDesc.sampleCount = sampleCount;
-		} else {
-			mtlTexDesc.textureType = MTLTextureType2DArray;
-		}
+        if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
+            mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
+            mtlTexDesc.sampleCount = sampleCount;
+        } else {
+            mtlTexDesc.textureType = MTLTextureType2DArray;
+        }
 #else
-		mtlTexDesc.textureType = MTLTextureType2DArray;
+        mtlTexDesc.textureType = MTLTextureType2DArray;
 #endif
-		mtlTexDesc.arrayLength = subpass->getViewCountInMetalPass(passIdx);
-	} else if (fbLayerCount > 1) {
+        mtlTexDesc.arrayLength = subpass->getViewCountInMetalPass(passIdx);
+    } else if (fbLayerCount > 1) {
 #if MVK_MACOS
-		if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
-			mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
-			mtlTexDesc.sampleCount = sampleCount;
-		} else {
-			mtlTexDesc.textureType = MTLTextureType2DArray;
-		}
+        if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
+            mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
+            mtlTexDesc.sampleCount = sampleCount;
+        } else {
+            mtlTexDesc.textureType = MTLTextureType2DArray;
+        }
 #else
-		mtlTexDesc.textureType = MTLTextureType2DArray;
+        mtlTexDesc.textureType = MTLTextureType2DArray;
 #endif
-		mtlTexDesc.arrayLength = fbLayerCount;
-	} else if (sampleCount > 1) {
-		mtlTexDesc.textureType = MTLTextureType2DMultisample;
-		mtlTexDesc.sampleCount = sampleCount;
-	}
+        mtlTexDesc.arrayLength = fbLayerCount;
+    } else if (sampleCount > 1) {
+        mtlTexDesc.textureType = MTLTextureType2DMultisample;
+        mtlTexDesc.sampleCount = sampleCount;
+    }
 #if !MVK_MACOS || MVK_XCODE_12
-	mtlTexDesc.storageMode = MTLStorageModeMemoryless;
+    mtlTexDesc.storageMode = MTLStorageModeMemoryless;
 #else
-	mtlTexDesc.storageMode = MTLStorageModePrivate;
+    mtlTexDesc.storageMode = MTLStorageModePrivate;
 #endif
-	mtlTexDesc.usage = MTLTextureUsageRenderTarget;
+    mtlTexDesc.usage = MTLTextureUsageRenderTarget;
 
-	_mtlDummyTex = [getMTLDevice() newTextureWithDescriptor: mtlTexDesc];	// retained
-	[_mtlDummyTex setPurgeableState: MTLPurgeableStateVolatile];
+    _mtlDummyTex =
+        [getMTLDevice() newTextureWithDescriptor:mtlTexDesc]; // retained
+    [_mtlDummyTex setPurgeableState:MTLPurgeableStateVolatile];
 
-	return _mtlDummyTex;
+    return _mtlDummyTex;
 }
 
 MVKFramebuffer::MVKFramebuffer(MVKDevice* device,
-							   const VkFramebufferCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	_layerCount = pCreateInfo->layers;
-    _extent = { .width = pCreateInfo->width, .height = pCreateInfo->height };
+                               const VkFramebufferCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    _layerCount = pCreateInfo->layers;
+    _extent = {.width = pCreateInfo->width, .height = pCreateInfo->height};
 
-	// If this is not an image-less framebuffer, add the attachments
-	if ( !mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) ) {
-		_attachments.reserve(pCreateInfo->attachmentCount);
-		for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
-			_attachments.push_back((MVKImageView*)pCreateInfo->pAttachments[i]);
-		}
-	}
+    // If this is not an image-less framebuffer, add the attachments
+    if (!mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                             VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
+        _attachments.reserve(pCreateInfo->attachmentCount);
+        for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
+            _attachments.push_back((MVKImageView*)pCreateInfo->pAttachments[i]);
+        }
+    }
 }
 
 MVKFramebuffer::MVKFramebuffer(MVKDevice* device,
-							   const VkRenderingInfo* pRenderingInfo) : MVKVulkanAPIDeviceObject(device) {
-	_layerCount = pRenderingInfo->layerCount;
+                               const VkRenderingInfo* pRenderingInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    _layerCount = pRenderingInfo->layerCount;
 
-	_extent = {};
-	for (uint32_t caIdx = 0; caIdx < pRenderingInfo->colorAttachmentCount; caIdx++) {
-		auto& clrAtt = pRenderingInfo->pColorAttachments[caIdx];
-		if (clrAtt.imageView) {
-			_extent = mvkVkExtent2DFromVkExtent3D(((MVKImageView*)clrAtt.imageView)->getExtent3D());
-		}
-	}
-	if (pRenderingInfo->pDepthAttachment && pRenderingInfo->pDepthAttachment->imageView) {
-		_extent = mvkVkExtent2DFromVkExtent3D(((MVKImageView*)pRenderingInfo->pDepthAttachment->imageView)->getExtent3D());
-	}
-	if (pRenderingInfo->pStencilAttachment && pRenderingInfo->pStencilAttachment->imageView) {
-		_extent = mvkVkExtent2DFromVkExtent3D(((MVKImageView*)pRenderingInfo->pStencilAttachment->imageView)->getExtent3D());
-	}
+    _extent = {};
+    for (uint32_t caIdx = 0; caIdx < pRenderingInfo->colorAttachmentCount;
+         caIdx++) {
+        auto& clrAtt = pRenderingInfo->pColorAttachments[caIdx];
+        if (clrAtt.imageView) {
+            _extent = mvkVkExtent2DFromVkExtent3D(
+                ((MVKImageView*)clrAtt.imageView)->getExtent3D());
+        }
+    }
+    if (pRenderingInfo->pDepthAttachment &&
+        pRenderingInfo->pDepthAttachment->imageView) {
+        _extent = mvkVkExtent2DFromVkExtent3D(
+            ((MVKImageView*)pRenderingInfo->pDepthAttachment->imageView)
+                ->getExtent3D());
+    }
+    if (pRenderingInfo->pStencilAttachment &&
+        pRenderingInfo->pStencilAttachment->imageView) {
+        _extent = mvkVkExtent2DFromVkExtent3D(
+            ((MVKImageView*)pRenderingInfo->pStencilAttachment->imageView)
+                ->getExtent3D());
+    }
 }
 
-MVKFramebuffer::~MVKFramebuffer() {
-	[_mtlDummyTex release];
-}
+MVKFramebuffer::~MVKFramebuffer() { [_mtlDummyTex release]; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,6 @@ class MVKSwapchain;
 class MVKQueue;
 class MVKCommandEncoder;
 
-
 #pragma mark -
 #pragma mark MVKImagePlane
 
@@ -47,39 +46,42 @@ typedef struct {
 
 class MVKImagePlane : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
-
-	/** Returns the Metal texture underlying this image plane. */
+    /** Returns the Metal texture underlying this image plane. */
     id<MTLTexture> getMTLTexture();
 
-    /** Returns a Metal texture that interprets the pixels in the specified format. */
+    /** Returns a Metal texture that interprets the pixels in the specified
+     * format. */
     id<MTLTexture> getMTLTexture(MTLPixelFormat mtlPixFmt);
 
     void releaseMTLTexture();
 
     ~MVKImagePlane();
 
-protected:
-	friend class MVKImageMemoryBinding;
-	friend MVKImage;
+  protected:
+    friend class MVKImageMemoryBinding;
+    friend MVKImage;
 
     MTLTextureDescriptor* newMTLTextureDescriptor();
     void initSubresources(const VkImageCreateInfo* pCreateInfo);
     MVKImageSubresource* getSubresource(uint32_t mipLevel, uint32_t arrayLayer);
-    void updateMTLTextureContent(MVKImageSubresource& subresource, VkDeviceSize offset, VkDeviceSize size);
-    void getMTLTextureContent(MVKImageSubresource& subresource, VkDeviceSize offset, VkDeviceSize size);
-	bool overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset, VkDeviceSize size);
+    void updateMTLTextureContent(MVKImageSubresource& subresource,
+                                 VkDeviceSize offset, VkDeviceSize size);
+    void getMTLTextureContent(MVKImageSubresource& subresource,
+                              VkDeviceSize offset, VkDeviceSize size);
+    bool overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset,
+                  VkDeviceSize size);
     void propagateDebugName();
     MVKImageMemoryBinding* getMemoryBinding() const;
-	void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
-								 MVKCommandEncoder* cmdEncoder,
-								 MVKCommandUse cmdUse);
-	void pullFromDeviceOnCompletion(MVKCommandEncoder* cmdEncoder,
-									MVKImageSubresource& subresource,
-									const MVKMappedMemoryRange& mappedRange);
+    void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
+                                 MVKCommandEncoder* cmdEncoder,
+                                 MVKCommandUse cmdUse);
+    void pullFromDeviceOnCompletion(MVKCommandEncoder* cmdEncoder,
+                                    MVKImageSubresource& subresource,
+                                    const MVKMappedMemoryRange& mappedRange);
 
     MVKImagePlane(MVKImage* image, uint8_t planeIndex);
 
@@ -93,28 +95,33 @@ protected:
     MVKSmallVector<MVKImageSubresource, 1> _subresources;
 };
 
-
 #pragma mark -
 #pragma mark MVKImageMemoryBinding
 
 class MVKImageMemoryBinding : public MVKResource {
 
-public:
-    
+  public:
     /** Returns the Vulkan type of this object. */
     VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_UNKNOWN; }
 
     /** Returns the debug report object type of this object. */
-    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT; }
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
 
-    /** Returns the memory requirements of this resource by populating the specified structure. */
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
     VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements);
 
-    /** Returns the memory requirements of this resource by populating the specified structure. */
-    VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
+    VkResult getMemoryRequirements(const void* pInfo,
+                                   VkMemoryRequirements2* pMemoryRequirements);
 
-    /** Binds this resource to the specified offset within the specified memory allocation. */
-    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                              VkDeviceSize memOffset) override;
 
     /** Applies the specified global memory barrier. */
     void applyMemoryBarrier(MVKPipelineBarrier& barrier,
@@ -123,7 +130,7 @@ public:
 
     ~MVKImageMemoryBinding();
 
-protected:
+  protected:
     friend MVKDeviceMemory;
     friend MVKImagePlane;
     friend MVKImage;
@@ -136,7 +143,8 @@ protected:
     uint8_t beginPlaneIndex() const;
     uint8_t endPlaneIndex() const;
 
-    MVKImageMemoryBinding(MVKDevice* device, MVKImage* image, uint8_t planeIndex);
+    MVKImageMemoryBinding(MVKDevice* device, MVKImage* image,
+                          uint8_t planeIndex);
 
     MVKImage* _image;
     id<MTLBuffer> _mtlTexelBuffer = nil;
@@ -145,159 +153,178 @@ protected:
     bool _ownsTexelBuffer = false;
 };
 
-
 #pragma mark -
 #pragma mark MVKImage
 
 /** Represents a Vulkan image. */
 class MVKImage : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_IMAGE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_IMAGE; }
-
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT;
+    }
 
     /** Returns the plane index of VkImageAspectFlags. */
-    static uint8_t getPlaneFromVkImageAspectFlags(VkImageAspectFlags aspectMask);
+    static uint8_t
+    getPlaneFromVkImageAspectFlags(VkImageAspectFlags aspectMask);
 
-	/**
-	 * Returns the Vulkan image type of this image.
-	 * This may be different than the value originally specified for the image
-	 * if a 1D texture is being handled via a Metal 2D texture with height of 1.
-	 */
+    /**
+     * Returns the Vulkan image type of this image.
+     * This may be different than the value originally specified for the image
+     * if a 1D texture is being handled via a Metal 2D texture with height of 1.
+     */
     VkImageType getImageType();
 
     /** Returns the Vulkan image format of this image. */
     VkFormat getVkFormat() { return _vkFormat; };
 
-	/** Returns whether this image has a depth or stencil format. */
-	bool getIsDepthStencil();
+    /** Returns whether this image has a depth or stencil format. */
+    bool getIsDepthStencil();
 
-	/** Returns whether this image is compressed. */
-	bool getIsCompressed();
+    /** Returns whether this image is compressed. */
+    bool getIsCompressed();
 
-	/** Returns whether this image has a linear memory layout. */
-	bool getIsLinear() { return _isLinear; }
+    /** Returns whether this image has a linear memory layout. */
+    bool getIsLinear() { return _isLinear; }
 
-	/** Returns whether this image is allowed to alias another image. */
-	bool getIsAliasable() { return _isAliasable; }
+    /** Returns whether this image is allowed to alias another image. */
+    bool getIsAliasable() { return _isAliasable; }
 
-	/**  Returns the 3D extent of this image at the specified mipmap level. */
-	VkExtent3D getExtent3D(uint8_t planeIndex = 0, uint32_t mipLevel = 0);
+    /**  Returns the 3D extent of this image at the specified mipmap level. */
+    VkExtent3D getExtent3D(uint8_t planeIndex = 0, uint32_t mipLevel = 0);
 
-	/** Returns the number of mipmap levels in this image. */
-	uint32_t getMipLevelCount() { return _mipLevels; }
+    /** Returns the number of mipmap levels in this image. */
+    uint32_t getMipLevelCount() { return _mipLevels; }
 
-	/**
-	 * Returns the number of layers at each mipmap level. For an array image type, this is
-	 * the number of elements in the array. For cube image type, this is a multiple of 6.
-	 */
-	uint32_t getLayerCount() { return _arrayLayers; }
+    /**
+     * Returns the number of layers at each mipmap level. For an array image
+     * type, this is the number of elements in the array. For cube image type,
+     * this is a multiple of 6.
+     */
+    uint32_t getLayerCount() { return _arrayLayers; }
 
     /** Returns the number of samples for each pixel of this image. */
     VkSampleCountFlagBits getSampleCount() { return _samples; }
 
-	 /** 
-	  * Returns the number of bytes per image row at the specified zero-based mip level.
-      * For non-compressed formats, this is the number of bytes in a row of texels.
-      * For compressed formats, this is the number of bytes in a row of blocks, which
-      * will typically span more than one row of texels.
-	  */
-	VkDeviceSize getBytesPerRow(uint8_t planeIndex, uint32_t mipLevel);
+    /**
+     * Returns the number of bytes per image row at the specified zero-based mip
+     * level. For non-compressed formats, this is the number of bytes in a row
+     * of texels. For compressed formats, this is the number of bytes in a row
+     * of blocks, which will typically span more than one row of texels.
+     */
+    VkDeviceSize getBytesPerRow(uint8_t planeIndex, uint32_t mipLevel);
 
-	/**
-	 * Returns the number of bytes per image layer (for cube, array, or 3D images) 
-	 * at the specified zero-based mip level. This value will normally be the number
-	 * of bytes per row (as returned by the getBytesPerRow() function, multiplied by 
-	 * the height of each 2D image.
-	 */
-	VkDeviceSize getBytesPerLayer(uint8_t planeIndex, uint32_t mipLevel);
-    
+    /**
+     * Returns the number of bytes per image layer (for cube, array, or 3D
+     * images) at the specified zero-based mip level. This value will normally
+     * be the number of bytes per row (as returned by the getBytesPerRow()
+     * function, multiplied by the height of each 2D image.
+     */
+    VkDeviceSize getBytesPerLayer(uint8_t planeIndex, uint32_t mipLevel);
+
     /** Returns the number of planes of this image view. */
     uint8_t getPlaneCount() { return _planes.size(); }
 
-	/** Returns whether or not the image format requires swizzling. */
-	bool needsSwizzle() { return getPixelFormats()->needsSwizzle(_vkFormat); }
+    /** Returns whether or not the image format requires swizzling. */
+    bool needsSwizzle() { return getPixelFormats()->needsSwizzle(_vkFormat); }
 
-	/** Populates the specified layout for the specified sub-resource. */
-	VkResult getSubresourceLayout(const VkImageSubresource* pSubresource,
-								  VkSubresourceLayout* pLayout);
+    /** Populates the specified layout for the specified sub-resource. */
+    VkResult getSubresourceLayout(const VkImageSubresource* pSubresource,
+                                  VkSubresourceLayout* pLayout);
 
-	/** Populates the specified layout for the specified sub-resource. */
-	VkResult getSubresourceLayout(const VkImageSubresource2KHR* pSubresource,
-								  VkSubresourceLayout2KHR* pLayout);
+    /** Populates the specified layout for the specified sub-resource. */
+    VkResult getSubresourceLayout(const VkImageSubresource2KHR* pSubresource,
+                                  VkSubresourceLayout2KHR* pLayout);
 
     /** Populates the specified transfer image descriptor data structure. */
     void getTransferDescriptorData(MVKImageDescriptorData& imgData);
 
-
 #pragma mark Resource memory
 
-	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements, uint8_t planeIndex);
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
+    VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements,
+                                   uint8_t planeIndex);
 
-	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+    /** Returns the memory requirements of this resource by populating the
+     * specified structure. */
+    VkResult getMemoryRequirements(const void* pInfo,
+                                   VkMemoryRequirements2* pMemoryRequirements);
 
-	/** Binds this resource to the specified offset within the specified memory allocation. */
-	virtual VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset, uint8_t planeIndex);
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    virtual VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                      VkDeviceSize memOffset,
+                                      uint8_t planeIndex);
 
-	/** Binds this resource to the specified offset within the specified memory allocation. */
-	virtual VkResult bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo);
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    virtual VkResult bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo);
 
-	/** Applies the specified image memory barrier. */
-	void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
-								 MVKCommandEncoder* cmdEncoder,
-								 MVKCommandUse cmdUse);
+    /** Applies the specified image memory barrier. */
+    void applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
+                                 MVKCommandEncoder* cmdEncoder,
+                                 MVKCommandUse cmdUse);
 
     /** Flush underlying buffer memory into the image if necessary */
     void flushToDevice(VkDeviceSize offset, VkDeviceSize size);
 
-	/** Host-copy the content of an image to another using the CPU. */
-	static VkResult copyImageToImage(const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo);
+    /** Host-copy the content of an image to another using the CPU. */
+    static VkResult
+    copyImageToImage(const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo);
 
-	/** Host-copy the content of an image to memory using the CPU. */
-	VkResult copyImageToMemory(const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo);
+    /** Host-copy the content of an image to memory using the CPU. */
+    VkResult
+    copyImageToMemory(const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo);
 
-	/** Host-copy the content of an image from memory using the CPU. */
-	VkResult copyMemoryToImage(const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo);
-
+    /** Host-copy the content of an image from memory using the CPU. */
+    VkResult
+    copyMemoryToImage(const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo);
 
 #pragma mark Metal
 
-	/** Returns the Metal texture underlying this image. */
-	virtual id<MTLTexture> getMTLTexture(uint8_t planeIndex = 0);
+    /** Returns the Metal texture underlying this image. */
+    virtual id<MTLTexture> getMTLTexture(uint8_t planeIndex = 0);
 
-	/** Returns a Metal texture that interprets the pixels in the specified format. */
-	id<MTLTexture> getMTLTexture(uint8_t planeIndex, MTLPixelFormat mtlPixFmt);
+    /** Returns a Metal texture that interprets the pixels in the specified
+     * format. */
+    id<MTLTexture> getMTLTexture(uint8_t planeIndex, MTLPixelFormat mtlPixFmt);
 
     /**
      * Sets this image to use the specified MTLTexture.
      *
-     * Any differences in the properties of mtlTexture and this image will modify the 
-     * properties of this image.
+     * Any differences in the properties of mtlTexture and this image will
+     * modify the properties of this image.
      *
-     * If a MTLTexture has already been created for this image, it will be destroyed.
+     * If a MTLTexture has already been created for this image, it will be
+     * destroyed.
      */
     VkResult setMTLTexture(uint8_t planeIndex, id<MTLTexture> mtlTexture);
 
     /**
-     * Indicates that this VkImage should use an IOSurface to underlay the Metal texture.
+     * Indicates that this VkImage should use an IOSurface to underlay the Metal
+     * texture.
      *
-     * If ioSurface is provided and is not nil, it will be used as the IOSurface.
+     * If ioSurface is provided and is not nil, it will be used as the
+     * IOSurface.
      *
-     * If ioSurface is not provided, or is nil, this image will create and use an IOSurface
-     * whose properties are compatible with the properties of this image.
+     * If ioSurface is not provided, or is nil, this image will create and use
+     * an IOSurface whose properties are compatible with the properties of this
+     * image.
      *
-     * If a MTLTexture has already been created for this image, it will be destroyed.
+     * If a MTLTexture has already been created for this image, it will be
+     * destroyed.
      *
      * Returns:
      *   - VK_SUCCESS.
-     *   - VK_ERROR_FEATURE_NOT_PRESENT if IOSurfaces are not supported on the platform.
-     *   - VK_ERROR_INITIALIZATION_FAILED if ioSurface is specified and is not compatible with this VkImage.
+     *   - VK_ERROR_FEATURE_NOT_PRESENT if IOSurfaces are not supported on the
+     * platform.
+     *   - VK_ERROR_INITIALIZATION_FAILED if ioSurface is specified and is not
+     * compatible with this VkImage.
      */
     VkResult useIOSurface(IOSurfaceRef ioSurface = nil);
 
@@ -307,267 +334,289 @@ public:
      */
     IOSurfaceRef getIOSurface();
 
-	/** Returns the Metal pixel format of this image. */
-	inline MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex = 0) { return _planes[planeIndex]->_mtlPixFmt; }
+    /** Returns the Metal pixel format of this image. */
+    inline MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex = 0) {
+        return _planes[planeIndex]->_mtlPixFmt;
+    }
 
-	/** Returns the Metal texture type of this image. */
-	inline MTLTextureType getMTLTextureType() { return _mtlTextureType; }
+    /** Returns the Metal texture type of this image. */
+    inline MTLTextureType getMTLTextureType() { return _mtlTextureType; }
 
-    /** 
-     * Returns whether the Metal texel size is the same as the Vulkan texel size.
+    /**
+     * Returns whether the Metal texel size is the same as the Vulkan texel
+     * size.
      *
-     * If a different MTLPixelFormat was substituted for the desired VkFormat, the texel 
-     * size may be different. This can occur for certain depth formats when the format 
-     * is not supported on a platform, and the application has not verified this. 
-     * In this case, a different depth format will automatically be substituted. 
-     * With depth formats, this is usually accpetable, but can cause problems when
-     * attempting to copy a depth image with a substituted format to and from a buffer.
+     * If a different MTLPixelFormat was substituted for the desired VkFormat,
+     * the texel size may be different. This can occur for certain depth formats
+     * when the format is not supported on a platform, and the application has
+     * not verified this. In this case, a different depth format will
+     * automatically be substituted. With depth formats, this is usually
+     * accpetable, but can cause problems when attempting to copy a depth image
+     * with a substituted format to and from a buffer.
      */
     inline bool hasExpectedTexelSize() { return _hasExpectedTexelSize; }
 
-	/** Returns whether the texture has the PixelFormatView usage flag, allowing it to be reinterpreted. */
-	inline bool hasPixelFormatView(uint32_t planeIndex) { return mvkIsAnyFlagEnabled(getMTLTexture(planeIndex).usage, MTLTextureUsagePixelFormatView); }
+    /** Returns whether the texture has the PixelFormatView usage flag, allowing
+     * it to be reinterpreted. */
+    inline bool hasPixelFormatView(uint32_t planeIndex) {
+        return mvkIsAnyFlagEnabled(getMTLTexture(planeIndex).usage,
+                                   MTLTextureUsagePixelFormatView);
+    }
 
-	/** Returns the Metal resource options for this image. */
+    /** Returns the Metal resource options for this image. */
     MTLStorageMode getMTLStorageMode();
 
-	/** Returns the Metal CPU cache mode used by this image. */
-	MTLCPUCacheMode getMTLCPUCacheMode();
-
+    /** Returns the Metal CPU cache mode used by this image. */
+    MTLCPUCacheMode getMTLCPUCacheMode();
 
 #pragma mark Construction
 
-	MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo);
+    MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo);
 
-	~MVKImage() override;
+    ~MVKImage() override;
 
-protected:
+  protected:
     friend MVKDeviceMemory;
     friend MVKDevice;
     friend MVKImageMemoryBinding;
     friend MVKImagePlane;
     friend class MVKImageViewPlane;
-	friend MVKImageView;
+    friend MVKImageView;
 
-	void propagateDebugName() override;
-	void validateConfig(const VkImageCreateInfo* pCreateInfo, bool isAttachment);
-	VkSampleCountFlagBits validateSamples(const VkImageCreateInfo* pCreateInfo, bool isAttachment);
-	uint32_t validateMipLevels(const VkImageCreateInfo* pCreateInfo, bool isAttachment);
-	bool validateLinear(const VkImageCreateInfo* pCreateInfo, bool isAttachment);
-	void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
+    void propagateDebugName() override;
+    void validateConfig(const VkImageCreateInfo* pCreateInfo,
+                        bool isAttachment);
+    VkSampleCountFlagBits validateSamples(const VkImageCreateInfo* pCreateInfo,
+                                          bool isAttachment);
+    uint32_t validateMipLevels(const VkImageCreateInfo* pCreateInfo,
+                               bool isAttachment);
+    bool validateLinear(const VkImageCreateInfo* pCreateInfo,
+                        bool isAttachment);
+    void initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes);
     void releaseIOSurface();
-	bool getIsValidViewFormat(VkFormat viewFormat);
-	VkImageUsageFlags getCombinedUsage() { return _usage | _stencilUsage; }
-	MTLTextureUsage getMTLTextureUsage(MTLPixelFormat mtlPixFmt);
-	uint8_t getMemoryBindingCount() const { return (uint8_t)_memoryBindings.size(); }
-	uint8_t getMemoryBindingIndex(uint8_t planeIndex) const;
-	MVKImageMemoryBinding* getMemoryBinding(uint8_t planeIndex);
-	template<typename CopyInfo> VkResult copyContent(const CopyInfo* pCopyInfo);
-	VkResult copyContent(id<MTLTexture> mtlTex,
-						 VkMemoryToImageCopyEXT imgRgn, uint32_t mipLevel, uint32_t slice,
-						 void* pImgBytes, size_t rowPitch, size_t depthPitch);
-	VkResult copyContent(id<MTLTexture> mtlTex,
-						 VkImageToMemoryCopyEXT imgRgn, uint32_t mipLevel, uint32_t slice,
-						 void* pImgBytes, size_t rowPitch, size_t depthPitch);
+    bool getIsValidViewFormat(VkFormat viewFormat);
+    VkImageUsageFlags getCombinedUsage() { return _usage | _stencilUsage; }
+    MTLTextureUsage getMTLTextureUsage(MTLPixelFormat mtlPixFmt);
+    uint8_t getMemoryBindingCount() const {
+        return (uint8_t)_memoryBindings.size();
+    }
+    uint8_t getMemoryBindingIndex(uint8_t planeIndex) const;
+    MVKImageMemoryBinding* getMemoryBinding(uint8_t planeIndex);
+    template <typename CopyInfo>
+    VkResult copyContent(const CopyInfo* pCopyInfo);
+    VkResult copyContent(id<MTLTexture> mtlTex, VkMemoryToImageCopyEXT imgRgn,
+                         uint32_t mipLevel, uint32_t slice, void* pImgBytes,
+                         size_t rowPitch, size_t depthPitch);
+    VkResult copyContent(id<MTLTexture> mtlTex, VkImageToMemoryCopyEXT imgRgn,
+                         uint32_t mipLevel, uint32_t slice, void* pImgBytes,
+                         size_t rowPitch, size_t depthPitch);
 
     MVKSmallVector<MVKImageMemoryBinding*, 3> _memoryBindings;
     MVKSmallVector<MVKImagePlane*, 3> _planes;
-	MVKSmallVector<VkFormat, 2> _viewFormats;
+    MVKSmallVector<VkFormat, 2> _viewFormats;
     VkExtent3D _extent;
     uint32_t _mipLevels;
     uint32_t _arrayLayers;
     VkSampleCountFlagBits _samples;
     VkImageUsageFlags _usage;
-	VkImageUsageFlags _stencilUsage;
+    VkImageUsageFlags _stencilUsage;
     VkFormat _vkFormat;
-	MTLTextureType _mtlTextureType;
+    MTLTextureType _mtlTextureType;
     std::mutex _lock;
     IOSurfaceRef _ioSurface;
-	VkDeviceSize _rowByteAlignment;
+    VkDeviceSize _rowByteAlignment;
     bool _isDepthStencilAttachment;
-	bool _canSupportMTLTextureView;
+    bool _canSupportMTLTextureView;
     bool _hasExpectedTexelSize;
     bool _hasChromaSubsampling;
-	bool _isLinear;
-	bool _is3DCompressed;
-	bool _isAliasable;
-	bool _hasExtendedUsage;
-	bool _hasMutableFormat;
-	bool _shouldSupportAtomics;
-	bool _isLinearForAtomics;
+    bool _isLinear;
+    bool _is3DCompressed;
+    bool _isAliasable;
+    bool _hasExtendedUsage;
+    bool _hasMutableFormat;
+    bool _shouldSupportAtomics;
+    bool _isLinearForAtomics;
 };
-
 
 #pragma mark -
 #pragma mark MVKSwapchainImage
 
-/** Abstract class of Vulkan image used as a rendering destination within a swapchain. */
+/** Abstract class of Vulkan image used as a rendering destination within a
+ * swapchain. */
 class MVKSwapchainImage : public MVKImage {
 
-public:
-
-	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset, uint8_t planeIndex) override;
-
+  public:
+    VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset,
+                              uint8_t planeIndex) override;
 
 #pragma mark Construction
 
-	MVKSwapchainImage(MVKDevice* device,
-					  const VkImageCreateInfo* pCreateInfo,
-					  MVKSwapchain* swapchain,
-					  uint32_t swapchainIndex);
+    MVKSwapchainImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo,
+                      MVKSwapchain* swapchain, uint32_t swapchainIndex);
 
-	void destroy() override;
+    void destroy() override;
 
-protected:
-	friend class MVKPeerSwapchainImage;
+  protected:
+    friend class MVKPeerSwapchainImage;
 
-	void detachSwapchain();
+    void detachSwapchain();
 
-	std::mutex _detachmentLock;
-	MVKSwapchain* _swapchain;
-	uint32_t _swapchainIndex;
+    std::mutex _detachmentLock;
+    MVKSwapchain* _swapchain;
+    uint32_t _swapchainIndex;
 };
-
 
 #pragma mark -
 #pragma mark MVKPresentableSwapchainImage
 
 /** Indicates the relative availability of each image in the swapchain. */
 typedef struct MVKSwapchainImageAvailability {
-	uint64_t acquisitionID;			/**< When this image was last made available, relative to the other images in the swapchain. Smaller value is earlier. */
-	bool isAvailable;				/**< Indicates whether this image is currently available. */
+    uint64_t acquisitionID; /**< When this image was last made available,
+                               relative to the other images in the swapchain.
+                               Smaller value is earlier. */
+    bool isAvailable; /**< Indicates whether this image is currently available.
+                       */
 
-	bool operator< (const MVKSwapchainImageAvailability& rhs) const;
+    bool operator<(const MVKSwapchainImageAvailability& rhs) const;
 } MVKSwapchainImageAvailability;
 
 /** Presentation info. */
-typedef struct  {
-	MVKPresentableSwapchainImage* presentableImage;
-	MVKQueue* queue;				// The queue on which the vkQueuePresentKHR() command was executed.
-	MVKFence* fence;				// VK_EXT_swapchain_maintenance1 fence signaled when resources can be destroyed
-	uint64_t desiredPresentTime;  	// VK_GOOGLE_display_timing desired presentation time in nanoseconds
-	uint32_t presentID;           	// VK_GOOGLE_display_timing presentID
-	VkPresentModeKHR presentMode;	// VK_EXT_swapchain_maintenance1 present mode specialization
+typedef struct {
+    MVKPresentableSwapchainImage* presentableImage;
+    MVKQueue* queue; // The queue on which the vkQueuePresentKHR() command was
+                     // executed.
+    MVKFence* fence; // VK_EXT_swapchain_maintenance1 fence signaled when
+                     // resources can be destroyed
+    uint64_t desiredPresentTime;  // VK_GOOGLE_display_timing desired
+                                  // presentation time in nanoseconds
+    uint32_t presentID;           // VK_GOOGLE_display_timing presentID
+    VkPresentModeKHR presentMode; // VK_EXT_swapchain_maintenance1 present mode
+                                  // specialization
 } MVKImagePresentInfo;
 
 /** Tracks a semaphore and fence for later signaling. */
 struct MVKSwapchainSignaler {
-	MVKFence* fence;
-	MVKSemaphore* semaphore;
-	uint64_t semaphoreSignalToken;
+    MVKFence* fence;
+    MVKSemaphore* semaphore;
+    uint64_t semaphoreSignalToken;
 };
 
-
-/** Represents a Vulkan swapchain image that can be submitted to the presentation engine. */
+/** Represents a Vulkan swapchain image that can be submitted to the
+ * presentation engine. */
 class MVKPresentableSwapchainImage : public MVKSwapchainImage {
 
-public:
-
+  public:
 #pragma mark Metal
 
-	id<MTLTexture> getMTLTexture(uint8_t planeIndex) override;
+    id<MTLTexture> getMTLTexture(uint8_t planeIndex) override;
 
-	/** Presents the contained drawable to the OS. */
-	VkResult presentCAMetalDrawable(id<MTLCommandBuffer> mtlCmdBuff, MVKImagePresentInfo presentInfo);
+    /** Presents the contained drawable to the OS. */
+    VkResult presentCAMetalDrawable(id<MTLCommandBuffer> mtlCmdBuff,
+                                    MVKImagePresentInfo presentInfo);
 
-	/** Called when the presentation begins. */
-	void beginPresentation(const MVKImagePresentInfo& presentInfo);
+    /** Called when the presentation begins. */
+    void beginPresentation(const MVKImagePresentInfo& presentInfo);
 
-	/** Called via callback when the presentation completes. */
-	void endPresentation(const MVKImagePresentInfo& presentInfo,
-						 const MVKSwapchainSignaler& signaler,
-						 uint64_t actualPresentTime = 0);
+    /** Called via callback when the presentation completes. */
+    void endPresentation(const MVKImagePresentInfo& presentInfo,
+                         const MVKSwapchainSignaler& signaler,
+                         uint64_t actualPresentTime = 0);
 
 #pragma mark Construction
 
-	MVKPresentableSwapchainImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo,
-								 MVKSwapchain* swapchain, uint32_t swapchainIndex);
+    MVKPresentableSwapchainImage(MVKDevice* device,
+                                 const VkImageCreateInfo* pCreateInfo,
+                                 MVKSwapchain* swapchain,
+                                 uint32_t swapchainIndex);
 
-	void destroy() override;
+    void destroy() override;
 
-	~MVKPresentableSwapchainImage() override;
+    ~MVKPresentableSwapchainImage() override;
 
-protected:
-	friend MVKSwapchain;
+  protected:
+    friend MVKSwapchain;
 
-	id<CAMetalDrawable> getCAMetalDrawable();
-	void addPresentedHandler(id<CAMetalDrawable> mtlDrawable, MVKImagePresentInfo presentInfo, MVKSwapchainSignaler signaler);
-	void releaseMetalDrawable();
-	MVKSwapchainImageAvailability getAvailability();
-	void makeAvailable();
-	VkResult acquireAndSignalWhenAvailable(MVKSemaphore* semaphore, MVKFence* fence);
-	MVKSwapchainSignaler getPresentationSignaler();
+    id<CAMetalDrawable> getCAMetalDrawable();
+    void addPresentedHandler(id<CAMetalDrawable> mtlDrawable,
+                             MVKImagePresentInfo presentInfo,
+                             MVKSwapchainSignaler signaler);
+    void releaseMetalDrawable();
+    MVKSwapchainImageAvailability getAvailability();
+    void makeAvailable();
+    VkResult acquireAndSignalWhenAvailable(MVKSemaphore* semaphore,
+                                           MVKFence* fence);
+    MVKSwapchainSignaler getPresentationSignaler();
 
-	id<CAMetalDrawable> _mtlDrawable = nil;
-	id<MTLTexture> _mtlTextureHeadless = nil;
-	MVKSwapchainImageAvailability _availability;
-	MVKSmallVector<MVKSwapchainSignaler, 1> _availabilitySignalers;
-	MVKSwapchainSignaler _preSignaler = {};
-	std::mutex _availabilityLock;
-	uint64_t _beginPresentTime = 0;
-	uint64_t _presentationStartTime = 0;
+    id<CAMetalDrawable> _mtlDrawable = nil;
+    id<MTLTexture> _mtlTextureHeadless = nil;
+    MVKSwapchainImageAvailability _availability;
+    MVKSmallVector<MVKSwapchainSignaler, 1> _availabilitySignalers;
+    MVKSwapchainSignaler _preSignaler = {};
+    std::mutex _availabilityLock;
+    uint64_t _beginPresentTime = 0;
+    uint64_t _presentationStartTime = 0;
 };
-
 
 #pragma mark -
 #pragma mark MVKPeerSwapchainImage
 
-/** Represents a Vulkan swapchain image that can be associated as a peer to a swapchain image. */
+/** Represents a Vulkan swapchain image that can be associated as a peer to a
+ * swapchain image. */
 class MVKPeerSwapchainImage : public MVKSwapchainImage {
 
-public:
+  public:
+    id<MTLTexture> getMTLTexture(uint8_t planeIndex) override;
 
-	id<MTLTexture> getMTLTexture(uint8_t planeIndex) override;
-
-	VkResult bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo) override;
-
+    VkResult bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo) override;
 
 #pragma mark Construction
 
-	MVKPeerSwapchainImage(MVKDevice* device,
-						  const VkImageCreateInfo* pCreateInfo,
-						  MVKSwapchain* swapchain,
-						  uint32_t swapchainIndex);
+    MVKPeerSwapchainImage(MVKDevice* device,
+                          const VkImageCreateInfo* pCreateInfo,
+                          MVKSwapchain* swapchain, uint32_t swapchainIndex);
 };
-
 
 #pragma mark -
 #pragma mark MVKImageViewPlane
 
 class MVKImageViewPlane : public MVKBaseDeviceObject {
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
-public:
+  public:
     /** Returns the Metal texture underlying this image view. */
     id<MTLTexture> getMTLTexture();
 
     void releaseMTLTexture();
 
-	/** Returns the packed component swizzle of this image view. */
-	uint32_t getPackedSwizzle() { return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
+    /** Returns the packed component swizzle of this image view. */
+    uint32_t getPackedSwizzle() {
+        return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0;
+    }
 
     ~MVKImageViewPlane();
 
-protected:
+  protected:
     void propagateDebugName();
     id<MTLTexture> newMTLTexture();
-	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
-	bool enableSwizzling();
-    MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
+    VkResult
+    initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
+    bool enableSwizzling();
+    MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex,
+                      MTLPixelFormat mtlPixFmt,
+                      const VkImageViewCreateInfo* pCreateInfo);
 
     friend MVKImageView;
     MVKImageView* _imageView;
-	id<MTLTexture> _mtlTexture;
-	VkComponentMapping _componentSwizzle;
+    id<MTLTexture> _mtlTexture;
+    VkComponentMapping _componentSwizzle;
     MTLPixelFormat _mtlPixFmt;
-	uint8_t _planeIndex;
+    uint8_t _planeIndex;
     bool _useMTLTextureView;
-	bool _useNativeSwizzle;
-	bool _useShaderSwizzle;
+    bool _useNativeSwizzle;
+    bool _useShaderSwizzle;
 };
-
 
 #pragma mark -
 #pragma mark MVKImageView
@@ -575,78 +624,94 @@ protected:
 /** Represents a Vulkan image view. */
 class MVKImageView : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_IMAGE_VIEW;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_IMAGE_VIEW; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT; }
+    /**  Returns the 3D extent of this image at the specified mipmap level. */
+    VkExtent3D getExtent3D(uint8_t planeIndex = 0, uint32_t mipLevel = 0) {
+        return _image->getExtent3D(planeIndex, mipLevel);
+    }
 
-	/**  Returns the 3D extent of this image at the specified mipmap level. */
-	VkExtent3D getExtent3D(uint8_t planeIndex = 0, uint32_t mipLevel = 0) { return _image->getExtent3D(planeIndex, mipLevel); }
-
-	/** Return the underlying image. */
-	MVKImage* getImage() { return _image; }
+    /** Return the underlying image. */
+    MVKImage* getImage() { return _image; }
 
 #pragma mark Metal
 
-	/** Returns the Metal texture underlying this image view.  */
-	id<MTLTexture> getMTLTexture(uint8_t planeIndex = 0) { return planeIndex < _planes.size() ? _planes[planeIndex]->getMTLTexture() : nil; }	// Guard against destroyed instance retained in a descriptor.
+    /** Returns the Metal texture underlying this image view.  */
+    id<MTLTexture> getMTLTexture(uint8_t planeIndex = 0) {
+        return planeIndex < _planes.size()
+                   ? _planes[planeIndex]->getMTLTexture()
+                   : nil;
+    } // Guard against destroyed instance retained in a descriptor.
 
-	/** Returns the Metal pixel format of this image view. */
-	MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex = 0) { return planeIndex < _planes.size() ? _planes[planeIndex]->_mtlPixFmt : MTLPixelFormatInvalid; }	// Guard against destroyed instance retained in a descriptor.
+    /** Returns the Metal pixel format of this image view. */
+    MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex = 0) {
+        return planeIndex < _planes.size() ? _planes[planeIndex]->_mtlPixFmt
+                                           : MTLPixelFormatInvalid;
+    } // Guard against destroyed instance retained in a descriptor.
 
-	/** Returns the Vulkan pixel format of this image view. */
-	VkFormat getVkFormat(uint8_t planeIndex = 0) { return getPixelFormats()->getVkFormat(getMTLPixelFormat(planeIndex)); }
+    /** Returns the Vulkan pixel format of this image view. */
+    VkFormat getVkFormat(uint8_t planeIndex = 0) {
+        return getPixelFormats()->getVkFormat(getMTLPixelFormat(planeIndex));
+    }
 
-	/** Returns the number of samples for each pixel of this image view. */
-	VkSampleCountFlagBits getSampleCount() { return _image->getSampleCount(); }
+    /** Returns the number of samples for each pixel of this image view. */
+    VkSampleCountFlagBits getSampleCount() { return _image->getSampleCount(); }
 
     /** Returns the packed component swizzle of this image view. */
-    uint32_t getPackedSwizzle() { return _planes.empty() ? 0 : _planes[0]->getPackedSwizzle(); }	// Guard against destroyed instance retained in a descriptor.
-    
+    uint32_t getPackedSwizzle() {
+        return _planes.empty() ? 0 : _planes[0]->getPackedSwizzle();
+    } // Guard against destroyed instance retained in a descriptor.
+
     /** Returns the number of planes of this image view. */
     uint8_t getPlaneCount() { return _planes.size(); }
 
-	/** Returns the Metal texture type of this image view. */
-	MTLTextureType getMTLTextureType() { return _mtlTextureType; }
+    /** Returns the Metal texture type of this image view. */
+    MTLTextureType getMTLTextureType() { return _mtlTextureType; }
 
-	/**
-	 * Populates the texture of the specified render pass descriptor
-	 * with the Metal texture underlying this image.
-	 */
-	void populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc);
+    /**
+     * Populates the texture of the specified render pass descriptor
+     * with the Metal texture underlying this image.
+     */
+    void populateMTLRenderPassAttachmentDescriptor(
+        MTLRenderPassAttachmentDescriptor* mtlAttDesc);
 
-	/**
-	 * Populates the resolve texture of the specified render pass descriptor
-	 * with the Metal texture underlying this image.
-	 */
-	void populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPassAttachmentDescriptor* mtlAttDesc);
-
+    /**
+     * Populates the resolve texture of the specified render pass descriptor
+     * with the Metal texture underlying this image.
+     */
+    void populateMTLRenderPassAttachmentDescriptorResolve(
+        MTLRenderPassAttachmentDescriptor* mtlAttDesc);
 
 #pragma mark Construction
 
-	MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCreateInfo);
+    MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCreateInfo);
 
-	~MVKImageView();
+    ~MVKImageView();
 
-	void destroy() override;
+    void destroy() override;
 
-protected:
+  protected:
     friend MVKImageViewPlane;
-    
-	void propagateDebugName() override;
-	void detachMemory();
+
+    void propagateDebugName() override;
+    void detachMemory();
 
     MVKImage* _image;
     MVKSmallVector<MVKImageViewPlane*, 3> _planes;
     VkImageSubresourceRange _subresourceRange;
     VkImageUsageFlags _usage;
-	std::mutex _lock;
-	MTLTextureType _mtlTextureType;
+    std::mutex _lock;
+    MTLTextureType _mtlTextureType;
 };
-
 
 #pragma mark -
 #pragma mark MVKSamplerYcbcrConversion
@@ -654,24 +719,31 @@ protected:
 /** Represents a Vulkan sampler ycbcr conversion. */
 class MVKSamplerYcbcrConversion : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
     /** Returns the Vulkan type of this object. */
-    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION; }
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION;
+    }
 
     /** Returns the debug report object type of this object. */
-    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT; }
-    
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT;
+    }
+
     /** Returns the number of planes of this ycbcr conversion. */
     uint8_t getPlaneCount() { return _planes; }
 
     /** Writes this conversion settings to a MSL constant sampler */
-    void updateConstExprSampler(SPIRV_CROSS_NAMESPACE::MSLConstexprSampler& constExprSampler) const;
+    void updateConstExprSampler(
+        SPIRV_CROSS_NAMESPACE::MSLConstexprSampler& constExprSampler) const;
 
-    MVKSamplerYcbcrConversion(MVKDevice* device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo);
+    MVKSamplerYcbcrConversion(
+        MVKDevice* device,
+        const VkSamplerYcbcrConversionCreateInfo* pCreateInfo);
 
     ~MVKSamplerYcbcrConversion() override {}
 
-protected:
+  protected:
     void propagateDebugName() override {}
 
     uint8_t _planes, _bpc;
@@ -684,53 +756,62 @@ protected:
     bool _forceExplicitReconstruction;
 };
 
-
 #pragma mark -
 #pragma mark MVKSampler
 
 /** Represents a Vulkan sampler. */
 class MVKSampler : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SAMPLER; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SAMPLER; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT; }
+    /** Returns the Metal sampler state. */
+    id<MTLSamplerState> getMTLSamplerState() { return _mtlSamplerState; }
 
-	/** Returns the Metal sampler state. */
-	id<MTLSamplerState> getMTLSamplerState() { return _mtlSamplerState; }
-    
-    /** Returns the number of planes if this is a ycbcr conversion or 0 otherwise. */
-    uint8_t getPlaneCount() { return (_ycbcrConversion) ? _ycbcrConversion->getPlaneCount() : 0; }
+    /** Returns the number of planes if this is a ycbcr conversion or 0
+     * otherwise. */
+    uint8_t getPlaneCount() {
+        return (_ycbcrConversion) ? _ycbcrConversion->getPlaneCount() : 0;
+    }
 
-	/**
-	 * If this sampler requires hardcoding in MSL, populates the hardcoded sampler in the resource binding.
-	 * Returns whether this sampler requires hardcoding in MSL, and the constant sampler was populated.
-	 */
-	bool getConstexprSampler(mvk::MSLResourceBinding& resourceBinding);
+    /**
+     * If this sampler requires hardcoding in MSL, populates the hardcoded
+     * sampler in the resource binding. Returns whether this sampler requires
+     * hardcoding in MSL, and the constant sampler was populated.
+     */
+    bool getConstexprSampler(mvk::MSLResourceBinding& resourceBinding);
 
-	/** Returns whether this sampler must be implemented as a hardcoded constant sampler in the shader MSL code. */
-	inline 	bool getRequiresConstExprSampler() { return _requiresConstExprSampler; }
+    /** Returns whether this sampler must be implemented as a hardcoded constant
+     * sampler in the shader MSL code. */
+    inline bool getRequiresConstExprSampler() {
+        return _requiresConstExprSampler;
+    }
 
-	/** Returns the Metal MTLSamplerAddressMode corresponding to the specified Vulkan VkSamplerAddressMode. */
-	MTLSamplerAddressMode getMTLSamplerAddressMode(VkSamplerAddressMode vkMode);
+    /** Returns the Metal MTLSamplerAddressMode corresponding to the specified
+     * Vulkan VkSamplerAddressMode. */
+    MTLSamplerAddressMode getMTLSamplerAddressMode(VkSamplerAddressMode vkMode);
 
-	MVKSampler(MVKDevice* device, const VkSamplerCreateInfo* pCreateInfo);
+    MVKSampler(MVKDevice* device, const VkSamplerCreateInfo* pCreateInfo);
 
-	~MVKSampler() override;
+    ~MVKSampler() override;
 
-	void destroy() override;
+    void destroy() override;
 
-protected:
-	void propagateDebugName() override {}
-	MTLSamplerDescriptor* newMTLSamplerDescriptor(const VkSamplerCreateInfo* pCreateInfo);
-	void initConstExprSampler(const VkSamplerCreateInfo* pCreateInfo);
-	void detachMemory();
+  protected:
+    void propagateDebugName() override {}
+    MTLSamplerDescriptor*
+    newMTLSamplerDescriptor(const VkSamplerCreateInfo* pCreateInfo);
+    void initConstExprSampler(const VkSamplerCreateInfo* pCreateInfo);
+    void detachMemory();
 
-	id<MTLSamplerState> _mtlSamplerState;
-	SPIRV_CROSS_NAMESPACE::MSLConstexprSampler _constExprSampler;
-	MVKSamplerYcbcrConversion* _ycbcrConversion;
-	bool _requiresConstExprSampler;
+    id<MTLSamplerState> _mtlSamplerState;
+    SPIRV_CROSS_NAMESPACE::MSLConstexprSampler _constExprSampler;
+    MVKSamplerYcbcrConversion* _ycbcrConversion;
+    bool _requiresConstExprSampler;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,43 +39,58 @@ using namespace SPIRV_CROSS_NAMESPACE;
 MVKVulkanAPIObject* MVKImagePlane::getVulkanAPIObject() { return _image; }
 
 id<MTLTexture> MVKImagePlane::getMTLTexture() {
-    if ( !_mtlTexture && _image->_vkFormat ) {
+    if (!_mtlTexture && _image->_vkFormat) {
         // Lock and check again in case another thread has created the texture.
         lock_guard<mutex> lock(_image->_lock);
-        if (_mtlTexture) { return _mtlTexture; }
+        if (_mtlTexture) {
+            return _mtlTexture;
+        }
 
-        MTLTextureDescriptor* mtlTexDesc = newMTLTextureDescriptor();    // temp retain
+        MTLTextureDescriptor* mtlTexDesc =
+            newMTLTextureDescriptor(); // temp retain
         MVKImageMemoryBinding* memoryBinding = getMemoryBinding();
-		MVKDeviceMemory* dvcMem = memoryBinding->_deviceMemory;
+        MVKDeviceMemory* dvcMem = memoryBinding->_deviceMemory;
 
         if (_image->_ioSurface) {
             _mtlTexture = [_image->getMTLDevice()
-                           newTextureWithDescriptor: mtlTexDesc
-                           iosurface: _image->_ioSurface
-                           plane: _planeIndex];
+                newTextureWithDescriptor:mtlTexDesc
+                               iosurface:_image->_ioSurface
+                                   plane:_planeIndex];
         } else if (memoryBinding->_mtlTexelBuffer) {
             _mtlTexture = [memoryBinding->_mtlTexelBuffer
-                           newTextureWithDescriptor: mtlTexDesc
-                           offset: memoryBinding->_mtlTexelBufferOffset + _subresources[0].layout.offset
-                           bytesPerRow: _subresources[0].layout.rowPitch];
-        } else if (dvcMem && dvcMem->getMTLHeap() && !_image->getIsDepthStencil()) {
+                newTextureWithDescriptor:mtlTexDesc
+                                  offset:memoryBinding->_mtlTexelBufferOffset +
+                                         _subresources[0].layout.offset
+                             bytesPerRow:_subresources[0].layout.rowPitch];
+        } else if (dvcMem && dvcMem->getMTLHeap() &&
+                   !_image->getIsDepthStencil()) {
             // Metal support for depth/stencil from heaps is flaky
             _mtlTexture = [dvcMem->getMTLHeap()
-                           newTextureWithDescriptor: mtlTexDesc
-                           offset: memoryBinding->getDeviceMemoryOffset() + _subresources[0].layout.offset];
-            if (_image->_isAliasable) { [_mtlTexture makeAliasable]; }
-        } else if (_image->_isAliasable && dvcMem && dvcMem->isDedicatedAllocation() &&
-            !mvkContains(dvcMem->_imageMemoryBindings, memoryBinding)) {
-            // This is a dedicated allocation, but it belongs to another aliasable image.
-            // In this case, use the MTLTexture from the memory's dedicated image.
-            // We know the other image must be aliasable, or I couldn't have been bound
-            // to its memory: the memory object wouldn't allow it.
-            _mtlTexture = [dvcMem->_imageMemoryBindings[0]->_image->getMTLTexture(_planeIndex, mtlTexDesc.pixelFormat) retain];
+                newTextureWithDescriptor:mtlTexDesc
+                                  offset:memoryBinding
+                                             ->getDeviceMemoryOffset() +
+                                         _subresources[0].layout.offset];
+            if (_image->_isAliasable) {
+                [_mtlTexture makeAliasable];
+            }
+        } else if (_image->_isAliasable && dvcMem &&
+                   dvcMem->isDedicatedAllocation() &&
+                   !mvkContains(dvcMem->_imageMemoryBindings, memoryBinding)) {
+            // This is a dedicated allocation, but it belongs to another
+            // aliasable image. In this case, use the MTLTexture from the
+            // memory's dedicated image. We know the other image must be
+            // aliasable, or I couldn't have been bound to its memory: the
+            // memory object wouldn't allow it.
+            _mtlTexture =
+                [dvcMem->_imageMemoryBindings[0]
+                        ->_image->getMTLTexture(_planeIndex,
+                                                mtlTexDesc.pixelFormat) retain];
         } else {
-            _mtlTexture = [_image->getMTLDevice() newTextureWithDescriptor: mtlTexDesc];
+            _mtlTexture =
+                [_image->getMTLDevice() newTextureWithDescriptor:mtlTexDesc];
         }
 
-        [mtlTexDesc release];                                            // temp release
+        [mtlTexDesc release]; // temp release
 
         propagateDebugName();
     }
@@ -83,17 +98,22 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
 }
 
 id<MTLTexture> MVKImagePlane::getMTLTexture(MTLPixelFormat mtlPixFmt) {
-    // Note: Retrieve the base texture outside of lock to avoid deadlock if it too needs to be lazily created.
-    // Delegate to _image in case the method is overriden. (e.g. if it's a swapchain image)
-    if (mtlPixFmt == _mtlPixFmt) { return _image->getMTLTexture(_planeIndex); }
+    // Note: Retrieve the base texture outside of lock to avoid deadlock if it
+    // too needs to be lazily created. Delegate to _image in case the method is
+    // overriden. (e.g. if it's a swapchain image)
+    if (mtlPixFmt == _mtlPixFmt) {
+        return _image->getMTLTexture(_planeIndex);
+    }
     id<MTLTexture> mtlTex = _mtlTextureViews[mtlPixFmt];
-    if ( !mtlTex ) {
-        // Lock and check again in case another thread has created the view texture.
+    if (!mtlTex) {
+        // Lock and check again in case another thread has created the view
+        // texture.
         id<MTLTexture> baseTexture = _image->getMTLTexture(_planeIndex);
         lock_guard<mutex> lock(_image->_lock);
         mtlTex = _mtlTextureViews[mtlPixFmt];
-        if ( !mtlTex ) {
-            mtlTex = [baseTexture newTextureViewWithPixelFormat: mtlPixFmt];    // retained
+        if (!mtlTex) {
+            mtlTex = [baseTexture
+                newTextureViewWithPixelFormat:mtlPixFmt]; // retained
             _mtlTextureViews[mtlPixFmt] = mtlTex;
         }
     }
@@ -110,26 +130,30 @@ void MVKImagePlane::releaseMTLTexture() {
     _mtlTextureViews.clear();
 }
 
-// Returns a Metal texture descriptor constructed from the properties of this image.
-// It is the caller's responsibility to release the returned descriptor object.
+// Returns a Metal texture descriptor constructed from the properties of this
+// image. It is the caller's responsibility to release the returned descriptor
+// object.
 MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
 
-	// Metal before 3.0 doesn't support 3D compressed textures, so we'll decompress
-	// the texture ourselves. This, then, is the *uncompressed* format.
-	bool shouldSubFmt = MVK_MACOS && _image->_is3DCompressed;
-	MTLPixelFormat mtlPixFmt = shouldSubFmt ? MTLPixelFormatBGRA8Unorm : _mtlPixFmt;
+    // Metal before 3.0 doesn't support 3D compressed textures, so we'll
+    // decompress the texture ourselves. This, then, is the *uncompressed*
+    // format.
+    bool shouldSubFmt = MVK_MACOS && _image->_is3DCompressed;
+    MTLPixelFormat mtlPixFmt =
+        shouldSubFmt ? MTLPixelFormatBGRA8Unorm : _mtlPixFmt;
 
     VkExtent3D extent = _image->getExtent3D(_planeIndex, 0);
-    MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor new];    // retained
+    MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor new]; // retained
     mtlTexDesc.pixelFormat = mtlPixFmt;
     mtlTexDesc.textureType = _image->_mtlTextureType;
     mtlTexDesc.width = extent.width;
     mtlTexDesc.height = extent.height;
     mtlTexDesc.depth = extent.depth;
     mtlTexDesc.mipmapLevelCount = _image->_mipLevels;
-    mtlTexDesc.sampleCount = mvkSampleCountFromVkSampleCountFlagBits(_image->_samples);
+    mtlTexDesc.sampleCount =
+        mvkSampleCountFromVkSampleCountFlagBits(_image->_samples);
     mtlTexDesc.arrayLength = _image->_arrayLayers;
-	mtlTexDesc.usageMVK = _image->getMTLTextureUsage(mtlPixFmt);
+    mtlTexDesc.usageMVK = _image->getMTLTextureUsage(mtlPixFmt);
     mtlTexDesc.storageModeMVK = _image->getMTLStorageMode();
     mtlTexDesc.cpuCacheMode = _image->getMTLCPUCacheMode();
 
@@ -146,22 +170,30 @@ void MVKImagePlane::initSubresources(const VkImageCreateInfo* pCreateInfo) {
 
     VkDeviceSize offset = 0;
     if (_planeIndex > 0 && _image->getMemoryBindingCount() == 1) {
-        if (!_image->_isLinear && !_image->_isLinearForAtomics && _image->getMetalFeatures().placementHeaps) {
-            // For textures allocated directly on the heap, we need to obey the size and alignment
-            // requirements reported by the device.
-            MTLTextureDescriptor* mtlTexDesc = _image->_planes[_planeIndex-1]->newMTLTextureDescriptor();    // temp retain
-            MTLSizeAndAlign sizeAndAlign = [_image->getMTLDevice() heapTextureSizeAndAlignWithDescriptor: mtlTexDesc];
-            [mtlTexDesc release];                                                                            // temp release
-            VkSubresourceLayout& firstLayout = _image->_planes[_planeIndex-1]->_subresources[0].layout;
+        if (!_image->_isLinear && !_image->_isLinearForAtomics &&
+            _image->getMetalFeatures().placementHeaps) {
+            // For textures allocated directly on the heap, we need to obey the
+            // size and alignment requirements reported by the device.
+            MTLTextureDescriptor* mtlTexDesc =
+                _image->_planes[_planeIndex - 1]
+                    ->newMTLTextureDescriptor(); // temp retain
+            MTLSizeAndAlign sizeAndAlign = [_image->getMTLDevice()
+                heapTextureSizeAndAlignWithDescriptor:mtlTexDesc];
+            [mtlTexDesc release]; // temp release
+            VkSubresourceLayout& firstLayout =
+                _image->_planes[_planeIndex - 1]->_subresources[0].layout;
             offset = firstLayout.offset + sizeAndAlign.size;
-            mtlTexDesc = newMTLTextureDescriptor();                                                          // temp retain
-            sizeAndAlign = [_image->getMTLDevice() heapTextureSizeAndAlignWithDescriptor: mtlTexDesc];
-            [mtlTexDesc release];                                                                            // temp release
+            mtlTexDesc = newMTLTextureDescriptor(); // temp retain
+            sizeAndAlign = [_image->getMTLDevice()
+                heapTextureSizeAndAlignWithDescriptor:mtlTexDesc];
+            [mtlTexDesc release]; // temp release
             offset = mvkAlignByteRef(offset, sizeAndAlign.align);
         } else {
-            auto subresources = &_image->_planes[_planeIndex-1]->_subresources;
-            VkSubresourceLayout& lastLayout = (*subresources)[subresources->size()-1].layout;
-            offset = lastLayout.offset+lastLayout.size;
+            auto subresources =
+                &_image->_planes[_planeIndex - 1]->_subresources;
+            VkSubresourceLayout& lastLayout =
+                (*subresources)[subresources->size() - 1].layout;
+            offset = lastLayout.offset + lastLayout.size;
         }
     }
 
@@ -171,14 +203,14 @@ void MVKImagePlane::initSubresources(const VkImageCreateInfo* pCreateInfo) {
         VkDeviceSize depthPitch = _image->getBytesPerLayer(_planeIndex, mipLvl);
 
         VkExtent3D mipExtent = _image->getExtent3D(_planeIndex, mipLvl);
-        
+
         for (uint32_t layer = 0; layer < _image->_arrayLayers; layer++) {
             subRez.subresource.arrayLayer = layer;
 
             VkSubresourceLayout& layout = subRez.layout;
             layout.offset = offset;
             layout.size = depthPitch * mipExtent.depth;
-            
+
             layout.rowPitch = rowPitch;
             layout.depthPitch = depthPitch;
 
@@ -188,8 +220,10 @@ void MVKImagePlane::initSubresources(const VkImageCreateInfo* pCreateInfo) {
     }
 }
 
-// Returns a pointer to the internal subresource for the specified MIP level layer.
-MVKImageSubresource* MVKImagePlane::getSubresource(uint32_t mipLevel, uint32_t arrayLayer) {
+// Returns a pointer to the internal subresource for the specified MIP level
+// layer.
+MVKImageSubresource* MVKImagePlane::getSubresource(uint32_t mipLevel,
+                                                   uint32_t arrayLayer) {
     uint32_t srIdx = (mipLevel * _image->_arrayLayers) + arrayLayer;
     return (srIdx < _subresources.size()) ? &_subresources[srIdx] : nullptr;
 }
@@ -197,17 +231,23 @@ MVKImageSubresource* MVKImagePlane::getSubresource(uint32_t mipLevel, uint32_t a
 // Updates the contents of the underlying MTLTexture, corresponding to the
 // specified subresource definition, from the underlying memory buffer.
 void MVKImagePlane::updateMTLTextureContent(MVKImageSubresource& subresource,
-                                            VkDeviceSize offset, VkDeviceSize size) {
+                                            VkDeviceSize offset,
+                                            VkDeviceSize size) {
 
     VkImageSubresource& imgSubRez = subresource.subresource;
     VkSubresourceLayout& imgLayout = subresource.layout;
-    size = getMemoryBinding()->getDeviceMemory()->adjustMemorySize(size, offset);
+    size =
+        getMemoryBinding()->getDeviceMemory()->adjustMemorySize(size, offset);
     // Check if subresource overlaps the memory range.
-	if ( !overlaps(imgLayout, offset, size) ) { return; }
+    if (!overlaps(imgLayout, offset, size)) {
+        return;
+    }
 
     // Don't update if host memory has not been mapped yet.
     void* pHostMem = getMemoryBinding()->getHostMemoryAddress();
-    if ( !pHostMem ) { return; }
+    if (!pHostMem) {
+        return;
+    }
 
     VkExtent3D mipExtent = _image->getExtent3D(_planeIndex, imgSubRez.mipLevel);
     void* pImgBytes = (void*)((uintptr_t)pHostMem + imgLayout.offset);
@@ -220,10 +260,12 @@ void MVKImagePlane::updateMTLTextureContent(MVKImageSubresource& subresource,
     std::unique_ptr<char[]> decompBuffer;
     if (_image->_is3DCompressed) {
         // We cannot upload the texture data directly in this case.
-		// But we can upload the decompressed image data.
+        // But we can upload the decompressed image data.
         std::unique_ptr<MVKCodec> codec = mvkCreateCodec(_image->getVkFormat());
         if (!codec) {
-            _image->reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "A 3D texture used a compressed format that MoltenVK does not yet support.");
+            _image->reportError(VK_ERROR_FORMAT_NOT_SUPPORTED,
+                                "A 3D texture used a compressed format that "
+                                "MoltenVK does not yet support.");
             return;
         }
         VkSubresourceLayout destLayout;
@@ -231,15 +273,18 @@ void MVKImagePlane::updateMTLTextureContent(MVKImageSubresource& subresource,
         destLayout.depthPitch = destLayout.rowPitch * mipExtent.height;
         destLayout.size = destLayout.depthPitch * mipExtent.depth;
         decompBuffer = std::unique_ptr<char[]>(new char[destLayout.size]);
-        codec->decompress(decompBuffer.get(), pImgBytes, destLayout, imgLayout, mipExtent);
+        codec->decompress(decompBuffer.get(), pImgBytes, destLayout, imgLayout,
+                          mipExtent);
         pImgBytes = decompBuffer.get();
         imgLayout = destLayout;
     }
 #endif
 
     VkImageType imgType = _image->getImageType();
-    VkDeviceSize bytesPerRow = (imgType != VK_IMAGE_TYPE_1D) ? imgLayout.rowPitch : 0;
-    VkDeviceSize bytesPerImage = (imgType == VK_IMAGE_TYPE_3D) ? imgLayout.depthPitch : 0;
+    VkDeviceSize bytesPerRow =
+        (imgType != VK_IMAGE_TYPE_1D) ? imgLayout.rowPitch : 0;
+    VkDeviceSize bytesPerImage =
+        (imgType == VK_IMAGE_TYPE_3D) ? imgLayout.depthPitch : 0;
 
     id<MTLTexture> mtlTex = getMTLTexture();
     if (_image->getPixelFormats()->isPVRTCFormat(mtlTex.pixelFormat)) {
@@ -247,28 +292,34 @@ void MVKImagePlane::updateMTLTextureContent(MVKImageSubresource& subresource,
         bytesPerImage = 0;
     }
 
-    [mtlTex replaceRegion: mtlRegion
-              mipmapLevel: imgSubRez.mipLevel
-                    slice: imgSubRez.arrayLayer
-                withBytes: pImgBytes
-              bytesPerRow: bytesPerRow
-            bytesPerImage: bytesPerImage];
+    [mtlTex replaceRegion:mtlRegion
+              mipmapLevel:imgSubRez.mipLevel
+                    slice:imgSubRez.arrayLayer
+                withBytes:pImgBytes
+              bytesPerRow:bytesPerRow
+            bytesPerImage:bytesPerImage];
 }
 
 // Updates the contents of the underlying memory buffer from the contents of
-// the underlying MTLTexture, corresponding to the specified subresource definition.
+// the underlying MTLTexture, corresponding to the specified subresource
+// definition.
 void MVKImagePlane::getMTLTextureContent(MVKImageSubresource& subresource,
-                                         VkDeviceSize offset, VkDeviceSize size) {
+                                         VkDeviceSize offset,
+                                         VkDeviceSize size) {
 
     VkImageSubresource& imgSubRez = subresource.subresource;
     VkSubresourceLayout& imgLayout = subresource.layout;
 
     // Check if subresource overlaps the memory range.
-    if ( !overlaps(imgLayout, offset, size) ) { return; }
+    if (!overlaps(imgLayout, offset, size)) {
+        return;
+    }
 
     // Don't update if host memory has not been mapped yet.
     void* pHostMem = getMemoryBinding()->getHostMemoryAddress();
-    if ( !pHostMem ) { return; }
+    if (!pHostMem) {
+        return;
+    }
 
     VkExtent3D mipExtent = _image->getExtent3D(_planeIndex, imgSubRez.mipLevel);
     void* pImgBytes = (void*)((uintptr_t)pHostMem + imgLayout.offset);
@@ -278,92 +329,112 @@ void MVKImagePlane::getMTLTextureContent(MVKImageSubresource& subresource,
     mtlRegion.size = mvkMTLSizeFromVkExtent3D(mipExtent);
 
     VkImageType imgType = _image->getImageType();
-    VkDeviceSize bytesPerRow = (imgType != VK_IMAGE_TYPE_1D) ? imgLayout.rowPitch : 0;
-    VkDeviceSize bytesPerImage = (imgType == VK_IMAGE_TYPE_3D) ? imgLayout.depthPitch : 0;
+    VkDeviceSize bytesPerRow =
+        (imgType != VK_IMAGE_TYPE_1D) ? imgLayout.rowPitch : 0;
+    VkDeviceSize bytesPerImage =
+        (imgType == VK_IMAGE_TYPE_3D) ? imgLayout.depthPitch : 0;
 
-    [_mtlTexture getBytes: pImgBytes
-              bytesPerRow: bytesPerRow
-            bytesPerImage: bytesPerImage
-               fromRegion: mtlRegion
-              mipmapLevel: imgSubRez.mipLevel
-                    slice: imgSubRez.arrayLayer];
+    [_mtlTexture getBytes:pImgBytes
+              bytesPerRow:bytesPerRow
+            bytesPerImage:bytesPerImage
+               fromRegion:mtlRegion
+              mipmapLevel:imgSubRez.mipLevel
+                    slice:imgSubRez.arrayLayer];
 }
 
 // Returns whether subresource layout overlaps the memory range.
-bool MVKImagePlane::overlaps(VkSubresourceLayout& imgLayout, VkDeviceSize offset, VkDeviceSize size) {
-	VkDeviceSize memStart = offset;
-	VkDeviceSize memEnd = offset + size;
-	VkDeviceSize imgStart = getMemoryBinding()->_deviceMemoryOffset + imgLayout.offset;
-	VkDeviceSize imgEnd = imgStart + imgLayout.size;
-	return imgStart < memEnd && imgEnd > memStart;
+bool MVKImagePlane::overlaps(VkSubresourceLayout& imgLayout,
+                             VkDeviceSize offset, VkDeviceSize size) {
+    VkDeviceSize memStart = offset;
+    VkDeviceSize memEnd = offset + size;
+    VkDeviceSize imgStart =
+        getMemoryBinding()->_deviceMemoryOffset + imgLayout.offset;
+    VkDeviceSize imgEnd = imgStart + imgLayout.size;
+    return imgStart < memEnd && imgEnd > memStart;
 }
 
 void MVKImagePlane::propagateDebugName() {
-	_image->setMetalObjectLabel(_image->_planes[_planeIndex]->_mtlTexture, _image->_debugName);
+    _image->setMetalObjectLabel(_image->_planes[_planeIndex]->_mtlTexture,
+                                _image->_debugName);
 }
 
 MVKImageMemoryBinding* MVKImagePlane::getMemoryBinding() const {
-	return _image->getMemoryBinding(_planeIndex);
+    return _image->getMemoryBinding(_planeIndex);
 }
 
 void MVKImagePlane::applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
-											MVKCommandEncoder* cmdEncoder,
-											MVKCommandUse cmdUse) {
+                                            MVKCommandEncoder* cmdEncoder,
+                                            MVKCommandUse cmdUse) {
 
-	// Extract the mipmap levels that are to be updated
-	uint32_t mipLvlStart = barrier.baseMipLevel;
-	uint32_t mipLvlEnd = (barrier.levelCount == (uint8_t)VK_REMAINING_MIP_LEVELS
-						  ? _image->getMipLevelCount()
-						  : (mipLvlStart + barrier.levelCount));
+    // Extract the mipmap levels that are to be updated
+    uint32_t mipLvlStart = barrier.baseMipLevel;
+    uint32_t mipLvlEnd = (barrier.levelCount == (uint8_t)VK_REMAINING_MIP_LEVELS
+                              ? _image->getMipLevelCount()
+                              : (mipLvlStart + barrier.levelCount));
 
-	// Extract the cube or array layers (slices) that are to be updated
-	uint32_t layerStart = barrier.baseArrayLayer;
-	uint32_t layerEnd = (barrier.layerCount == (uint16_t)VK_REMAINING_ARRAY_LAYERS
-						 ? _image->getLayerCount()
-						 : (layerStart + barrier.layerCount));
+    // Extract the cube or array layers (slices) that are to be updated
+    uint32_t layerStart = barrier.baseArrayLayer;
+    uint32_t layerEnd =
+        (barrier.layerCount == (uint16_t)VK_REMAINING_ARRAY_LAYERS
+             ? _image->getLayerCount()
+             : (layerStart + barrier.layerCount));
 
-	MVKImageMemoryBinding* memBind = getMemoryBinding();
-	bool needsSync = memBind->needsHostReadSync(barrier);
-	bool needsPull = ((!memBind->_mtlTexelBuffer || memBind->_ownsTexelBuffer) &&
-					  memBind->isMemoryHostCoherent() &&
-					  barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL &&
-					  mvkIsAnyFlagEnabled(barrier.dstAccessMask, (VK_ACCESS_HOST_READ_BIT | VK_ACCESS_MEMORY_READ_BIT)));
-	MVKDeviceMemory* dvcMem = memBind->getDeviceMemory();
-	const MVKMappedMemoryRange& mappedRange = dvcMem ? dvcMem->getMappedRange() : MVKMappedMemoryRange();
+    MVKImageMemoryBinding* memBind = getMemoryBinding();
+    bool needsSync = memBind->needsHostReadSync(barrier);
+    bool needsPull =
+        ((!memBind->_mtlTexelBuffer || memBind->_ownsTexelBuffer) &&
+         memBind->isMemoryHostCoherent() &&
+         barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL &&
+         mvkIsAnyFlagEnabled(barrier.dstAccessMask,
+                             (VK_ACCESS_HOST_READ_BIT |
+                              VK_ACCESS_MEMORY_READ_BIT)));
+    MVKDeviceMemory* dvcMem = memBind->getDeviceMemory();
+    const MVKMappedMemoryRange& mappedRange =
+        dvcMem ? dvcMem->getMappedRange() : MVKMappedMemoryRange();
 
-	// Iterate across mipmap levels and layers, and update the image layout state for each
-	for (uint32_t mipLvl = mipLvlStart; mipLvl < mipLvlEnd; mipLvl++) {
-		for (uint32_t layer = layerStart; layer < layerEnd; layer++) {
-			MVKImageSubresource* pImgRez = getSubresource(mipLvl, layer);
-			if (pImgRez) { pImgRez->layoutState = barrier.newLayout; }
-			if (needsSync) {
+    // Iterate across mipmap levels and layers, and update the image layout
+    // state for each
+    for (uint32_t mipLvl = mipLvlStart; mipLvl < mipLvlEnd; mipLvl++) {
+        for (uint32_t layer = layerStart; layer < layerEnd; layer++) {
+            MVKImageSubresource* pImgRez = getSubresource(mipLvl, layer);
+            if (pImgRez) {
+                pImgRez->layoutState = barrier.newLayout;
+            }
+            if (needsSync) {
 #if MVK_MACOS
-				[cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeTexture: getMTLTexture() slice: layer level: mipLvl];
+                [cmdEncoder->getMTLBlitEncoder(cmdUse)
+                    synchronizeTexture:getMTLTexture()
+                                 slice:layer
+                                 level:mipLvl];
 #endif
-			}
-			// Check if image content should be pulled into host-mapped device memory after
-			// the GPU is done with it. This only applies if the image is intended to be
-			// host-coherent, is not using a texel buffer, is transitioning to host-readable,
-			// AND the device memory has an already-open memory mapping. If a memory mapping is
-			// created later, it will pull the image contents in at that time, so it is not needed now.
-			// The mapped range will be {0,0} if device memory is not currently mapped.
-			if (needsPull && pImgRez && overlaps(pImgRez->layout, mappedRange.offset, mappedRange.size)) {
-				pullFromDeviceOnCompletion(cmdEncoder, *pImgRez, mappedRange);
-			}
-		}
-	}
+            }
+            // Check if image content should be pulled into host-mapped device
+            // memory after the GPU is done with it. This only applies if the
+            // image is intended to be host-coherent, is not using a texel
+            // buffer, is transitioning to host-readable, AND the device memory
+            // has an already-open memory mapping. If a memory mapping is
+            // created later, it will pull the image contents in at that time,
+            // so it is not needed now. The mapped range will be {0,0} if device
+            // memory is not currently mapped.
+            if (needsPull && pImgRez &&
+                overlaps(pImgRez->layout, mappedRange.offset,
+                         mappedRange.size)) {
+                pullFromDeviceOnCompletion(cmdEncoder, *pImgRez, mappedRange);
+            }
+        }
+    }
 }
 
-// Once the command buffer completes, pull the content of the subresource into host memory.
-// This is only necessary when the image memory is intended to be host-coherent, and the
-// device memory is currently mapped to host memory
-void MVKImagePlane::pullFromDeviceOnCompletion(MVKCommandEncoder* cmdEncoder,
-											   MVKImageSubresource& subresource,
-											   const MVKMappedMemoryRange& mappedRange) {
+// Once the command buffer completes, pull the content of the subresource into
+// host memory. This is only necessary when the image memory is intended to be
+// host-coherent, and the device memory is currently mapped to host memory
+void MVKImagePlane::pullFromDeviceOnCompletion(
+    MVKCommandEncoder* cmdEncoder, MVKImageSubresource& subresource,
+    const MVKMappedMemoryRange& mappedRange) {
 
-	[cmdEncoder->_mtlCmdBuffer addCompletedHandler: ^(id<MTLCommandBuffer> mcb) {
-		getMTLTextureContent(subresource, mappedRange.offset, mappedRange.size);
-	}];
+    [cmdEncoder->_mtlCmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> mcb) {
+      getMTLTextureContent(subresource, mappedRange.offset, mappedRange.size);
+    }];
 }
 
 MVKImagePlane::MVKImagePlane(MVKImage* image, uint8_t planeIndex) {
@@ -372,32 +443,41 @@ MVKImagePlane::MVKImagePlane(MVKImage* image, uint8_t planeIndex) {
     _mtlTexture = nil;
 }
 
-MVKImagePlane::~MVKImagePlane() {
-    releaseMTLTexture();
-}
-
+MVKImagePlane::~MVKImagePlane() { releaseMTLTexture(); }
 
 #pragma mark -
 #pragma mark MVKImageMemoryBinding
 
-VkResult MVKImageMemoryBinding::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements) {
+VkResult MVKImageMemoryBinding::getMemoryRequirements(
+    VkMemoryRequirements* pMemoryRequirements) {
     pMemoryRequirements->size = _byteCount;
     pMemoryRequirements->alignment = _byteAlignment;
     return VK_SUCCESS;
 }
 
-VkResult MVKImageMemoryBinding::getMemoryRequirements(const void*, VkMemoryRequirements2* pMemoryRequirements) {
-	auto& mtlFeats = getMetalFeatures();
+VkResult MVKImageMemoryBinding::getMemoryRequirements(
+    const void*, VkMemoryRequirements2* pMemoryRequirements) {
+    auto& mtlFeats = getMetalFeatures();
     pMemoryRequirements->sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
-    for (auto* next = (VkBaseOutStructure*)pMemoryRequirements->pNext; next; next = next->pNext) {
+    for (auto* next = (VkBaseOutStructure*)pMemoryRequirements->pNext; next;
+         next = next->pNext) {
         switch (next->sType) {
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS: {
             auto* dedicatedReqs = (VkMemoryDedicatedRequirements*)next;
-            bool writable = mvkIsAnyFlagEnabled(_image->getCombinedUsage(), VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-            bool canUseTexelBuffer = mtlFeats.texelBuffers && _image->_isLinear && !_image->getIsCompressed();
-            dedicatedReqs->requiresDedicatedAllocation = _requiresDedicatedMemoryAllocation;
-            dedicatedReqs->prefersDedicatedAllocation = (dedicatedReqs->requiresDedicatedAllocation ||
-                                                        (!canUseTexelBuffer && (writable || !mtlFeats.placementHeaps)));
+            bool writable = mvkIsAnyFlagEnabled(
+                _image->getCombinedUsage(),
+                VK_IMAGE_USAGE_STORAGE_BIT |
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+            bool canUseTexelBuffer = mtlFeats.texelBuffers &&
+                                     _image->_isLinear &&
+                                     !_image->getIsCompressed();
+            dedicatedReqs->requiresDedicatedAllocation =
+                _requiresDedicatedMemoryAllocation;
+            dedicatedReqs->prefersDedicatedAllocation =
+                (dedicatedReqs->requiresDedicatedAllocation ||
+                 (!canUseTexelBuffer &&
+                  (writable || !mtlFeats.placementHeaps)));
             break;
         }
         default:
@@ -407,35 +487,62 @@ VkResult MVKImageMemoryBinding::getMemoryRequirements(const void*, VkMemoryRequi
     return VK_SUCCESS;
 }
 
-// Memory may have been mapped before image was bound, and needs to be loaded into the MTLTexture.
-VkResult MVKImageMemoryBinding::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) {
-    if (_deviceMemory) { _deviceMemory->removeImageMemoryBinding(this); }
+// Memory may have been mapped before image was bound, and needs to be loaded
+// into the MTLTexture.
+VkResult MVKImageMemoryBinding::bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                                 VkDeviceSize memOffset) {
+    if (_deviceMemory) {
+        _deviceMemory->removeImageMemoryBinding(this);
+    }
     MVKResource::bindDeviceMemory(mvkMem, memOffset);
 
-    if (!_deviceMemory) { return VK_SUCCESS; }
+    if (!_deviceMemory) {
+        return VK_SUCCESS;
+    }
 
-	auto& mtlFeats = getMetalFeatures();
+    auto& mtlFeats = getMetalFeatures();
     bool usesTexelBuffer = mtlFeats.texelBuffers; // Texel buffers available
-    usesTexelBuffer = usesTexelBuffer && (isMemoryHostAccessible() || mtlFeats.placementHeaps) && _image->_isLinear && !_image->getIsCompressed(); // Applicable memory layout
+    usesTexelBuffer = usesTexelBuffer &&
+                      (isMemoryHostAccessible() || mtlFeats.placementHeaps) &&
+                      _image->_isLinear &&
+                      !_image->getIsCompressed(); // Applicable memory layout
 
     // macOS before 10.15.5 cannot use shared memory for texel buffers.
-    usesTexelBuffer = usesTexelBuffer && (mtlFeats.sharedLinearTextures || !isMemoryHostCoherent());
+    usesTexelBuffer = usesTexelBuffer && (mtlFeats.sharedLinearTextures ||
+                                          !isMemoryHostCoherent());
 
-    if (_image->_isLinearForAtomics || (usesTexelBuffer && mtlFeats.placementHeaps)) {
+    if (_image->_isLinearForAtomics ||
+        (usesTexelBuffer && mtlFeats.placementHeaps)) {
         if (usesTexelBuffer && _deviceMemory->ensureMTLBuffer()) {
             _mtlTexelBuffer = _deviceMemory->_mtlBuffer;
             _mtlTexelBufferOffset = getDeviceMemoryOffset();
         } else {
             // Create our own buffer for this.
-            if (_ownsTexelBuffer) { [_mtlTexelBuffer release]; }
-            if (_deviceMemory->_mtlHeap && _image->getMTLStorageMode() == _deviceMemory->_mtlStorageMode) {
-                _mtlTexelBuffer = [_deviceMemory->_mtlHeap newBufferWithLength: _byteCount options: _deviceMemory->getMTLResourceOptions() offset: getDeviceMemoryOffset()];
-                if (_image->_isAliasable) { [_mtlTexelBuffer makeAliasable]; }
+            if (_ownsTexelBuffer) {
+                [_mtlTexelBuffer release];
+            }
+            if (_deviceMemory->_mtlHeap &&
+                _image->getMTLStorageMode() == _deviceMemory->_mtlStorageMode) {
+                _mtlTexelBuffer = [_deviceMemory->_mtlHeap
+                    newBufferWithLength:_byteCount
+                                options:_deviceMemory->getMTLResourceOptions()
+                                 offset:getDeviceMemoryOffset()];
+                if (_image->_isAliasable) {
+                    [_mtlTexelBuffer makeAliasable];
+                }
             } else {
-                _mtlTexelBuffer = [getMTLDevice() newBufferWithLength: _byteCount options: _image->getMTLStorageMode() << MTLResourceStorageModeShift];
+                _mtlTexelBuffer = [getMTLDevice()
+                    newBufferWithLength:_byteCount
+                                options:_image->getMTLStorageMode()
+                                        << MTLResourceStorageModeShift];
             }
             if (!_mtlTexelBuffer) {
-                return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "Could not create an MTLBuffer for an image that requires a buffer backing store. Images that can be used for atomic accesses must have a texel buffer backing them.");
+                return reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                                   "Could not create an MTLBuffer for an image "
+                                   "that requires a buffer backing store. "
+                                   "Images that can be used for atomic "
+                                   "accesses must have a texel buffer backing "
+                                   "them.");
             }
             _mtlTexelBufferOffset = 0;
             _ownsTexelBuffer = true;
@@ -454,15 +561,18 @@ void MVKImageMemoryBinding::applyMemoryBarrier(MVKPipelineBarrier& barrier,
                                                MVKCommandUse cmdUse) {
 #if MVK_MACOS
     if (needsHostReadSync(barrier)) {
-        for(uint8_t planeIndex = beginPlaneIndex(); planeIndex < endPlaneIndex(); planeIndex++) {
-            [cmdEncoder->getMTLBlitEncoder(cmdUse) synchronizeResource: _image->_planes[planeIndex]->_mtlTexture];
+        for (uint8_t planeIndex = beginPlaneIndex();
+             planeIndex < endPlaneIndex(); planeIndex++) {
+            [cmdEncoder->getMTLBlitEncoder(cmdUse)
+                synchronizeResource:_image->_planes[planeIndex]->_mtlTexture];
         }
     }
 #endif
 }
 
 void MVKImageMemoryBinding::propagateDebugName() {
-    for(uint8_t planeIndex = beginPlaneIndex(); planeIndex < endPlaneIndex(); planeIndex++) {
+    for (uint8_t planeIndex = beginPlaneIndex(); planeIndex < endPlaneIndex();
+         planeIndex++) {
         _image->_planes[planeIndex]->propagateDebugName();
     }
     if (_ownsTexelBuffer) {
@@ -470,35 +580,48 @@ void MVKImageMemoryBinding::propagateDebugName() {
     }
 }
 
-// Returns whether the specified image memory barrier requires a sync between this
-// texture and host memory for the purpose of the host reading texture memory.
+// Returns whether the specified image memory barrier requires a sync between
+// this texture and host memory for the purpose of the host reading texture
+// memory.
 bool MVKImageMemoryBinding::needsHostReadSync(MVKPipelineBarrier& barrier) {
 #if MVK_MACOS
-    return ( !isUnifiedMemoryGPU() && (barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL) &&
-            mvkIsAnyFlagEnabled(barrier.dstAccessMask, (VK_ACCESS_HOST_READ_BIT | VK_ACCESS_MEMORY_READ_BIT)) &&
-            isMemoryHostAccessible() && (!getMetalFeatures().sharedLinearTextures || !isMemoryHostCoherent()));
+    return (
+        !isUnifiedMemoryGPU() &&
+        (barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL) &&
+        mvkIsAnyFlagEnabled(barrier.dstAccessMask,
+                            (VK_ACCESS_HOST_READ_BIT |
+                             VK_ACCESS_MEMORY_READ_BIT)) &&
+        isMemoryHostAccessible() &&
+        (!getMetalFeatures().sharedLinearTextures || !isMemoryHostCoherent()));
 #else
-	return false;
+    return false;
 #endif
 }
 
-bool MVKImageMemoryBinding::shouldFlushHostMemory() { return isMemoryHostAccessible() && (!_mtlTexelBuffer || _ownsTexelBuffer); }
+bool MVKImageMemoryBinding::shouldFlushHostMemory() {
+    return isMemoryHostAccessible() && (!_mtlTexelBuffer || _ownsTexelBuffer);
+}
 
-// Flushes the memory at the specified memory range into the MTLTexture. 
-// Updates all subresources that overlap the specified range and are in an updatable layout state.
-VkResult MVKImageMemoryBinding::flushToDevice(VkDeviceSize offset, VkDeviceSize size) {
+// Flushes the memory at the specified memory range into the MTLTexture.
+// Updates all subresources that overlap the specified range and are in an
+// updatable layout state.
+VkResult MVKImageMemoryBinding::flushToDevice(VkDeviceSize offset,
+                                              VkDeviceSize size) {
     if (shouldFlushHostMemory()) {
-        for(uint8_t planeIndex = beginPlaneIndex(); planeIndex < endPlaneIndex(); planeIndex++) {
+        for (uint8_t planeIndex = beginPlaneIndex();
+             planeIndex < endPlaneIndex(); planeIndex++) {
             for (auto& subRez : _image->_planes[planeIndex]->_subresources) {
                 switch (subRez.layoutState) {
-                    case VK_IMAGE_LAYOUT_UNDEFINED:
-                    case VK_IMAGE_LAYOUT_PREINITIALIZED:
-                    case VK_IMAGE_LAYOUT_GENERAL: {
-                        _image->_planes[planeIndex]->updateMTLTextureContent(subRez, offset, size);
-                        break;
-                    }
-                    default:
-                        break;
+                case VK_IMAGE_LAYOUT_UNDEFINED:
+                case VK_IMAGE_LAYOUT_PREINITIALIZED:
+                case VK_IMAGE_LAYOUT_GENERAL: {
+                    _image->_planes[planeIndex]->updateMTLTextureContent(subRez,
+                                                                         offset,
+                                                                         size);
+                    break;
+                }
+                default:
+                    break;
                 }
             }
         }
@@ -507,18 +630,23 @@ VkResult MVKImageMemoryBinding::flushToDevice(VkDeviceSize offset, VkDeviceSize 
 }
 
 // Pulls content from the MTLTexture into memory at the specified memory range.
-// Pulls from all subresources that overlap the specified range and are in an updatable layout state.
-VkResult MVKImageMemoryBinding::pullFromDevice(VkDeviceSize offset, VkDeviceSize size) {
+// Pulls from all subresources that overlap the specified range and are in an
+// updatable layout state.
+VkResult MVKImageMemoryBinding::pullFromDevice(VkDeviceSize offset,
+                                               VkDeviceSize size) {
     if (shouldFlushHostMemory()) {
-        for(uint8_t planeIndex = beginPlaneIndex(); planeIndex < endPlaneIndex(); planeIndex++) {
+        for (uint8_t planeIndex = beginPlaneIndex();
+             planeIndex < endPlaneIndex(); planeIndex++) {
             for (auto& subRez : _image->_planes[planeIndex]->_subresources) {
                 switch (subRez.layoutState) {
-                    case VK_IMAGE_LAYOUT_GENERAL: {
-                        _image->_planes[planeIndex]->getMTLTextureContent(subRez, offset, size);
-                        break;
-                    }
-                    default:
-                        break;
+                case VK_IMAGE_LAYOUT_GENERAL: {
+                    _image->_planes[planeIndex]->getMTLTextureContent(subRez,
+                                                                      offset,
+                                                                      size);
+                    break;
+                }
+                default:
+                    break;
                 }
             }
         }
@@ -533,24 +661,31 @@ uint8_t MVKImageMemoryBinding::beginPlaneIndex() const {
 
 // If I am the only memory binding, I cover all planes.
 uint8_t MVKImageMemoryBinding::endPlaneIndex() const {
-    return (_image->getMemoryBindingCount() > 1) ? _planeIndex + 1 : (uint8_t)_image->_planes.size();
+    return (_image->getMemoryBindingCount() > 1)
+               ? _planeIndex + 1
+               : (uint8_t)_image->_planes.size();
 }
 
-MVKImageMemoryBinding::MVKImageMemoryBinding(MVKDevice* device, MVKImage* image, uint8_t planeIndex) : MVKResource(device), _image(image), _planeIndex(planeIndex) {
-}
+MVKImageMemoryBinding::MVKImageMemoryBinding(MVKDevice* device, MVKImage* image,
+                                             uint8_t planeIndex)
+    : MVKResource(device), _image(image), _planeIndex(planeIndex) {}
 
 MVKImageMemoryBinding::~MVKImageMemoryBinding() {
-    if (_deviceMemory) { _deviceMemory->removeImageMemoryBinding(this); }
-    if (_ownsTexelBuffer) { [_mtlTexelBuffer release]; }
+    if (_deviceMemory) {
+        _deviceMemory->removeImageMemoryBinding(this);
+    }
+    if (_ownsTexelBuffer) {
+        [_mtlTexelBuffer release];
+    }
 }
-
 
 #pragma mark MVKImage
 
-uint8_t MVKImage::getPlaneFromVkImageAspectFlags(VkImageAspectFlags aspectMask) {
-    return (aspectMask & VK_IMAGE_ASPECT_PLANE_2_BIT) ? 2 :
-           (aspectMask & VK_IMAGE_ASPECT_PLANE_1_BIT) ? 1 :
-           0;
+uint8_t
+MVKImage::getPlaneFromVkImageAspectFlags(VkImageAspectFlags aspectMask) {
+    return (aspectMask & VK_IMAGE_ASPECT_PLANE_2_BIT)   ? 2
+           : (aspectMask & VK_IMAGE_ASPECT_PLANE_1_BIT) ? 1
+                                                        : 0;
 }
 
 void MVKImage::propagateDebugName() {
@@ -560,201 +695,241 @@ void MVKImage::propagateDebugName() {
 }
 
 void MVKImage::flushToDevice(VkDeviceSize offset, VkDeviceSize size) {
-    for (int bindingIndex = 0; bindingIndex < getMemoryBindingCount(); bindingIndex++) {
-        MVKImageMemoryBinding *binding = _memoryBindings[bindingIndex];
+    for (int bindingIndex = 0; bindingIndex < getMemoryBindingCount();
+         bindingIndex++) {
+        MVKImageMemoryBinding* binding = _memoryBindings[bindingIndex];
         binding->flushToDevice(offset, size);
     }
 }
 
-template<typename ImgRgn>
-static MTLRegion getMTLRegion(const ImgRgn& imgRgn) {
-	return { mvkMTLOriginFromVkOffset3D(imgRgn.imageOffset), mvkMTLSizeFromVkExtent3D(imgRgn.imageExtent) };
+template <typename ImgRgn> static MTLRegion getMTLRegion(const ImgRgn& imgRgn) {
+    return {mvkMTLOriginFromVkOffset3D(imgRgn.imageOffset),
+            mvkMTLSizeFromVkExtent3D(imgRgn.imageExtent)};
 }
 
 // Host-copy from a MTLTexture to memory.
 VkResult MVKImage::copyContent(id<MTLTexture> mtlTex,
-							   VkImageToMemoryCopyEXT imgRgn, uint32_t mipLevel, uint32_t slice,
-							   void* pImgBytes, size_t rowPitch, size_t depthPitch) {
-	[mtlTex getBytes: pImgBytes
-		 bytesPerRow: rowPitch
-	   bytesPerImage: depthPitch
-		  fromRegion: getMTLRegion(imgRgn)
-		 mipmapLevel: mipLevel
-			   slice: slice];
-	return VK_SUCCESS;
+                               VkImageToMemoryCopyEXT imgRgn, uint32_t mipLevel,
+                               uint32_t slice, void* pImgBytes, size_t rowPitch,
+                               size_t depthPitch) {
+    [mtlTex getBytes:pImgBytes
+          bytesPerRow:rowPitch
+        bytesPerImage:depthPitch
+           fromRegion:getMTLRegion(imgRgn)
+          mipmapLevel:mipLevel
+                slice:slice];
+    return VK_SUCCESS;
 }
 
 // Host-copy from memory to a MTLTexture.
 VkResult MVKImage::copyContent(id<MTLTexture> mtlTex,
-							   VkMemoryToImageCopyEXT imgRgn, uint32_t mipLevel, uint32_t slice,
-							   void* pImgBytes, size_t rowPitch, size_t depthPitch) {
-	VkSubresourceLayout imgLayout = { 0, 0, rowPitch, 0, depthPitch};
+                               VkMemoryToImageCopyEXT imgRgn, uint32_t mipLevel,
+                               uint32_t slice, void* pImgBytes, size_t rowPitch,
+                               size_t depthPitch) {
+    VkSubresourceLayout imgLayout = {0, 0, rowPitch, 0, depthPitch};
 #if MVK_MACOS
-	// Compressed content cannot be directly uploaded to a compressed 3D texture.
-	// But we can upload the decompressed image data.
-	std::unique_ptr<char[]> decompBuffer;
-	if (_is3DCompressed) {
-		std::unique_ptr<MVKCodec> codec = mvkCreateCodec(getPixelFormats()->getVkFormat(mtlTex.pixelFormat));
-		if ( !codec ) { return reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "A 3D texture used a compressed format that MoltenVK does not yet support."); }
-		VkSubresourceLayout linearLayout = {};
-		linearLayout.rowPitch = 4 * imgRgn.imageExtent.width;
-		linearLayout.depthPitch = linearLayout.rowPitch * imgRgn.imageExtent.height;
-		linearLayout.size = linearLayout.depthPitch * imgRgn.imageExtent.depth;
-		decompBuffer = std::unique_ptr<char[]>(new char[linearLayout.size]);
-		codec->decompress(decompBuffer.get(), pImgBytes, linearLayout, imgLayout, imgRgn.imageExtent);
-		pImgBytes = decompBuffer.get();
-		imgLayout = linearLayout;
-	}
+    // Compressed content cannot be directly uploaded to a compressed 3D
+    // texture. But we can upload the decompressed image data.
+    std::unique_ptr<char[]> decompBuffer;
+    if (_is3DCompressed) {
+        std::unique_ptr<MVKCodec> codec =
+            mvkCreateCodec(getPixelFormats()->getVkFormat(mtlTex.pixelFormat));
+        if (!codec) {
+            return reportError(VK_ERROR_FORMAT_NOT_SUPPORTED,
+                               "A 3D texture used a compressed format that "
+                               "MoltenVK does not yet support.");
+        }
+        VkSubresourceLayout linearLayout = {};
+        linearLayout.rowPitch = 4 * imgRgn.imageExtent.width;
+        linearLayout.depthPitch =
+            linearLayout.rowPitch * imgRgn.imageExtent.height;
+        linearLayout.size = linearLayout.depthPitch * imgRgn.imageExtent.depth;
+        decompBuffer = std::unique_ptr<char[]>(new char[linearLayout.size]);
+        codec->decompress(decompBuffer.get(), pImgBytes, linearLayout,
+                          imgLayout, imgRgn.imageExtent);
+        pImgBytes = decompBuffer.get();
+        imgLayout = linearLayout;
+    }
 #endif
-	[mtlTex replaceRegion: getMTLRegion(imgRgn)
-			  mipmapLevel: mipLevel
-					slice: slice
-				withBytes: pImgBytes
-			  bytesPerRow: imgLayout.rowPitch
-			bytesPerImage: imgLayout.depthPitch];
-	return VK_SUCCESS;
+    [mtlTex replaceRegion:getMTLRegion(imgRgn)
+              mipmapLevel:mipLevel
+                    slice:slice
+                withBytes:pImgBytes
+              bytesPerRow:imgLayout.rowPitch
+            bytesPerImage:imgLayout.depthPitch];
+    return VK_SUCCESS;
 }
 
-template<typename CopyInfo>
+template <typename CopyInfo>
 VkResult MVKImage::copyContent(const CopyInfo* pCopyInfo) {
-	MVKPixelFormats* pixFmts = getPixelFormats();
-	VkImageType imgType = getImageType();
-	bool is1D = imgType == VK_IMAGE_TYPE_1D;
-	bool is3D = imgType == VK_IMAGE_TYPE_3D;
+    MVKPixelFormats* pixFmts = getPixelFormats();
+    VkImageType imgType = getImageType();
+    bool is1D = imgType == VK_IMAGE_TYPE_1D;
+    bool is3D = imgType == VK_IMAGE_TYPE_3D;
 
-	for (uint32_t imgRgnIdx = 0; imgRgnIdx < pCopyInfo->regionCount; imgRgnIdx++) {
-		auto& imgRgn = pCopyInfo->pRegions[imgRgnIdx];
-		auto& imgSubRez = imgRgn.imageSubresource;
+    for (uint32_t imgRgnIdx = 0; imgRgnIdx < pCopyInfo->regionCount;
+         imgRgnIdx++) {
+        auto& imgRgn = pCopyInfo->pRegions[imgRgnIdx];
+        auto& imgSubRez = imgRgn.imageSubresource;
 
-		id<MTLTexture> mtlTex = getMTLTexture(getPlaneFromVkImageAspectFlags(imgSubRez.aspectMask));
-		MTLPixelFormat mtlPixFmt = mtlTex.pixelFormat;
-		bool isPVRTC = pixFmts->isPVRTCFormat(mtlPixFmt);
+        id<MTLTexture> mtlTex =
+            getMTLTexture(getPlaneFromVkImageAspectFlags(imgSubRez.aspectMask));
+        MTLPixelFormat mtlPixFmt = mtlTex.pixelFormat;
+        bool isPVRTC = pixFmts->isPVRTCFormat(mtlPixFmt);
 
-		uint32_t texelsWidth = imgRgn.memoryRowLength ? imgRgn.memoryRowLength : imgRgn.imageExtent.width;
-		uint32_t texelsHeight = imgRgn.memoryImageHeight ? imgRgn.memoryImageHeight : imgRgn.imageExtent.height;
-		uint32_t texelsDepth = imgRgn.imageExtent.depth;
-		size_t rowPitch = pixFmts->getBytesPerRow(mtlPixFmt, texelsWidth);
-		size_t depthPitch = pixFmts->getBytesPerLayer(mtlPixFmt, rowPitch, texelsHeight);
-		size_t arrayPitch = depthPitch * texelsDepth;
+        uint32_t texelsWidth = imgRgn.memoryRowLength
+                                   ? imgRgn.memoryRowLength
+                                   : imgRgn.imageExtent.width;
+        uint32_t texelsHeight = imgRgn.memoryImageHeight
+                                    ? imgRgn.memoryImageHeight
+                                    : imgRgn.imageExtent.height;
+        uint32_t texelsDepth = imgRgn.imageExtent.depth;
+        size_t rowPitch = pixFmts->getBytesPerRow(mtlPixFmt, texelsWidth);
+        size_t depthPitch =
+            pixFmts->getBytesPerLayer(mtlPixFmt, rowPitch, texelsHeight);
+        size_t arrayPitch = depthPitch * texelsDepth;
 
-		for (uint32_t imgLyrIdx = 0; imgLyrIdx < imgSubRez.layerCount; imgLyrIdx++) {
-			VkResult rslt = copyContent(mtlTex,
-										imgRgn,
-										imgSubRez.mipLevel,
-										imgSubRez.baseArrayLayer + imgLyrIdx,
-										(void*)((uintptr_t)imgRgn.pHostPointer + (arrayPitch * imgLyrIdx)),
-										(isPVRTC || is1D) ? 0 : rowPitch,
-										(isPVRTC || !is3D) ? 0 : depthPitch);
-			if (rslt) { return rslt; }
-		}
-	}
-	return VK_SUCCESS;
+        for (uint32_t imgLyrIdx = 0; imgLyrIdx < imgSubRez.layerCount;
+             imgLyrIdx++) {
+            VkResult rslt = copyContent(mtlTex, imgRgn, imgSubRez.mipLevel,
+                                        imgSubRez.baseArrayLayer + imgLyrIdx,
+                                        (void*)((uintptr_t)imgRgn.pHostPointer +
+                                                (arrayPitch * imgLyrIdx)),
+                                        (isPVRTC || is1D) ? 0 : rowPitch,
+                                        (isPVRTC || !is3D) ? 0 : depthPitch);
+            if (rslt) {
+                return rslt;
+            }
+        }
+    }
+    return VK_SUCCESS;
 }
 
-// Host-copy content between images by allocating a temporary memory buffer, copying into it from the
-// source image, and then copying from the memory buffer into the destination image, all using the CPU.
-VkResult MVKImage::copyImageToImage(const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo) {
-	for (uint32_t imgRgnIdx = 0; imgRgnIdx < pCopyImageToImageInfo->regionCount; imgRgnIdx++) {
-		auto& imgRgn = pCopyImageToImageInfo->pRegions[imgRgnIdx];
+// Host-copy content between images by allocating a temporary memory buffer,
+// copying into it from the source image, and then copying from the memory
+// buffer into the destination image, all using the CPU.
+VkResult MVKImage::copyImageToImage(
+    const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo) {
+    for (uint32_t imgRgnIdx = 0; imgRgnIdx < pCopyImageToImageInfo->regionCount;
+         imgRgnIdx++) {
+        auto& imgRgn = pCopyImageToImageInfo->pRegions[imgRgnIdx];
 
-		// Create a temporary memory buffer to copy the image region content.
-		MVKImage* srcMVKImg = (MVKImage*)pCopyImageToImageInfo->srcImage;
-		MVKPixelFormats* pixFmts = srcMVKImg->getPixelFormats();
-		MTLPixelFormat srcMTLPixFmt = srcMVKImg->getMTLPixelFormat(getPlaneFromVkImageAspectFlags(imgRgn.srcSubresource.aspectMask));
-		size_t rowPitch = pixFmts->getBytesPerRow(srcMTLPixFmt, imgRgn.extent.width);
-		size_t depthPitch = pixFmts->getBytesPerLayer(srcMTLPixFmt, rowPitch, imgRgn.extent.height);
-		size_t arrayPitch = depthPitch * imgRgn.extent.depth;
-		size_t rgnSizeInBytes = arrayPitch * imgRgn.srcSubresource.layerCount;
-		auto xfrBuffer = unique_ptr<char[]>(new char[rgnSizeInBytes]);
-		void* pImgBytes = xfrBuffer.get();
+        // Create a temporary memory buffer to copy the image region content.
+        MVKImage* srcMVKImg = (MVKImage*)pCopyImageToImageInfo->srcImage;
+        MVKPixelFormats* pixFmts = srcMVKImg->getPixelFormats();
+        MTLPixelFormat srcMTLPixFmt = srcMVKImg->getMTLPixelFormat(
+            getPlaneFromVkImageAspectFlags(imgRgn.srcSubresource.aspectMask));
+        size_t rowPitch =
+            pixFmts->getBytesPerRow(srcMTLPixFmt, imgRgn.extent.width);
+        size_t depthPitch = pixFmts->getBytesPerLayer(srcMTLPixFmt, rowPitch,
+                                                      imgRgn.extent.height);
+        size_t arrayPitch = depthPitch * imgRgn.extent.depth;
+        size_t rgnSizeInBytes = arrayPitch * imgRgn.srcSubresource.layerCount;
+        auto xfrBuffer = unique_ptr<char[]>(new char[rgnSizeInBytes]);
+        void* pImgBytes = xfrBuffer.get();
 
-		// Host-copy the source image content into the memory buffer using the CPU.
-		VkImageToMemoryCopyEXT srcCopy = {
-			VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT,
-			nullptr,
-			pImgBytes,
-			0,
-			0,
-			imgRgn.srcSubresource,
-			imgRgn.srcOffset,
-			imgRgn.extent
-		};
-		VkCopyImageToMemoryInfoEXT srcCopyInfo = {
-			VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT,
-			nullptr,
-			pCopyImageToImageInfo->flags,
-			pCopyImageToImageInfo->srcImage,
-			pCopyImageToImageInfo->srcImageLayout,
-			1,
-			&srcCopy
-		};
-		srcMVKImg->copyContent(&srcCopyInfo);
+        // Host-copy the source image content into the memory buffer using the
+        // CPU.
+        VkImageToMemoryCopyEXT srcCopy =
+            {VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT,
+             nullptr,
+             pImgBytes,
+             0,
+             0,
+             imgRgn.srcSubresource,
+             imgRgn.srcOffset,
+             imgRgn.extent};
+        VkCopyImageToMemoryInfoEXT srcCopyInfo =
+            {VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT,
+             nullptr,
+             pCopyImageToImageInfo->flags,
+             pCopyImageToImageInfo->srcImage,
+             pCopyImageToImageInfo->srcImageLayout,
+             1,
+             &srcCopy};
+        srcMVKImg->copyContent(&srcCopyInfo);
 
-		// Host-copy the image content from the memory buffer into the destination image using the CPU.
-		MVKImage* dstMVKImg = (MVKImage*)pCopyImageToImageInfo->dstImage;
-		VkMemoryToImageCopyEXT dstCopy = {
-			VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT,
-			nullptr,
-			pImgBytes,
-			0,
-			0,
-			imgRgn.dstSubresource,
-			imgRgn.dstOffset,
-			imgRgn.extent
-		};
-		VkCopyMemoryToImageInfoEXT dstCopyInfo = {
-			VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT,
-			nullptr,
-			pCopyImageToImageInfo->flags,
-			pCopyImageToImageInfo->dstImage,
-			pCopyImageToImageInfo->dstImageLayout,
-			1,
-			&dstCopy
-		};
-		dstMVKImg->copyContent(&dstCopyInfo);
-	}
-	return VK_SUCCESS;
+        // Host-copy the image content from the memory buffer into the
+        // destination image using the CPU.
+        MVKImage* dstMVKImg = (MVKImage*)pCopyImageToImageInfo->dstImage;
+        VkMemoryToImageCopyEXT dstCopy =
+            {VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT,
+             nullptr,
+             pImgBytes,
+             0,
+             0,
+             imgRgn.dstSubresource,
+             imgRgn.dstOffset,
+             imgRgn.extent};
+        VkCopyMemoryToImageInfoEXT dstCopyInfo =
+            {VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT,
+             nullptr,
+             pCopyImageToImageInfo->flags,
+             pCopyImageToImageInfo->dstImage,
+             pCopyImageToImageInfo->dstImageLayout,
+             1,
+             &dstCopy};
+        dstMVKImg->copyContent(&dstCopyInfo);
+    }
+    return VK_SUCCESS;
 }
 
-VkResult MVKImage::copyImageToMemory(const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo) {
+VkResult MVKImage::copyImageToMemory(
+    const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo) {
 #if MVK_MACOS
-	// On macOS, if the device doesn't have unified memory, and the texture is using managed memory, we need
-	// to sync the managed memory from the GPU, so the texture content is accessible to be copied by the CPU.
-	if ( !isUnifiedMemoryGPU() && getMTLStorageMode() == MTLStorageModeManaged ) {
-		@autoreleasepool {
-			id<MTLCommandBuffer> mtlCmdBuff = getDevice()->getAnyQueue()->getMTLCommandBuffer(kMVKCommandUseCopyImageToMemory);
-			id<MTLBlitCommandEncoder> mtlBlitEnc = [mtlCmdBuff blitCommandEncoder];
+    // On macOS, if the device doesn't have unified memory, and the texture is
+    // using managed memory, we need to sync the managed memory from the GPU, so
+    // the texture content is accessible to be copied by the CPU.
+    if (!isUnifiedMemoryGPU() && getMTLStorageMode() == MTLStorageModeManaged) {
+        @autoreleasepool {
+            id<MTLCommandBuffer> mtlCmdBuff =
+                getDevice()->getAnyQueue()->getMTLCommandBuffer(
+                    kMVKCommandUseCopyImageToMemory);
+            id<MTLBlitCommandEncoder> mtlBlitEnc =
+                [mtlCmdBuff blitCommandEncoder];
 
-			for (uint32_t imgRgnIdx = 0; imgRgnIdx < pCopyImageToMemoryInfo->regionCount; imgRgnIdx++) {
-				auto& imgRgn = pCopyImageToMemoryInfo->pRegions[imgRgnIdx];
-				auto& imgSubRez = imgRgn.imageSubresource;
-				id<MTLTexture> mtlTex = getMTLTexture(getPlaneFromVkImageAspectFlags(imgSubRez.aspectMask));
-				for (uint32_t imgLyrIdx = 0; imgLyrIdx < imgSubRez.layerCount; imgLyrIdx++) {
-					[mtlBlitEnc synchronizeTexture: mtlTex
-											 slice: imgSubRez.baseArrayLayer + imgLyrIdx
-											 level: imgSubRez.mipLevel];
-				}
-			}
+            for (uint32_t imgRgnIdx = 0;
+                 imgRgnIdx < pCopyImageToMemoryInfo->regionCount; imgRgnIdx++) {
+                auto& imgRgn = pCopyImageToMemoryInfo->pRegions[imgRgnIdx];
+                auto& imgSubRez = imgRgn.imageSubresource;
+                id<MTLTexture> mtlTex = getMTLTexture(
+                    getPlaneFromVkImageAspectFlags(imgSubRez.aspectMask));
+                for (uint32_t imgLyrIdx = 0; imgLyrIdx < imgSubRez.layerCount;
+                     imgLyrIdx++) {
+                    [mtlBlitEnc
+                        synchronizeTexture:mtlTex
+                                     slice:imgSubRez.baseArrayLayer + imgLyrIdx
+                                     level:imgSubRez.mipLevel];
+                }
+            }
 
-			[mtlBlitEnc endEncoding];
-			[mtlCmdBuff commit];
-			[mtlCmdBuff waitUntilCompleted];
-		}
-	}
+            [mtlBlitEnc endEncoding];
+            [mtlCmdBuff commit];
+            [mtlCmdBuff waitUntilCompleted];
+        }
+    }
 #endif
 
-	return copyContent(pCopyImageToMemoryInfo);
+    return copyContent(pCopyImageToMemoryInfo);
 }
 
-VkResult MVKImage::copyMemoryToImage(const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo) {
-	return copyContent(pCopyMemoryToImageInfo);
+VkResult MVKImage::copyMemoryToImage(
+    const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo) {
+    return copyContent(pCopyMemoryToImageInfo);
 }
 
-VkImageType MVKImage::getImageType() { return mvkVkImageTypeFromMTLTextureType(_mtlTextureType); }
+VkImageType MVKImage::getImageType() {
+    return mvkVkImageTypeFromMTLTextureType(_mtlTextureType);
+}
 
-bool MVKImage::getIsDepthStencil() { return getPixelFormats()->getFormatType(_vkFormat) == kMVKFormatDepthStencil; }
+bool MVKImage::getIsDepthStencil() {
+    return getPixelFormats()->getFormatType(_vkFormat) ==
+           kMVKFormatDepthStencil;
+}
 
-bool MVKImage::getIsCompressed() { return getPixelFormats()->getFormatType(_vkFormat) == kMVKFormatCompressed; }
+bool MVKImage::getIsCompressed() {
+    return getPixelFormats()->getFormatType(_vkFormat) == kMVKFormatCompressed;
+}
 
 VkExtent3D MVKImage::getExtent3D(uint8_t planeIndex, uint32_t mipLevel) {
     VkExtent3D extent = _extent;
@@ -762,55 +937,74 @@ VkExtent3D MVKImage::getExtent3D(uint8_t planeIndex, uint32_t mipLevel) {
         extent.width /= _planes[planeIndex]->_blockTexelSize.width;
         extent.height /= _planes[planeIndex]->_blockTexelSize.height;
     }
-	return mvkMipmapLevelSizeFromBaseSize3D(extent, mipLevel);
+    return mvkMipmapLevelSizeFromBaseSize3D(extent, mipLevel);
 }
 
 VkDeviceSize MVKImage::getBytesPerRow(uint8_t planeIndex, uint32_t mipLevel) {
-    MTLPixelFormat planeMTLPixFmt = getPixelFormats()->getChromaSubsamplingPlaneMTLPixelFormat(_vkFormat, planeIndex);
-    size_t bytesPerRow = getPixelFormats()->getBytesPerRow(planeMTLPixFmt, getExtent3D(planeIndex, mipLevel).width);
+    MTLPixelFormat planeMTLPixFmt =
+        getPixelFormats()->getChromaSubsamplingPlaneMTLPixelFormat(_vkFormat,
+                                                                   planeIndex);
+    size_t bytesPerRow =
+        getPixelFormats()
+            ->getBytesPerRow(planeMTLPixFmt,
+                             getExtent3D(planeIndex, mipLevel).width);
     return mvkAlignByteCount(bytesPerRow, _rowByteAlignment);
 }
 
 VkDeviceSize MVKImage::getBytesPerLayer(uint8_t planeIndex, uint32_t mipLevel) {
-    MTLPixelFormat planeMTLPixFmt = getPixelFormats()->getChromaSubsamplingPlaneMTLPixelFormat(_vkFormat, planeIndex);
+    MTLPixelFormat planeMTLPixFmt =
+        getPixelFormats()->getChromaSubsamplingPlaneMTLPixelFormat(_vkFormat,
+                                                                   planeIndex);
     VkExtent3D extent = getExtent3D(planeIndex, mipLevel);
     size_t bytesPerRow = getBytesPerRow(planeIndex, mipLevel);
-    return getPixelFormats()->getBytesPerLayer(planeMTLPixFmt, bytesPerRow, extent.height);
+    return getPixelFormats()->getBytesPerLayer(planeMTLPixFmt, bytesPerRow,
+                                               extent.height);
 }
 
 VkResult MVKImage::getSubresourceLayout(const VkImageSubresource* pSubresource,
-										VkSubresourceLayout* pLayout) {
-	VkImageSubresource2KHR subresource2 = { VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, nullptr, *pSubresource};
-	VkSubresourceLayout2KHR layout2 = { VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, nullptr, *pLayout};
-	VkResult rslt = getSubresourceLayout(&subresource2, &layout2);
-	*pLayout = layout2.subresourceLayout;
-	return rslt;
+                                        VkSubresourceLayout* pLayout) {
+    VkImageSubresource2KHR subresource2 =
+        {VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, nullptr, *pSubresource};
+    VkSubresourceLayout2KHR layout2 =
+        {VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, nullptr, *pLayout};
+    VkResult rslt = getSubresourceLayout(&subresource2, &layout2);
+    *pLayout = layout2.subresourceLayout;
+    return rslt;
 }
 
-VkResult MVKImage::getSubresourceLayout(const VkImageSubresource2KHR* pSubresource,
-										VkSubresourceLayout2KHR* pLayout) {
-	pLayout->sType = VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR;
-	VkSubresourceHostMemcpySizeEXT* pMemcpySize = nullptr;
-	for (auto* next = (VkBaseOutStructure*)pLayout->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT: {
-				pMemcpySize = (VkSubresourceHostMemcpySizeEXT*)next;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+VkResult
+MVKImage::getSubresourceLayout(const VkImageSubresource2KHR* pSubresource,
+                               VkSubresourceLayout2KHR* pLayout) {
+    pLayout->sType = VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR;
+    VkSubresourceHostMemcpySizeEXT* pMemcpySize = nullptr;
+    for (auto* next = (VkBaseOutStructure*)pLayout->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT: {
+            pMemcpySize = (VkSubresourceHostMemcpySizeEXT*)next;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(pSubresource->imageSubresource.aspectMask);
-	MVKImageSubresource* pImgRez = _planes[planeIndex]->getSubresource(pSubresource->imageSubresource.mipLevel, 
-																	   pSubresource->imageSubresource.arrayLayer);
-	if ( !pImgRez ) { return VK_INCOMPLETE; }
+    uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(
+        pSubresource->imageSubresource.aspectMask);
+    MVKImageSubresource* pImgRez =
+        _planes[planeIndex]
+            ->getSubresource(pSubresource->imageSubresource.mipLevel,
+                             pSubresource->imageSubresource.arrayLayer);
+    if (!pImgRez) {
+        return VK_INCOMPLETE;
+    }
 
-	pLayout->subresourceLayout = pImgRez->layout;
-	if (pMemcpySize) { pMemcpySize->size = pImgRez->layout.size; }
+    pLayout->subresourceLayout = pImgRez->layout;
+    if (pMemcpySize) {
+        pMemcpySize->size = pImgRez->layout.size;
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 void MVKImage::getTransferDescriptorData(MVKImageDescriptorData& imgData) {
@@ -827,143 +1021,190 @@ void MVKImage::getTransferDescriptorData(MVKImageDescriptorData& imgData) {
 // If the list of pre-declared view formats is not empty,
 // and the format is not on that list, the view format is not valid.
 bool MVKImage::getIsValidViewFormat(VkFormat viewFormat) {
-	for (VkFormat viewFmt : _viewFormats) {
-		if (viewFormat == viewFmt) { return true; }
-	}
-	return _viewFormats.empty();
+    for (VkFormat viewFmt : _viewFormats) {
+        if (viewFormat == viewFmt) {
+            return true;
+        }
+    }
+    return _viewFormats.empty();
 }
-
 
 #pragma mark Resource memory
 
-// There may be less memory bindings than planes, but there will always be at least one.
+// There may be less memory bindings than planes, but there will always be at
+// least one.
 uint8_t MVKImage::getMemoryBindingIndex(uint8_t planeIndex) const {
-	return std::min<uint8_t>(planeIndex, getMemoryBindingCount() - 1);
+    return std::min<uint8_t>(planeIndex, getMemoryBindingCount() - 1);
 }
 
 MVKImageMemoryBinding* MVKImage::getMemoryBinding(uint8_t planeIndex) {
-	return _memoryBindings[getMemoryBindingIndex(planeIndex)];
+    return _memoryBindings[getMemoryBindingIndex(planeIndex)];
 }
 
 void MVKImage::applyImageMemoryBarrier(MVKPipelineBarrier& barrier,
-									   MVKCommandEncoder* cmdEncoder,
-									   MVKCommandUse cmdUse) {
+                                       MVKCommandEncoder* cmdEncoder,
+                                       MVKCommandUse cmdUse) {
 
-	for (uint8_t planeIndex = 0; planeIndex < _planes.size(); planeIndex++) {
-		if ( !_hasChromaSubsampling || mvkIsAnyFlagEnabled(barrier.aspectMask, (VK_IMAGE_ASPECT_PLANE_0_BIT << planeIndex)) ) {
-			_planes[planeIndex]->applyImageMemoryBarrier(barrier, cmdEncoder, cmdUse);
-		}
+    for (uint8_t planeIndex = 0; planeIndex < _planes.size(); planeIndex++) {
+        if (!_hasChromaSubsampling ||
+            mvkIsAnyFlagEnabled(barrier.aspectMask,
+                                (VK_IMAGE_ASPECT_PLANE_0_BIT << planeIndex))) {
+            _planes[planeIndex]->applyImageMemoryBarrier(barrier, cmdEncoder,
+                                                         cmdUse);
+        }
     }
 }
 
-VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements, uint8_t planeIndex) {
-	MVKPhysicalDevice* mvkPD = getPhysicalDevice();
-	VkImageUsageFlags combinedUsage = getCombinedUsage();
+VkResult
+MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements,
+                                uint8_t planeIndex) {
+    MVKPhysicalDevice* mvkPD = getPhysicalDevice();
+    VkImageUsageFlags combinedUsage = getCombinedUsage();
 
     pMemoryRequirements->memoryTypeBits = (_isDepthStencilAttachment)
-                                          ? mvkPD->getPrivateMemoryTypes()
-                                          : mvkPD->getAllMemoryTypes();
-    // Metal on non-Apple GPUs does not provide native support for host-coherent memory, but Vulkan requires it for Linear images
+                                              ? mvkPD->getPrivateMemoryTypes()
+                                              : mvkPD->getAllMemoryTypes();
+    // Metal on non-Apple GPUs does not provide native support for host-coherent
+    // memory, but Vulkan requires it for Linear images
 #if MVK_MACOS
-    if ( !isAppleGPU() && !_isLinear ) {
-        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getHostCoherentMemoryTypes());
+    if (!isAppleGPU() && !_isLinear) {
+        mvkDisableFlags(pMemoryRequirements->memoryTypeBits,
+                        mvkPD->getHostCoherentMemoryTypes());
     }
 #endif
 
-	// If the image can be used in a host-copy transfer, the memory cannot be private.
-	if (mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT)) {
-		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getPrivateMemoryTypes());
-	}
-
-    // Only transient attachments may use memoryless storage.
-	// Using memoryless as an input attachment requires shader framebuffer fetch, which MoltenVK does not support yet.
-	// TODO: support framebuffer fetch so VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT uses color(m) in shader instead of setFragmentTexture:, which crashes Metal
-    if (!mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ||
-		 mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) ) {
-        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getLazilyAllocatedMemoryTypes());
+    // If the image can be used in a host-copy transfer, the memory cannot be
+    // private.
+    if (mvkIsAnyFlagEnabled(combinedUsage,
+                            VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT)) {
+        mvkDisableFlags(pMemoryRequirements->memoryTypeBits,
+                        mvkPD->getPrivateMemoryTypes());
     }
 
-    return getMemoryBinding(planeIndex)->getMemoryRequirements(pMemoryRequirements);
+    // Only transient attachments may use memoryless storage.
+    // Using memoryless as an input attachment requires shader framebuffer
+    // fetch, which MoltenVK does not support yet.
+    // TODO: support framebuffer fetch so VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT
+    // uses color(m) in shader instead of setFragmentTexture:, which crashes
+    // Metal
+    if (!mvkIsAnyFlagEnabled(combinedUsage,
+                             VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ||
+        mvkIsAnyFlagEnabled(combinedUsage,
+                            VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
+        mvkDisableFlags(pMemoryRequirements->memoryTypeBits,
+                        mvkPD->getLazilyAllocatedMemoryTypes());
+    }
+
+    return getMemoryBinding(planeIndex)
+        ->getMemoryRequirements(pMemoryRequirements);
 }
 
-VkResult MVKImage::getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements) {
+VkResult
+MVKImage::getMemoryRequirements(const void* pInfo,
+                                VkMemoryRequirements2* pMemoryRequirements) {
     uint8_t planeIndex = 0;
-	const auto* pImageInfo = (const VkImageMemoryRequirementsInfo2*)pInfo;
-	for (const auto* next = (const VkBaseInStructure*)pImageInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-		case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO: {
-			const auto* planeReqs = (const VkImagePlaneMemoryRequirementsInfo*)next;
-            planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(planeReqs->planeAspect);
-			break;
-		}
-		default:
-			break;
-		}
-	}
-    VkResult rslt = getMemoryRequirements(&pMemoryRequirements->memoryRequirements, planeIndex);
-    if (rslt != VK_SUCCESS) { return rslt; }
-    return getMemoryBinding(planeIndex)->getMemoryRequirements(pInfo, pMemoryRequirements);
+    const auto* pImageInfo = (const VkImageMemoryRequirementsInfo2*)pInfo;
+    for (const auto* next = (const VkBaseInStructure*)pImageInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO: {
+            const auto* planeReqs =
+                (const VkImagePlaneMemoryRequirementsInfo*)next;
+            planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(
+                planeReqs->planeAspect);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    VkResult rslt =
+        getMemoryRequirements(&pMemoryRequirements->memoryRequirements,
+                              planeIndex);
+    if (rslt != VK_SUCCESS) {
+        return rslt;
+    }
+    return getMemoryBinding(planeIndex)
+        ->getMemoryRequirements(pInfo, pMemoryRequirements);
 }
 
-VkResult MVKImage::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset, uint8_t planeIndex) {
+VkResult MVKImage::bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                    VkDeviceSize memOffset,
+                                    uint8_t planeIndex) {
     return getMemoryBinding(planeIndex)->bindDeviceMemory(mvkMem, memOffset);
 }
 
 VkResult MVKImage::bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo) {
     uint8_t planeIndex = 0;
-    for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next; next = next->pNext) {
+    for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next;
+         next = next->pNext) {
         switch (next->sType) {
-            case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO: {
-                const VkBindImagePlaneMemoryInfo* imagePlaneMemoryInfo = (const VkBindImagePlaneMemoryInfo*)next;
-                planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(imagePlaneMemoryInfo->planeAspect);
-                break;
-            }
-            default:
-                break;
+        case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO: {
+            const VkBindImagePlaneMemoryInfo* imagePlaneMemoryInfo =
+                (const VkBindImagePlaneMemoryInfo*)next;
+            planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(
+                imagePlaneMemoryInfo->planeAspect);
+            break;
+        }
+        default:
+            break;
         }
     }
-    return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset, planeIndex);
+    return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory,
+                            pBindInfo->memoryOffset, planeIndex);
 }
-
 
 #pragma mark Metal
 
 id<MTLTexture> MVKImage::getMTLTexture(uint8_t planeIndex) {
-	return _planes[planeIndex]->getMTLTexture();
+    return _planes[planeIndex]->getMTLTexture();
 }
 
-id<MTLTexture> MVKImage::getMTLTexture(uint8_t planeIndex, MTLPixelFormat mtlPixFmt) {
+id<MTLTexture> MVKImage::getMTLTexture(uint8_t planeIndex,
+                                       MTLPixelFormat mtlPixFmt) {
     return _planes[planeIndex]->getMTLTexture(mtlPixFmt);
 }
 
-VkResult MVKImage::setMTLTexture(uint8_t planeIndex, id<MTLTexture> mtlTexture) {
-	lock_guard<mutex> lock(_lock);
+VkResult MVKImage::setMTLTexture(uint8_t planeIndex,
+                                 id<MTLTexture> mtlTexture) {
+    lock_guard<mutex> lock(_lock);
 
-	if (planeIndex >= _planes.size()) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "Plane index is out of bounds. Attempted to set MTLTexture at plane index %d in VkImage that has %zu planes.", planeIndex, _planes.size()); }
+    if (planeIndex >= _planes.size()) {
+        return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                           "Plane index is out of bounds. Attempted to set "
+                           "MTLTexture at plane index %d in VkImage "
+                           "that has %zu planes.",
+                           planeIndex, _planes.size());
+    }
 
-	if (_planes[planeIndex]->_mtlTexture == mtlTexture) { return VK_SUCCESS; }
+    if (_planes[planeIndex]->_mtlTexture == mtlTexture) {
+        return VK_SUCCESS;
+    }
 
-	releaseIOSurface();
+    releaseIOSurface();
     _planes[planeIndex]->releaseMTLTexture();
-	_planes[planeIndex]->_mtlTexture = [mtlTexture retain];		// retained
+    _planes[planeIndex]->_mtlTexture = [mtlTexture retain]; // retained
 
     _vkFormat = getPixelFormats()->getVkFormat(mtlTexture.pixelFormat);
-	_mtlTextureType = mtlTexture.textureType;
-	_extent.width = uint32_t(mtlTexture.width);
-	_extent.height = uint32_t(mtlTexture.height);
-	_extent.depth = uint32_t(mtlTexture.depth);
-	_mipLevels = uint32_t(mtlTexture.mipmapLevelCount);
-	_samples = mvkVkSampleCountFlagBitsFromSampleCount(mtlTexture.sampleCount);
-	_arrayLayers = uint32_t(mtlTexture.arrayLength);
-	_usage = getPixelFormats()->getVkImageUsageFlags(mtlTexture.usage, mtlTexture.pixelFormat);
-	_stencilUsage = _usage;
+    _mtlTextureType = mtlTexture.textureType;
+    _extent.width = uint32_t(mtlTexture.width);
+    _extent.height = uint32_t(mtlTexture.height);
+    _extent.depth = uint32_t(mtlTexture.depth);
+    _mipLevels = uint32_t(mtlTexture.mipmapLevelCount);
+    _samples = mvkVkSampleCountFlagBitsFromSampleCount(mtlTexture.sampleCount);
+    _arrayLayers = uint32_t(mtlTexture.arrayLength);
+    _usage = getPixelFormats()->getVkImageUsageFlags(mtlTexture.usage,
+                                                     mtlTexture.pixelFormat);
+    _stencilUsage = _usage;
 
-	if (getMetalFeatures().ioSurfaces) {
-		_ioSurface = mtlTexture.iosurface;
-		if (_ioSurface) { CFRetain(_ioSurface); }
-	}
+    if (getMetalFeatures().ioSurfaces) {
+        _ioSurface = mtlTexture.iosurface;
+        if (_ioSurface) {
+            CFRetain(_ioSurface);
+        }
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
 void MVKImage::releaseIOSurface() {
@@ -976,12 +1217,19 @@ void MVKImage::releaseIOSurface() {
 IOSurfaceRef MVKImage::getIOSurface() { return _ioSurface; }
 
 VkResult MVKImage::useIOSurface(IOSurfaceRef ioSurface) {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	// Don't recreate existing. But special case of incoming nil if already nil means create a new IOSurface.
-	if (ioSurface && _ioSurface == ioSurface) { return VK_SUCCESS; }
+    // Don't recreate existing. But special case of incoming nil if already nil
+    // means create a new IOSurface.
+    if (ioSurface && _ioSurface == ioSurface) {
+        return VK_SUCCESS;
+    }
 
-    if (!getMetalFeatures().ioSurfaces) { return reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkUseIOSurfaceMVK() : IOSurfaces are not supported on this platform."); }
+    if (!getMetalFeatures().ioSurfaces) {
+        return reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                           "vkUseIOSurfaceMVK() : IOSurfaces are not supported "
+                           "on this platform.");
+    }
 
 #if MVK_SUPPORT_IOSURFACE_BOOL
 
@@ -992,20 +1240,112 @@ VkResult MVKImage::useIOSurface(IOSurfaceRef ioSurface) {
 
     MVKPixelFormats* pixFmts = getPixelFormats();
 
-	if (ioSurface) {
-		if (IOSurfaceGetWidth(ioSurface) != _extent.width) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface width %zu does not match VkImage width %d.", IOSurfaceGetWidth(ioSurface), _extent.width); }
-		if (IOSurfaceGetHeight(ioSurface) != _extent.height) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface height %zu does not match VkImage height %d.", IOSurfaceGetHeight(ioSurface), _extent.height); }
-		if (IOSurfaceGetBytesPerElement(ioSurface) != pixFmts->getBytesPerBlock(_vkFormat)) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface bytes per element %zu does not match VkImage bytes per element %d.", IOSurfaceGetBytesPerElement(ioSurface), pixFmts->getBytesPerBlock(_vkFormat)); }
-		if (IOSurfaceGetElementWidth(ioSurface) != pixFmts->getBlockTexelSize(_vkFormat).width) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface element width %zu does not match VkImage element width %d.", IOSurfaceGetElementWidth(ioSurface), pixFmts->getBlockTexelSize(_vkFormat).width); }
-		if (IOSurfaceGetElementHeight(ioSurface) != pixFmts->getBlockTexelSize(_vkFormat).height) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface element height %zu does not match VkImage element height %d.", IOSurfaceGetElementHeight(ioSurface), pixFmts->getBlockTexelSize(_vkFormat).height); }
+    if (ioSurface) {
+        if (IOSurfaceGetWidth(ioSurface) != _extent.width) {
+            return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                               "vkUseIOSurfaceMVK() : IOSurface width %zu does "
+                               "not match VkImage width %d.",
+                               IOSurfaceGetWidth(ioSurface), _extent.width);
+        }
+        if (IOSurfaceGetHeight(ioSurface) != _extent.height) {
+            return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                               "vkUseIOSurfaceMVK() : IOSurface height %zu "
+                               "does not match VkImage height %d.",
+                               IOSurfaceGetHeight(ioSurface), _extent.height);
+        }
+        if (IOSurfaceGetBytesPerElement(ioSurface) !=
+            pixFmts->getBytesPerBlock(_vkFormat)) {
+            return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                               "vkUseIOSurfaceMVK() : IOSurface bytes per "
+                               "element %zu does not match VkImage bytes per "
+                               "element %d.",
+                               IOSurfaceGetBytesPerElement(ioSurface),
+                               pixFmts->getBytesPerBlock(_vkFormat));
+        }
+        if (IOSurfaceGetElementWidth(ioSurface) !=
+            pixFmts->getBlockTexelSize(_vkFormat).width) {
+            return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                               "vkUseIOSurfaceMVK() : IOSurface element width "
+                               "%zu does not match VkImage element width "
+                               "%d.",
+                               IOSurfaceGetElementWidth(ioSurface),
+                               pixFmts->getBlockTexelSize(_vkFormat).width);
+        }
+        if (IOSurfaceGetElementHeight(ioSurface) !=
+            pixFmts->getBlockTexelSize(_vkFormat).height) {
+            return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                               "vkUseIOSurfaceMVK() : IOSurface element height "
+                               "%zu does not match VkImage element "
+                               "height %d.",
+                               IOSurfaceGetElementHeight(ioSurface),
+                               pixFmts->getBlockTexelSize(_vkFormat).height);
+        }
         if (_hasChromaSubsampling) {
-            if (IOSurfaceGetPlaneCount(ioSurface) != _planes.size()) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface plane count %zu does not match VkImage plane count %lu.", IOSurfaceGetPlaneCount(ioSurface), _planes.size()); }
-            for (uint8_t planeIndex = 0; planeIndex < _planes.size(); ++planeIndex) {
-                if (IOSurfaceGetWidthOfPlane(ioSurface, planeIndex) != getExtent3D(planeIndex, 0).width) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface width %zu of plane %d does not match VkImage width %d.", IOSurfaceGetWidthOfPlane(ioSurface, planeIndex), planeIndex, getExtent3D(planeIndex, 0).width); }
-                if (IOSurfaceGetHeightOfPlane(ioSurface, planeIndex) != getExtent3D(planeIndex, 0).height) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface height %zu of plane %d does not match VkImage height %d.", IOSurfaceGetHeightOfPlane(ioSurface, planeIndex), planeIndex, getExtent3D(planeIndex, 0).height); }
-                if (IOSurfaceGetBytesPerElementOfPlane(ioSurface, planeIndex) != _planes[planeIndex]->_bytesPerBlock) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface bytes per element %zu of plane %d does not match VkImage bytes per element %d.", IOSurfaceGetBytesPerElementOfPlane(ioSurface, planeIndex), planeIndex, _planes[planeIndex]->_bytesPerBlock); }
-                if (IOSurfaceGetElementWidthOfPlane(ioSurface, planeIndex) != _planes[planeIndex]->_blockTexelSize.width) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface element width %zu of plane %d does not match VkImage element width %d.", IOSurfaceGetElementWidthOfPlane(ioSurface, planeIndex), planeIndex, _planes[planeIndex]->_blockTexelSize.width); }
-                if (IOSurfaceGetElementHeightOfPlane(ioSurface, planeIndex) != _planes[planeIndex]->_blockTexelSize.height) { return reportError(VK_ERROR_INITIALIZATION_FAILED, "vkUseIOSurfaceMVK() : IOSurface element height %zu of plane %d does not match VkImage element height %d.", IOSurfaceGetElementHeightOfPlane(ioSurface, planeIndex), planeIndex, _planes[planeIndex]->_blockTexelSize.height); }
+            if (IOSurfaceGetPlaneCount(ioSurface) != _planes.size()) {
+                return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                   "vkUseIOSurfaceMVK() : IOSurface plane "
+                                   "count %zu does not match VkImage plane "
+                                   "count "
+                                   "%lu.",
+                                   IOSurfaceGetPlaneCount(ioSurface),
+                                   _planes.size());
+            }
+            for (uint8_t planeIndex = 0; planeIndex < _planes.size();
+                 ++planeIndex) {
+                if (IOSurfaceGetWidthOfPlane(ioSurface, planeIndex) !=
+                    getExtent3D(planeIndex, 0).width) {
+                    return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                       "vkUseIOSurfaceMVK() : IOSurface width "
+                                       "%zu of plane %d does not match VkImage "
+                                       "width %d.",
+                                       IOSurfaceGetWidthOfPlane(ioSurface,
+                                                                planeIndex),
+                                       planeIndex,
+                                       getExtent3D(planeIndex, 0).width);
+                }
+                if (IOSurfaceGetHeightOfPlane(ioSurface, planeIndex) !=
+                    getExtent3D(planeIndex, 0).height) {
+                    return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                       "vkUseIOSurfaceMVK() : IOSurface height "
+                                       "%zu of plane %d does not match VkImage "
+                                       "height %d.",
+                                       IOSurfaceGetHeightOfPlane(ioSurface,
+                                                                 planeIndex),
+                                       planeIndex,
+                                       getExtent3D(planeIndex, 0).height);
+                }
+                if (IOSurfaceGetBytesPerElementOfPlane(ioSurface, planeIndex) !=
+                    _planes[planeIndex]->_bytesPerBlock) {
+                    return reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                       "vkUseIOSurfaceMVK() : IOSurface bytes "
+                                       "per element %zu of plane %d does not "
+                                       "match VkImage bytes per element %d.",
+                                       IOSurfaceGetBytesPerElementOfPlane(
+                                           ioSurface, planeIndex),
+                                       planeIndex,
+                                       _planes[planeIndex]->_bytesPerBlock);
+                }
+                if (IOSurfaceGetElementWidthOfPlane(ioSurface, planeIndex) !=
+                    _planes[planeIndex]->_blockTexelSize.width) {
+                    return reportError(
+                        VK_ERROR_INITIALIZATION_FAILED,
+                        "vkUseIOSurfaceMVK() : IOSurface element width %zu of "
+                        "plane %d does not match "
+                        "VkImage element width %d.",
+                        IOSurfaceGetElementWidthOfPlane(ioSurface, planeIndex),
+                        planeIndex, _planes[planeIndex]->_blockTexelSize.width);
+                }
+                if (IOSurfaceGetElementHeightOfPlane(ioSurface, planeIndex) !=
+                    _planes[planeIndex]->_blockTexelSize.height) {
+                    return reportError(
+                        VK_ERROR_INITIALIZATION_FAILED,
+                        "vkUseIOSurfaceMVK() : IOSurface element height %zu of "
+                        "plane %d does not match "
+                        "VkImage element height %d.",
+                        IOSurfaceGetElementHeightOfPlane(ioSurface, planeIndex),
+                        planeIndex,
+                        _planes[planeIndex]->_blockTexelSize.height);
+                }
             }
         }
 
@@ -1013,29 +1353,44 @@ VkResult MVKImage::useIOSurface(IOSurfaceRef ioSurface) {
         CFRetain(_ioSurface);
     } else {
         @autoreleasepool {
-            CFMutableDictionaryRef properties = CFDictionaryCreateMutableCopy(NULL, 0, (CFDictionaryRef)@{
-			    (id)kIOSurfaceWidth: @(_extent.width),
-			    (id)kIOSurfaceHeight: @(_extent.height),
-			    (id)kIOSurfaceBytesPerElement: @(pixFmts->getBytesPerBlock(_vkFormat)),
-			    (id)kIOSurfaceElementWidth: @(pixFmts->getBlockTexelSize(_vkFormat).width),
-			    (id)kIOSurfaceElementHeight: @(pixFmts->getBlockTexelSize(_vkFormat).height),
+            CFMutableDictionaryRef properties = CFDictionaryCreateMutableCopy(
+                NULL, 0, (CFDictionaryRef) @{
+                    (id)kIOSurfaceWidth : @(_extent.width),
+                    (id)kIOSurfaceHeight : @(_extent.height),
+                    (id)kIOSurfaceBytesPerElement :
+                        @(pixFmts->getBytesPerBlock(_vkFormat)),
+                    (id)kIOSurfaceElementWidth :
+                        @(pixFmts->getBlockTexelSize(_vkFormat).width),
+                    (id)kIOSurfaceElementHeight :
+                        @(pixFmts->getBlockTexelSize(_vkFormat).height),
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			    (id)kIOSurfaceIsGlobal: @(true), // Deprecated but needed for interprocess transfers
+                    (id)
+                    kIOSurfaceIsGlobal : @(true), // Deprecated but needed for
+                                                  // interprocess transfers
 #pragma clang diagnostic pop
-            });
-            if(_hasChromaSubsampling) {
-                CFMutableArrayRef planeProperties = CFArrayCreateMutable(NULL, _planes.size(), NULL);
-                for (uint8_t planeIndex = 0; planeIndex < _planes.size(); ++planeIndex) {
-                    CFArrayAppendValue(planeProperties, (CFDictionaryRef)@{
-                        (id)kIOSurfacePlaneWidth: @(getExtent3D(planeIndex, 0).width),
-                        (id)kIOSurfacePlaneHeight: @(getExtent3D(planeIndex, 0).height),
-                        (id)kIOSurfacePlaneBytesPerElement: @(_planes[planeIndex]->_bytesPerBlock),
-                        (id)kIOSurfacePlaneElementWidth: @(_planes[planeIndex]->_blockTexelSize.width),
-                        (id)kIOSurfacePlaneElementHeight: @(_planes[planeIndex]->_blockTexelSize.height),
-                    });
+                });
+            if (_hasChromaSubsampling) {
+                CFMutableArrayRef planeProperties =
+                    CFArrayCreateMutable(NULL, _planes.size(), NULL);
+                for (uint8_t planeIndex = 0; planeIndex < _planes.size();
+                     ++planeIndex) {
+                    CFArrayAppendValue(
+                        planeProperties, (CFDictionaryRef) @{
+                            (id)kIOSurfacePlaneWidth :
+                                @(getExtent3D(planeIndex, 0).width),
+                            (id)kIOSurfacePlaneHeight :
+                                @(getExtent3D(planeIndex, 0).height),
+                            (id)kIOSurfacePlaneBytesPerElement :
+                                @(_planes[planeIndex]->_bytesPerBlock),
+                            (id)kIOSurfacePlaneElementWidth :
+                                @(_planes[planeIndex]->_blockTexelSize.width),
+                            (id)kIOSurfacePlaneElementHeight :
+                                @(_planes[planeIndex]->_blockTexelSize.height),
+                        });
                 }
-                CFDictionaryAddValue(properties, (id)kIOSurfacePlaneInfo, planeProperties);
+                CFDictionaryAddValue(properties, (id)kIOSurfacePlaneInfo,
+                                     planeProperties);
                 CFRelease(planeProperties);
             }
             _ioSurface = IOSurfaceCreate(properties);
@@ -1049,16 +1404,21 @@ VkResult MVKImage::useIOSurface(IOSurfaceRef ioSurface) {
 }
 
 MTLStorageMode MVKImage::getMTLStorageMode() {
-    if ( !_memoryBindings[0]->_deviceMemory ) return MTLStorageModePrivate;
+    if (!_memoryBindings[0]->_deviceMemory) return MTLStorageModePrivate;
 
-    MTLStorageMode stgMode = _memoryBindings[0]->_deviceMemory->getMTLStorageMode();
+    MTLStorageMode stgMode =
+        _memoryBindings[0]->_deviceMemory->getMTLStorageMode();
 
-    if (_ioSurface && stgMode == MTLStorageModePrivate) { stgMode = MTLStorageModeShared; }
+    if (_ioSurface && stgMode == MTLStorageModePrivate) {
+        stgMode = MTLStorageModeShared;
+    }
 
 #if MVK_MACOS
-	// For macOS prior to 10.15.5, textures cannot use Shared storage mode, so change to Managed storage mode.
-	// All Apple GPUs support shared linear textures, so this only applies to other GPUs.
-    if (stgMode == MTLStorageModeShared && !getMetalFeatures().sharedLinearTextures) {
+    // For macOS prior to 10.15.5, textures cannot use Shared storage mode, so
+    // change to Managed storage mode. All Apple GPUs support shared linear
+    // textures, so this only applies to other GPUs.
+    if (stgMode == MTLStorageModeShared &&
+        !getMetalFeatures().sharedLinearTextures) {
         stgMode = MTLStorageModeManaged;
     }
 #endif
@@ -1066,724 +1426,1006 @@ MTLStorageMode MVKImage::getMTLStorageMode() {
 }
 
 MTLCPUCacheMode MVKImage::getMTLCPUCacheMode() {
-	return _memoryBindings[0]->_deviceMemory ? _memoryBindings[0]->_deviceMemory->getMTLCPUCacheMode() : MTLCPUCacheModeDefaultCache;
+    return _memoryBindings[0]->_deviceMemory
+               ? _memoryBindings[0]->_deviceMemory->getMTLCPUCacheMode()
+               : MTLCPUCacheModeDefaultCache;
 }
 
 MTLTextureUsage MVKImage::getMTLTextureUsage(MTLPixelFormat mtlPixFmt) {
 
-	// In the special case of a dedicated aliasable image, we must presume the texture can be used for anything.
-	MVKDeviceMemory* dvcMem = _memoryBindings[0]->_deviceMemory;
-	if (_isAliasable && dvcMem && dvcMem->isDedicatedAllocation()) { return MTLTextureUsageUnknown; }
+    // In the special case of a dedicated aliasable image, we must presume the
+    // texture can be used for anything.
+    MVKDeviceMemory* dvcMem = _memoryBindings[0]->_deviceMemory;
+    if (_isAliasable && dvcMem && dvcMem->isDedicatedAllocation()) {
+        return MTLTextureUsageUnknown;
+    }
 
-	MVKPixelFormats* pixFmts = getPixelFormats();
+    MVKPixelFormats* pixFmts = getPixelFormats();
 
-	// The image view will need reinterpretation if this image is mutable, unless view formats are provided
-	// and all of the view formats are either identical to, or an sRGB variation of, the incoming format.
-	bool needsReinterpretation = _hasMutableFormat && _viewFormats.empty();
-	for (VkFormat viewFmt : _viewFormats) {
-		needsReinterpretation = needsReinterpretation || !pixFmts->compatibleAsLinearOrSRGB(mtlPixFmt, viewFmt);
-	}
+    // The image view will need reinterpretation if this image is mutable,
+    // unless view formats are provided and all of the view formats are either
+    // identical to, or an sRGB variation of, the incoming format.
+    bool needsReinterpretation = _hasMutableFormat && _viewFormats.empty();
+    for (VkFormat viewFmt : _viewFormats) {
+        needsReinterpretation =
+            needsReinterpretation ||
+            !pixFmts->compatibleAsLinearOrSRGB(mtlPixFmt, viewFmt);
+    }
 
-	MTLTextureUsage mtlUsage = pixFmts->getMTLTextureUsage(getCombinedUsage(), mtlPixFmt, _samples,
-														   _isLinear || _isLinearForAtomics, needsReinterpretation, _hasExtendedUsage,
-														   _shouldSupportAtomics && getMetalFeatures().nativeTextureAtomics);
+    MTLTextureUsage mtlUsage =
+        pixFmts
+            ->getMTLTextureUsage(getCombinedUsage(), mtlPixFmt, _samples,
+                                 _isLinear || _isLinearForAtomics,
+                                 needsReinterpretation, _hasExtendedUsage,
+                                 _shouldSupportAtomics &&
+                                     getMetalFeatures().nativeTextureAtomics);
 
-	// Metal before 3.0 doesn't support 3D compressed textures, so we'll
-	// decompress the texture ourselves, and we need to be able to write to it.
-	bool makeWritable = MVK_MACOS && _is3DCompressed;
-	if (makeWritable) {
-		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
-	}
+    // Metal before 3.0 doesn't support 3D compressed textures, so we'll
+    // decompress the texture ourselves, and we need to be able to write to it.
+    bool makeWritable = MVK_MACOS && _is3DCompressed;
+    if (makeWritable) {
+        mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
+    }
 
-	return mtlUsage;
+    return mtlUsage;
 }
 
 #pragma mark Construction
 
-MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	_ioSurface = nil;
+MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    _ioSurface = nil;
 
-	// Stencil usage is implied to be the same as usage, unless overridden in the pNext chain.
-	_usage = pCreateInfo->usage;
-	_stencilUsage = _usage;
+    // Stencil usage is implied to be the same as usage, unless overridden in
+    // the pNext chain.
+    _usage = pCreateInfo->usage;
+    _stencilUsage = _usage;
 
-	const VkExternalMemoryImageCreateInfo* pExtMemInfo = nullptr;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO: {
-				pExtMemInfo = (const VkExternalMemoryImageCreateInfo*)next;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
-				// Must set before calls to getIsValidViewFormat() below.
-				auto* pFmtListInfo = (const VkImageFormatListCreateInfo*)next;
-				for (uint32_t fmtIdx = 0; fmtIdx < pFmtListInfo->viewFormatCount; fmtIdx++) {
-					_viewFormats.push_back(pFmtListInfo->pViewFormats[fmtIdx]);
-				}
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
-				_stencilUsage = ((VkImageStencilUsageCreateInfo*)next)->stencilUsage;
-				break;
-			default:
-				break;
-		}
-	}
+    const VkExternalMemoryImageCreateInfo* pExtMemInfo = nullptr;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO: {
+            pExtMemInfo = (const VkExternalMemoryImageCreateInfo*)next;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
+            // Must set before calls to getIsValidViewFormat() below.
+            auto* pFmtListInfo = (const VkImageFormatListCreateInfo*)next;
+            for (uint32_t fmtIdx = 0; fmtIdx < pFmtListInfo->viewFormatCount;
+                 fmtIdx++) {
+                _viewFormats.push_back(pFmtListInfo->pViewFormats[fmtIdx]);
+            }
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
+            _stencilUsage =
+                ((VkImageStencilUsageCreateInfo*)next)->stencilUsage;
+            break;
+        default:
+            break;
+        }
+    }
 
-    // Adjust the info components to be compatible with Metal, then use the modified versions to set other
-	// config info. Vulkan allows unused extent dimensions to be zero, but Metal requires minimum of one.
+    // Adjust the info components to be compatible with Metal, then use the
+    // modified versions to set other config info. Vulkan allows unused extent
+    // dimensions to be zero, but Metal requires minimum of one.
     uint32_t minDim = 1;
     _extent.width = max(pCreateInfo->extent.width, minDim);
-	_extent.height = max(pCreateInfo->extent.height, minDim);
-	_extent.depth = max(pCreateInfo->extent.depth, minDim);
+    _extent.height = max(pCreateInfo->extent.height, minDim);
+    _extent.depth = max(pCreateInfo->extent.depth, minDim);
     _arrayLayers = max(pCreateInfo->arrayLayers, minDim);
 
-	// Perform validation and adjustments before configuring other settings
-	bool isAttachment = mvkIsAnyFlagEnabled(pCreateInfo->usage, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-																 VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-																 VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
-																 VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
-	// Texture type depends on validated samples. Other validation depends on possibly modified texture type.
-	_samples = validateSamples(pCreateInfo, isAttachment);
-	_mtlTextureType = mvkMTLTextureTypeFromVkImageType(pCreateInfo->imageType, _arrayLayers, _samples > VK_SAMPLE_COUNT_1_BIT);
+    // Perform validation and adjustments before configuring other settings
+    bool isAttachment =
+        mvkIsAnyFlagEnabled(pCreateInfo->usage,
+                            (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
+    // Texture type depends on validated samples. Other validation depends on
+    // possibly modified texture type.
+    _samples = validateSamples(pCreateInfo, isAttachment);
+    _mtlTextureType =
+        mvkMTLTextureTypeFromVkImageType(pCreateInfo->imageType, _arrayLayers,
+                                         _samples > VK_SAMPLE_COUNT_1_BIT);
 
-	validateConfig(pCreateInfo, isAttachment);
-	_mipLevels = validateMipLevels(pCreateInfo, isAttachment);
-	_isLinear = validateLinear(pCreateInfo, isAttachment);
+    validateConfig(pCreateInfo, isAttachment);
+    _mipLevels = validateMipLevels(pCreateInfo, isAttachment);
+    _isLinear = validateLinear(pCreateInfo, isAttachment);
 
-	auto& mtlFeats = getMetalFeatures();
-	MVKPixelFormats* pixFmts = getPixelFormats();
+    auto& mtlFeats = getMetalFeatures();
+    MVKPixelFormats* pixFmts = getPixelFormats();
     _vkFormat = pCreateInfo->format;
-    _isAliasable = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_ALIAS_BIT);
-	_hasMutableFormat = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT);
-	_hasExtendedUsage = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+    _isAliasable =
+        mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_ALIAS_BIT);
+    _hasMutableFormat = mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                                            VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT);
+    _hasExtendedUsage = mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                                            VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
 
-    // If this is a storage image of format R32_UINT or R32_SINT, or MUTABLE_FORMAT is set
-    // and R32_UINT is in the set of possible view formats, then we must use a texel buffer,
-    // or image atomics won't work.
-	_shouldSupportAtomics = mvkIsAnyFlagEnabled(getCombinedUsage(), VK_IMAGE_USAGE_STORAGE_BIT) && _mipLevels == 1 &&
-				((_vkFormat == VK_FORMAT_R32_UINT || _vkFormat == VK_FORMAT_R32_SINT) ||
-					(_hasMutableFormat && pixFmts->getViewClass(_vkFormat) == MVKMTLViewClass::Color32 && (getIsValidViewFormat(VK_FORMAT_R32_UINT) || getIsValidViewFormat(VK_FORMAT_R32_SINT))));
+    // If this is a storage image of format R32_UINT or R32_SINT, or
+    // MUTABLE_FORMAT is set and R32_UINT is in the set of possible view
+    // formats, then we must use a texel buffer, or image atomics won't work.
+    _shouldSupportAtomics =
+        mvkIsAnyFlagEnabled(getCombinedUsage(), VK_IMAGE_USAGE_STORAGE_BIT) &&
+        _mipLevels == 1 &&
+        ((_vkFormat == VK_FORMAT_R32_UINT || _vkFormat == VK_FORMAT_R32_SINT) ||
+         (_hasMutableFormat &&
+          pixFmts->getViewClass(_vkFormat) == MVKMTLViewClass::Color32 &&
+          (getIsValidViewFormat(VK_FORMAT_R32_UINT) ||
+           getIsValidViewFormat(VK_FORMAT_R32_SINT))));
 
-	_isLinearForAtomics = _shouldSupportAtomics && !getMetalFeatures().nativeTextureAtomics && _arrayLayers == 1 && getImageType() == VK_IMAGE_TYPE_2D;
+    _isLinearForAtomics =
+        _shouldSupportAtomics && !getMetalFeatures().nativeTextureAtomics &&
+        _arrayLayers == 1 && getImageType() == VK_IMAGE_TYPE_2D;
 
-	_is3DCompressed = (getImageType() == VK_IMAGE_TYPE_3D) && (pixFmts->getFormatType(pCreateInfo->format) == kMVKFormatCompressed) && !mtlFeats.native3DCompressedTextures;
-	_isDepthStencilAttachment = (mvkAreAllFlagsEnabled(pCreateInfo->usage, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ||
-								 mvkAreAllFlagsEnabled(pixFmts->getVkFormatProperties3(pCreateInfo->format).optimalTilingFeatures, VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT));
-	_canSupportMTLTextureView = !_isDepthStencilAttachment || mtlFeats.stencilViews;
-	_rowByteAlignment = _isLinear || _isLinearForAtomics ? _device->getVkFormatTexelBufferAlignment(pCreateInfo->format, this) : mvkEnsurePowerOfTwo(pixFmts->getBytesPerBlock(pCreateInfo->format));
+    _is3DCompressed =
+        (getImageType() == VK_IMAGE_TYPE_3D) &&
+        (pixFmts->getFormatType(pCreateInfo->format) == kMVKFormatCompressed) &&
+        !mtlFeats.native3DCompressedTextures;
+    _isDepthStencilAttachment =
+        (mvkAreAllFlagsEnabled(pCreateInfo->usage,
+                               VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ||
+         mvkAreAllFlagsEnabled(
+             pixFmts->getVkFormatProperties3(pCreateInfo->format)
+                 .optimalTilingFeatures,
+             VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT));
+    _canSupportMTLTextureView =
+        !_isDepthStencilAttachment || mtlFeats.stencilViews;
+    _rowByteAlignment =
+        _isLinear || _isLinearForAtomics
+            ? _device->getVkFormatTexelBufferAlignment(pCreateInfo->format,
+                                                       this)
+            : mvkEnsurePowerOfTwo(
+                  pixFmts->getBytesPerBlock(pCreateInfo->format));
 
     VkExtent2D blockTexelSizeOfPlane[3];
     uint32_t bytesPerBlockOfPlane[3];
     MTLPixelFormat mtlPixFmtOfPlane[3];
-	uint8_t subsamplingPlaneCount = pixFmts->getChromaSubsamplingPlanes(_vkFormat, blockTexelSizeOfPlane, bytesPerBlockOfPlane, mtlPixFmtOfPlane);
-	uint8_t planeCount = std::max(subsamplingPlaneCount, (uint8_t)1);
-    uint8_t memoryBindingCount = (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) ? planeCount : 1;
+    uint8_t subsamplingPlaneCount =
+        pixFmts->getChromaSubsamplingPlanes(_vkFormat, blockTexelSizeOfPlane,
+                                            bytesPerBlockOfPlane,
+                                            mtlPixFmtOfPlane);
+    uint8_t planeCount = std::max(subsamplingPlaneCount, (uint8_t)1);
+    uint8_t memoryBindingCount =
+        (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) ? planeCount : 1;
     _hasChromaSubsampling = (subsamplingPlaneCount > 0);
 
-    for (uint8_t planeIndex = 0; planeIndex < memoryBindingCount; ++planeIndex) {
-        _memoryBindings.push_back(new MVKImageMemoryBinding(device, this, planeIndex));
+    for (uint8_t planeIndex = 0; planeIndex < memoryBindingCount;
+         ++planeIndex) {
+        _memoryBindings.push_back(
+            new MVKImageMemoryBinding(device, this, planeIndex));
     }
 
     for (uint8_t planeIndex = 0; planeIndex < planeCount; ++planeIndex) {
         _planes.push_back(new MVKImagePlane(this, planeIndex));
         if (_hasChromaSubsampling) {
-            _planes[planeIndex]->_blockTexelSize = blockTexelSizeOfPlane[planeIndex];
-            _planes[planeIndex]->_bytesPerBlock = bytesPerBlockOfPlane[planeIndex];
+            _planes[planeIndex]->_blockTexelSize =
+                blockTexelSizeOfPlane[planeIndex];
+            _planes[planeIndex]->_bytesPerBlock =
+                bytesPerBlockOfPlane[planeIndex];
             _planes[planeIndex]->_mtlPixFmt = mtlPixFmtOfPlane[planeIndex];
         } else {
-            _planes[planeIndex]->_mtlPixFmt = getPixelFormats()->getMTLPixelFormat(_vkFormat);
+            _planes[planeIndex]->_mtlPixFmt =
+                getPixelFormats()->getMTLPixelFormat(_vkFormat);
         }
         _planes[planeIndex]->initSubresources(pCreateInfo);
-        MVKImageMemoryBinding* memoryBinding = _planes[planeIndex]->getMemoryBinding();
+        MVKImageMemoryBinding* memoryBinding =
+            _planes[planeIndex]->getMemoryBinding();
         if (!_isLinear && !_isLinearForAtomics && mtlFeats.placementHeaps) {
-            MTLTextureDescriptor* mtlTexDesc = _planes[planeIndex]->newMTLTextureDescriptor();    // temp retain
-            MTLSizeAndAlign sizeAndAlign = [getMTLDevice() heapTextureSizeAndAlignWithDescriptor: mtlTexDesc];
+            MTLTextureDescriptor* mtlTexDesc =
+                _planes[planeIndex]->newMTLTextureDescriptor(); // temp retain
+            MTLSizeAndAlign sizeAndAlign = [getMTLDevice()
+                heapTextureSizeAndAlignWithDescriptor:mtlTexDesc];
             [mtlTexDesc release];
-            // Textures allocated on heaps must be aligned to the alignment reported here,
-            // so make sure there's enough space to hold all the planes after alignment.
-            memoryBinding->_byteCount = mvkAlignByteRef(memoryBinding->_byteCount, sizeAndAlign.align) + sizeAndAlign.size;
-            memoryBinding->_byteAlignment = std::max(memoryBinding->_byteAlignment, (VkDeviceSize)sizeAndAlign.align);
+            // Textures allocated on heaps must be aligned to the alignment
+            // reported here, so make sure there's enough space to hold all the
+            // planes after alignment.
+            memoryBinding->_byteCount =
+                mvkAlignByteRef(memoryBinding->_byteCount, sizeAndAlign.align) +
+                sizeAndAlign.size;
+            memoryBinding->_byteAlignment =
+                std::max(memoryBinding->_byteAlignment,
+                         (VkDeviceSize)sizeAndAlign.align);
         } else if (_isLinearForAtomics && mtlFeats.placementHeaps) {
             NSUInteger bufferLength = 0;
             for (uint32_t mipLvl = 0; mipLvl < _mipLevels; mipLvl++) {
                 VkExtent3D mipExtent = getExtent3D(planeIndex, mipLvl);
-                bufferLength += getBytesPerLayer(planeIndex, mipLvl) * mipExtent.depth * _arrayLayers;
+                bufferLength += getBytesPerLayer(planeIndex, mipLvl) *
+                                mipExtent.depth * _arrayLayers;
             }
-            MTLSizeAndAlign sizeAndAlign = [getMTLDevice() heapBufferSizeAndAlignWithLength: bufferLength options: MTLResourceStorageModePrivate];
+            MTLSizeAndAlign sizeAndAlign = [getMTLDevice()
+                heapBufferSizeAndAlignWithLength:bufferLength
+                                         options:MTLResourceStorageModePrivate];
             memoryBinding->_byteCount += sizeAndAlign.size;
-            memoryBinding->_byteAlignment = std::max(std::max(memoryBinding->_byteAlignment, _rowByteAlignment), (VkDeviceSize)sizeAndAlign.align);
+            memoryBinding->_byteAlignment =
+                std::max(std::max(memoryBinding->_byteAlignment,
+                                  _rowByteAlignment),
+                         (VkDeviceSize)sizeAndAlign.align);
         } else {
             for (uint32_t mipLvl = 0; mipLvl < _mipLevels; mipLvl++) {
                 VkExtent3D mipExtent = getExtent3D(planeIndex, mipLvl);
-                memoryBinding->_byteCount += getBytesPerLayer(planeIndex, mipLvl) * mipExtent.depth * _arrayLayers;
+                memoryBinding->_byteCount +=
+                    getBytesPerLayer(planeIndex, mipLvl) * mipExtent.depth *
+                    _arrayLayers;
             }
-            memoryBinding->_byteAlignment = std::max(memoryBinding->_byteAlignment, _rowByteAlignment);
+            memoryBinding->_byteAlignment =
+                std::max(memoryBinding->_byteAlignment, _rowByteAlignment);
         }
     }
-    _hasExpectedTexelSize = _hasChromaSubsampling || (pixFmts->getBytesPerBlock(_planes[0]->_mtlPixFmt) == pixFmts->getBytesPerBlock(_vkFormat));
+    _hasExpectedTexelSize =
+        _hasChromaSubsampling ||
+        (pixFmts->getBytesPerBlock(_planes[0]->_mtlPixFmt) ==
+         pixFmts->getBytesPerBlock(_vkFormat));
 
-	if (pExtMemInfo) { initExternalMemory(pExtMemInfo->handleTypes); }
+    if (pExtMemInfo) {
+        initExternalMemory(pExtMemInfo->handleTypes);
+    }
 
-	// Setting Metal objects directly will override Vulkan settings.
-	// It is responsibility of app to ensure these are consistent. Not doing so results in undefined behavior.
-	const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT: {
-				const auto* pMTLTexInfo = (VkImportMetalTextureInfoEXT*)next;
-				uint8_t planeIndex = MVKImage::getPlaneFromVkImageAspectFlags(pMTLTexInfo->plane);
-				setConfigurationResult(setMTLTexture(planeIndex, pMTLTexInfo->mtlTexture));
-				break;
-			}
-			case VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT: {
-				const auto* pIOSurfInfo = (VkImportMetalIOSurfaceInfoEXT*)next;
-				setConfigurationResult(useIOSurface(pIOSurfInfo->ioSurface));
-				break;
-			}
-			case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
-				pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
-				break;
-			default:
-				break;
-		}
-	}
+    // Setting Metal objects directly will override Vulkan settings.
+    // It is responsibility of app to ensure these are consistent. Not doing so
+    // results in undefined behavior.
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo = nullptr;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT: {
+            const auto* pMTLTexInfo = (VkImportMetalTextureInfoEXT*)next;
+            uint8_t planeIndex =
+                MVKImage::getPlaneFromVkImageAspectFlags(pMTLTexInfo->plane);
+            setConfigurationResult(
+                setMTLTexture(planeIndex, pMTLTexInfo->mtlTexture));
+            break;
+        }
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT: {
+            const auto* pIOSurfInfo = (VkImportMetalIOSurfaceInfoEXT*)next;
+            setConfigurationResult(useIOSurface(pIOSurfInfo->ioSurface));
+            break;
+        }
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
+            pExportInfo = (VkExportMetalObjectCreateInfoEXT*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	// If we're expecting to export an IOSurface, and weren't give one,
-	// base this image on a new IOSurface that matches its configuration.
-	if (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT && !_ioSurface) {
-		setConfigurationResult(useIOSurface(nil));
-	}
+    // If we're expecting to export an IOSurface, and weren't give one,
+    // base this image on a new IOSurface that matches its configuration.
+    if (pExportInfo &&
+        pExportInfo->exportObjectType ==
+            VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT &&
+        !_ioSurface) {
+        setConfigurationResult(useIOSurface(nil));
+    }
 }
 
-VkSampleCountFlagBits MVKImage::validateSamples(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {
+VkSampleCountFlagBits
+MVKImage::validateSamples(const VkImageCreateInfo* pCreateInfo,
+                          bool isAttachment) {
 
-	VkSampleCountFlagBits validSamples = pCreateInfo->samples;
+    VkSampleCountFlagBits validSamples = pCreateInfo->samples;
 
-	if (validSamples == VK_SAMPLE_COUNT_1_BIT) { return validSamples; }
+    if (validSamples == VK_SAMPLE_COUNT_1_BIT) {
+        return validSamples;
+    }
 
-	// Don't use getImageType() because it hasn't been set yet.
-	if ( !((pCreateInfo->imageType == VK_IMAGE_TYPE_2D) || ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) && getMVKConfig().texture1DAs2D)) ) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, multisampling can only be used with a 2D image type. Setting sample count to 1."));
-		validSamples = VK_SAMPLE_COUNT_1_BIT;
-	}
+    // Don't use getImageType() because it hasn't been set yet.
+    if (!((pCreateInfo->imageType == VK_IMAGE_TYPE_2D) ||
+          ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) &&
+           getMVKConfig().texture1DAs2D))) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, multisampling can only "
+                        "be used "
+                        "with a 2D image type. Setting sample count to 1."));
+        validSamples = VK_SAMPLE_COUNT_1_BIT;
+    }
 
-	if (getPixelFormats()->getFormatType(pCreateInfo->format) == kMVKFormatCompressed) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, multisampling cannot be used with compressed images. Setting sample count to 1."));
-		validSamples = VK_SAMPLE_COUNT_1_BIT;
-	}
-	if (getPixelFormats()->getChromaSubsamplingPlaneCount(pCreateInfo->format) > 0) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, multisampling cannot be used with chroma subsampled images. Setting sample count to 1."));
-		validSamples = VK_SAMPLE_COUNT_1_BIT;
-	}
+    if (getPixelFormats()->getFormatType(pCreateInfo->format) ==
+        kMVKFormatCompressed) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, multisampling cannot "
+                        "be used "
+                        "with compressed images. Setting sample count to 1."));
+        validSamples = VK_SAMPLE_COUNT_1_BIT;
+    }
+    if (getPixelFormats()->getChromaSubsamplingPlaneCount(pCreateInfo->format) >
+        0) {
+        setConfigurationResult(reportError(
+            VK_ERROR_FEATURE_NOT_PRESENT,
+            "vkCreateImage() : Under Metal, multisampling cannot be used "
+            "with chroma subsampled images. Setting sample count to 1."));
+        validSamples = VK_SAMPLE_COUNT_1_BIT;
+    }
 
-	if (pCreateInfo->arrayLayers > 1 && !getMetalFeatures().multisampleArrayTextures ) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : This device does not support multisampled array textures. Setting sample count to 1."));
-		validSamples = VK_SAMPLE_COUNT_1_BIT;
-	}
+    if (pCreateInfo->arrayLayers > 1 &&
+        !getMetalFeatures().multisampleArrayTextures) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : This device does not support "
+                        "multisampled "
+                        "array textures. Setting sample count to 1."));
+        validSamples = VK_SAMPLE_COUNT_1_BIT;
+    }
 
-	return validSamples;
+    return validSamples;
 }
 
-void MVKImage::validateConfig(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {
-	MVKPixelFormats* pixFmts = getPixelFormats();
+void MVKImage::validateConfig(const VkImageCreateInfo* pCreateInfo,
+                              bool isAttachment) {
+    MVKPixelFormats* pixFmts = getPixelFormats();
 
-	bool is2D = (getImageType() == VK_IMAGE_TYPE_2D);
-	bool isChromaSubsampled = pixFmts->getChromaSubsamplingPlaneCount(pCreateInfo->format) > 0;
+    bool is2D = (getImageType() == VK_IMAGE_TYPE_2D);
+    bool isChromaSubsampled =
+        pixFmts->getChromaSubsamplingPlaneCount(pCreateInfo->format) > 0;
 
-	if (isChromaSubsampled && !is2D) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, chroma subsampled formats may only be used with 2D images."));
-	}
-	if (isChromaSubsampled && mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, chroma subsampled formats may not be used with cube images."));
-	}
-	if (isChromaSubsampled && (pCreateInfo->arrayLayers > 1)) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Chroma-subsampled formats may only have one array layer."));
-	}
-	if ((pixFmts->getFormatType(pCreateInfo->format) == kMVKFormatDepthStencil) && !is2D ) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, depth/stencil formats may only be used with 2D images."));
-	}
-	if (isAttachment && (getImageType() == VK_IMAGE_TYPE_1D)) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Metal does not support rendering to native 1D attachments. Consider enabling MVK_CONFIG_TEXTURE_1D_AS_2D."));
-	}
-	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT)) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Metal does not allow uncompressed views of compressed images."));
-	}
-	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Metal does not support split-instance memory binding."));
-	}
+    if (isChromaSubsampled && !is2D) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, chroma subsampled "
+                        "formats may only be used with 2D images."));
+    }
+    if (isChromaSubsampled &&
+        mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                            VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, chroma subsampled "
+                        "formats may not be used with cube images."));
+    }
+    if (isChromaSubsampled && (pCreateInfo->arrayLayers > 1)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Chroma-subsampled formats may only "
+                        "have one array layer."));
+    }
+    if ((pixFmts->getFormatType(pCreateInfo->format) ==
+         kMVKFormatDepthStencil) &&
+        !is2D) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, depth/stencil formats "
+                        "may only be used with 2D images."));
+    }
+    if (isAttachment && (getImageType() == VK_IMAGE_TYPE_1D)) {
+        setConfigurationResult(reportError(
+            VK_ERROR_FEATURE_NOT_PRESENT,
+            "vkCreateImage() : Metal does not support rendering to native 1D "
+            "attachments. Consider enabling MVK_CONFIG_TEXTURE_1D_AS_2D."));
+    }
+    if (mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                            VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Metal does not allow uncompressed "
+                        "views of compressed images."));
+    }
+    if (mvkIsAnyFlagEnabled(pCreateInfo->flags,
+                            VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Metal does not support "
+                        "split-instance memory binding."));
+    }
 }
 
-uint32_t MVKImage::validateMipLevels(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {
-	uint32_t minDim = 1;
-	uint32_t validMipLevels = max(pCreateInfo->mipLevels, minDim);
+uint32_t MVKImage::validateMipLevels(const VkImageCreateInfo* pCreateInfo,
+                                     bool isAttachment) {
+    uint32_t minDim = 1;
+    uint32_t validMipLevels = max(pCreateInfo->mipLevels, minDim);
 
-	if (validMipLevels == 1) { return validMipLevels; }
+    if (validMipLevels == 1) {
+        return validMipLevels;
+    }
 
-	if (getPixelFormats()->getChromaSubsamplingPlaneCount(pCreateInfo->format) == 1) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, GBGR and BGRG images cannot use mipmaps. Setting mip levels to 1."));
-		validMipLevels = 1;
-	}
-	if (getImageType() == VK_IMAGE_TYPE_1D) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : Under Metal, native 1D images cannot use mipmaps. Setting mip levels to 1. Consider enabling MVK_CONFIG_TEXTURE_1D_AS_2D."));
-		validMipLevels = 1;
-	}
+    if (getPixelFormats()->getChromaSubsamplingPlaneCount(
+            pCreateInfo->format) == 1) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, GBGR and BGRG images "
+                        "cannot use "
+                        "mipmaps. Setting mip levels to 1."));
+        validMipLevels = 1;
+    }
+    if (getImageType() == VK_IMAGE_TYPE_1D) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : Under Metal, native 1D images "
+                        "cannot use mipmaps. "
+                        "Setting mip levels to 1. Consider enabling "
+                        "MVK_CONFIG_TEXTURE_1D_AS_2D."));
+        validMipLevels = 1;
+    }
 
-	return validMipLevels;
+    return validMipLevels;
 }
 
-bool MVKImage::validateLinear(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {
+bool MVKImage::validateLinear(const VkImageCreateInfo* pCreateInfo,
+                              bool isAttachment) {
 
-	if (pCreateInfo->tiling != VK_IMAGE_TILING_LINEAR ) { return false; }
+    if (pCreateInfo->tiling != VK_IMAGE_TILING_LINEAR) {
+        return false;
+    }
 
-	bool isLin = true;
+    bool isLin = true;
 
-	if (getImageType() != VK_IMAGE_TYPE_2D) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, imageType must be VK_IMAGE_TYPE_2D."));
-		isLin = false;
-	}
+    if (getImageType() != VK_IMAGE_TYPE_2D) {
+        setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                           "vkCreateImage() : If tiling is "
+                                           "VK_IMAGE_TILING_LINEAR, imageType "
+                                           "must be VK_IMAGE_TYPE_2D."));
+        isLin = false;
+    }
 
-	if (getPixelFormats()->getFormatType(pCreateInfo->format) == kMVKFormatDepthStencil) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, format must not be a depth/stencil format."));
-		isLin = false;
-	}
-	if (getPixelFormats()->getFormatType(pCreateInfo->format) == kMVKFormatCompressed) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, format must not be a compressed format."));
-		isLin = false;
-	}
-	if (getPixelFormats()->getChromaSubsamplingPlaneCount(pCreateInfo->format) == 1) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, format must not be a single-plane chroma subsampled format."));
-		isLin = false;
-	}
+    if (getPixelFormats()->getFormatType(pCreateInfo->format) ==
+        kMVKFormatDepthStencil) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : If tiling is "
+                        "VK_IMAGE_TILING_LINEAR, format "
+                        "must not be a depth/stencil format."));
+        isLin = false;
+    }
+    if (getPixelFormats()->getFormatType(pCreateInfo->format) ==
+        kMVKFormatCompressed) {
+        setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                           "vkCreateImage() : If tiling is "
+                                           "VK_IMAGE_TILING_LINEAR, format "
+                                           "must not be a compressed format."));
+        isLin = false;
+    }
+    if (getPixelFormats()->getChromaSubsamplingPlaneCount(
+            pCreateInfo->format) == 1) {
+        setConfigurationResult(reportError(
+            VK_ERROR_FEATURE_NOT_PRESENT,
+            "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, format "
+            "must not be a single-plane chroma subsampled format."));
+        isLin = false;
+    }
 
-	if (pCreateInfo->mipLevels > 1) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, mipLevels must be 1."));
-		isLin = false;
-	}
+    if (pCreateInfo->mipLevels > 1) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : If tiling is "
+                        "VK_IMAGE_TILING_LINEAR, mipLevels must be 1."));
+        isLin = false;
+    }
 
-	if (pCreateInfo->arrayLayers > 1) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, arrayLayers must be 1."));
-		isLin = false;
-	}
+    if (pCreateInfo->arrayLayers > 1) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : If tiling is "
+                        "VK_IMAGE_TILING_LINEAR, arrayLayers must be 1."));
+        isLin = false;
+    }
 
-	if (pCreateInfo->samples > VK_SAMPLE_COUNT_1_BIT) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : If tiling is VK_IMAGE_TILING_LINEAR, samples must be VK_SAMPLE_COUNT_1_BIT."));
-		isLin = false;
-	}
+    if (pCreateInfo->samples > VK_SAMPLE_COUNT_1_BIT) {
+        setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                           "vkCreateImage() : If tiling is "
+                                           "VK_IMAGE_TILING_LINEAR, samples "
+                                           "must be VK_SAMPLE_COUNT_1_BIT."));
+        isLin = false;
+    }
 
 #if !MVK_APPLE_SILICON
-	if (isAttachment) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage() : This device does not support rendering to linear (VK_IMAGE_TILING_LINEAR) images."));
-		isLin = false;
-	}
+    if (isAttachment) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage() : This device does not support "
+                        "rendering to "
+                        "linear (VK_IMAGE_TILING_LINEAR) images."));
+        isLin = false;
+    }
 #endif
 
-	return isLin;
+    return isLin;
 }
 
 void MVKImage::initExternalMemory(VkExternalMemoryHandleTypeFlags handleTypes) {
-	if ( !handleTypes ) { return; }
-	if (mvkIsOnlyAnyFlagEnabled(handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
-        auto& xmProps = getPhysicalDevice()->getExternalImageProperties(VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
-        for(auto& memoryBinding : _memoryBindings) {
+    if (!handleTypes) {
+        return;
+    }
+    if (mvkIsOnlyAnyFlagEnabled(
+            handleTypes, VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR)) {
+        auto& xmProps = getPhysicalDevice()->getExternalImageProperties(
+            VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR);
+        for (auto& memoryBinding : _memoryBindings) {
             memoryBinding->_externalMemoryHandleTypes = handleTypes;
-            memoryBinding->_requiresDedicatedMemoryAllocation = memoryBinding->_requiresDedicatedMemoryAllocation || mvkIsAnyFlagEnabled(xmProps.externalMemoryFeatures, VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+            memoryBinding->_requiresDedicatedMemoryAllocation =
+                memoryBinding->_requiresDedicatedMemoryAllocation ||
+                mvkIsAnyFlagEnabled(
+                    xmProps.externalMemoryFeatures,
+                    VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
         }
-	} else {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImage(): Only external memory handle type VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR is supported."));
-	}
+    } else {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateImage(): Only external memory handle type "
+                        "VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_KHR is "
+                        "supported."));
+    }
 }
 
 MVKImage::~MVKImage() {
-	mvkDestroyContainerContents(_memoryBindings);
-	mvkDestroyContainerContents(_planes);
+    mvkDestroyContainerContents(_memoryBindings);
+    mvkDestroyContainerContents(_planes);
     releaseIOSurface();
 }
-
 
 #pragma mark -
 #pragma mark MVKSwapchainImage
 
-VkResult MVKSwapchainImage::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset, uint8_t planeIndex) {
-	return VK_ERROR_OUT_OF_DEVICE_MEMORY;
+VkResult MVKSwapchainImage::bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                             VkDeviceSize memOffset,
+                                             uint8_t planeIndex) {
+    return VK_ERROR_OUT_OF_DEVICE_MEMORY;
 }
-
 
 #pragma mark Construction
 
 MVKSwapchainImage::MVKSwapchainImage(MVKDevice* device,
-									 const VkImageCreateInfo* pCreateInfo,
-									 MVKSwapchain* swapchain,
-									 uint32_t swapchainIndex) : MVKImage(device, pCreateInfo) {
-	_swapchain = swapchain;
-	_swapchainIndex = swapchainIndex;
+                                     const VkImageCreateInfo* pCreateInfo,
+                                     MVKSwapchain* swapchain,
+                                     uint32_t swapchainIndex)
+    : MVKImage(device, pCreateInfo) {
+    _swapchain = swapchain;
+    _swapchainIndex = swapchainIndex;
 }
 
 void MVKSwapchainImage::detachSwapchain() {
-	lock_guard<mutex> lock(_detachmentLock);
-	_swapchain = nullptr;
-	_device = nullptr;
+    lock_guard<mutex> lock(_detachmentLock);
+    _swapchain = nullptr;
+    _device = nullptr;
 }
 
 void MVKSwapchainImage::destroy() {
-	detachSwapchain();
-	MVKImage::destroy();
+    detachSwapchain();
+    MVKImage::destroy();
 }
-
 
 #pragma mark -
 #pragma mark MVKPresentableSwapchainImage
 
-bool MVKSwapchainImageAvailability::operator< (const MVKSwapchainImageAvailability& rhs) const {
-	if (  isAvailable && !rhs.isAvailable) { return true; }
-	if ( !isAvailable &&  rhs.isAvailable) { return false; }
-	return acquisitionID < rhs.acquisitionID;
+bool MVKSwapchainImageAvailability::operator<(
+    const MVKSwapchainImageAvailability& rhs) const {
+    if (isAvailable && !rhs.isAvailable) {
+        return true;
+    }
+    if (!isAvailable && rhs.isAvailable) {
+        return false;
+    }
+    return acquisitionID < rhs.acquisitionID;
 }
 
 MVKSwapchainImageAvailability MVKPresentableSwapchainImage::getAvailability() {
-	lock_guard<mutex> lock(_availabilityLock);
+    lock_guard<mutex> lock(_availabilityLock);
 
-	return _availability;
+    return _availability;
 }
 
-// Tell the semaphore and fence that they are being tracked for future signaling.
+// Tell the semaphore and fence that they are being tracked for future
+// signaling.
 static void track(const MVKSwapchainSignaler& signaler) {
-	if (signaler.semaphore) { signaler.semaphore->retain(); }
-	if (signaler.fence) { signaler.fence->retain(); }
+    if (signaler.semaphore) {
+        signaler.semaphore->retain();
+    }
+    if (signaler.fence) {
+        signaler.fence->retain();
+    }
 }
 
-static void signal(MVKSemaphore* semaphore, uint64_t semaphoreSignalToken, id<MTLCommandBuffer> mtlCmdBuff) {
-	if (semaphore) { semaphore->encodeDeferredSignal(mtlCmdBuff, semaphoreSignalToken); }
+static void signal(MVKSemaphore* semaphore, uint64_t semaphoreSignalToken,
+                   id<MTLCommandBuffer> mtlCmdBuff) {
+    if (semaphore) {
+        semaphore->encodeDeferredSignal(mtlCmdBuff, semaphoreSignalToken);
+    }
 }
 
 static void signal(MVKFence* fence) {
-	if (fence) { fence->signal(); }
+    if (fence) {
+        fence->signal();
+    }
 }
 
-// Signal the semaphore and fence and tell them that they are no longer being tracked for future signaling.
+// Signal the semaphore and fence and tell them that they are no longer being
+// tracked for future signaling.
 static void signalAndUntrack(const MVKSwapchainSignaler& signaler) {
-	signal(signaler.semaphore, signaler.semaphoreSignalToken, nil);
-	if (signaler.semaphore) { signaler.semaphore->release(); }
+    signal(signaler.semaphore, signaler.semaphoreSignalToken, nil);
+    if (signaler.semaphore) {
+        signaler.semaphore->release();
+    }
 
-	signal(signaler.fence);
-	if (signaler.fence) { signaler.fence->release(); }
+    signal(signaler.fence);
+    if (signaler.fence) {
+        signaler.fence->release();
+    }
 }
 
-VkResult MVKPresentableSwapchainImage::acquireAndSignalWhenAvailable(MVKSemaphore* semaphore, MVKFence* fence) {
+VkResult MVKPresentableSwapchainImage::acquireAndSignalWhenAvailable(
+    MVKSemaphore* semaphore, MVKFence* fence) {
 
-	// Now that this image is being acquired, release the existing drawable and its texture.
-	// This is not done earlier so the texture is retained for any post-processing such as screen captures, etc.
-	releaseMetalDrawable();
+    // Now that this image is being acquired, release the existing drawable and
+    // its texture. This is not done earlier so the texture is retained for any
+    // post-processing such as screen captures, etc.
+    releaseMetalDrawable();
 
-	lock_guard<mutex> lock(_availabilityLock);
+    lock_guard<mutex> lock(_availabilityLock);
 
-	// Upon acquisition, update acquisition ID immediately, to move it to the back of the chain,
-	// so other images will be preferred if either all images are available or no images are available.
-	_availability.acquisitionID = _swapchain->getNextAcquisitionID();
+    // Upon acquisition, update acquisition ID immediately, to move it to the
+    // back of the chain, so other images will be preferred if either all images
+    // are available or no images are available.
+    _availability.acquisitionID = _swapchain->getNextAcquisitionID();
 
-	auto signaler = MVKSwapchainSignaler{fence, semaphore, semaphore ? semaphore->deferSignal() : 0};
-	if (_availability.isAvailable) {
-		_availability.isAvailable = false;
+    auto signaler =
+        MVKSwapchainSignaler{fence, semaphore,
+                             semaphore ? semaphore->deferSignal() : 0};
+    if (_availability.isAvailable) {
+        _availability.isAvailable = false;
 
-		// If signalling through a MTLEvent, signal through an ephemeral MTLCommandBuffer.
-		// Another option would be to use MTLSharedEvent in MVKSemaphore, but that might
-		// impose unacceptable performance costs to handle this particular case.
-		@autoreleasepool {
-			MVKSemaphore* mvkSem = signaler.semaphore;
-			id<MTLCommandBuffer> mtlCmdBuff = nil;
-			if (mvkSem && mvkSem->isUsingCommandEncoding()) {
-				mtlCmdBuff = _device->getAnyQueue()->getMTLCommandBuffer(kMVKCommandUseAcquireNextImage);
-				if ( !mtlCmdBuff ) { setConfigurationResult(VK_ERROR_OUT_OF_POOL_MEMORY); }
-			}
-			signal(signaler.semaphore, signaler.semaphoreSignalToken, mtlCmdBuff);
-			signal(signaler.fence);
-			[mtlCmdBuff commit];
-		}
+        // If signalling through a MTLEvent, signal through an ephemeral
+        // MTLCommandBuffer. Another option would be to use MTLSharedEvent in
+        // MVKSemaphore, but that might impose unacceptable performance costs to
+        // handle this particular case.
+        @autoreleasepool {
+            MVKSemaphore* mvkSem = signaler.semaphore;
+            id<MTLCommandBuffer> mtlCmdBuff = nil;
+            if (mvkSem && mvkSem->isUsingCommandEncoding()) {
+                mtlCmdBuff = _device->getAnyQueue()->getMTLCommandBuffer(
+                    kMVKCommandUseAcquireNextImage);
+                if (!mtlCmdBuff) {
+                    setConfigurationResult(VK_ERROR_OUT_OF_POOL_MEMORY);
+                }
+            }
+            signal(signaler.semaphore, signaler.semaphoreSignalToken,
+                   mtlCmdBuff);
+            signal(signaler.fence);
+            [mtlCmdBuff commit];
+        }
 
-		_preSignaler = signaler;
-	} else {
-		_availabilitySignalers.push_back(signaler);
-	}
-	track(signaler);
+        _preSignaler = signaler;
+    } else {
+        _availabilitySignalers.push_back(signaler);
+    }
+    track(signaler);
 
-	return getConfigurationResult();
+    return getConfigurationResult();
 }
 
-// Calling nextDrawable may result in a nil drawable, or a drawable with no pixel format.
-// Attempt several times to retrieve a good drawable, and set an error to trigger the
-// swapchain to be re-established if one cannot be retrieved.
+// Calling nextDrawable may result in a nil drawable, or a drawable with no
+// pixel format. Attempt several times to retrieve a good drawable, and set an
+// error to trigger the swapchain to be re-established if one cannot be
+// retrieved.
 id<CAMetalDrawable> MVKPresentableSwapchainImage::getCAMetalDrawable() {
 
-	if (_mtlTextureHeadless) { return nil; }	// If headless, there is no drawable.
+    if (_mtlTextureHeadless) {
+        return nil;
+    } // If headless, there is no drawable.
 
-	if ( !_mtlDrawable ) {
-		@autoreleasepool {
-			bool hasInvalidFormat = false;
-			uint32_t attemptCnt = _swapchain->getImageCount();	// Attempt a resonable number of times
-			for (uint32_t attemptIdx = 0; !_mtlDrawable && attemptIdx < attemptCnt; attemptIdx++) {
-				uint64_t startTime = getPerformanceTimestamp();
-				_mtlDrawable = [_swapchain->getCAMetalLayer().nextDrawable retain];	// retained
-				addPerformanceInterval(getPerformanceStats().queue.retrieveCAMetalDrawable, startTime);
-				hasInvalidFormat = _mtlDrawable && !_mtlDrawable.texture.pixelFormat;
-				if (hasInvalidFormat) { releaseMetalDrawable(); }
-			}
-			if (hasInvalidFormat) {
-				setConfigurationResult(reportError(VK_ERROR_OUT_OF_DATE_KHR, "CAMetalDrawable with valid format could not be acquired after %d attempts.", attemptCnt));
-			} else if ( !_mtlDrawable ) {
-				setConfigurationResult(reportError(VK_ERROR_OUT_OF_POOL_MEMORY, "CAMetalDrawable could not be acquired after %d attempts.", attemptCnt));
-			}
-		}
-	}
-	return _mtlDrawable;
+    if (!_mtlDrawable) {
+        @autoreleasepool {
+            bool hasInvalidFormat = false;
+            uint32_t attemptCnt =
+                _swapchain
+                    ->getImageCount(); // Attempt a resonable number of times
+            for (uint32_t attemptIdx = 0;
+                 !_mtlDrawable && attemptIdx < attemptCnt; attemptIdx++) {
+                uint64_t startTime = getPerformanceTimestamp();
+                _mtlDrawable = [_swapchain->getCAMetalLayer()
+                                    .nextDrawable retain]; // retained
+                addPerformanceInterval(getPerformanceStats()
+                                           .queue.retrieveCAMetalDrawable,
+                                       startTime);
+                hasInvalidFormat =
+                    _mtlDrawable && !_mtlDrawable.texture.pixelFormat;
+                if (hasInvalidFormat) {
+                    releaseMetalDrawable();
+                }
+            }
+            if (hasInvalidFormat) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_OUT_OF_DATE_KHR,
+                                "CAMetalDrawable with valid format could not "
+                                "be acquired after %d attempts.",
+                                attemptCnt));
+            } else if (!_mtlDrawable) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_OUT_OF_POOL_MEMORY,
+                                "CAMetalDrawable could not be acquired after "
+                                "%d attempts.",
+                                attemptCnt));
+            }
+        }
+    }
+    return _mtlDrawable;
 }
 
 // If not headless, retrieve the MTLTexture directly from the CAMetalDrawable.
 id<MTLTexture> MVKPresentableSwapchainImage::getMTLTexture(uint8_t planeIndex) {
-	return _mtlTextureHeadless ? _mtlTextureHeadless : getCAMetalDrawable().texture;
+    return _mtlTextureHeadless ? _mtlTextureHeadless
+                               : getCAMetalDrawable().texture;
 }
 
-// Present the drawable and make myself available only once the command buffer has completed.
-// Pass MVKImagePresentInfo by value because it may not exist when the callback runs.
-VkResult MVKPresentableSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffer> mtlCmdBuff,
-															  MVKImagePresentInfo presentInfo) {
-	_swapchain->renderWatermark(getMTLTexture(0), mtlCmdBuff);
+// Present the drawable and make myself available only once the command buffer
+// has completed. Pass MVKImagePresentInfo by value because it may not exist
+// when the callback runs.
+VkResult MVKPresentableSwapchainImage::presentCAMetalDrawable(
+    id<MTLCommandBuffer> mtlCmdBuff, MVKImagePresentInfo presentInfo) {
+    _swapchain->renderWatermark(getMTLTexture(0), mtlCmdBuff);
 
-	// According to Apple, it is more performant to call MTLDrawable present from within a
-	// MTLCommandBuffer scheduled-handler than it is to call MTLCommandBuffer presentDrawable:.
-	// But get current drawable now, intead of in handler, because a new drawable might be acquired by then.
-	// Attach present handler before presenting to avoid race condition.
-	id<CAMetalDrawable> mtlDrwbl = getCAMetalDrawable();
-	MVKSwapchainSignaler signaler = getPresentationSignaler();
-	[mtlCmdBuff addScheduledHandler: ^(id<MTLCommandBuffer> mcb) {
+    // According to Apple, it is more performant to call MTLDrawable present
+    // from within a MTLCommandBuffer scheduled-handler than it is to call
+    // MTLCommandBuffer presentDrawable:. But get current drawable now, intead
+    // of in handler, because a new drawable might be acquired by then. Attach
+    // present handler before presenting to avoid race condition.
+    id<CAMetalDrawable> mtlDrwbl = getCAMetalDrawable();
+    MVKSwapchainSignaler signaler = getPresentationSignaler();
+    [mtlCmdBuff addScheduledHandler:^(id<MTLCommandBuffer> mcb) {
+      addPresentedHandler(mtlDrwbl, presentInfo, signaler);
 
-		addPresentedHandler(mtlDrwbl, presentInfo, signaler);
+      // Try to do any present mode transitions as late as possible in an
+      // attempt to avoid visual disruptions on any presents already on the
+      // queue.
+      if (presentInfo.presentMode != VK_PRESENT_MODE_MAX_ENUM_KHR) {
+          mtlDrwbl.layer.displaySyncEnabledMVK =
+              (presentInfo.presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
+      }
+      if (presentInfo.desiredPresentTime) {
+          [mtlDrwbl
+              presentAtTime:(double)presentInfo.desiredPresentTime * 1.0e-9];
+      } else {
+          [mtlDrwbl present];
+      }
+    }];
 
-		// Try to do any present mode transitions as late as possible in an attempt
-		// to avoid visual disruptions on any presents already on the queue.
-		if (presentInfo.presentMode != VK_PRESENT_MODE_MAX_ENUM_KHR) {
-			mtlDrwbl.layer.displaySyncEnabledMVK = (presentInfo.presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
-		}
-		if (presentInfo.desiredPresentTime) {
-			[mtlDrwbl presentAtTime: (double)presentInfo.desiredPresentTime * 1.0e-9];
-		} else {
-			[mtlDrwbl present];
-		}
-	}];
+    // Ensure this image, the drawable, and the present fence are not destroyed
+    // while awaiting MTLCommandBuffer completion. We retain the drawable
+    // separately because a new drawable might be acquired by this image by
+    // then. Signal the fence from this callback, because the last one or two
+    // presentation completion callbacks can occasionally stall.
+    retain();
+    [mtlDrwbl retain];
+    auto* fence = presentInfo.fence;
+    if (fence) {
+        fence->retain();
+    }
+    [mtlCmdBuff addCompletedHandler:^(id<MTLCommandBuffer> mcb) {
+      signal(fence);
+      if (fence) {
+          fence->release();
+      }
+      [mtlDrwbl release];
+      release();
+    }];
 
-	// Ensure this image, the drawable, and the present fence are not destroyed while
-	// awaiting MTLCommandBuffer completion. We retain the drawable separately because
-	// a new drawable might be acquired by this image by then.
-	// Signal the fence from this callback, because the last one or two presentation
-	// completion callbacks can occasionally stall.
-	retain();
-	[mtlDrwbl retain];
-	auto* fence = presentInfo.fence;
-	if (fence) { fence->retain(); }
-	[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mcb) {
-		signal(fence);
-		if (fence) { fence->release(); }
-		[mtlDrwbl release];
-		release();
-	}];
+    signal(signaler.semaphore, signaler.semaphoreSignalToken, mtlCmdBuff);
 
-	signal(signaler.semaphore, signaler.semaphoreSignalToken, mtlCmdBuff);
-
-	return getConfigurationResult();
+    return getConfigurationResult();
 }
 
 MVKSwapchainSignaler MVKPresentableSwapchainImage::getPresentationSignaler() {
-	lock_guard<mutex> lock(_availabilityLock);
+    lock_guard<mutex> lock(_availabilityLock);
 
-	// Mark this image as available if no semaphores or fences are waiting to be signaled.
-	_availability.isAvailable = _availabilitySignalers.empty();
-	if (_availability.isAvailable) {
-		// If this image is available, signal the semaphore and fence that were associated
-		// with the last time this image was acquired while available. This is a workaround for
-		// when an app uses a single semaphore or fence for more than one swapchain image.
-		// Because the semaphore or fence will be signaled by more than one image, it will
-		// get out of sync, and the final use of the image would not be signaled as a result.
-		return _preSignaler;
-	} else {
-		// If this image is not yet available, extract and signal the first semaphore and fence.
-		MVKSwapchainSignaler signaler;
-		auto sigIter = _availabilitySignalers.begin();
-		signaler = *sigIter;
-		_availabilitySignalers.erase(sigIter);
-		return signaler;
-	}
+    // Mark this image as available if no semaphores or fences are waiting to be
+    // signaled.
+    _availability.isAvailable = _availabilitySignalers.empty();
+    if (_availability.isAvailable) {
+        // If this image is available, signal the semaphore and fence that were
+        // associated with the last time this image was acquired while
+        // available. This is a workaround for when an app uses a single
+        // semaphore or fence for more than one swapchain image. Because the
+        // semaphore or fence will be signaled by more than one image, it will
+        // get out of sync, and the final use of the image would not be signaled
+        // as a result.
+        return _preSignaler;
+    } else {
+        // If this image is not yet available, extract and signal the first
+        // semaphore and fence.
+        MVKSwapchainSignaler signaler;
+        auto sigIter = _availabilitySignalers.begin();
+        signaler = *sigIter;
+        _availabilitySignalers.erase(sigIter);
+        return signaler;
+    }
 }
 
-// Pass MVKImagePresentInfo & MVKSwapchainSignaler by value because they may not exist when the callback runs.
-void MVKPresentableSwapchainImage::addPresentedHandler(id<CAMetalDrawable> mtlDrawable,
-													   MVKImagePresentInfo presentInfo,
-													   MVKSwapchainSignaler signaler) {
-	beginPresentation(presentInfo);
+// Pass MVKImagePresentInfo & MVKSwapchainSignaler by value because they may not
+// exist when the callback runs.
+void MVKPresentableSwapchainImage::addPresentedHandler(
+    id<CAMetalDrawable> mtlDrawable, MVKImagePresentInfo presentInfo,
+    MVKSwapchainSignaler signaler) {
+    beginPresentation(presentInfo);
 
 #if !MVK_OS_SIMULATOR
-	if ([mtlDrawable respondsToSelector: @selector(addPresentedHandler:)]) {
-		[mtlDrawable addPresentedHandler: ^(id<MTLDrawable> mtlDrwbl) {
-			endPresentation(presentInfo, signaler, mtlDrwbl.presentedTime * 1.0e9);
-		}];
-	} else
+    if ([mtlDrawable respondsToSelector:@selector(addPresentedHandler:)]) {
+        [mtlDrawable addPresentedHandler:^(id<MTLDrawable> mtlDrwbl) {
+          endPresentation(presentInfo, signaler,
+                          mtlDrwbl.presentedTime * 1.0e9);
+        }];
+    } else
 #endif
-	{
-		// If MTLDrawable.presentedTime/addPresentedHandler isn't supported,
-		// treat it as if the present happened when requested.
-		endPresentation(presentInfo, signaler);
-	}
+    {
+        // If MTLDrawable.presentedTime/addPresentedHandler isn't supported,
+        // treat it as if the present happened when requested.
+        endPresentation(presentInfo, signaler);
+    }
 }
 
-// Ensure this image and the swapchain are not destroyed while awaiting presentation
-void MVKPresentableSwapchainImage::beginPresentation(const MVKImagePresentInfo& presentInfo) {
-	retain();
-	_swapchain->beginPresentation(presentInfo);
-	_beginPresentTime = mvkGetRuntimeNanoseconds();
-	_presentationStartTime = getPerformanceTimestamp();
+// Ensure this image and the swapchain are not destroyed while awaiting
+// presentation
+void MVKPresentableSwapchainImage::beginPresentation(
+    const MVKImagePresentInfo& presentInfo) {
+    retain();
+    _swapchain->beginPresentation(presentInfo);
+    _beginPresentTime = mvkGetRuntimeNanoseconds();
+    _presentationStartTime = getPerformanceTimestamp();
 }
 
-void MVKPresentableSwapchainImage::endPresentation(const MVKImagePresentInfo& presentInfo,
-												   const MVKSwapchainSignaler& signaler,
-												   uint64_t actualPresentTime) {
+void MVKPresentableSwapchainImage::endPresentation(
+    const MVKImagePresentInfo& presentInfo,
+    const MVKSwapchainSignaler& signaler, uint64_t actualPresentTime) {
 
-	// If the presentation time is not available, use the current nanosecond runtime clock,
-	// which should be reasonably accurate (sub-ms) to the presentation time. The presentation
-	// time will not be available if the presentation did not actually happen, such as when
-	// running headless, or on a test harness that is not attached to the windowing system.
-	if (actualPresentTime == 0) { actualPresentTime = mvkGetRuntimeNanoseconds(); }
+    // If the presentation time is not available, use the current nanosecond
+    // runtime clock, which should be reasonably accurate (sub-ms) to the
+    // presentation time. The presentation time will not be available if the
+    // presentation did not actually happen, such as when running headless, or
+    // on a test harness that is not attached to the windowing system.
+    if (actualPresentTime == 0) {
+        actualPresentTime = mvkGetRuntimeNanoseconds();
+    }
 
-	{	// Scope to avoid deadlock if release() is run within detachment lock
-		// If I have become detached from the swapchain, it means the swapchain, and possibly the
-		// VkDevice, have been destroyed by the time of this callback, so do not reference them.
-		lock_guard<mutex> lock(_detachmentLock);
-		if (_device) { addPerformanceInterval(getPerformanceStats().queue.presentSwapchains, _presentationStartTime); }
-		if (_swapchain) { _swapchain->endPresentation(presentInfo, _beginPresentTime, actualPresentTime); }
-	}
+    { // Scope to avoid deadlock if release() is run within detachment lock
+        // If I have become detached from the swapchain, it means the swapchain,
+        // and possibly the VkDevice, have been destroyed by the time of this
+        // callback, so do not reference them.
+        lock_guard<mutex> lock(_detachmentLock);
+        if (_device) {
+            addPerformanceInterval(getPerformanceStats()
+                                       .queue.presentSwapchains,
+                                   _presentationStartTime);
+        }
+        if (_swapchain) {
+            _swapchain->endPresentation(presentInfo, _beginPresentTime,
+                                        actualPresentTime);
+        }
+    }
 
-	// Makes an image available for acquisition by the app.
-	// If any semaphores are waiting to be signaled when this image becomes available, the
-	// earliest semaphore is signaled, and this image remains unavailable for other uses.
-	signalAndUntrack(signaler);
-	release();
+    // Makes an image available for acquisition by the app.
+    // If any semaphores are waiting to be signaled when this image becomes
+    // available, the earliest semaphore is signaled, and this image remains
+    // unavailable for other uses.
+    signalAndUntrack(signaler);
+    release();
 }
 
 // Releases the CAMetalDrawable underlying this image.
 void MVKPresentableSwapchainImage::releaseMetalDrawable() {
     [_mtlDrawable release];
-	_mtlDrawable = nil;
+    _mtlDrawable = nil;
 }
 
 // Signal, untrack, and release any signalers that are tracking.
 // Release the drawable before the lock, as it may trigger completion callback.
 void MVKPresentableSwapchainImage::makeAvailable() {
-	releaseMetalDrawable();
-	lock_guard<mutex> lock(_availabilityLock);
+    releaseMetalDrawable();
+    lock_guard<mutex> lock(_availabilityLock);
 
-	if ( !_availability.isAvailable ) {
-		signalAndUntrack(_preSignaler);
-		for (auto& sig : _availabilitySignalers) {
-			signalAndUntrack(sig);
-		}
-		_availabilitySignalers.clear();
-		_availability.isAvailable = true;
-	}
+    if (!_availability.isAvailable) {
+        signalAndUntrack(_preSignaler);
+        for (auto& sig : _availabilitySignalers) {
+            signalAndUntrack(sig);
+        }
+        _availabilitySignalers.clear();
+        _availability.isAvailable = true;
+    }
 }
 
 #pragma mark Construction
 
-MVKPresentableSwapchainImage::MVKPresentableSwapchainImage(MVKDevice* device,
-														   const VkImageCreateInfo* pCreateInfo,
-														   MVKSwapchain* swapchain,
-														   uint32_t swapchainIndex) :
-	MVKSwapchainImage(device, pCreateInfo, swapchain, swapchainIndex) {
+MVKPresentableSwapchainImage::MVKPresentableSwapchainImage(
+    MVKDevice* device, const VkImageCreateInfo* pCreateInfo,
+    MVKSwapchain* swapchain, uint32_t swapchainIndex)
+    : MVKSwapchainImage(device, pCreateInfo, swapchain, swapchainIndex) {
 
-	_availability.acquisitionID = _swapchain->getNextAcquisitionID();
-	_availability.isAvailable = true;
+    _availability.acquisitionID = _swapchain->getNextAcquisitionID();
+    _availability.isAvailable = true;
 
-	if (swapchain->isHeadless()) {
-		@autoreleasepool {
-			MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: getMTLPixelFormat()
-																								  width: pCreateInfo->extent.width
-																								 height: pCreateInfo->extent.height
-																							  mipmapped: NO];
-			mtlTexDesc.usageMVK = MTLTextureUsageRenderTarget;
-			mtlTexDesc.storageModeMVK = MTLStorageModePrivate;
+    if (swapchain->isHeadless()) {
+        @autoreleasepool {
+            MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor
+                texture2DDescriptorWithPixelFormat:getMTLPixelFormat()
+                                             width:pCreateInfo->extent.width
+                                            height:pCreateInfo->extent.height
+                                         mipmapped:NO];
+            mtlTexDesc.usageMVK = MTLTextureUsageRenderTarget;
+            mtlTexDesc.storageModeMVK = MTLStorageModePrivate;
 
-			_mtlTextureHeadless = [[getMTLDevice() newTextureWithDescriptor: mtlTexDesc] retain];	// retained
-		}
-	}
+            _mtlTextureHeadless = [[getMTLDevice()
+                newTextureWithDescriptor:mtlTexDesc] retain]; // retained
+        }
+    }
 }
-
 
 void MVKPresentableSwapchainImage::destroy() {
-	releaseMetalDrawable();
-	[_mtlTextureHeadless release];
-	_mtlTextureHeadless = nil;
-	MVKSwapchainImage::destroy();
+    releaseMetalDrawable();
+    [_mtlTextureHeadless release];
+    _mtlTextureHeadless = nil;
+    MVKSwapchainImage::destroy();
 }
 
-// Unsignaled signalers will exist if this image is acquired more than it is presented.
-// Ensure they are signaled and untracked so the fences and semaphores will be released.
+// Unsignaled signalers will exist if this image is acquired more than it is
+// presented. Ensure they are signaled and untracked so the fences and
+// semaphores will be released.
 MVKPresentableSwapchainImage::~MVKPresentableSwapchainImage() {
-	makeAvailable();
+    makeAvailable();
 }
-
 
 #pragma mark -
 #pragma mark MVKPeerSwapchainImage
 
-VkResult MVKPeerSwapchainImage::bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo) {
-	const VkBindImageMemorySwapchainInfoKHR* swapchainInfo = nullptr;
-	for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
-				swapchainInfo = (const VkBindImageMemorySwapchainInfoKHR*)next;
-				break;
-			default:
-				break;
-		}
-	}
-	if (!swapchainInfo) { return VK_ERROR_OUT_OF_DEVICE_MEMORY; }
+VkResult MVKPeerSwapchainImage::bindDeviceMemory2(
+    const VkBindImageMemoryInfo* pBindInfo) {
+    const VkBindImageMemorySwapchainInfoKHR* swapchainInfo = nullptr;
+    for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
+            swapchainInfo = (const VkBindImageMemorySwapchainInfoKHR*)next;
+            break;
+        default:
+            break;
+        }
+    }
+    if (!swapchainInfo) {
+        return VK_ERROR_OUT_OF_DEVICE_MEMORY;
+    }
 
-	_swapchainIndex = swapchainInfo->imageIndex;
-	return VK_SUCCESS;
+    _swapchainIndex = swapchainInfo->imageIndex;
+    return VK_SUCCESS;
 }
-
 
 #pragma mark Metal
 
-id<MTLTexture> MVKPeerSwapchainImage::getMTLTexture(uint8_t planeIndex) { 
-	return ((MVKSwapchainImage*)_swapchain->getPresentableImage(_swapchainIndex))->getMTLTexture(planeIndex);
+id<MTLTexture> MVKPeerSwapchainImage::getMTLTexture(uint8_t planeIndex) {
+    return ((MVKSwapchainImage*)_swapchain->getPresentableImage(
+                _swapchainIndex))
+        ->getMTLTexture(planeIndex);
 }
-
 
 #pragma mark Construction
 
-MVKPeerSwapchainImage::MVKPeerSwapchainImage(MVKDevice* device,
-											 const VkImageCreateInfo* pCreateInfo,
-											 MVKSwapchain* swapchain,
-											 uint32_t swapchainIndex) :
-	MVKSwapchainImage(device, pCreateInfo, swapchain, swapchainIndex) {}
-
-
+MVKPeerSwapchainImage::MVKPeerSwapchainImage(
+    MVKDevice* device, const VkImageCreateInfo* pCreateInfo,
+    MVKSwapchain* swapchain, uint32_t swapchainIndex)
+    : MVKSwapchainImage(device, pCreateInfo, swapchain, swapchainIndex) {}
 
 #pragma mark -
 #pragma mark MVKImageViewPlane
 
-MVKVulkanAPIObject* MVKImageViewPlane::getVulkanAPIObject() { return _imageView; }
+MVKVulkanAPIObject* MVKImageViewPlane::getVulkanAPIObject() {
+    return _imageView;
+}
 
-void MVKImageViewPlane::propagateDebugName() { _imageView->setMetalObjectLabel(_mtlTexture, _imageView->_debugName); }
-
+void MVKImageViewPlane::propagateDebugName() {
+    _imageView->setMetalObjectLabel(_mtlTexture, _imageView->_debugName);
+}
 
 #pragma mark Metal
 
 id<MTLTexture> MVKImageViewPlane::getMTLTexture() {
-    // If we can use a Metal texture view, lazily create it, otherwise use the image texture directly.
+    // If we can use a Metal texture view, lazily create it, otherwise use the
+    // image texture directly.
     if (_useMTLTextureView) {
-        if ( !_mtlTexture && _mtlPixFmt ) {
+        if (!_mtlTexture && _mtlPixFmt) {
 
-            // Lock and check again in case another thread created the texture view
+            // Lock and check again in case another thread created the texture
+            // view
             lock_guard<mutex> lock(_imageView->_lock);
-            if (_mtlTexture) { return _mtlTexture; }
+            if (_mtlTexture) {
+                return _mtlTexture;
+            }
 
             _mtlTexture = newMTLTexture(); // retained
 
@@ -1799,53 +2441,77 @@ id<MTLTexture> MVKImageViewPlane::getMTLTexture() {
 // overlay on the Metal texture of the underlying image.
 id<MTLTexture> MVKImageViewPlane::newMTLTexture() {
     MTLTextureType mtlTextureType = _imageView->_mtlTextureType;
-    NSRange sliceRange = NSMakeRange(_imageView->_subresourceRange.baseArrayLayer, _imageView->_subresourceRange.layerCount);
+    NSRange sliceRange =
+        NSMakeRange(_imageView->_subresourceRange.baseArrayLayer,
+                    _imageView->_subresourceRange.layerCount);
     // Fake support for 2D views of 3D textures.
     if (_imageView->_image->getImageType() == VK_IMAGE_TYPE_3D &&
-        (mtlTextureType == MTLTextureType2D || mtlTextureType == MTLTextureType2DArray)) {
+        (mtlTextureType == MTLTextureType2D ||
+         mtlTextureType == MTLTextureType2DArray)) {
         mtlTextureType = MTLTextureType3D;
         sliceRange = NSMakeRange(0, 1);
     }
     id<MTLTexture> mtlTex = _imageView->_image->getMTLTexture(_planeIndex);
     if (_useNativeSwizzle) {
-        return [mtlTex newTextureViewWithPixelFormat: _mtlPixFmt
-                                         textureType: mtlTextureType
-                                              levels: NSMakeRange(_imageView->_subresourceRange.baseMipLevel, _imageView->_subresourceRange.levelCount)
-                                              slices: sliceRange
-                                             swizzle: mvkMTLTextureSwizzleChannelsFromVkComponentMapping(_componentSwizzle)];    // retained
+        return [mtlTex
+            newTextureViewWithPixelFormat:_mtlPixFmt
+                              textureType:mtlTextureType
+                                   levels:NSMakeRange(_imageView
+                                                          ->_subresourceRange
+                                                          .baseMipLevel,
+                                                      _imageView
+                                                          ->_subresourceRange
+                                                          .levelCount)
+                                   slices:sliceRange
+                                  swizzle:
+                                      mvkMTLTextureSwizzleChannelsFromVkComponentMapping(
+                                          _componentSwizzle)]; // retained
     } else {
-        return [mtlTex newTextureViewWithPixelFormat: _mtlPixFmt
-                                         textureType: mtlTextureType
-                                              levels: NSMakeRange(_imageView->_subresourceRange.baseMipLevel, _imageView->_subresourceRange.levelCount)
-                                              slices: sliceRange];    // retained
+        return [mtlTex
+            newTextureViewWithPixelFormat:_mtlPixFmt
+                              textureType:mtlTextureType
+                                   levels:NSMakeRange(_imageView
+                                                          ->_subresourceRange
+                                                          .baseMipLevel,
+                                                      _imageView
+                                                          ->_subresourceRange
+                                                          .levelCount)
+                                   slices:sliceRange]; // retained
     }
 }
-
 
 #pragma mark Construction
 
 MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
-									 uint8_t planeIndex,
-									 MTLPixelFormat mtlPixFmt,
-									 const VkImageViewCreateInfo* pCreateInfo) : MVKBaseDeviceObject(imageView->_device) {
+                                     uint8_t planeIndex,
+                                     MTLPixelFormat mtlPixFmt,
+                                     const VkImageViewCreateInfo* pCreateInfo)
+    : MVKBaseDeviceObject(imageView->_device) {
     _imageView = imageView;
     _planeIndex = planeIndex;
     _mtlPixFmt = mtlPixFmt;
     _mtlTexture = nil;
 
-	getVulkanAPIObject()->setConfigurationResult(initSwizzledMTLPixelFormat(pCreateInfo));
+    getVulkanAPIObject()->setConfigurationResult(
+        initSwizzledMTLPixelFormat(pCreateInfo));
 
     // Determine whether this image view should use a Metal texture view,
     // and set the _useMTLTextureView variable appropriately.
-    if ( _imageView->_image ) {
+    if (_imageView->_image) {
         _useMTLTextureView = _imageView->_image->_canSupportMTLTextureView;
         bool is3D = _imageView->_image->_mtlTextureType == MTLTextureType3D;
-        // If the view is identical to underlying image, don't bother using a Metal view
+        // If the view is identical to underlying image, don't bother using a
+        // Metal view
         if (_mtlPixFmt == _imageView->_image->getMTLPixelFormat(planeIndex) &&
-            (_imageView->_mtlTextureType == _imageView->_image->_mtlTextureType ||
-             ((_imageView->_mtlTextureType == MTLTextureType2D || _imageView->_mtlTextureType == MTLTextureType2DArray) && is3D)) &&
-            _imageView->_subresourceRange.levelCount == _imageView->_image->_mipLevels &&
-            (is3D || _imageView->_subresourceRange.layerCount == _imageView->_image->_arrayLayers) &&
+            (_imageView->_mtlTextureType ==
+                 _imageView->_image->_mtlTextureType ||
+             ((_imageView->_mtlTextureType == MTLTextureType2D ||
+               _imageView->_mtlTextureType == MTLTextureType2DArray) &&
+              is3D)) &&
+            _imageView->_subresourceRange.levelCount ==
+                _imageView->_image->_mipLevels &&
+            (is3D || _imageView->_subresourceRange.layerCount ==
+                         _imageView->_image->_arrayLayers) &&
             !_useNativeSwizzle) {
             _useMTLTextureView = false;
         }
@@ -1854,296 +2520,342 @@ MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
     }
 }
 
-VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo) {
+VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(
+    const VkImageViewCreateInfo* pCreateInfo) {
 
-	_useNativeSwizzle = false;
-	_useShaderSwizzle = false;
-	_componentSwizzle = pCreateInfo->components;
-	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
+    _useNativeSwizzle = false;
+    _useShaderSwizzle = false;
+    _componentSwizzle = pCreateInfo->components;
+    VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
 
-#define adjustComponentSwizzleValue(comp, currVal, newVal)    if (_componentSwizzle.comp == VK_COMPONENT_SWIZZLE_ ##currVal) { _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_ ##newVal; }
-#define adjustAnyComponentSwizzleValue(comp, I, R, G, B, A) \
-	switch (_componentSwizzle.comp) { \
-		case VK_COMPONENT_SWIZZLE_IDENTITY: \
-			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##I; \
-			break; \
-		case VK_COMPONENT_SWIZZLE_R: \
-			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##R; \
-			break; \
-		case VK_COMPONENT_SWIZZLE_G: \
-			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##G; \
-			break; \
-		case VK_COMPONENT_SWIZZLE_B: \
-			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##B; \
-			break; \
-		case VK_COMPONENT_SWIZZLE_A: \
-			_componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##A; \
-			break; \
-		default: \
-			break; \
-	}
+#define adjustComponentSwizzleValue(comp, currVal, newVal)                     \
+    if (_componentSwizzle.comp == VK_COMPONENT_SWIZZLE_##currVal) {            \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##newVal;                \
+    }
+#define adjustAnyComponentSwizzleValue(comp, I, R, G, B, A)                    \
+    switch (_componentSwizzle.comp) {                                          \
+    case VK_COMPONENT_SWIZZLE_IDENTITY:                                        \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##I;                     \
+        break;                                                                 \
+    case VK_COMPONENT_SWIZZLE_R:                                               \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##R;                     \
+        break;                                                                 \
+    case VK_COMPONENT_SWIZZLE_G:                                               \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##G;                     \
+        break;                                                                 \
+    case VK_COMPONENT_SWIZZLE_B:                                               \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##B;                     \
+        break;                                                                 \
+    case VK_COMPONENT_SWIZZLE_A:                                               \
+        _componentSwizzle.comp = VK_COMPONENT_SWIZZLE_##A;                     \
+        break;                                                                 \
+    default:                                                                   \
+        break;                                                                 \
+    }
 
-	// Use swizzle adjustment to bridge some differences between Vulkan and Metal pixel formats.
-	// Do this ahead of other tests and adjustments so that swizzling will be enabled by tests below.
-	switch (pCreateInfo->format) {
-		case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
-		case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
-			// Metal doesn't support BC1_RGB, so force references to substituted BC1_RGBA alpha to 1.0.
-			adjustComponentSwizzleValue(r, A, ONE);
-			adjustComponentSwizzleValue(g, A, ONE);
-			adjustComponentSwizzleValue(b, A, ONE);
-			adjustComponentSwizzleValue(a, A, ONE);
-			adjustComponentSwizzleValue(a, IDENTITY, ONE);
-			break;
+    // Use swizzle adjustment to bridge some differences between Vulkan and
+    // Metal pixel formats. Do this ahead of other tests and adjustments so that
+    // swizzling will be enabled by tests below.
+    switch (pCreateInfo->format) {
+    case VK_FORMAT_BC1_RGB_UNORM_BLOCK:
+    case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+        // Metal doesn't support BC1_RGB, so force references to substituted
+        // BC1_RGBA alpha to 1.0.
+        adjustComponentSwizzleValue(r, A, ONE);
+        adjustComponentSwizzleValue(g, A, ONE);
+        adjustComponentSwizzleValue(b, A, ONE);
+        adjustComponentSwizzleValue(a, A, ONE);
+        adjustComponentSwizzleValue(a, IDENTITY, ONE);
+        break;
 
-		case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
-			// Metal doesn't (publicly) support this directly, so use a swizzle to get the ordering right.
-			// n.b. **Do NOT use adjustComponentSwizzleValue if multiple values need substitution,
-			// and some of the substitutes are keys for other substitutions!**
-			adjustAnyComponentSwizzleValue(r, G, G, B, A, R);
-			adjustAnyComponentSwizzleValue(g, B, G, B, A, R);
-			adjustAnyComponentSwizzleValue(b, A, G, B, A, R);
-			adjustAnyComponentSwizzleValue(a, R, G, B, A, R);
-			break;
+    case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
+        // Metal doesn't (publicly) support this directly, so use a swizzle to
+        // get the ordering right. n.b. **Do NOT use adjustComponentSwizzleValue
+        // if multiple values need substitution, and some of the substitutes are
+        // keys for other substitutions!**
+        adjustAnyComponentSwizzleValue(r, G, G, B, A, R);
+        adjustAnyComponentSwizzleValue(g, B, G, B, A, R);
+        adjustAnyComponentSwizzleValue(b, A, G, B, A, R);
+        adjustAnyComponentSwizzleValue(a, R, G, B, A, R);
+        break;
 
-		case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
-			// Metal doesn't support this directly, so use a swizzle to get the ordering right.
-			adjustAnyComponentSwizzleValue(r, A, A, B, G, R);
-			adjustAnyComponentSwizzleValue(g, B, A, B, G, R);
-			adjustAnyComponentSwizzleValue(b, G, A, B, G, R);
-			adjustAnyComponentSwizzleValue(a, R, A, B, G, R);
-			break;
+    case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
+        // Metal doesn't support this directly, so use a swizzle to get the
+        // ordering right.
+        adjustAnyComponentSwizzleValue(r, A, A, B, G, R);
+        adjustAnyComponentSwizzleValue(g, B, A, B, G, R);
+        adjustAnyComponentSwizzleValue(b, G, A, B, G, R);
+        adjustAnyComponentSwizzleValue(a, R, A, B, G, R);
+        break;
 
-		case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
-		case VK_FORMAT_B5G6R5_UNORM_PACK16:
-		case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
-			// Metal doesn't support this directly, so use a swizzle to get the ordering right.
-			adjustAnyComponentSwizzleValue(r, B, B, G, R, A);
-			adjustAnyComponentSwizzleValue(g, G, B, G, R, A);
-			adjustAnyComponentSwizzleValue(b, R, B, G, R, A);
-			adjustAnyComponentSwizzleValue(a, A, B, G, R, A);
-			break;
+    case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
+    case VK_FORMAT_B5G6R5_UNORM_PACK16:
+    case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
+        // Metal doesn't support this directly, so use a swizzle to get the
+        // ordering right.
+        adjustAnyComponentSwizzleValue(r, B, B, G, R, A);
+        adjustAnyComponentSwizzleValue(g, G, B, G, R, A);
+        adjustAnyComponentSwizzleValue(b, R, B, G, R, A);
+        adjustAnyComponentSwizzleValue(a, A, B, G, R, A);
+        break;
 
-		default:
-			break;
-	}
+    default:
+        break;
+    }
 
-	// Metal requires special handling when sampling depth/stencil textures in the following cases:
-	// 1. Sampling stencil from a depth/stencil format
-	// 2. Metal's undefined values for depth/stencil sample to vec4 conversion
-	if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT) &&
-		mvkIsAnyFlagEnabled(_imageView->_usage, (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)))
-	{
-		// 1. Sampling stencil from a depth/stencil format
-		// To sample the stencil value from a depth/stencil format, Metal requires to drop the depth for the view format.
-		// Meaning that MTLPixelFormatDepth32Float_Stencil8 needs to be MTLPixelFormatX32_Stencil8 for the view according to spec:
-		// You can't directly read the stencil value of a texture with the MTLPixelFormatDepth32Float_Stencil8 format.
-		// To read stencil values from a texture with the MTLPixelFormatDepth32Float_Stencil8 format, create a texture view
-		// of that texture using the MTLPixelFormatX32_Stencil8 format, and sample the texture view instead.
-		if (aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
-			if (_mtlPixFmt == MTLPixelFormatDepth32Float_Stencil8) {
-				_mtlPixFmt = MTLPixelFormatX32_Stencil8;
-			}
+    // Metal requires special handling when sampling depth/stencil textures in
+    // the following cases:
+    // 1. Sampling stencil from a depth/stencil format
+    // 2. Metal's undefined values for depth/stencil sample to vec4 conversion
+    if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_DEPTH_BIT |
+                                            VK_IMAGE_ASPECT_STENCIL_BIT) &&
+        mvkIsAnyFlagEnabled(_imageView->_usage,
+                            (VK_IMAGE_USAGE_SAMPLED_BIT |
+                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT))) {
+        // 1. Sampling stencil from a depth/stencil format
+        // To sample the stencil value from a depth/stencil format, Metal
+        // requires to drop the depth for the view format. Meaning that
+        // MTLPixelFormatDepth32Float_Stencil8 needs to be
+        // MTLPixelFormatX32_Stencil8 for the view according to spec: You can't
+        // directly read the stencil value of a texture with the
+        // MTLPixelFormatDepth32Float_Stencil8 format. To read stencil values
+        // from a texture with the MTLPixelFormatDepth32Float_Stencil8 format,
+        // create a texture view of that texture using the
+        // MTLPixelFormatX32_Stencil8 format, and sample the texture view
+        // instead.
+        if (aspectMask == VK_IMAGE_ASPECT_STENCIL_BIT) {
+            if (_mtlPixFmt == MTLPixelFormatDepth32Float_Stencil8) {
+                _mtlPixFmt = MTLPixelFormatX32_Stencil8;
+            }
 #if MVK_MACOS
-			else if (_mtlPixFmt == MTLPixelFormatDepth24Unorm_Stencil8) {
-				_mtlPixFmt = MTLPixelFormatX24_Stencil8;
-			}
+            else if (_mtlPixFmt == MTLPixelFormatDepth24Unorm_Stencil8) {
+                _mtlPixFmt = MTLPixelFormatX24_Stencil8;
+            }
 #endif
-		}
-		
-		// 2. Metal's undefined values for depth/stencil sample to vec4 conversion
-		// Due to differences in Metal and Vulkan specification for sampling depth/stencil textures into vec4, we need to
-		// provide the correct mapping from Vulkan to Metal
-		// Metal states:
-		// "For a texture with depth or stencil pixel format (such as MTLPixelFormatDepth24Unorm_Stencil8 or MTLPixelFormatStencil8),
-		// the default value for an unspecified component is undefined." which means all values but R will be undefined.
-		// Vulkan requires that all components be defined, with `G` and `B` set to `0` and `A` set to `1`.
-		// See https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-conversion-to-rgba.
-		if (enableSwizzling()) {
-			if (_componentSwizzle.r == VK_COMPONENT_SWIZZLE_A) {
-				_componentSwizzle.r = VK_COMPONENT_SWIZZLE_ONE;
-			} else if (_componentSwizzle.r == VK_COMPONENT_SWIZZLE_G || _componentSwizzle.r == VK_COMPONENT_SWIZZLE_B) {
-				_componentSwizzle.r = VK_COMPONENT_SWIZZLE_ZERO;
-			}
-			if (_componentSwizzle.g == VK_COMPONENT_SWIZZLE_A) {
-				_componentSwizzle.g = VK_COMPONENT_SWIZZLE_ONE;
-			} else if (_componentSwizzle.g == VK_COMPONENT_SWIZZLE_G || _componentSwizzle.g == VK_COMPONENT_SWIZZLE_B || _componentSwizzle.g == VK_COMPONENT_SWIZZLE_IDENTITY) {
-				_componentSwizzle.g = VK_COMPONENT_SWIZZLE_ZERO;
-			}
-			if (_componentSwizzle.b == VK_COMPONENT_SWIZZLE_A) {
-				_componentSwizzle.b = VK_COMPONENT_SWIZZLE_ONE;
-			} else if (_componentSwizzle.b == VK_COMPONENT_SWIZZLE_G || _componentSwizzle.b == VK_COMPONENT_SWIZZLE_B || _componentSwizzle.b == VK_COMPONENT_SWIZZLE_IDENTITY) {
-				_componentSwizzle.b = VK_COMPONENT_SWIZZLE_ZERO;
-			}
-			if (_componentSwizzle.a == VK_COMPONENT_SWIZZLE_A || _componentSwizzle.a == VK_COMPONENT_SWIZZLE_IDENTITY) {
-				_componentSwizzle.a = VK_COMPONENT_SWIZZLE_ONE;
-			} else if (_componentSwizzle.a == VK_COMPONENT_SWIZZLE_G || _componentSwizzle.a == VK_COMPONENT_SWIZZLE_B ) {
-				_componentSwizzle.a = VK_COMPONENT_SWIZZLE_ZERO;
-			}
-			
-			return VK_SUCCESS;
-		}
-	}
+        }
 
-#define SWIZZLE_MATCHES(R, G, B, A)    mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_ ##R, VK_COMPONENT_SWIZZLE_ ##G, VK_COMPONENT_SWIZZLE_ ##B, VK_COMPONENT_SWIZZLE_ ##A} )
-#define VK_COMPONENT_SWIZZLE_ANY       VK_COMPONENT_SWIZZLE_MAX_ENUM
+        // 2. Metal's undefined values for depth/stencil sample to vec4
+        // conversion Due to differences in Metal and Vulkan specification for
+        // sampling depth/stencil textures into vec4, we need to provide the
+        // correct mapping from Vulkan to Metal Metal states: "For a texture
+        // with depth or stencil pixel format (such as
+        // MTLPixelFormatDepth24Unorm_Stencil8 or MTLPixelFormatStencil8), the
+        // default value for an unspecified component is undefined." which means
+        // all values but R will be undefined. Vulkan requires that all
+        // components be defined, with `G` and `B` set to `0` and `A` set to
+        // `1`. See
+        // https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#textures-conversion-to-rgba.
+        if (enableSwizzling()) {
+            if (_componentSwizzle.r == VK_COMPONENT_SWIZZLE_A) {
+                _componentSwizzle.r = VK_COMPONENT_SWIZZLE_ONE;
+            } else if (_componentSwizzle.r == VK_COMPONENT_SWIZZLE_G ||
+                       _componentSwizzle.r == VK_COMPONENT_SWIZZLE_B) {
+                _componentSwizzle.r = VK_COMPONENT_SWIZZLE_ZERO;
+            }
+            if (_componentSwizzle.g == VK_COMPONENT_SWIZZLE_A) {
+                _componentSwizzle.g = VK_COMPONENT_SWIZZLE_ONE;
+            } else if (_componentSwizzle.g == VK_COMPONENT_SWIZZLE_G ||
+                       _componentSwizzle.g == VK_COMPONENT_SWIZZLE_B ||
+                       _componentSwizzle.g == VK_COMPONENT_SWIZZLE_IDENTITY) {
+                _componentSwizzle.g = VK_COMPONENT_SWIZZLE_ZERO;
+            }
+            if (_componentSwizzle.b == VK_COMPONENT_SWIZZLE_A) {
+                _componentSwizzle.b = VK_COMPONENT_SWIZZLE_ONE;
+            } else if (_componentSwizzle.b == VK_COMPONENT_SWIZZLE_G ||
+                       _componentSwizzle.b == VK_COMPONENT_SWIZZLE_B ||
+                       _componentSwizzle.b == VK_COMPONENT_SWIZZLE_IDENTITY) {
+                _componentSwizzle.b = VK_COMPONENT_SWIZZLE_ZERO;
+            }
+            if (_componentSwizzle.a == VK_COMPONENT_SWIZZLE_A ||
+                _componentSwizzle.a == VK_COMPONENT_SWIZZLE_IDENTITY) {
+                _componentSwizzle.a = VK_COMPONENT_SWIZZLE_ONE;
+            } else if (_componentSwizzle.a == VK_COMPONENT_SWIZZLE_G ||
+                       _componentSwizzle.a == VK_COMPONENT_SWIZZLE_B) {
+                _componentSwizzle.a = VK_COMPONENT_SWIZZLE_ZERO;
+            }
 
-	// If we have an identity swizzle, we're all good.
-	if (SWIZZLE_MATCHES(R, G, B, A)) {
-		return VK_SUCCESS;
-	}
+            return VK_SUCCESS;
+        }
+    }
 
-	if (mvkIsAnyFlagEnabled(_imageView->_usage, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT)) {
-		// Vulkan forbids using image views with non-identity swizzles as storage images or attachments.
-		// Let's catch some cases which are essentially identity, but would still result in Metal restricting
-		// the resulting texture's usage.
+#define SWIZZLE_MATCHES(R, G, B, A)                                            \
+    mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_##R,  \
+                                                    VK_COMPONENT_SWIZZLE_##G,  \
+                                                    VK_COMPONENT_SWIZZLE_##B,  \
+                                                    VK_COMPONENT_SWIZZLE_##A})
+#define VK_COMPONENT_SWIZZLE_ANY VK_COMPONENT_SWIZZLE_MAX_ENUM
 
-		switch (_mtlPixFmt) {
-			case MTLPixelFormatR8Unorm:
+    // If we have an identity swizzle, we're all good.
+    if (SWIZZLE_MATCHES(R, G, B, A)) {
+        return VK_SUCCESS;
+    }
+
+    if (mvkIsAnyFlagEnabled(_imageView->_usage,
+                            VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+                                VK_IMAGE_USAGE_STORAGE_BIT)) {
+        // Vulkan forbids using image views with non-identity swizzles as
+        // storage images or attachments. Let's catch some cases which are
+        // essentially identity, but would still result in Metal restricting the
+        // resulting texture's usage.
+
+        switch (_mtlPixFmt) {
+        case MTLPixelFormatR8Unorm:
 #if MVK_APPLE_SILICON
-			case MTLPixelFormatR8Unorm_sRGB:
+        case MTLPixelFormatR8Unorm_sRGB:
 #endif
-			case MTLPixelFormatR8Snorm:
-			case MTLPixelFormatR8Uint:
-			case MTLPixelFormatR8Sint:
-			case MTLPixelFormatR16Unorm:
-			case MTLPixelFormatR16Snorm:
-			case MTLPixelFormatR16Uint:
-			case MTLPixelFormatR16Sint:
-			case MTLPixelFormatR16Float:
-			case MTLPixelFormatR32Uint:
-			case MTLPixelFormatR32Sint:
-			case MTLPixelFormatR32Float:
-				if (SWIZZLE_MATCHES(R, ZERO, ZERO, ONE)) {
-					return VK_SUCCESS;
-				}
-				break;
+        case MTLPixelFormatR8Snorm:
+        case MTLPixelFormatR8Uint:
+        case MTLPixelFormatR8Sint:
+        case MTLPixelFormatR16Unorm:
+        case MTLPixelFormatR16Snorm:
+        case MTLPixelFormatR16Uint:
+        case MTLPixelFormatR16Sint:
+        case MTLPixelFormatR16Float:
+        case MTLPixelFormatR32Uint:
+        case MTLPixelFormatR32Sint:
+        case MTLPixelFormatR32Float:
+            if (SWIZZLE_MATCHES(R, ZERO, ZERO, ONE)) {
+                return VK_SUCCESS;
+            }
+            break;
 
-			case MTLPixelFormatRG8Unorm:
+        case MTLPixelFormatRG8Unorm:
 #if MVK_APPLE_SILICON
-			case MTLPixelFormatRG8Unorm_sRGB:
+        case MTLPixelFormatRG8Unorm_sRGB:
 #endif
-			case MTLPixelFormatRG8Snorm:
-			case MTLPixelFormatRG8Uint:
-			case MTLPixelFormatRG8Sint:
-			case MTLPixelFormatRG16Unorm:
-			case MTLPixelFormatRG16Snorm:
-			case MTLPixelFormatRG16Uint:
-			case MTLPixelFormatRG16Sint:
-			case MTLPixelFormatRG16Float:
-			case MTLPixelFormatRG32Uint:
-			case MTLPixelFormatRG32Sint:
-			case MTLPixelFormatRG32Float:
-				if (SWIZZLE_MATCHES(R, G, ZERO, ONE)) {
-					return VK_SUCCESS;
-				}
-				break;
+        case MTLPixelFormatRG8Snorm:
+        case MTLPixelFormatRG8Uint:
+        case MTLPixelFormatRG8Sint:
+        case MTLPixelFormatRG16Unorm:
+        case MTLPixelFormatRG16Snorm:
+        case MTLPixelFormatRG16Uint:
+        case MTLPixelFormatRG16Sint:
+        case MTLPixelFormatRG16Float:
+        case MTLPixelFormatRG32Uint:
+        case MTLPixelFormatRG32Sint:
+        case MTLPixelFormatRG32Float:
+            if (SWIZZLE_MATCHES(R, G, ZERO, ONE)) {
+                return VK_SUCCESS;
+            }
+            break;
 
-			case MTLPixelFormatRG11B10Float:
-			case MTLPixelFormatRGB9E5Float:
-				if (SWIZZLE_MATCHES(R, G, B, ONE)) {
-					return VK_SUCCESS;
-				}
-				break;
+        case MTLPixelFormatRG11B10Float:
+        case MTLPixelFormatRGB9E5Float:
+            if (SWIZZLE_MATCHES(R, G, B, ONE)) {
+                return VK_SUCCESS;
+            }
+            break;
 
-			default:
-				break;
-		}
-	}
+        default:
+            break;
+        }
+    }
 
-	if (!_imageView->_image->hasPixelFormatView(_planeIndex)) {
-		if (!enableSwizzling()) {
-			MVKAssert(0, "Image without PixelFormatView usage couldn't enable swizzling!");
-		}
-		return VK_SUCCESS;
-	}
+    if (!_imageView->_image->hasPixelFormatView(_planeIndex)) {
+        if (!enableSwizzling()) {
+            MVKAssert(0, "Image without PixelFormatView usage couldn't enable "
+                         "swizzling!");
+        }
+        return VK_SUCCESS;
+    }
 
-	switch (_mtlPixFmt) {
-		case MTLPixelFormatR8Unorm:
-			if (SWIZZLE_MATCHES(ZERO, ANY, ANY, R)) {
-				_mtlPixFmt = MTLPixelFormatA8Unorm;
-				return VK_SUCCESS;
-			}
-			break;
+    switch (_mtlPixFmt) {
+    case MTLPixelFormatR8Unorm:
+        if (SWIZZLE_MATCHES(ZERO, ANY, ANY, R)) {
+            _mtlPixFmt = MTLPixelFormatA8Unorm;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatA8Unorm:
-			if (SWIZZLE_MATCHES(A, ANY, ANY, ZERO)) {
-				_mtlPixFmt = MTLPixelFormatR8Unorm;
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatA8Unorm:
+        if (SWIZZLE_MATCHES(A, ANY, ANY, ZERO)) {
+            _mtlPixFmt = MTLPixelFormatR8Unorm;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatRGBA8Unorm:
-			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				_mtlPixFmt = MTLPixelFormatBGRA8Unorm;
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatRGBA8Unorm:
+        if (SWIZZLE_MATCHES(B, G, R, A)) {
+            _mtlPixFmt = MTLPixelFormatBGRA8Unorm;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatRGBA8Unorm_sRGB:
-			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				_mtlPixFmt = MTLPixelFormatBGRA8Unorm_sRGB;
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatRGBA8Unorm_sRGB:
+        if (SWIZZLE_MATCHES(B, G, R, A)) {
+            _mtlPixFmt = MTLPixelFormatBGRA8Unorm_sRGB;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatBGRA8Unorm:
-			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				_mtlPixFmt = MTLPixelFormatRGBA8Unorm;
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatBGRA8Unorm:
+        if (SWIZZLE_MATCHES(B, G, R, A)) {
+            _mtlPixFmt = MTLPixelFormatRGBA8Unorm;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatBGRA8Unorm_sRGB:
-			if (SWIZZLE_MATCHES(B, G, R, A)) {
-				_mtlPixFmt = MTLPixelFormatRGBA8Unorm_sRGB;
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatBGRA8Unorm_sRGB:
+        if (SWIZZLE_MATCHES(B, G, R, A)) {
+            _mtlPixFmt = MTLPixelFormatRGBA8Unorm_sRGB;
+            return VK_SUCCESS;
+        }
+        break;
 
-		case MTLPixelFormatX32_Stencil8:
-			if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatX32_Stencil8:
+        if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
+            return VK_SUCCESS;
+        }
+        break;
 
 #if MVK_MACOS
-		case MTLPixelFormatX24_Stencil8:
-			if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
-				return VK_SUCCESS;
-			}
-			break;
+    case MTLPixelFormatX24_Stencil8:
+        if (SWIZZLE_MATCHES(R, ANY, ANY, ANY)) {
+            return VK_SUCCESS;
+        }
+        break;
 #endif
 
-		default:
-			break;
-	}
+    default:
+        break;
+    }
 
-	// No format transformation swizzles were found, so we'll need to use either native or shader swizzling, if supported.
-	if ( !enableSwizzling() ) {
-		return getVulkanAPIObject()->reportError(VK_ERROR_FEATURE_NOT_PRESENT,
-												 "The value of %s::components) (%s, %s, %s, %s), when applied to a VkImageView, requires full component swizzling to be enabled both at the"
-												 " time when the VkImageView is created and at the time any pipeline that uses that VkImageView is compiled. Full component swizzling can"
-												 " be enabled via the MVKConfiguration::fullImageViewSwizzle config parameter or MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable.",
-												 pCreateInfo->image ? "vkCreateImageView(VkImageViewCreateInfo" : "vkGetPhysicalDeviceImageFormatProperties2KHR(VkPhysicalDeviceImageViewSupportEXTX",
-												 mvkVkComponentSwizzleName(_componentSwizzle.r), mvkVkComponentSwizzleName(_componentSwizzle.g),
-												 mvkVkComponentSwizzleName(_componentSwizzle.b), mvkVkComponentSwizzleName(_componentSwizzle.a));
-	}
+    // No format transformation swizzles were found, so we'll need to use either
+    // native or shader swizzling, if supported.
+    if (!enableSwizzling()) {
+        return getVulkanAPIObject()->reportError(
+            VK_ERROR_FEATURE_NOT_PRESENT,
+            "The value of %s::components) (%s, %s, %s, %s), when applied to a "
+            "VkImageView, requires full "
+            "component swizzling to be enabled both at the"
+            " time when the VkImageView is created and at the time any "
+            "pipeline that uses that "
+            "VkImageView is compiled. Full component swizzling can"
+            " be enabled via the MVKConfiguration::fullImageViewSwizzle config "
+            "parameter or "
+            "MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE environment variable.",
+            pCreateInfo->image ? "vkCreateImageView(VkImageViewCreateInfo"
+                               : "vkGetPhysicalDeviceImageFormatProperties2KHR("
+                                 "VkPhysicalDeviceImageViewSupportEXTX",
+            mvkVkComponentSwizzleName(_componentSwizzle.r),
+            mvkVkComponentSwizzleName(_componentSwizzle.g),
+            mvkVkComponentSwizzleName(_componentSwizzle.b),
+            mvkVkComponentSwizzleName(_componentSwizzle.a));
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-// Enable either native or shader swizzling, depending on what is available, preferring native, and return whether successful.
+// Enable either native or shader swizzling, depending on what is available,
+// preferring native, and return whether successful.
 bool MVKImageViewPlane::enableSwizzling() {
-	_useNativeSwizzle = getMetalFeatures().nativeTextureSwizzle;
-	_useShaderSwizzle = !_useNativeSwizzle && getMVKConfig().fullImageViewSwizzle;
-	return _useNativeSwizzle || _useShaderSwizzle;
+    _useNativeSwizzle = getMetalFeatures().nativeTextureSwizzle;
+    _useShaderSwizzle =
+        !_useNativeSwizzle && getMVKConfig().fullImageViewSwizzle;
+    return _useNativeSwizzle || _useShaderSwizzle;
 }
 
-MVKImageViewPlane::~MVKImageViewPlane() {
-    [_mtlTexture release];
-}
-
+MVKImageViewPlane::~MVKImageViewPlane() { [_mtlTexture release]; }
 
 #pragma mark -
 #pragma mark MVKImageView
@@ -2154,12 +2866,14 @@ void MVKImageView::propagateDebugName() {
     }
 }
 
-void MVKImageView::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
+void MVKImageView::populateMTLRenderPassAttachmentDescriptor(
+    MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
     MVKImageViewPlane* plane = _planes[0];
     bool useView = plane->_useMTLTextureView;
     mtlAttDesc.texture = plane->getMTLTexture();
     // If a native swizzle is being applied, use the unswizzled parent texture.
-    // This is relevant for depth/stencil attachments that are also sampled and might have forced swizzles.
+    // This is relevant for depth/stencil attachments that are also sampled and
+    // might have forced swizzles.
     if (plane->_useNativeSwizzle && mtlAttDesc.texture.parentTexture) {
         useView = false;
         mtlAttDesc.texture = mtlAttDesc.texture.parentTexture;
@@ -2174,12 +2888,14 @@ void MVKImageView::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttach
     }
 }
 
-void MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
+void MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve(
+    MTLRenderPassAttachmentDescriptor* mtlAttDesc) {
     MVKImageViewPlane* plane = _planes[0];
     bool useView = plane->_useMTLTextureView;
     mtlAttDesc.resolveTexture = plane->getMTLTexture();
     // If a native swizzle is being applied, use the unswizzled parent texture.
-    // This is relevant for depth/stencil attachments that are also sampled and might have forced swizzles.
+    // This is relevant for depth/stencil attachments that are also sampled and
+    // might have forced swizzles.
     if (plane->_useNativeSwizzle && mtlAttDesc.resolveTexture.parentTexture) {
         useView = false;
         mtlAttDesc.resolveTexture = mtlAttDesc.resolveTexture.parentTexture;
@@ -2187,424 +2903,565 @@ void MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPas
     mtlAttDesc.resolveLevel = useView ? 0 : _subresourceRange.baseMipLevel;
     if (mtlAttDesc.resolveTexture.textureType == MTLTextureType3D) {
         mtlAttDesc.resolveSlice = 0;
-        mtlAttDesc.resolveDepthPlane = useView ? 0 : _subresourceRange.baseArrayLayer;
+        mtlAttDesc.resolveDepthPlane =
+            useView ? 0 : _subresourceRange.baseArrayLayer;
     } else {
-        mtlAttDesc.resolveSlice = useView ? 0 : _subresourceRange.baseArrayLayer;
+        mtlAttDesc.resolveSlice =
+            useView ? 0 : _subresourceRange.baseArrayLayer;
         mtlAttDesc.resolveDepthPlane = 0;
     }
 }
 
-
 #pragma mark Construction
 
-MVKImageView::MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	_image = (MVKImage*)pCreateInfo->image;
-	_image->retain();		// Ensure image sticks around while this image view is in flight.
+MVKImageView::MVKImageView(MVKDevice* device,
+                           const VkImageViewCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    _image = (MVKImage*)pCreateInfo->image;
+    _image->retain(); // Ensure image sticks around while this image view is in
+                      // flight.
 
-    _mtlTextureType = mvkMTLTextureTypeFromVkImageViewType(pCreateInfo->viewType,
-														   _image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT);
+    _mtlTextureType =
+        mvkMTLTextureTypeFromVkImageViewType(pCreateInfo->viewType,
+                                             _image->getSampleCount() !=
+                                                 VK_SAMPLE_COUNT_1_BIT);
 
-	// Per spec, for depth/stencil formats, determine the appropriate usage
-	// based on whether stencil or depth or both aspects are being used.
-	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
-	if (mvkAreAllFlagsEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT)) {
-		_usage = _image->_usage & _image->_stencilUsage;
-	} else if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT)) {
-		_usage = _image->_stencilUsage;
-	} else {
-		_usage = _image->_usage;
-	}
-	// Image views can't be used in transfer commands.
-	mvkDisableFlags(_usage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+    // Per spec, for depth/stencil formats, determine the appropriate usage
+    // based on whether stencil or depth or both aspects are being used.
+    VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
+    if (mvkAreAllFlagsEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT |
+                                              VK_IMAGE_ASPECT_DEPTH_BIT)) {
+        _usage = _image->_usage & _image->_stencilUsage;
+    } else if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT)) {
+        _usage = _image->_stencilUsage;
+    } else {
+        _usage = _image->_usage;
+    }
+    // Image views can't be used in transfer commands.
+    mvkDisableFlags(_usage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                             VK_IMAGE_USAGE_TRANSFER_DST_BIT));
 
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO: {
-				auto* pViewUsageInfo = (VkImageViewUsageCreateInfo*)next;
-				VkImageUsageFlags newUsage = pViewUsageInfo->usage;
-				mvkDisableFlags(newUsage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
-				if (mvkAreAllFlagsEnabled(_usage, newUsage)) { _usage = newUsage; }
-				break;
-			}
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO: {
+            auto* pViewUsageInfo = (VkImageViewUsageCreateInfo*)next;
+            VkImageUsageFlags newUsage = pViewUsageInfo->usage;
+            mvkDisableFlags(newUsage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                       VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+            if (mvkAreAllFlagsEnabled(_usage, newUsage)) {
+                _usage = newUsage;
+            }
+            break;
+        }
             /* case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO_KHR: {
-                const VkSamplerYcbcrConversionInfoKHR* sampConvInfo = (const VkSamplerYcbcrConversionInfoKHR*)next;
-                break;
+                const VkSamplerYcbcrConversionInfoKHR* sampConvInfo = (const
+            VkSamplerYcbcrConversionInfoKHR*)next; break;
             } */
-			default:
-				break;
-		}
-	}
+        default:
+            break;
+        }
+    }
 
-	VkImageType imgType = _image->getImageType();
-	VkImageViewType viewType = pCreateInfo->viewType;
+    VkImageType imgType = _image->getImageType();
+    VkImageViewType viewType = pCreateInfo->viewType;
 
-	// VK_KHR_maintenance1 supports taking 2D image views of 3D slices for sampling.
-	// No dice in Metal. But we are able to fake out a 3D render attachment by making the Metal view
-	// itself a 3D texture (when we create it), and setting the rendering depthPlane appropriately.
-	if ((viewType == VK_IMAGE_VIEW_TYPE_2D || viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) && (imgType == VK_IMAGE_TYPE_3D)) {
-		if (!mvkIsOnlyAnyFlagEnabled(_usage, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImageView(): 2D views on 3D images can only be used as color attachments."));
-		}
-	}
+    // VK_KHR_maintenance1 supports taking 2D image views of 3D slices for
+    // sampling. No dice in Metal. But we are able to fake out a 3D render
+    // attachment by making the Metal view itself a 3D texture (when we create
+    // it), and setting the rendering depthPlane appropriately.
+    if ((viewType == VK_IMAGE_VIEW_TYPE_2D ||
+         viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) &&
+        (imgType == VK_IMAGE_TYPE_3D)) {
+        if (!mvkIsOnlyAnyFlagEnabled(_usage,
+                                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
+            setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "vkCreateImageView(): 2D views on 3D images can "
+                            "only be used as color attachments."));
+        }
+    }
 
-	// If a 2D array view on a 2D image with layerCount 1, and the only usages are
-	// attachment usages, then force the use of a 2D non-arrayed view. This is important for
-	// input attachments, or they won't match the types declared in the fragment shader.
-	// Sampled and storage usages are not: if we try to bind a non-arrayed 2D view
-	// to a 2D image variable, we could wind up with the same problem this is intended to fix.
-	if (mvkIsOnlyAnyFlagEnabled(_usage, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-										 VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-										 VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
-										 VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))) {
-		if (_mtlTextureType == MTLTextureType2DArray && _image->_mtlTextureType == MTLTextureType2D) {
-			_mtlTextureType = MTLTextureType2D;
+    // If a 2D array view on a 2D image with layerCount 1, and the only usages
+    // are attachment usages, then force the use of a 2D non-arrayed view. This
+    // is important for input attachments, or they won't match the types
+    // declared in the fragment shader. Sampled and storage usages are not: if
+    // we try to bind a non-arrayed 2D view to a 2D image variable, we could
+    // wind up with the same problem this is intended to fix.
+    if (mvkIsOnlyAnyFlagEnabled(_usage,
+                                (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                                 VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                                 VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+                                 VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))) {
+        if (_mtlTextureType == MTLTextureType2DArray &&
+            _image->_mtlTextureType == MTLTextureType2D) {
+            _mtlTextureType = MTLTextureType2D;
 #if MVK_MACOS_OR_IOS
-		} else if (_mtlTextureType == MTLTextureType2DMultisampleArray && _image->_mtlTextureType == MTLTextureType2DMultisample) {
-			_mtlTextureType = MTLTextureType2DMultisample;
+        } else if (_mtlTextureType == MTLTextureType2DMultisampleArray &&
+                   _image->_mtlTextureType == MTLTextureType2DMultisample) {
+            _mtlTextureType = MTLTextureType2DMultisample;
 #endif
-		}
-	}
+        }
+    }
 
-	// Remember the subresource range, and determine the actual number of mip levels and texture slices
+    // Remember the subresource range, and determine the actual number of mip
+    // levels and texture slices
     _subresourceRange = pCreateInfo->subresourceRange;
-	if (_subresourceRange.levelCount == VK_REMAINING_MIP_LEVELS) {
-		_subresourceRange.levelCount = _image->getMipLevelCount() - _subresourceRange.baseMipLevel;
-	}
-	if (_subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS) {
-		_subresourceRange.layerCount = _image->getLayerCount() - _subresourceRange.baseArrayLayer;
-	}
+    if (_subresourceRange.levelCount == VK_REMAINING_MIP_LEVELS) {
+        _subresourceRange.levelCount =
+            _image->getMipLevelCount() - _subresourceRange.baseMipLevel;
+    }
+    if (_subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS) {
+        _subresourceRange.layerCount =
+            _image->getLayerCount() - _subresourceRange.baseArrayLayer;
+    }
 
-	auto& mtlFeats = getMetalFeatures();
-	bool isAttachment = mvkIsAnyFlagEnabled(_usage, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-													 VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-													 VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
-													 VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
-	if (isAttachment && _subresourceRange.layerCount > 1) {
-		if ( !mtlFeats.layeredRendering ) {
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImageView() : This device does not support rendering to array (layered) attachments."));
-		}
-		if (_image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT && !mtlFeats.multisampleLayeredRendering ) {
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImageView() : This device does not support rendering to multisampled array (layered) attachments."));
-		}
-	}
+    auto& mtlFeats = getMetalFeatures();
+    bool isAttachment =
+        mvkIsAnyFlagEnabled(_usage,
+                            (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
+                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
+    if (isAttachment && _subresourceRange.layerCount > 1) {
+        if (!mtlFeats.layeredRendering) {
+            setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "vkCreateImageView() : This device does not "
+                            "support "
+                            "rendering to array (layered) attachments."));
+        }
+        if (_image->getSampleCount() != VK_SAMPLE_COUNT_1_BIT &&
+            !mtlFeats.multisampleLayeredRendering) {
+            setConfigurationResult(reportError(
+                VK_ERROR_FEATURE_NOT_PRESENT,
+                "vkCreateImageView() : This device does not support "
+                "rendering to multisampled array (layered) attachments."));
+        }
+    }
 
     VkExtent2D blockTexelSizeOfPlane[3];
     uint32_t bytesPerBlockOfPlane[3];
     MTLPixelFormat mtlPixFmtOfPlane[3];
-    uint8_t subsamplingPlaneCount = getPixelFormats()->getChromaSubsamplingPlanes(pCreateInfo->format, blockTexelSizeOfPlane, bytesPerBlockOfPlane, mtlPixFmtOfPlane),
-            beginPlaneIndex = 0,
-            endPlaneIndex = subsamplingPlaneCount;
+    uint8_t subsamplingPlaneCount =
+                getPixelFormats()
+                    ->getChromaSubsamplingPlanes(pCreateInfo->format,
+                                                 blockTexelSizeOfPlane,
+                                                 bytesPerBlockOfPlane,
+                                                 mtlPixFmtOfPlane),
+            beginPlaneIndex = 0, endPlaneIndex = subsamplingPlaneCount;
     if (subsamplingPlaneCount == 0) {
-        if (_subresourceRange.aspectMask & (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-            beginPlaneIndex = MVKImage::getPlaneFromVkImageAspectFlags(_subresourceRange.aspectMask);
+        if (_subresourceRange.aspectMask &
+            (VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT |
+             VK_IMAGE_ASPECT_PLANE_2_BIT)) {
+            beginPlaneIndex = MVKImage::getPlaneFromVkImageAspectFlags(
+                _subresourceRange.aspectMask);
         }
         endPlaneIndex = beginPlaneIndex + 1;
-        mtlPixFmtOfPlane[beginPlaneIndex] = getPixelFormats()->getMTLPixelFormat(pCreateInfo->format);
+        mtlPixFmtOfPlane[beginPlaneIndex] =
+            getPixelFormats()->getMTLPixelFormat(pCreateInfo->format);
     } else {
-        if (!mvkVkComponentMappingsMatch(pCreateInfo->components, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A})) {
-            setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateImageView() : Image view swizzling for multi planar formats is not supported."));
+        if (!mvkVkComponentMappingsMatch(pCreateInfo->components,
+                                         {VK_COMPONENT_SWIZZLE_R,
+                                          VK_COMPONENT_SWIZZLE_G,
+                                          VK_COMPONENT_SWIZZLE_B,
+                                          VK_COMPONENT_SWIZZLE_A})) {
+            setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "vkCreateImageView() : Image view swizzling for "
+                            "multi planar formats is not supported."));
         }
     }
-    for (uint8_t planeIndex = beginPlaneIndex; planeIndex < endPlaneIndex; planeIndex++) {
-        _planes.push_back(new MVKImageViewPlane(this, planeIndex, mtlPixFmtOfPlane[planeIndex], pCreateInfo));
+    for (uint8_t planeIndex = beginPlaneIndex; planeIndex < endPlaneIndex;
+         planeIndex++) {
+        _planes.push_back(new MVKImageViewPlane(this, planeIndex,
+                                                mtlPixFmtOfPlane[planeIndex],
+                                                pCreateInfo));
     }
 }
 
 // Memory detached in destructor too, as a fail-safe.
 MVKImageView::~MVKImageView() {
-	detachMemory();
-	_image->release();
+    detachMemory();
+    _image->release();
 }
 
-// Overridden to detach from the resource memory when the app destroys this object.
-// This object can be retained in a descriptor after the app destroys it, even
-// though the descriptor can't use it. But doing so retains usuable resource memory.
+// Overridden to detach from the resource memory when the app destroys this
+// object. This object can be retained in a descriptor after the app destroys
+// it, even though the descriptor can't use it. But doing so retains usuable
+// resource memory.
 void MVKImageView::destroy() {
-	detachMemory();
-	MVKVulkanAPIDeviceObject::destroy();
+    detachMemory();
+    MVKVulkanAPIDeviceObject::destroy();
 }
 
-// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
-void MVKImageView::detachMemory() {
-	mvkDestroyContainerContents(_planes);
-}
-
+// Potentially called twice, from destroy() and destructor, so ensure everything
+// is nulled out.
+void MVKImageView::detachMemory() { mvkDestroyContainerContents(_planes); }
 
 #pragma mark -
 #pragma mark MVKSamplerYcbcrConversion
 
-void MVKSamplerYcbcrConversion::updateConstExprSampler(MSLConstexprSampler& constExprSampler) const {
-	constExprSampler.planes = _planes;
-	constExprSampler.resolution = _resolution;
-	constExprSampler.chroma_filter = _chroma_filter;
-	constExprSampler.x_chroma_offset = _x_chroma_offset;
-	constExprSampler.y_chroma_offset = _y_chroma_offset;
+void MVKSamplerYcbcrConversion::updateConstExprSampler(
+    MSLConstexprSampler& constExprSampler) const {
+    constExprSampler.planes = _planes;
+    constExprSampler.resolution = _resolution;
+    constExprSampler.chroma_filter = _chroma_filter;
+    constExprSampler.x_chroma_offset = _x_chroma_offset;
+    constExprSampler.y_chroma_offset = _y_chroma_offset;
     for (uint32_t i = 0; i < 4; ++i) {
-		constExprSampler.swizzle[i] = _swizzle[i];
+        constExprSampler.swizzle[i] = _swizzle[i];
     }
-	constExprSampler.ycbcr_model = _ycbcr_model;
-	constExprSampler.ycbcr_range = _ycbcr_range;
+    constExprSampler.ycbcr_model = _ycbcr_model;
+    constExprSampler.ycbcr_range = _ycbcr_range;
     constExprSampler.bpc = _bpc;
-	constExprSampler.ycbcr_conversion_enable = true;
+    constExprSampler.ycbcr_conversion_enable = true;
 }
 
 static MSLSamplerFilter getSpvMinMagFilterFromVkFilter(VkFilter vkFilter) {
     switch (vkFilter) {
-        case VK_FILTER_LINEAR:    return MSL_SAMPLER_FILTER_LINEAR;
+    case VK_FILTER_LINEAR:
+        return MSL_SAMPLER_FILTER_LINEAR;
 
-        case VK_FILTER_NEAREST:
-        default:
-            return MSL_SAMPLER_FILTER_NEAREST;
+    case VK_FILTER_NEAREST:
+    default:
+        return MSL_SAMPLER_FILTER_NEAREST;
     }
 }
 
-static MSLChromaLocation getSpvChromaLocationFromVkChromaLocation(VkChromaLocation vkChromaLocation) {
-	switch (vkChromaLocation) {
-		default:
-		case VK_CHROMA_LOCATION_COSITED_EVEN:   return MSL_CHROMA_LOCATION_COSITED_EVEN;
-		case VK_CHROMA_LOCATION_MIDPOINT:       return MSL_CHROMA_LOCATION_MIDPOINT;
-	}
+static MSLChromaLocation
+getSpvChromaLocationFromVkChromaLocation(VkChromaLocation vkChromaLocation) {
+    switch (vkChromaLocation) {
+    default:
+    case VK_CHROMA_LOCATION_COSITED_EVEN:
+        return MSL_CHROMA_LOCATION_COSITED_EVEN;
+    case VK_CHROMA_LOCATION_MIDPOINT:
+        return MSL_CHROMA_LOCATION_MIDPOINT;
+    }
 }
 
-static MSLComponentSwizzle getSpvComponentSwizzleFromVkComponentMapping(VkComponentSwizzle vkComponentSwizzle) {
-	switch (vkComponentSwizzle) {
-		default:
-		case VK_COMPONENT_SWIZZLE_IDENTITY:     return MSL_COMPONENT_SWIZZLE_IDENTITY;
-		case VK_COMPONENT_SWIZZLE_ZERO:         return MSL_COMPONENT_SWIZZLE_ZERO;
-		case VK_COMPONENT_SWIZZLE_ONE:          return MSL_COMPONENT_SWIZZLE_ONE;
-		case VK_COMPONENT_SWIZZLE_R:            return MSL_COMPONENT_SWIZZLE_R;
-		case VK_COMPONENT_SWIZZLE_G:            return MSL_COMPONENT_SWIZZLE_G;
-		case VK_COMPONENT_SWIZZLE_B:            return MSL_COMPONENT_SWIZZLE_B;
-		case VK_COMPONENT_SWIZZLE_A:            return MSL_COMPONENT_SWIZZLE_A;
-	}
+static MSLComponentSwizzle getSpvComponentSwizzleFromVkComponentMapping(
+    VkComponentSwizzle vkComponentSwizzle) {
+    switch (vkComponentSwizzle) {
+    default:
+    case VK_COMPONENT_SWIZZLE_IDENTITY:
+        return MSL_COMPONENT_SWIZZLE_IDENTITY;
+    case VK_COMPONENT_SWIZZLE_ZERO:
+        return MSL_COMPONENT_SWIZZLE_ZERO;
+    case VK_COMPONENT_SWIZZLE_ONE:
+        return MSL_COMPONENT_SWIZZLE_ONE;
+    case VK_COMPONENT_SWIZZLE_R:
+        return MSL_COMPONENT_SWIZZLE_R;
+    case VK_COMPONENT_SWIZZLE_G:
+        return MSL_COMPONENT_SWIZZLE_G;
+    case VK_COMPONENT_SWIZZLE_B:
+        return MSL_COMPONENT_SWIZZLE_B;
+    case VK_COMPONENT_SWIZZLE_A:
+        return MSL_COMPONENT_SWIZZLE_A;
+    }
 }
 
-static MSLSamplerYCbCrModelConversion getSpvSamplerYCbCrModelConversionFromVkSamplerYcbcrModelConversion(VkSamplerYcbcrModelConversion vkSamplerYcbcrModelConversion) {
-	switch (vkSamplerYcbcrModelConversion) {
-		default:
-		case VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY:   return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
-		case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY: return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY;
-		case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709:      return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_709;
-		case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601:      return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_601;
-		case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020:     return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_2020;
-	}
+static MSLSamplerYCbCrModelConversion
+getSpvSamplerYCbCrModelConversionFromVkSamplerYcbcrModelConversion(
+    VkSamplerYcbcrModelConversion vkSamplerYcbcrModelConversion) {
+    switch (vkSamplerYcbcrModelConversion) {
+    default:
+    case VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY:
+        return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
+    case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY:
+        return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY;
+    case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709:
+        return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_709;
+    case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601:
+        return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_601;
+    case VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020:
+        return MSL_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_BT_2020;
+    }
 }
 
-static MSLSamplerYCbCrRange getSpvSamplerYcbcrRangeFromVkSamplerYcbcrRange(VkSamplerYcbcrRange vkSamplerYcbcrRange) {
-	switch (vkSamplerYcbcrRange) {
-		default:
-		case VK_SAMPLER_YCBCR_RANGE_ITU_FULL:   return MSL_SAMPLER_YCBCR_RANGE_ITU_FULL;
-		case VK_SAMPLER_YCBCR_RANGE_ITU_NARROW: return MSL_SAMPLER_YCBCR_RANGE_ITU_NARROW;
-	}
+static MSLSamplerYCbCrRange getSpvSamplerYcbcrRangeFromVkSamplerYcbcrRange(
+    VkSamplerYcbcrRange vkSamplerYcbcrRange) {
+    switch (vkSamplerYcbcrRange) {
+    default:
+    case VK_SAMPLER_YCBCR_RANGE_ITU_FULL:
+        return MSL_SAMPLER_YCBCR_RANGE_ITU_FULL;
+    case VK_SAMPLER_YCBCR_RANGE_ITU_NARROW:
+        return MSL_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+    }
 }
 
-MVKSamplerYcbcrConversion::MVKSamplerYcbcrConversion(MVKDevice* device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
-	MVKPixelFormats* pixFmts = getPixelFormats();
-	_planes = std::max(pixFmts->getChromaSubsamplingPlaneCount(pCreateInfo->format), (uint8_t)1u);
-	_bpc = pixFmts->getChromaSubsamplingComponentBits(pCreateInfo->format);
-	_resolution = pixFmts->getChromaSubsamplingResolution(pCreateInfo->format);
-	_chroma_filter = getSpvMinMagFilterFromVkFilter(pCreateInfo->chromaFilter);
-	_x_chroma_offset = getSpvChromaLocationFromVkChromaLocation(pCreateInfo->xChromaOffset);
-	_y_chroma_offset = getSpvChromaLocationFromVkChromaLocation(pCreateInfo->yChromaOffset);
-	_swizzle[0] = getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.r);
-	_swizzle[1] = getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.g);
-	_swizzle[2] = getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.b);
-	_swizzle[3] = getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.a);
-	_ycbcr_model = getSpvSamplerYCbCrModelConversionFromVkSamplerYcbcrModelConversion(pCreateInfo->ycbcrModel);
-	_ycbcr_range = getSpvSamplerYcbcrRangeFromVkSamplerYcbcrRange(pCreateInfo->ycbcrRange);
-	_forceExplicitReconstruction = pCreateInfo->forceExplicitReconstruction;
+MVKSamplerYcbcrConversion::MVKSamplerYcbcrConversion(
+    MVKDevice* device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
+    MVKPixelFormats* pixFmts = getPixelFormats();
+    _planes =
+        std::max(pixFmts->getChromaSubsamplingPlaneCount(pCreateInfo->format),
+                 (uint8_t)1u);
+    _bpc = pixFmts->getChromaSubsamplingComponentBits(pCreateInfo->format);
+    _resolution = pixFmts->getChromaSubsamplingResolution(pCreateInfo->format);
+    _chroma_filter = getSpvMinMagFilterFromVkFilter(pCreateInfo->chromaFilter);
+    _x_chroma_offset =
+        getSpvChromaLocationFromVkChromaLocation(pCreateInfo->xChromaOffset);
+    _y_chroma_offset =
+        getSpvChromaLocationFromVkChromaLocation(pCreateInfo->yChromaOffset);
+    _swizzle[0] =
+        getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.r);
+    _swizzle[1] =
+        getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.g);
+    _swizzle[2] =
+        getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.b);
+    _swizzle[3] =
+        getSpvComponentSwizzleFromVkComponentMapping(pCreateInfo->components.a);
+    _ycbcr_model =
+        getSpvSamplerYCbCrModelConversionFromVkSamplerYcbcrModelConversion(
+            pCreateInfo->ycbcrModel);
+    _ycbcr_range =
+        getSpvSamplerYcbcrRangeFromVkSamplerYcbcrRange(pCreateInfo->ycbcrRange);
+    _forceExplicitReconstruction = pCreateInfo->forceExplicitReconstruction;
 }
-
 
 #pragma mark -
 #pragma mark MVKSampler
 
 bool MVKSampler::getConstexprSampler(mvk::MSLResourceBinding& resourceBinding) {
-	resourceBinding.requiresConstExprSampler = _requiresConstExprSampler;
-	if (_requiresConstExprSampler) {
-		resourceBinding.constExprSampler = _constExprSampler;
-	}
-	return _requiresConstExprSampler;
+    resourceBinding.requiresConstExprSampler = _requiresConstExprSampler;
+    if (_requiresConstExprSampler) {
+        resourceBinding.constExprSampler = _constExprSampler;
+    }
+    return _requiresConstExprSampler;
 }
 
 // Ensure available Metal features.
-MTLSamplerAddressMode MVKSampler::getMTLSamplerAddressMode(VkSamplerAddressMode vkMode) {
-	auto& mtlFeats = getMetalFeatures();
-	if ((vkMode == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER && !mtlFeats.samplerClampToBorder) ||
-		(vkMode == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE && !mtlFeats.samplerMirrorClampToEdge)) {
-		return MTLSamplerAddressModeClampToZero;
-	}
-	return mvkMTLSamplerAddressModeFromVkSamplerAddressMode(vkMode);
+MTLSamplerAddressMode
+MVKSampler::getMTLSamplerAddressMode(VkSamplerAddressMode vkMode) {
+    auto& mtlFeats = getMetalFeatures();
+    if ((vkMode == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER &&
+         !mtlFeats.samplerClampToBorder) ||
+        (vkMode == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE &&
+         !mtlFeats.samplerMirrorClampToEdge)) {
+        return MTLSamplerAddressModeClampToZero;
+    }
+    return mvkMTLSamplerAddressModeFromVkSamplerAddressMode(vkMode);
 }
 
-// Returns an Metal sampler descriptor constructed from the properties of this image.
-// It is the caller's responsibility to release the returned descriptor object.
-MTLSamplerDescriptor* MVKSampler::newMTLSamplerDescriptor(const VkSamplerCreateInfo* pCreateInfo) {
+// Returns an Metal sampler descriptor constructed from the properties of this
+// image. It is the caller's responsibility to release the returned descriptor
+// object.
+MTLSamplerDescriptor*
+MVKSampler::newMTLSamplerDescriptor(const VkSamplerCreateInfo* pCreateInfo) {
 
-	MTLSamplerDescriptor* mtlSampDesc = [MTLSamplerDescriptor new];		// retained
-	mtlSampDesc.sAddressMode = getMTLSamplerAddressMode(pCreateInfo->addressModeU);
-	mtlSampDesc.tAddressMode = getMTLSamplerAddressMode(pCreateInfo->addressModeV);
+    MTLSamplerDescriptor* mtlSampDesc = [MTLSamplerDescriptor new]; // retained
+    mtlSampDesc.sAddressMode =
+        getMTLSamplerAddressMode(pCreateInfo->addressModeU);
+    mtlSampDesc.tAddressMode =
+        getMTLSamplerAddressMode(pCreateInfo->addressModeV);
     if (!pCreateInfo->unnormalizedCoordinates) {
-        mtlSampDesc.rAddressMode = getMTLSamplerAddressMode(pCreateInfo->addressModeW);
+        mtlSampDesc.rAddressMode =
+            getMTLSamplerAddressMode(pCreateInfo->addressModeW);
     }
 #if MVK_MACOS_OR_IOS
-	mtlSampDesc.borderColorMVK = mvkMTLSamplerBorderColorFromVkBorderColor(pCreateInfo->borderColor);
+    mtlSampDesc.borderColorMVK =
+        mvkMTLSamplerBorderColorFromVkBorderColor(pCreateInfo->borderColor);
 #endif
 
-	mtlSampDesc.minFilter = mvkMTLSamplerMinMagFilterFromVkFilter(pCreateInfo->minFilter);
-	mtlSampDesc.magFilter = mvkMTLSamplerMinMagFilterFromVkFilter(pCreateInfo->magFilter);
-    mtlSampDesc.mipFilter = (pCreateInfo->unnormalizedCoordinates
-                             ? MTLSamplerMipFilterNotMipmapped
-                             : mvkMTLSamplerMipFilterFromVkSamplerMipmapMode(pCreateInfo->mipmapMode));
+    mtlSampDesc.minFilter =
+        mvkMTLSamplerMinMagFilterFromVkFilter(pCreateInfo->minFilter);
+    mtlSampDesc.magFilter =
+        mvkMTLSamplerMinMagFilterFromVkFilter(pCreateInfo->magFilter);
+    mtlSampDesc.mipFilter =
+        (pCreateInfo->unnormalizedCoordinates
+             ? MTLSamplerMipFilterNotMipmapped
+             : mvkMTLSamplerMipFilterFromVkSamplerMipmapMode(
+                   pCreateInfo->mipmapMode));
 #if MVK_USE_METAL_PRIVATE_API
-	if (getMVKConfig().useMetalPrivateAPI) {
-		mtlSampDesc.lodBiasMVK = pCreateInfo->mipLodBias;
-	}
+    if (getMVKConfig().useMetalPrivateAPI) {
+        mtlSampDesc.lodBiasMVK = pCreateInfo->mipLodBias;
+    }
 #endif
-	mtlSampDesc.lodMinClamp = pCreateInfo->minLod;
-	mtlSampDesc.lodMaxClamp = pCreateInfo->maxLod;
-	mtlSampDesc.maxAnisotropy = (pCreateInfo->anisotropyEnable
-								 ? mvkClamp(pCreateInfo->maxAnisotropy, 1.0f, getDeviceProperties().limits.maxSamplerAnisotropy)
-								 : 1);
-	mtlSampDesc.normalizedCoordinates = !pCreateInfo->unnormalizedCoordinates;
-	mtlSampDesc.supportArgumentBuffers = isUsingMetalArgumentBuffers();
+    mtlSampDesc.lodMinClamp = pCreateInfo->minLod;
+    mtlSampDesc.lodMaxClamp = pCreateInfo->maxLod;
+    mtlSampDesc.maxAnisotropy =
+        (pCreateInfo->anisotropyEnable
+             ? mvkClamp(pCreateInfo->maxAnisotropy, 1.0f,
+                        getDeviceProperties().limits.maxSamplerAnisotropy)
+             : 1);
+    mtlSampDesc.normalizedCoordinates = !pCreateInfo->unnormalizedCoordinates;
+    mtlSampDesc.supportArgumentBuffers = isUsingMetalArgumentBuffers();
 
-	// If compareEnable is true, but dynamic samplers with depth compare are not available
-	// on this device, this sampler must only be used as an immutable sampler, and will
-	// be automatically hardcoded into the shader MSL. An error will be triggered if this
-	// sampler is used to update or push a descriptor.
-	if (pCreateInfo->compareEnable && !_requiresConstExprSampler) {
-		mtlSampDesc.compareFunctionMVK = mvkMTLCompareFunctionFromVkCompareOp(pCreateInfo->compareOp);
-	}
+    // If compareEnable is true, but dynamic samplers with depth compare are not
+    // available on this device, this sampler must only be used as an immutable
+    // sampler, and will be automatically hardcoded into the shader MSL. An
+    // error will be triggered if this sampler is used to update or push a
+    // descriptor.
+    if (pCreateInfo->compareEnable && !_requiresConstExprSampler) {
+        mtlSampDesc.compareFunctionMVK =
+            mvkMTLCompareFunctionFromVkCompareOp(pCreateInfo->compareOp);
+    }
 
-	return mtlSampDesc;
+    return mtlSampDesc;
 }
 
-MVKSampler::MVKSampler(MVKDevice* device, const VkSamplerCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
+MVKSampler::MVKSampler(MVKDevice* device,
+                       const VkSamplerCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
     _ycbcrConversion = NULL;
-    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO_KHR: {
-				const VkSamplerYcbcrConversionInfoKHR* sampConvInfo = (const VkSamplerYcbcrConversionInfoKHR*)next;
-				_ycbcrConversion = (MVKSamplerYcbcrConversion*)(sampConvInfo->conversion);
-				break;
-			}
-			case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO: {
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO_KHR: {
+            const VkSamplerYcbcrConversionInfoKHR* sampConvInfo =
+                (const VkSamplerYcbcrConversionInfoKHR*)next;
+            _ycbcrConversion =
+                (MVKSamplerYcbcrConversion*)(sampConvInfo->conversion);
+            break;
+        }
+        case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO: {
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	_requiresConstExprSampler = (pCreateInfo->compareEnable && !getMetalFeatures().depthSampleCompare) || _ycbcrConversion;
+    _requiresConstExprSampler = (pCreateInfo->compareEnable &&
+                                 !getMetalFeatures().depthSampleCompare) ||
+                                _ycbcrConversion;
 
-	@autoreleasepool {
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			_mtlSamplerState = [mtlDev newSamplerStateWithDescriptor: [newMTLSamplerDescriptor(pCreateInfo) autorelease]];
-		}
-	}
+    @autoreleasepool {
+        auto mtlDev = getMTLDevice();
+        @synchronized(mtlDev) {
+            _mtlSamplerState = [mtlDev
+                newSamplerStateWithDescriptor:[newMTLSamplerDescriptor(
+                                                  pCreateInfo) autorelease]];
+        }
+    }
 
-	initConstExprSampler(pCreateInfo);
+    initConstExprSampler(pCreateInfo);
 }
 
-static MSLSamplerMipFilter getSpvMipFilterFromVkMipMode(VkSamplerMipmapMode vkMipMode) {
-	switch (vkMipMode) {
-		case VK_SAMPLER_MIPMAP_MODE_LINEAR:		return MSL_SAMPLER_MIP_FILTER_LINEAR;
-		case VK_SAMPLER_MIPMAP_MODE_NEAREST:	return MSL_SAMPLER_MIP_FILTER_NEAREST;
+static MSLSamplerMipFilter
+getSpvMipFilterFromVkMipMode(VkSamplerMipmapMode vkMipMode) {
+    switch (vkMipMode) {
+    case VK_SAMPLER_MIPMAP_MODE_LINEAR:
+        return MSL_SAMPLER_MIP_FILTER_LINEAR;
+    case VK_SAMPLER_MIPMAP_MODE_NEAREST:
+        return MSL_SAMPLER_MIP_FILTER_NEAREST;
 
-		default:
-			return MSL_SAMPLER_MIP_FILTER_NONE;
-	}
+    default:
+        return MSL_SAMPLER_MIP_FILTER_NONE;
+    }
 }
 
-static MSLSamplerAddress getSpvAddressModeFromVkAddressMode(VkSamplerAddressMode vkAddrMode) {
-	switch (vkAddrMode) {
-		case VK_SAMPLER_ADDRESS_MODE_REPEAT:			return MSL_SAMPLER_ADDRESS_REPEAT;
-		case VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT:	return MSL_SAMPLER_ADDRESS_MIRRORED_REPEAT;
-		case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER:	return MSL_SAMPLER_ADDRESS_CLAMP_TO_BORDER;
+static MSLSamplerAddress
+getSpvAddressModeFromVkAddressMode(VkSamplerAddressMode vkAddrMode) {
+    switch (vkAddrMode) {
+    case VK_SAMPLER_ADDRESS_MODE_REPEAT:
+        return MSL_SAMPLER_ADDRESS_REPEAT;
+    case VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT:
+        return MSL_SAMPLER_ADDRESS_MIRRORED_REPEAT;
+    case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER:
+        return MSL_SAMPLER_ADDRESS_CLAMP_TO_BORDER;
 
-		case VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE:
-		case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE:
-		default:
-			return MSL_SAMPLER_ADDRESS_CLAMP_TO_EDGE;
-	}
+    case VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE:
+    case VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE:
+    default:
+        return MSL_SAMPLER_ADDRESS_CLAMP_TO_EDGE;
+    }
 }
 
 static MSLSamplerCompareFunc getSpvCompFuncFromVkCompOp(VkCompareOp vkCompOp) {
-	switch (vkCompOp) {
-		case VK_COMPARE_OP_LESS:				return MSL_SAMPLER_COMPARE_FUNC_LESS;
-		case VK_COMPARE_OP_EQUAL:				return MSL_SAMPLER_COMPARE_FUNC_EQUAL;
-		case VK_COMPARE_OP_LESS_OR_EQUAL:		return MSL_SAMPLER_COMPARE_FUNC_LESS_EQUAL;
-		case VK_COMPARE_OP_GREATER:				return MSL_SAMPLER_COMPARE_FUNC_GREATER;
-		case VK_COMPARE_OP_NOT_EQUAL:			return MSL_SAMPLER_COMPARE_FUNC_NOT_EQUAL;
-		case VK_COMPARE_OP_GREATER_OR_EQUAL:	return MSL_SAMPLER_COMPARE_FUNC_GREATER_EQUAL;
-		case VK_COMPARE_OP_ALWAYS:				return MSL_SAMPLER_COMPARE_FUNC_ALWAYS;
+    switch (vkCompOp) {
+    case VK_COMPARE_OP_LESS:
+        return MSL_SAMPLER_COMPARE_FUNC_LESS;
+    case VK_COMPARE_OP_EQUAL:
+        return MSL_SAMPLER_COMPARE_FUNC_EQUAL;
+    case VK_COMPARE_OP_LESS_OR_EQUAL:
+        return MSL_SAMPLER_COMPARE_FUNC_LESS_EQUAL;
+    case VK_COMPARE_OP_GREATER:
+        return MSL_SAMPLER_COMPARE_FUNC_GREATER;
+    case VK_COMPARE_OP_NOT_EQUAL:
+        return MSL_SAMPLER_COMPARE_FUNC_NOT_EQUAL;
+    case VK_COMPARE_OP_GREATER_OR_EQUAL:
+        return MSL_SAMPLER_COMPARE_FUNC_GREATER_EQUAL;
+    case VK_COMPARE_OP_ALWAYS:
+        return MSL_SAMPLER_COMPARE_FUNC_ALWAYS;
 
-		case VK_COMPARE_OP_NEVER:
-		default:
-			return MSL_SAMPLER_COMPARE_FUNC_NEVER;
-	}
+    case VK_COMPARE_OP_NEVER:
+    default:
+        return MSL_SAMPLER_COMPARE_FUNC_NEVER;
+    }
 }
 
-static MSLSamplerBorderColor getSpvBorderColorFromVkBorderColor(VkBorderColor vkBorderColor) {
-	switch (vkBorderColor) {
-		case VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK:
-		case VK_BORDER_COLOR_INT_OPAQUE_BLACK:
-			return MSL_SAMPLER_BORDER_COLOR_OPAQUE_BLACK;
+static MSLSamplerBorderColor
+getSpvBorderColorFromVkBorderColor(VkBorderColor vkBorderColor) {
+    switch (vkBorderColor) {
+    case VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK:
+    case VK_BORDER_COLOR_INT_OPAQUE_BLACK:
+        return MSL_SAMPLER_BORDER_COLOR_OPAQUE_BLACK;
 
-		case VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE:
-		case VK_BORDER_COLOR_INT_OPAQUE_WHITE:
-			return MSL_SAMPLER_BORDER_COLOR_OPAQUE_WHITE;
+    case VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE:
+    case VK_BORDER_COLOR_INT_OPAQUE_WHITE:
+        return MSL_SAMPLER_BORDER_COLOR_OPAQUE_WHITE;
 
-		case VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK:
-		case VK_BORDER_COLOR_INT_TRANSPARENT_BLACK:
-		default:
-			return MSL_SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK;
-	}
+    case VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK:
+    case VK_BORDER_COLOR_INT_TRANSPARENT_BLACK:
+    default:
+        return MSL_SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK;
+    }
 }
 
 void MVKSampler::initConstExprSampler(const VkSamplerCreateInfo* pCreateInfo) {
-	if ( !_requiresConstExprSampler ) { return; }
+    if (!_requiresConstExprSampler) {
+        return;
+    }
 
-	_constExprSampler.coord = pCreateInfo->unnormalizedCoordinates ? MSL_SAMPLER_COORD_PIXEL : MSL_SAMPLER_COORD_NORMALIZED;
-	_constExprSampler.min_filter = getSpvMinMagFilterFromVkFilter(pCreateInfo->minFilter);
-	_constExprSampler.mag_filter = getSpvMinMagFilterFromVkFilter(pCreateInfo->magFilter);
-	_constExprSampler.mip_filter = getSpvMipFilterFromVkMipMode(pCreateInfo->mipmapMode);
-	_constExprSampler.s_address = getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeU);
-	_constExprSampler.t_address = getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeV);
-	_constExprSampler.r_address = getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeW);
-	_constExprSampler.compare_func = getSpvCompFuncFromVkCompOp(pCreateInfo->compareOp);
-	_constExprSampler.border_color = getSpvBorderColorFromVkBorderColor(pCreateInfo->borderColor);
-	_constExprSampler.lod_clamp_min = pCreateInfo->minLod;
-	_constExprSampler.lod_clamp_max = pCreateInfo->maxLod;
-	_constExprSampler.max_anisotropy = pCreateInfo->maxAnisotropy;
-	_constExprSampler.compare_enable = pCreateInfo->compareEnable;
-	_constExprSampler.lod_clamp_enable = false;
-	_constExprSampler.anisotropy_enable = pCreateInfo->anisotropyEnable;
+    _constExprSampler.coord = pCreateInfo->unnormalizedCoordinates
+                                  ? MSL_SAMPLER_COORD_PIXEL
+                                  : MSL_SAMPLER_COORD_NORMALIZED;
+    _constExprSampler.min_filter =
+        getSpvMinMagFilterFromVkFilter(pCreateInfo->minFilter);
+    _constExprSampler.mag_filter =
+        getSpvMinMagFilterFromVkFilter(pCreateInfo->magFilter);
+    _constExprSampler.mip_filter =
+        getSpvMipFilterFromVkMipMode(pCreateInfo->mipmapMode);
+    _constExprSampler.s_address =
+        getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeU);
+    _constExprSampler.t_address =
+        getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeV);
+    _constExprSampler.r_address =
+        getSpvAddressModeFromVkAddressMode(pCreateInfo->addressModeW);
+    _constExprSampler.compare_func =
+        getSpvCompFuncFromVkCompOp(pCreateInfo->compareOp);
+    _constExprSampler.border_color =
+        getSpvBorderColorFromVkBorderColor(pCreateInfo->borderColor);
+    _constExprSampler.lod_clamp_min = pCreateInfo->minLod;
+    _constExprSampler.lod_clamp_max = pCreateInfo->maxLod;
+    _constExprSampler.max_anisotropy = pCreateInfo->maxAnisotropy;
+    _constExprSampler.compare_enable = pCreateInfo->compareEnable;
+    _constExprSampler.lod_clamp_enable = false;
+    _constExprSampler.anisotropy_enable = pCreateInfo->anisotropyEnable;
     if (_ycbcrConversion) {
         _ycbcrConversion->updateConstExprSampler(_constExprSampler);
     }
 }
 
 // Memory detached in destructor too, as a fail-safe.
-MVKSampler::~MVKSampler() {
-	detachMemory();
-}
+MVKSampler::~MVKSampler() { detachMemory(); }
 
-// Overridden to detach from the resource memory when the app destroys this object.
-// This object can be retained in a descriptor after the app destroys it, even
-// though the descriptor can't use it. But doing so retains usuable resource memory.
+// Overridden to detach from the resource memory when the app destroys this
+// object. This object can be retained in a descriptor after the app destroys
+// it, even though the descriptor can't use it. But doing so retains usuable
+// resource memory.
 void MVKSampler::destroy() {
-	detachMemory();
-	MVKVulkanAPIDeviceObject::destroy();
+    detachMemory();
+    MVKVulkanAPIDeviceObject::destroy();
 }
 
-// Potentially called twice, from destroy() and destructor, so ensure everything is nulled out.
+// Potentially called twice, from destroy() and destructor, so ensure everything
+// is nulled out.
 void MVKSampler::detachMemory() {
-	@synchronized (getMTLDevice()) {
-		[_mtlSamplerState release];
-		_mtlSamplerState = nil;
-	}
+    @synchronized(getMTLDevice()) {
+        [_mtlSamplerState release];
+        _mtlSamplerState = nil;
+    }
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,28 +31,30 @@ class MVKSurface;
 class MVKDebugReportCallback;
 class MVKDebugUtilsMessenger;
 
-
 /** Tracks info about entry point function pointer addresses. */
 typedef struct MVKEntryPoint {
-	PFN_vkVoidFunction functionPointer;
-	uint32_t apiVersion;
-	const char* ext1Name;
-	const char* ext2Name;
-	bool isDevice;
+    PFN_vkVoidFunction functionPointer;
+    uint32_t apiVersion;
+    const char* ext1Name;
+    const char* ext2Name;
+    bool isDevice;
 
-	bool isCore() { return !ext1Name && !ext2Name; }
-	bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList, const MVKExtensionList* instExtList = nullptr) {
-		bool isAPISupported = MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion;
-		auto isExtnSupported = [this, isAPISupported](const MVKExtensionList& extList) {
-			return extList.isEnabled(this->ext1Name) && (isAPISupported || !this->ext2Name || extList.isEnabled(this->ext2Name));
-		};
-		return ((isCore() && isAPISupported) ||
-				isExtnSupported(extList) ||
-				(instExtList && isExtnSupported(*instExtList)));
-	}
+    bool isCore() { return !ext1Name && !ext2Name; }
+    bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList,
+                   const MVKExtensionList* instExtList = nullptr) {
+        bool isAPISupported =
+            MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion;
+        auto isExtnSupported =
+            [this, isAPISupported](const MVKExtensionList& extList) {
+                return extList.isEnabled(this->ext1Name) &&
+                       (isAPISupported || !this->ext2Name ||
+                        extList.isEnabled(this->ext2Name));
+            };
+        return ((isCore() && isAPISupported) || isExtnSupported(extList) ||
+                (instExtList && isExtnSupported(*instExtList)));
+    }
 
 } MVKEntryPoint;
-
 
 #pragma mark -
 #pragma mark MVKInstance
@@ -60,116 +62,134 @@ typedef struct MVKEntryPoint {
 /** Represents a Vulkan instance. */
 class MVKInstance : public MVKDispatchableVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_INSTANCE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_INSTANCE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return this; }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return this; }
+    /** Return the MoltenVK configuration info for this VkInstance. */
+    const MVKConfiguration& getMVKConfig() override {
+        return _enabledExtensions.vk_EXT_layer_settings.enabled
+                   ? _mvkConfig
+                   : getGlobalMVKConfig();
+    }
 
-	/** Return the MoltenVK configuration info for this VkInstance. */
-	const MVKConfiguration& getMVKConfig() override { return _enabledExtensions.vk_EXT_layer_settings.enabled ? _mvkConfig : getGlobalMVKConfig(); }
+    /** Returns the maximum version of Vulkan the application supports. */
+    inline uint32_t getAPIVersion() { return _appInfo.apiVersion; }
 
-	/** Returns the maximum version of Vulkan the application supports. */
-	inline uint32_t getAPIVersion() { return _appInfo.apiVersion; }
+    /** Returns a pointer to the layer manager. */
+    inline MVKLayerManager* getLayerManager() {
+        return MVKLayerManager::globalManager();
+    }
 
-	/** Returns a pointer to the layer manager. */
-	inline MVKLayerManager* getLayerManager() { return MVKLayerManager::globalManager(); }
+    /** Returns the function pointer corresponding to the named entry point, or
+     * NULL if it doesn't exist. */
+    PFN_vkVoidFunction getProcAddr(const char* pName);
 
-	/** Returns the function pointer corresponding to the named entry point, or NULL if it doesn't exist. */
-	PFN_vkVoidFunction getProcAddr(const char* pName);
+    /** Returns the number of available physical devices. */
+    uint32_t getPhysicalDeviceCount() {
+        return (uint32_t)_physicalDevices.size();
+    }
 
-	/** Returns the number of available physical devices. */
-	uint32_t getPhysicalDeviceCount() { return (uint32_t)_physicalDevices.size(); }
+    /**
+     * If pPhysicalDevices is null, the value of pCount is updated with the
+     * number of physical devices supported by this instance.
+     *
+     * If pPhysicalDevices is not null, then pCount physical devices are copied
+     * into the array. If the number of available physical devices is less than
+     * pCount, the value of pCount is updated to indicate the number of physical
+     * devices actually returned in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * physical devices available in this instance is larger than the specified
+     * pCount. Returns other values if an error occurs.
+     */
+    VkResult getPhysicalDevices(uint32_t* pCount,
+                                VkPhysicalDevice* pPhysicalDevices);
 
-	/**
-	 * If pPhysicalDevices is null, the value of pCount is updated with the number of 
-	 * physical devices supported by this instance.
-	 *
-	 * If pPhysicalDevices is not null, then pCount physical devices are copied into the array.
-	 * If the number of available physical devices is less than pCount, the value of pCount is 
-	 * updated to indicate the number of physical devices actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of physical
-	 * devices available in this instance is larger than the specified pCount. Returns other 
-	 * values if an error occurs.
-	 */
-	VkResult getPhysicalDevices(uint32_t* pCount, VkPhysicalDevice* pPhysicalDevices);
+    /**
+     * If pPhysicalDeviceGroups is null, the value of pCount is updated with the
+     * number of physical device groups supported by this instance.
+     *
+     * If pPhysicalDeviceGroups is not null, then pCount physical device groups
+     * are copied into the array. If the number of available physical device
+     * groups is less than pCount, the value of pCount is updated to indicate
+     * the number of physical device groups actually returned in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * physical device groups available in this instance is larger than the
+     * specified pCount. Returns other values if an error occurs.
+     */
+    VkResult getPhysicalDeviceGroups(
+        uint32_t* pCount,
+        VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProps);
 
-	/**
-	 * If pPhysicalDeviceGroups is null, the value of pCount is updated with the number of 
-	 * physical device groups supported by this instance.
-	 *
-	 * If pPhysicalDeviceGroups is not null, then pCount physical device groups are copied into the array.
-	 * If the number of available physical device groups is less than pCount, the value of pCount is 
-	 * updated to indicate the number of physical device groups actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of physical
-	 * device groups available in this instance is larger than the specified pCount. Returns other 
-	 * values if an error occurs.
-	 */
-	VkResult getPhysicalDeviceGroups(uint32_t* pCount, VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProps);
+    /** Returns the driver layer. */
+    MVKLayer* getDriverLayer() { return getLayerManager()->getDriverLayer(); }
 
-	/** Returns the driver layer. */
-	MVKLayer* getDriverLayer() { return getLayerManager()->getDriverLayer(); }
+    MVKSurface* createSurface(const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                              const VkAllocationCallbacks* pAllocator);
 
-	MVKSurface* createSurface(const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
-							  const VkAllocationCallbacks* pAllocator);
+    MVKSurface* createSurface(const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
+                              const VkAllocationCallbacks* pAllocator);
 
-	MVKSurface* createSurface(const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
-							  const VkAllocationCallbacks* pAllocator);
+    MVKSurface*
+    createSurface(const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
+                  const VkAllocationCallbacks* pAllocator);
 
-	MVKSurface* createSurface(const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
-							  const VkAllocationCallbacks* pAllocator);
+    void destroySurface(MVKSurface* mvkSrfc,
+                        const VkAllocationCallbacks* pAllocator);
 
-	void destroySurface(MVKSurface* mvkSrfc,
-						const VkAllocationCallbacks* pAllocator);
+    MVKDebugReportCallback* createDebugReportCallback(
+        const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator);
 
-	MVKDebugReportCallback* createDebugReportCallback(const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-													  const VkAllocationCallbacks* pAllocator);
+    void destroyDebugReportCallback(MVKDebugReportCallback* mvkDRCB,
+                                    const VkAllocationCallbacks* pAllocator);
 
-	void destroyDebugReportCallback(MVKDebugReportCallback* mvkDRCB,
-									const VkAllocationCallbacks* pAllocator);
+    void debugReportMessage(VkDebugReportFlagsEXT flags,
+                            VkDebugReportObjectTypeEXT objectType,
+                            uint64_t object, size_t location,
+                            int32_t messageCode, const char* pLayerPrefix,
+                            const char* pMessage);
 
-	void debugReportMessage(VkDebugReportFlagsEXT flags,
-							VkDebugReportObjectTypeEXT objectType,
-							uint64_t object,
-							size_t location,
-							int32_t messageCode,
-							const char* pLayerPrefix,
-							const char* pMessage);
+    MVKDebugUtilsMessenger* createDebugUtilsMessenger(
+        const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+        const VkAllocationCallbacks* pAllocator);
 
+    void destroyDebugUtilsMessenger(MVKDebugUtilsMessenger* mvkDUM,
+                                    const VkAllocationCallbacks* pAllocator);
 
-	MVKDebugUtilsMessenger* createDebugUtilsMessenger(const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
-													  const VkAllocationCallbacks* pAllocator);
+    void debugUtilsMessage(
+        VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+        VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+        const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
 
-	void destroyDebugUtilsMessenger(MVKDebugUtilsMessenger* mvkDUM,
-									const VkAllocationCallbacks* pAllocator);
+    void debugReportMessage(MVKVulkanAPIObject* mvkAPIObj,
+                            MVKConfigLogLevel logLevel, const char* pMessage);
 
-	void debugUtilsMessage(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-						   VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-						   const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
-
-	void debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, MVKConfigLogLevel logLevel, const char* pMessage);
-
-	/** Returns whether debug callbacks are being used. */
-	bool hasDebugCallbacks() { return _hasDebugReportCallbacks || _hasDebugUtilsMessengers; }
-
+    /** Returns whether debug callbacks are being used. */
+    bool hasDebugCallbacks() {
+        return _hasDebugReportCallbacks || _hasDebugUtilsMessengers;
+    }
 
 #pragma mark Object Creation
 
-	/** Constructs an instance from the specified instance config. */
-	MVKInstance(const VkInstanceCreateInfo* pCreateInfo);
+    /** Constructs an instance from the specified instance config. */
+    MVKInstance(const VkInstanceCreateInfo* pCreateInfo);
 
-	~MVKInstance() override;
+    ~MVKInstance() override;
 
     /**
-     * Returns a reference to this object suitable for use as a Vulkan API handle.
-     * This is the compliment of the getMVKInstance() method.
+     * Returns a reference to this object suitable for use as a Vulkan API
+     * handle. This is the compliment of the getMVKInstance() method.
      */
     inline VkInstance getVkInstance() { return (VkInstance)getVkHandle(); }
 
@@ -181,35 +201,38 @@ public:
         return (MVKInstance*)getDispatchableObject(vkInstance);
     }
 
-protected:
-	friend MVKDevice;
+  protected:
+    friend MVKDevice;
 
-	void propagateDebugName() override {}
-	void initProcAddrs();
-	void initMVKConfig(const VkInstanceCreateInfo* pCreateInfo);
-	void initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo);
-	VkDebugReportFlagsEXT getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel);
-	VkDebugUtilsMessageSeverityFlagBitsEXT getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(MVKConfigLogLevel logLevel);
-	VkDebugUtilsMessageTypeFlagsEXT getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(MVKConfigLogLevel logLevel);
-	MVKEntryPoint* getEntryPoint(const char* pName);
+    void propagateDebugName() override {}
+    void initProcAddrs();
+    void initMVKConfig(const VkInstanceCreateInfo* pCreateInfo);
+    void initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo);
+    VkDebugReportFlagsEXT
+    getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel);
+    VkDebugUtilsMessageSeverityFlagBitsEXT
+    getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(
+        MVKConfigLogLevel logLevel);
+    VkDebugUtilsMessageTypeFlagsEXT
+    getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(MVKConfigLogLevel logLevel);
+    MVKEntryPoint* getEntryPoint(const char* pName);
     void logVersions();
-	VkResult verifyLayers(uint32_t count, const char* const* names);
+    VkResult verifyLayers(uint32_t count, const char* const* names);
 
-	MVKExtensionList _enabledExtensions;
-	MVKConfiguration _mvkConfig;
-	VkApplicationInfo _appInfo;
-	MVKSmallVector<MVKPhysicalDevice*, 2> _physicalDevices;
-	MVKSmallVector<MVKDebugReportCallback*> _debugReportCallbacks;
-	MVKSmallVector<MVKDebugUtilsMessenger*> _debugUtilMessengers;
-	std::unordered_map<std::string, MVKEntryPoint> _entryPoints;
-	std::string _mvkConfigStringHolders[kMVKConfigurationStringCount] = {};
-	std::mutex _dcbLock;
-	bool _hasDebugReportCallbacks;
-	bool _hasDebugUtilsMessengers;
-	bool _useCreationCallbacks;
-	const char* _debugReportCallbackLayerPrefix;
+    MVKExtensionList _enabledExtensions;
+    MVKConfiguration _mvkConfig;
+    VkApplicationInfo _appInfo;
+    MVKSmallVector<MVKPhysicalDevice*, 2> _physicalDevices;
+    MVKSmallVector<MVKDebugReportCallback*> _debugReportCallbacks;
+    MVKSmallVector<MVKDebugUtilsMessenger*> _debugUtilMessengers;
+    std::unordered_map<std::string, MVKEntryPoint> _entryPoints;
+    std::string _mvkConfigStringHolders[kMVKConfigurationStringCount] = {};
+    std::mutex _dcbLock;
+    bool _hasDebugReportCallbacks;
+    bool _hasDebugUtilsMessengers;
+    bool _useCreationCallbacks;
+    const char* _debugReportCallbackLayerPrefix;
 };
-
 
 #pragma mark -
 #pragma mark MVKDebugReportCallback
@@ -217,37 +240,39 @@ protected:
 /** Represents a Vulkan Debug Report callback. */
 class MVKDebugReportCallback : public MVKVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return _mvkInstance; }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _mvkInstance; }
+    MVKDebugReportCallback(
+        MVKInstance* mvkInstance,
+        const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
+        bool isCreationCallback)
+        : _mvkInstance(mvkInstance), _info(*pCreateInfo),
+          _isCreationCallback(isCreationCallback) {
 
-	MVKDebugReportCallback(MVKInstance* mvkInstance,
-						   const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-						   bool isCreationCallback) :
-	_mvkInstance(mvkInstance),
-	_info(*pCreateInfo),
-	_isCreationCallback(isCreationCallback) {
+        _info.pNext = nullptr;
+    }
 
-		_info.pNext = nullptr;
-	}
+  protected:
+    friend MVKInstance;
 
-protected:
-	friend MVKInstance;
-	
-	void propagateDebugName() override {}
+    void propagateDebugName() override {}
 
-	MVKInstance* _mvkInstance;
-	VkDebugReportCallbackCreateInfoEXT _info;
-	bool _isCreationCallback;
+    MVKInstance* _mvkInstance;
+    VkDebugReportCallbackCreateInfoEXT _info;
+    bool _isCreationCallback;
 };
-
 
 #pragma mark -
 #pragma mark MVKDebugUtilsMessenger
@@ -255,34 +280,36 @@ protected:
 /** Represents a Vulkan Debug Utils callback. */
 class MVKDebugUtilsMessenger : public MVKVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return _mvkInstance; }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _mvkInstance; }
+    MVKDebugUtilsMessenger(
+        MVKInstance* mvkInstance,
+        const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+        bool isCreationCallback)
+        : _mvkInstance(mvkInstance), _info(*pCreateInfo),
+          _isCreationCallback(isCreationCallback) {
 
-	MVKDebugUtilsMessenger(MVKInstance* mvkInstance,
-						   const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
-						   bool isCreationCallback) :
-	_mvkInstance(mvkInstance),
-	_info(*pCreateInfo),
-	_isCreationCallback(isCreationCallback) {
+        _info.pNext = nullptr;
+    }
 
-		_info.pNext = nullptr;
-	}
+  protected:
+    friend MVKInstance;
 
-protected:
-	friend MVKInstance;
+    void propagateDebugName() override {}
 
-	void propagateDebugName() override {}
-
-	MVKInstance* _mvkInstance;
-	VkDebugUtilsMessengerCreateInfoEXT _info;
-	bool _isCreationCallback;
+    MVKInstance* _mvkInstance;
+    VkDebugUtilsMessengerCreateInfoEXT _info;
+    bool _isCreationCallback;
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -6,16 +6,15 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 #include "MVKInstance.h"
 #include "MVKDevice.h"
@@ -28,783 +27,1028 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKInstance
 
 MVKEntryPoint* MVKInstance::getEntryPoint(const char* pName) {
-	auto iter = _entryPoints.find(pName);
-	return (iter != _entryPoints.end()) ? &iter->second : nullptr;
+    auto iter = _entryPoints.find(pName);
+    return (iter != _entryPoints.end()) ? &iter->second : nullptr;
 }
 
-// Returns core instance commands, enabled instance extension commands, and all device commands.
+// Returns core instance commands, enabled instance extension commands, and all
+// device commands.
 PFN_vkVoidFunction MVKInstance::getProcAddr(const char* pName) {
-	MVKEntryPoint* pMVKPA = getEntryPoint(pName);
+    MVKEntryPoint* pMVKPA = getEntryPoint(pName);
 
-	bool isSupported = (pMVKPA &&														// Command exists and...
-						(pMVKPA->isDevice ||											// ...is a device command or...
-						 pMVKPA->isEnabled(_appInfo.apiVersion, _enabledExtensions)));	// ...is a core or enabled extension command.
+    bool isSupported =
+        (pMVKPA &&            // Command exists and...
+         (pMVKPA->isDevice || // ...is a device command or...
+          pMVKPA->isEnabled(_appInfo.apiVersion,
+                            _enabledExtensions))); // ...is a core or enabled
+                                                   // extension command.
 
-	return isSupported ? pMVKPA->functionPointer : nullptr;
+    return isSupported ? pMVKPA->functionPointer : nullptr;
 }
 
-VkResult MVKInstance::getPhysicalDevices(uint32_t* pCount, VkPhysicalDevice* pPhysicalDevices) {
+VkResult MVKInstance::getPhysicalDevices(uint32_t* pCount,
+                                         VkPhysicalDevice* pPhysicalDevices) {
 
-	// Get the number of physical devices
-	uint32_t pdCnt = getPhysicalDeviceCount();
+    // Get the number of physical devices
+    uint32_t pdCnt = getPhysicalDeviceCount();
 
-	// If properties aren't actually being requested yet, simply update the returned count
-	if ( !pPhysicalDevices ) {
-		*pCount = pdCnt;
-		return VK_SUCCESS;
-	}
+    // If properties aren't actually being requested yet, simply update the
+    // returned count
+    if (!pPhysicalDevices) {
+        *pCount = pdCnt;
+        return VK_SUCCESS;
+    }
 
-	// Othewise, determine how many physical devices we'll return, and return that count
-	VkResult result = (*pCount >= pdCnt) ? VK_SUCCESS : VK_INCOMPLETE;
-	*pCount = min(pdCnt, *pCount);
+    // Othewise, determine how many physical devices we'll return, and return
+    // that count
+    VkResult result = (*pCount >= pdCnt) ? VK_SUCCESS : VK_INCOMPLETE;
+    *pCount = min(pdCnt, *pCount);
 
-	// Now populate the devices
-	for (uint32_t pdIdx = 0; pdIdx < *pCount; pdIdx++) {
-		pPhysicalDevices[pdIdx] = _physicalDevices[pdIdx]->getVkPhysicalDevice();
-	}
+    // Now populate the devices
+    for (uint32_t pdIdx = 0; pdIdx < *pCount; pdIdx++) {
+        pPhysicalDevices[pdIdx] =
+            _physicalDevices[pdIdx]->getVkPhysicalDevice();
+    }
 
-	return result;
+    return result;
 }
 
-VkResult MVKInstance::getPhysicalDeviceGroups(uint32_t* pCount, VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProps) {
+VkResult MVKInstance::getPhysicalDeviceGroups(
+    uint32_t* pCount,
+    VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProps) {
 
-	// According to the Vulkan spec: "Every physical device *must* be in exactly one device group."
-	// Since we don't really support this yet, we must return one group for every device.
+    // According to the Vulkan spec: "Every physical device *must* be in exactly
+    // one device group." Since we don't really support this yet, we must return
+    // one group for every device.
 
-	// Get the number of physical devices
-	uint32_t pdCnt = getPhysicalDeviceCount();
+    // Get the number of physical devices
+    uint32_t pdCnt = getPhysicalDeviceCount();
 
-	// If properties aren't actually being requested yet, simply update the returned count
-	if ( !pPhysicalDeviceGroupProps ) {
-		*pCount = pdCnt;
-		return VK_SUCCESS;
-	}
+    // If properties aren't actually being requested yet, simply update the
+    // returned count
+    if (!pPhysicalDeviceGroupProps) {
+        *pCount = pdCnt;
+        return VK_SUCCESS;
+    }
 
-	// Othewise, determine how many physical device groups we'll return, and return that count
-	VkResult result = (*pCount >= pdCnt) ? VK_SUCCESS : VK_INCOMPLETE;
-	*pCount = min(pdCnt, *pCount);
+    // Othewise, determine how many physical device groups we'll return, and
+    // return that count
+    VkResult result = (*pCount >= pdCnt) ? VK_SUCCESS : VK_INCOMPLETE;
+    *pCount = min(pdCnt, *pCount);
 
-	// Now populate the device groups
-	for (uint32_t pdIdx = 0; pdIdx < *pCount; pdIdx++) {
-		pPhysicalDeviceGroupProps[pdIdx].physicalDeviceCount = 1;
-		pPhysicalDeviceGroupProps[pdIdx].physicalDevices[0] = _physicalDevices[pdIdx]->getVkPhysicalDevice();
-		pPhysicalDeviceGroupProps[pdIdx].subsetAllocation = VK_FALSE;
-	}
+    // Now populate the device groups
+    for (uint32_t pdIdx = 0; pdIdx < *pCount; pdIdx++) {
+        pPhysicalDeviceGroupProps[pdIdx].physicalDeviceCount = 1;
+        pPhysicalDeviceGroupProps[pdIdx].physicalDevices[0] =
+            _physicalDevices[pdIdx]->getVkPhysicalDevice();
+        pPhysicalDeviceGroupProps[pdIdx].subsetAllocation = VK_FALSE;
+    }
 
-	return result;
+    return result;
 }
 
-MVKSurface* MVKInstance::createSurface(const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
-									   const VkAllocationCallbacks* pAllocator) {
-	return new MVKSurface(this, pCreateInfo, pAllocator);
+MVKSurface*
+MVKInstance::createSurface(const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    return new MVKSurface(this, pCreateInfo, pAllocator);
 }
 
-MVKSurface* MVKInstance::createSurface(const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
-									   const VkAllocationCallbacks* pAllocator) {
-	return new MVKSurface(this, pCreateInfo, pAllocator);
+MVKSurface*
+MVKInstance::createSurface(const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    return new MVKSurface(this, pCreateInfo, pAllocator);
 }
 
-MVKSurface* MVKInstance::createSurface(const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
-									   const VkAllocationCallbacks* pAllocator) {
-	return new MVKSurface(this, pCreateInfo, pAllocator);
+MVKSurface*
+MVKInstance::createSurface(const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
+                           const VkAllocationCallbacks* pAllocator) {
+    return new MVKSurface(this, pCreateInfo, pAllocator);
 }
 
 void MVKInstance::destroySurface(MVKSurface* mvkSrfc,
-								const VkAllocationCallbacks* pAllocator) {
-	if (mvkSrfc) { mvkSrfc->destroy(); }
+                                 const VkAllocationCallbacks* pAllocator) {
+    if (mvkSrfc) {
+        mvkSrfc->destroy();
+    }
 }
 
-MVKDebugReportCallback* MVKInstance::createDebugReportCallback(const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
-															   const VkAllocationCallbacks* pAllocator) {
-	lock_guard<mutex> lock(_dcbLock);
+MVKDebugReportCallback* MVKInstance::createDebugReportCallback(
+    const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator) {
+    lock_guard<mutex> lock(_dcbLock);
 
-	MVKDebugReportCallback* mvkDRCB = new MVKDebugReportCallback(this, pCreateInfo, _useCreationCallbacks);
-	_debugReportCallbacks.push_back(mvkDRCB);
-	_hasDebugReportCallbacks = true;
-	return mvkDRCB;
+    MVKDebugReportCallback* mvkDRCB =
+        new MVKDebugReportCallback(this, pCreateInfo, _useCreationCallbacks);
+    _debugReportCallbacks.push_back(mvkDRCB);
+    _hasDebugReportCallbacks = true;
+    return mvkDRCB;
 }
 
-void MVKInstance::destroyDebugReportCallback(MVKDebugReportCallback* mvkDRCB,
-								const VkAllocationCallbacks* pAllocator) {
-	if ( !mvkDRCB ) { return; }
+void MVKInstance::destroyDebugReportCallback(
+    MVKDebugReportCallback* mvkDRCB, const VkAllocationCallbacks* pAllocator) {
+    if (!mvkDRCB) {
+        return;
+    }
 
-	lock_guard<mutex> lock(_dcbLock);
+    lock_guard<mutex> lock(_dcbLock);
 
-	mvkRemoveAllOccurances(_debugReportCallbacks, mvkDRCB);
-	_hasDebugReportCallbacks = (_debugReportCallbacks.size() != 0);
-	mvkDRCB->destroy();
+    mvkRemoveAllOccurances(_debugReportCallbacks, mvkDRCB);
+    _hasDebugReportCallbacks = (_debugReportCallbacks.size() != 0);
+    mvkDRCB->destroy();
 }
 
 void MVKInstance::debugReportMessage(VkDebugReportFlagsEXT flags,
-									 VkDebugReportObjectTypeEXT objectType,
-									 uint64_t object,
-									 size_t location,
-									 int32_t messageCode,
-									 const char* pLayerPrefix,
-									 const char* pMessage) {
+                                     VkDebugReportObjectTypeEXT objectType,
+                                     uint64_t object, size_t location,
+                                     int32_t messageCode,
+                                     const char* pLayerPrefix,
+                                     const char* pMessage) {
 
-	// Fail fast to avoid further unnecessary processing and locking.
-	if ( !(_hasDebugReportCallbacks) ) { return; }
+    // Fail fast to avoid further unnecessary processing and locking.
+    if (!(_hasDebugReportCallbacks)) {
+        return;
+    }
 
-	lock_guard<mutex> lock(_dcbLock);
+    lock_guard<mutex> lock(_dcbLock);
 
-	for (auto mvkDRCB : _debugReportCallbacks) {
-		auto& drbcInfo = mvkDRCB->_info;
-		if (drbcInfo.pfnCallback &&
-			mvkIsAnyFlagEnabled(drbcInfo.flags, flags) &&
-			(mvkDRCB->_isCreationCallback == _useCreationCallbacks)) {
+    for (auto mvkDRCB : _debugReportCallbacks) {
+        auto& drbcInfo = mvkDRCB->_info;
+        if (drbcInfo.pfnCallback &&
+            mvkIsAnyFlagEnabled(drbcInfo.flags, flags) &&
+            (mvkDRCB->_isCreationCallback == _useCreationCallbacks)) {
 
-			drbcInfo.pfnCallback(flags, objectType, object, location, messageCode, pLayerPrefix, pMessage, drbcInfo.pUserData);
-		}
-	}
+            drbcInfo.pfnCallback(flags, objectType, object, location,
+                                 messageCode, pLayerPrefix, pMessage,
+                                 drbcInfo.pUserData);
+        }
+    }
 }
 
-MVKDebugUtilsMessenger* MVKInstance::createDebugUtilsMessenger(const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
-															   const VkAllocationCallbacks* pAllocator) {
-	lock_guard<mutex> lock(_dcbLock);
+MVKDebugUtilsMessenger* MVKInstance::createDebugUtilsMessenger(
+    const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
+    const VkAllocationCallbacks* pAllocator) {
+    lock_guard<mutex> lock(_dcbLock);
 
-	MVKDebugUtilsMessenger* mvkDUM = new MVKDebugUtilsMessenger(this, pCreateInfo, _useCreationCallbacks);
-	_debugUtilMessengers.push_back(mvkDUM);
-	_hasDebugUtilsMessengers = true;
-	return mvkDUM;
+    MVKDebugUtilsMessenger* mvkDUM =
+        new MVKDebugUtilsMessenger(this, pCreateInfo, _useCreationCallbacks);
+    _debugUtilMessengers.push_back(mvkDUM);
+    _hasDebugUtilsMessengers = true;
+    return mvkDUM;
 }
 
-void MVKInstance::destroyDebugUtilsMessenger(MVKDebugUtilsMessenger* mvkDUM,
-											 const VkAllocationCallbacks* pAllocator) {
-	if ( !mvkDUM ) { return; }
+void MVKInstance::destroyDebugUtilsMessenger(
+    MVKDebugUtilsMessenger* mvkDUM, const VkAllocationCallbacks* pAllocator) {
+    if (!mvkDUM) {
+        return;
+    }
 
-	lock_guard<mutex> lock(_dcbLock);
+    lock_guard<mutex> lock(_dcbLock);
 
-	mvkRemoveAllOccurances(_debugUtilMessengers, mvkDUM);
-	_hasDebugUtilsMessengers = (_debugUtilMessengers.size() != 0);
-	mvkDUM->destroy();
+    mvkRemoveAllOccurances(_debugUtilMessengers, mvkDUM);
+    _hasDebugUtilsMessengers = (_debugUtilMessengers.size() != 0);
+    mvkDUM->destroy();
 }
 
-void MVKInstance::debugUtilsMessage(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-									VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-									const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData) {
+void MVKInstance::debugUtilsMessage(
+    VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+    VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+    const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData) {
 
-	// Fail fast to avoid further unnecessary processing and locking.
-	if ( !(_hasDebugUtilsMessengers) ) { return; }
+    // Fail fast to avoid further unnecessary processing and locking.
+    if (!(_hasDebugUtilsMessengers)) {
+        return;
+    }
 
-	lock_guard<mutex> lock(_dcbLock);
+    lock_guard<mutex> lock(_dcbLock);
 
-	for (auto mvkDUM : _debugUtilMessengers) {
-		auto& dumInfo = mvkDUM->_info;
-		if (dumInfo.pfnUserCallback &&
-			mvkIsAnyFlagEnabled(dumInfo.messageSeverity, messageSeverity) &&
-			mvkIsAnyFlagEnabled(dumInfo.messageType, messageTypes) &&
-			(mvkDUM->_isCreationCallback == _useCreationCallbacks)) {
+    for (auto mvkDUM : _debugUtilMessengers) {
+        auto& dumInfo = mvkDUM->_info;
+        if (dumInfo.pfnUserCallback &&
+            mvkIsAnyFlagEnabled(dumInfo.messageSeverity, messageSeverity) &&
+            mvkIsAnyFlagEnabled(dumInfo.messageType, messageTypes) &&
+            (mvkDUM->_isCreationCallback == _useCreationCallbacks)) {
 
-			dumInfo.pfnUserCallback(messageSeverity, messageTypes, pCallbackData, dumInfo.pUserData);
-		}
-	}
+            dumInfo.pfnUserCallback(messageSeverity, messageTypes,
+                                    pCallbackData, dumInfo.pUserData);
+        }
+    }
 }
 
-void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj, MVKConfigLogLevel logLevel, const char* pMessage) {
+void MVKInstance::debugReportMessage(MVKVulkanAPIObject* mvkAPIObj,
+                                     MVKConfigLogLevel logLevel,
+                                     const char* pMessage) {
 
-	if (_hasDebugReportCallbacks) {
-		VkDebugReportFlagsEXT flags = getVkDebugReportFlagsFromLogLevel(logLevel);
-		uint64_t object = (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr);
-		VkDebugReportObjectTypeEXT objectType = mvkAPIObj ? mvkAPIObj->getVkDebugReportObjectType() : VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
-		debugReportMessage(flags, objectType, object, 0, 0, _debugReportCallbackLayerPrefix, pMessage);
-	}
+    if (_hasDebugReportCallbacks) {
+        VkDebugReportFlagsEXT flags =
+            getVkDebugReportFlagsFromLogLevel(logLevel);
+        uint64_t object =
+            (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr);
+        VkDebugReportObjectTypeEXT objectType =
+            mvkAPIObj ? mvkAPIObj->getVkDebugReportObjectType()
+                      : VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+        debugReportMessage(flags, objectType, object, 0, 0,
+                           _debugReportCallbackLayerPrefix, pMessage);
+    }
 
-	if (_hasDebugUtilsMessengers) {
-		VkDebugUtilsObjectNameInfoEXT duObjName = {
-			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
-			.pNext = nullptr,
-			.objectType = mvkAPIObj ? mvkAPIObj->getVkObjectType() : VK_OBJECT_TYPE_UNKNOWN,
-			.objectHandle = (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr),
-			.pObjectName = mvkAPIObj ? mvkAPIObj->getDebugName().UTF8String : nullptr
-		};
-		VkDebugUtilsMessengerCallbackDataEXT dumcbd = {
-			.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT,
-			.pNext = nullptr,
-			.flags = 0,
-			.pMessageIdName = mvkGetReportingLevelString(logLevel),
-			.messageIdNumber = 0,
-			.pMessage = pMessage,
-			.queueLabelCount = 0,
-			.pQueueLabels = nullptr,
-			.cmdBufLabelCount = 0,
-			.pCmdBufLabels = nullptr,
-			.objectCount = 1,
-			.pObjects = &duObjName
-		};
-		debugUtilsMessage(getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(logLevel),
-						  getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(logLevel),
-						  &dumcbd);
-	}
+    if (_hasDebugUtilsMessengers) {
+        VkDebugUtilsObjectNameInfoEXT duObjName =
+            {.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
+             .pNext = nullptr,
+             .objectType = mvkAPIObj ? mvkAPIObj->getVkObjectType()
+                                     : VK_OBJECT_TYPE_UNKNOWN,
+             .objectHandle =
+                 (uint64_t)(mvkAPIObj ? mvkAPIObj->getVkHandle() : nullptr),
+             .pObjectName =
+                 mvkAPIObj ? mvkAPIObj->getDebugName().UTF8String : nullptr};
+        VkDebugUtilsMessengerCallbackDataEXT dumcbd =
+            {.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT,
+             .pNext = nullptr,
+             .flags = 0,
+             .pMessageIdName = mvkGetReportingLevelString(logLevel),
+             .messageIdNumber = 0,
+             .pMessage = pMessage,
+             .queueLabelCount = 0,
+             .pQueueLabels = nullptr,
+             .cmdBufLabelCount = 0,
+             .pCmdBufLabels = nullptr,
+             .objectCount = 1,
+             .pObjects = &duObjName};
+        debugUtilsMessage(getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(
+                              logLevel),
+                          getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(
+                              logLevel),
+                          &dumcbd);
+    }
 }
 
-VkDebugReportFlagsEXT MVKInstance::getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel) {
-	switch (logLevel) {
-		case MVK_CONFIG_LOG_LEVEL_ERROR:    return VK_DEBUG_REPORT_ERROR_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_WARNING:  return VK_DEBUG_REPORT_WARNING_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_INFO:     return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_DEBUG:    return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
-		default:                            return VK_DEBUG_REPORT_ERROR_BIT_EXT;
-	}
+VkDebugReportFlagsEXT
+MVKInstance::getVkDebugReportFlagsFromLogLevel(MVKConfigLogLevel logLevel) {
+    switch (logLevel) {
+    case MVK_CONFIG_LOG_LEVEL_ERROR:
+        return VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_WARNING:
+        return VK_DEBUG_REPORT_WARNING_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_INFO:
+        return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_DEBUG:
+        return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
+    default:
+        return VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    }
 }
 
-VkDebugUtilsMessageSeverityFlagBitsEXT MVKInstance::getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(MVKConfigLogLevel logLevel) {
-	switch (logLevel) {
-		case MVK_CONFIG_LOG_LEVEL_ERROR:    return VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_WARNING:  return VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_INFO:     return VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_DEBUG:    return VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-		default:                            return VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-	}
+VkDebugUtilsMessageSeverityFlagBitsEXT
+MVKInstance::getVkDebugUtilsMessageSeverityFlagBitsFromLogLevel(
+    MVKConfigLogLevel logLevel) {
+    switch (logLevel) {
+    case MVK_CONFIG_LOG_LEVEL_ERROR:
+        return VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_WARNING:
+        return VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_INFO:
+        return VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_DEBUG:
+        return VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+    default:
+        return VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    }
 }
 
-VkDebugUtilsMessageTypeFlagsEXT MVKInstance::getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(MVKConfigLogLevel logLevel) {
-	switch (logLevel) {
-		case MVK_CONFIG_LOG_LEVEL_ERROR:    return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_WARNING:  return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_DEBUG:    return VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
-		case MVK_CONFIG_LOG_LEVEL_INFO:     return VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
-		default:                            return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-	}
+VkDebugUtilsMessageTypeFlagsEXT
+MVKInstance::getVkDebugUtilsMessageTypesFlagBitsFromLogLevel(
+    MVKConfigLogLevel logLevel) {
+    switch (logLevel) {
+    case MVK_CONFIG_LOG_LEVEL_ERROR:
+        return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_WARNING:
+        return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_DEBUG:
+        return VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    case MVK_CONFIG_LOG_LEVEL_INFO:
+        return VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT;
+    default:
+        return VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+    }
 }
-
 
 #pragma mark Object Creation
 
-MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo) : _enabledExtensions(this) {
+MVKInstance::MVKInstance(const VkInstanceCreateInfo* pCreateInfo)
+    : _enabledExtensions(this) {
 
-	initDebugCallbacks(pCreateInfo);	// Do before any creation activities
+    initDebugCallbacks(pCreateInfo); // Do before any creation activities
 
-	mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
+    mvkSetOrClear(&_appInfo, pCreateInfo->pApplicationInfo);
     if (_appInfo.apiVersion == 0) {
-        _appInfo.apiVersion = VK_API_VERSION_1_0;   // Default
-    }
-    else if (MVK_VULKAN_API_VERSION_CONFORM(_appInfo.apiVersion) > MVK_VULKAN_API_VERSION_CONFORM(MVK_VULKAN_API_VERSION)) {
+        _appInfo.apiVersion = VK_API_VERSION_1_0; // Default
+    } else if (MVK_VULKAN_API_VERSION_CONFORM(_appInfo.apiVersion) >
+               MVK_VULKAN_API_VERSION_CONFORM(MVK_VULKAN_API_VERSION)) {
         _appInfo.apiVersion = MVK_VULKAN_API_VERSION;
     }
 
-	// Enable extensions before setting config.
-	setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames));
-	MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_enabledExtensions;
-	setConfigurationResult(pWritableExtns->enable(pCreateInfo->enabledExtensionCount,
-												  pCreateInfo->ppEnabledExtensionNames,
-												  getDriverLayer()->getSupportedInstanceExtensions()));
+    // Enable extensions before setting config.
+    setConfigurationResult(verifyLayers(pCreateInfo->enabledLayerCount,
+                                        pCreateInfo->ppEnabledLayerNames));
+    MVKExtensionList* pWritableExtns = (MVKExtensionList*)&_enabledExtensions;
+    setConfigurationResult(
+        pWritableExtns
+            ->enable(pCreateInfo->enabledExtensionCount,
+                     pCreateInfo->ppEnabledExtensionNames,
+                     getDriverLayer()->getSupportedInstanceExtensions()));
 
-	initMVKConfig(pCreateInfo);		// After extensions enabled.
-	initProcAddrs();				// Init function pointers
-	logVersions();					// Log the MoltenVK and Vulkan versions. After config.
+    initMVKConfig(pCreateInfo); // After extensions enabled.
+    initProcAddrs();            // Init function pointers
+    logVersions(); // Log the MoltenVK and Vulkan versions. After config.
 
-	// Populate the array of physical GPU devices.
-	// This must be performed after extensions and config are established.
-	// This effort creates a number of autoreleased Metal objects, so wrap it all in an autorelease pool.
-	@autoreleasepool {
-		NSArray<id<MTLDevice>>* mtlDevices = mvkGetAvailableMTLDevicesArray(this);
-		_physicalDevices.reserve(mtlDevices.count);
-		for (id<MTLDevice> mtlDev in mtlDevices) {
-			_physicalDevices.push_back(new MVKPhysicalDevice(this, mtlDev));
-		}
-	}
-    
-	if (_physicalDevices.empty()) {
-		setConfigurationResult(reportError(VK_ERROR_INCOMPATIBLE_DRIVER, "Vulkan is not supported on this device. MoltenVK requires Metal, which is not available on this device."));
-	}
+    // Populate the array of physical GPU devices.
+    // This must be performed after extensions and config are established.
+    // This effort creates a number of autoreleased Metal objects, so wrap it
+    // all in an autorelease pool.
+    @autoreleasepool {
+        NSArray<id<MTLDevice>>* mtlDevices =
+            mvkGetAvailableMTLDevicesArray(this);
+        _physicalDevices.reserve(mtlDevices.count);
+        for (id<MTLDevice> mtlDev in mtlDevices) {
+            _physicalDevices.push_back(new MVKPhysicalDevice(this, mtlDev));
+        }
+    }
 
-	if (MVK_MACCAT && !mvkOSVersionIsAtLeast(11.0)) {
-		setConfigurationResult(reportError(VK_ERROR_INCOMPATIBLE_DRIVER, "To support Mac Catalyst, MoltenVK requires macOS 11.0 or above."));
-	}
+    if (_physicalDevices.empty()) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INCOMPATIBLE_DRIVER,
+                        "Vulkan is not supported on this device. MoltenVK "
+                        "requires "
+                        "Metal, which is not available on this device."));
+    }
 
-	MVKLogInfo("Created VkInstance for Vulkan version %s, as requested by app, with the following %d Vulkan extensions enabled:%s",
-			   mvkGetVulkanVersionString(_appInfo.apiVersion).c_str(),
-			   _enabledExtensions.getEnabledCount(),
-			   _enabledExtensions.enabledNamesString("\n\t", true).c_str());
+    if (MVK_MACCAT && !mvkOSVersionIsAtLeast(11.0)) {
+        setConfigurationResult(reportError(VK_ERROR_INCOMPATIBLE_DRIVER,
+                                           "To support Mac Catalyst, MoltenVK "
+                                           "requires macOS 11.0 or above."));
+    }
 
-	_useCreationCallbacks = false;
+    MVKLogInfo("Created VkInstance for Vulkan version %s, as requested by app, "
+               "with the following %d Vulkan extensions "
+               "enabled:%s",
+               mvkGetVulkanVersionString(_appInfo.apiVersion).c_str(),
+               _enabledExtensions.getEnabledCount(),
+               _enabledExtensions.enabledNamesString("\n\t", true).c_str());
+
+    _useCreationCallbacks = false;
 }
 
 void MVKInstance::initDebugCallbacks(const VkInstanceCreateInfo* pCreateInfo) {
-	_useCreationCallbacks = true;
-	_hasDebugReportCallbacks = false;
-	_hasDebugUtilsMessengers = false;
-	_debugReportCallbackLayerPrefix = getDriverLayer()->getName();
+    _useCreationCallbacks = true;
+    _hasDebugReportCallbacks = false;
+    _hasDebugUtilsMessengers = false;
+    _debugReportCallbackLayerPrefix = getDriverLayer()->getName();
 
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
-				createDebugReportCallback((VkDebugReportCallbackCreateInfoEXT*)next, nullptr);
-				break;
-			case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-				createDebugUtilsMessenger((VkDebugUtilsMessengerCreateInfoEXT*)next, nullptr);
-				break;
-			default:
-				break;
-		}
-	}
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
+            createDebugReportCallback((VkDebugReportCallbackCreateInfoEXT*)next,
+                                      nullptr);
+            break;
+        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
+            createDebugUtilsMessenger((VkDebugUtilsMessengerCreateInfoEXT*)next,
+                                      nullptr);
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 // If the VK_EXT_layer_settings extension is enabled, initialize the local
 // MVKConfiguration from the global version built from environment variables.
 void MVKInstance::initMVKConfig(const VkInstanceCreateInfo* pCreateInfo) {
 
-	if ( !_enabledExtensions.vk_EXT_layer_settings.enabled ) { return; }
+    if (!_enabledExtensions.vk_EXT_layer_settings.enabled) {
+        return;
+    }
 
-	_mvkConfig = getGlobalMVKConfig();
+    _mvkConfig = getGlobalMVKConfig();
 
-	VkLayerSettingsCreateInfoEXT* pLSCreateInfo = nil;
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT:
-				pLSCreateInfo = (VkLayerSettingsCreateInfoEXT*)next;
-				break;
-			default:
-				break;
-		}
-	}
+    VkLayerSettingsCreateInfoEXT* pLSCreateInfo = nil;
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT:
+            pLSCreateInfo = (VkLayerSettingsCreateInfoEXT*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	if ( !pLSCreateInfo ) { return; }
+    if (!pLSCreateInfo) {
+        return;
+    }
 
-	for (uint32_t lsIdx = 0; lsIdx < pLSCreateInfo->settingCount; lsIdx++) {
-		const auto* pSetting = &pLSCreateInfo->pSettings[lsIdx];
+    for (uint32_t lsIdx = 0; lsIdx < pLSCreateInfo->settingCount; lsIdx++) {
+        const auto* pSetting = &pLSCreateInfo->pSettings[lsIdx];
 
 #define STR(name) #name
-#define MVK_CONFIG_MEMBER(member, mbrType, name) \
-		if(mvkStringsAreEqual(pSetting->pLayerName, getDriverLayer()->getName()) &&  \
-		   mvkStringsAreEqual(pSetting->pSettingName, STR(MVK_CONFIG_##name))) {  \
-			_mvkConfig.member = *(mbrType*)(pSetting->pValues);  \
-			continue;  \
-		}
+#define MVK_CONFIG_MEMBER(member, mbrType, name)                               \
+    if (mvkStringsAreEqual(pSetting->pLayerName,                               \
+                           getDriverLayer()->getName()) &&                     \
+        mvkStringsAreEqual(pSetting->pSettingName, STR(MVK_CONFIG_##name))) {  \
+        _mvkConfig.member = *(mbrType*)(pSetting->pValues);                    \
+        continue;                                                              \
+    }
 #include "MVKConfigMembers.def"
-	}
-	mvkSetConfig(_mvkConfig, _mvkConfig, _mvkConfigStringHolders);
+    }
+    mvkSetConfig(_mvkConfig, _mvkConfig, _mvkConfigStringHolders);
 }
 
-#define ADD_ENTRY_POINT_MAP(name, func, api, ext1, ext2, isDev)	\
-	_entryPoints[""#name] = { (PFN_vkVoidFunction)&func, api, ext1,  ext2,  isDev }
+#define ADD_ENTRY_POINT_MAP(name, func, api, ext1, ext2, isDev)                \
+    _entryPoints["" #name] = {(PFN_vkVoidFunction) & func, api, ext1, ext2,    \
+                              isDev}
 
-#define ADD_ENTRY_POINT(func, api, ext1, ext2, isDev)	ADD_ENTRY_POINT_MAP(func, func, api, ext1, ext2, isDev)
+#define ADD_ENTRY_POINT(func, api, ext1, ext2, isDev)                          \
+    ADD_ENTRY_POINT_MAP(func, func, api, ext1, ext2, isDev)
 
-#define ADD_INST_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, false)
-#define ADD_DVC_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, true)
+#define ADD_INST_ENTRY_POINT(func)                                             \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, false)
+#define ADD_DVC_ENTRY_POINT(func)                                              \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, true)
 
 // Add a core function.
-#define ADD_INST_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, false)
-#define ADD_INST_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, false)
-#define ADD_DVC_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, true)
-#define ADD_DVC_1_2_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_2, nullptr, nullptr, true)
-#define ADD_DVC_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, true)
+#define ADD_INST_1_1_ENTRY_POINT(func)                                         \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, false)
+#define ADD_INST_1_3_ENTRY_POINT(func)                                         \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, false)
+#define ADD_DVC_1_1_ENTRY_POINT(func)                                          \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, true)
+#define ADD_DVC_1_2_ENTRY_POINT(func)                                          \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_2, nullptr, nullptr, true)
+#define ADD_DVC_1_3_ENTRY_POINT(func)                                          \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, true)
 
 // Add both the promoted core function and the extension function.
-#define ADD_INST_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
-	ADD_INST_1_1_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+#define ADD_INST_1_1_PROMOTED_ENTRY_POINT(func, EXT)                           \
+    ADD_INST_1_1_ENTRY_POINT(func);                                            \
+    ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME,         \
+                        nullptr, false)
 
-#define ADD_DVC_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
-	ADD_DVC_1_1_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_DVC_1_1_PROMOTED_ENTRY_POINT(func, EXT)                            \
+    ADD_DVC_1_1_ENTRY_POINT(func);                                             \
+    ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME,         \
+                        nullptr, true)
 
-#define ADD_DVC_1_2_PROMOTED_ENTRY_POINT(func, suffix, EXT) \
-	ADD_DVC_1_2_ENTRY_POINT(func); \
-	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_DVC_1_2_PROMOTED_ENTRY_POINT(func, suffix, EXT)                    \
+    ADD_DVC_1_2_ENTRY_POINT(func);                                             \
+    ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME,      \
+                        nullptr, true)
 
-#define ADD_INST_1_3_PROMOTED_ENTRY_POINT(func, EXT)	\
-	ADD_INST_1_3_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+#define ADD_INST_1_3_PROMOTED_ENTRY_POINT(func, EXT)                           \
+    ADD_INST_1_3_ENTRY_POINT(func);                                            \
+    ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME,         \
+                        nullptr, false)
 
-#define ADD_DVC_1_3_PROMOTED_ENTRY_POINT(func, suffix, EXT) \
-	ADD_DVC_1_3_ENTRY_POINT(func); \
-	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_DVC_1_3_PROMOTED_ENTRY_POINT(func, suffix, EXT)                    \
+    ADD_DVC_1_3_ENTRY_POINT(func);                                             \
+    ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME,      \
+                        nullptr, true)
 
 // Add an extension function.
-#define ADD_INST_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
-#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_INST_EXT_ENTRY_POINT(func, EXT)                                    \
+    ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)                                     \
+    ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
 
-#define ADD_INST_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)	ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, false)
-#define ADD_DVC_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)		ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, true)
+#define ADD_INST_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)                       \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME,    \
+                    VK_##EXT2##_EXTENSION_NAME, false)
+#define ADD_DVC_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)                        \
+    ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME,    \
+                    VK_##EXT2##_EXTENSION_NAME, true)
 
-#define ADD_INST_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)	ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
-#define ADD_DVC_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)		ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_INST_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)                       \
+    ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr,    \
+                        false)
+#define ADD_DVC_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)                        \
+    ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr,    \
+                        true)
 
 // Add an open function, not tied to core or an extension.
-#define ADD_INST_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, false)
-#define ADD_DVC_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, true)
+#define ADD_INST_OPEN_ENTRY_POINT(func)                                        \
+    ADD_ENTRY_POINT(func, 0, nullptr, nullptr, false)
+#define ADD_DVC_OPEN_ENTRY_POINT(func)                                         \
+    ADD_ENTRY_POINT(func, 0, nullptr, nullptr, true)
 
 // Initializes the function pointer map.
 void MVKInstance::initProcAddrs() {
 
-	// Instance functions.
-	ADD_INST_ENTRY_POINT(vkDestroyInstance);
-	ADD_INST_ENTRY_POINT(vkEnumeratePhysicalDevices);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceFeatures);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceProperties);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties);
-	ADD_INST_ENTRY_POINT(vkCreateDevice);
-	ADD_INST_ENTRY_POINT(vkEnumerateDeviceExtensionProperties);
-	ADD_INST_ENTRY_POINT(vkEnumerateDeviceLayerProperties);
-	ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties);
+    // Instance functions.
+    ADD_INST_ENTRY_POINT(vkDestroyInstance);
+    ADD_INST_ENTRY_POINT(vkEnumeratePhysicalDevices);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceFeatures);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceProperties);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties);
+    ADD_INST_ENTRY_POINT(vkCreateDevice);
+    ADD_INST_ENTRY_POINT(vkEnumerateDeviceExtensionProperties);
+    ADD_INST_ENTRY_POINT(vkEnumerateDeviceLayerProperties);
+    ADD_INST_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties);
 
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkEnumeratePhysicalDeviceGroups, KHR_DEVICE_GROUP_CREATION);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFeatures2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceSparseImageFormatProperties2, KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalFenceProperties, KHR_EXTERNAL_FENCE_CAPABILITIES);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalBufferProperties, KHR_EXTERNAL_MEMORY_CAPABILITIES);
-	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalSemaphoreProperties, KHR_EXTERNAL_SEMAPHORE_CAPABILITIES);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkEnumeratePhysicalDeviceGroups,
+                                      KHR_DEVICE_GROUP_CREATION);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFeatures2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceProperties2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceFormatProperties2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceImageFormatProperties2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceQueueFamilyProperties2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceMemoryProperties2,
+                                      KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(
+        vkGetPhysicalDeviceSparseImageFormatProperties2,
+        KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(
+        vkGetPhysicalDeviceExternalFenceProperties,
+        KHR_EXTERNAL_FENCE_CAPABILITIES);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(
+        vkGetPhysicalDeviceExternalBufferProperties,
+        KHR_EXTERNAL_MEMORY_CAPABILITIES);
+    ADD_INST_1_1_PROMOTED_ENTRY_POINT(
+        vkGetPhysicalDeviceExternalSemaphoreProperties,
+        KHR_EXTERNAL_SEMAPHORE_CAPABILITIES);
 
-	ADD_INST_1_3_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceToolProperties, EXT_TOOLING_INFO);
+    ADD_INST_1_3_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceToolProperties,
+                                      EXT_TOOLING_INFO);
 
-	// Instance extension functions.
-	ADD_INST_EXT_ENTRY_POINT(vkDestroySurfaceKHR, KHR_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceSupportKHR, KHR_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR, KHR_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceFormatsKHR, KHR_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfacePresentModesKHR, KHR_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilities2KHR, KHR_GET_SURFACE_CAPABILITIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceFormats2KHR, KHR_GET_SURFACE_CAPABILITIES_2);
-	ADD_INST_EXT_ENTRY_POINT(vkCreateHeadlessSurfaceEXT, EXT_HEADLESS_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkCreateMetalSurfaceEXT, EXT_METAL_SURFACE);
-	ADD_INST_EXT_ENTRY_POINT(vkCreateDebugReportCallbackEXT, EXT_DEBUG_REPORT);
-	ADD_INST_EXT_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, EXT_DEBUG_REPORT);
-	ADD_INST_EXT_ENTRY_POINT(vkDebugReportMessageEXT, EXT_DEBUG_REPORT);
-	// n.b. Despite that VK_EXT_debug_utils is an instance extension, these functions are device functions.
-	ADD_DVC_EXT_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkSetDebugUtilsObjectTagEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkQueueBeginDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkQueueEndDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkQueueInsertDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdBeginDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdEndDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdInsertDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
-	ADD_INST_EXT_ENTRY_POINT(vkCreateDebugUtilsMessengerEXT, EXT_DEBUG_UTILS);
-	ADD_INST_EXT_ENTRY_POINT(vkDestroyDebugUtilsMessengerEXT, EXT_DEBUG_UTILS);
-	ADD_INST_EXT_ENTRY_POINT(vkSubmitDebugUtilsMessageEXT, EXT_DEBUG_UTILS);
+    // Instance extension functions.
+    ADD_INST_EXT_ENTRY_POINT(vkDestroySurfaceKHR, KHR_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceSupportKHR, KHR_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilitiesKHR,
+                             KHR_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceFormatsKHR, KHR_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfacePresentModesKHR,
+                             KHR_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceCapabilities2KHR,
+                             KHR_GET_SURFACE_CAPABILITIES_2);
+    ADD_INST_EXT_ENTRY_POINT(vkGetPhysicalDeviceSurfaceFormats2KHR,
+                             KHR_GET_SURFACE_CAPABILITIES_2);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateHeadlessSurfaceEXT, EXT_HEADLESS_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateMetalSurfaceEXT, EXT_METAL_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateDebugReportCallbackEXT, EXT_DEBUG_REPORT);
+    ADD_INST_EXT_ENTRY_POINT(vkDestroyDebugReportCallbackEXT, EXT_DEBUG_REPORT);
+    ADD_INST_EXT_ENTRY_POINT(vkDebugReportMessageEXT, EXT_DEBUG_REPORT);
+    // n.b. Despite that VK_EXT_debug_utils is an instance extension, these
+    // functions are device functions.
+    ADD_DVC_EXT_ENTRY_POINT(vkSetDebugUtilsObjectNameEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkSetDebugUtilsObjectTagEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkQueueBeginDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkQueueEndDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkQueueInsertDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdBeginDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdEndDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdInsertDebugUtilsLabelEXT, EXT_DEBUG_UTILS);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateDebugUtilsMessengerEXT, EXT_DEBUG_UTILS);
+    ADD_INST_EXT_ENTRY_POINT(vkDestroyDebugUtilsMessengerEXT, EXT_DEBUG_UTILS);
+    ADD_INST_EXT_ENTRY_POINT(vkSubmitDebugUtilsMessageEXT, EXT_DEBUG_UTILS);
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-	ADD_INST_EXT_ENTRY_POINT(vkCreateIOSSurfaceMVK, MVK_IOS_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateIOSSurfaceMVK, MVK_IOS_SURFACE);
 #endif
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-	ADD_INST_EXT_ENTRY_POINT(vkCreateMacOSSurfaceMVK, MVK_MACOS_SURFACE);
+    ADD_INST_EXT_ENTRY_POINT(vkCreateMacOSSurfaceMVK, MVK_MACOS_SURFACE);
 #endif
 
-	// MoltenVK-specific instannce functions, not tied to a Vulkan API version or an extension.
-	ADD_INST_OPEN_ENTRY_POINT(vkGetMoltenVKConfigurationMVK);
-	ADD_INST_OPEN_ENTRY_POINT(vkGetPhysicalDeviceMetalFeaturesMVK);
-	ADD_INST_OPEN_ENTRY_POINT(vkGetPerformanceStatisticsMVK);
+    // MoltenVK-specific instannce functions, not tied to a Vulkan API version
+    // or an extension.
+    ADD_INST_OPEN_ENTRY_POINT(vkGetMoltenVKConfigurationMVK);
+    ADD_INST_OPEN_ENTRY_POINT(vkGetPhysicalDeviceMetalFeaturesMVK);
+    ADD_INST_OPEN_ENTRY_POINT(vkGetPerformanceStatisticsMVK);
 
-	// For deprecated MoltenVK-specific functions, suppress compiler deprecation warning.
+    // For deprecated MoltenVK-specific functions, suppress compiler deprecation
+    // warning.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	ADD_INST_OPEN_ENTRY_POINT(vkSetMoltenVKConfigurationMVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetVersionStringsMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetMTLDeviceMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkSetMTLTextureMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetMTLTextureMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetMTLBufferMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkUseIOSurfaceMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetIOSurfaceMVK, MVK_MOLTENVK);
-	ADD_INST_EXT_ENTRY_POINT(vkGetMTLCommandQueueMVK, MVK_MOLTENVK);
+    ADD_INST_OPEN_ENTRY_POINT(vkSetMoltenVKConfigurationMVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetVersionStringsMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetMTLDeviceMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkSetMTLTextureMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetMTLTextureMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetMTLBufferMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkUseIOSurfaceMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetIOSurfaceMVK, MVK_MOLTENVK);
+    ADD_INST_EXT_ENTRY_POINT(vkGetMTLCommandQueueMVK, MVK_MOLTENVK);
 #pragma clang diagnostic pop
 
-	// Device functions.
-	ADD_DVC_ENTRY_POINT(vkGetDeviceProcAddr);
-	ADD_DVC_ENTRY_POINT(vkDestroyDevice);
-	ADD_DVC_ENTRY_POINT(vkGetDeviceQueue);
-	ADD_DVC_ENTRY_POINT(vkQueueSubmit);
-	ADD_DVC_ENTRY_POINT(vkQueueWaitIdle);
-	ADD_DVC_ENTRY_POINT(vkDeviceWaitIdle);
-	ADD_DVC_ENTRY_POINT(vkAllocateMemory);
-	ADD_DVC_ENTRY_POINT(vkFreeMemory);
-	ADD_DVC_ENTRY_POINT(vkMapMemory);
-	ADD_DVC_ENTRY_POINT(vkUnmapMemory);
-	ADD_DVC_ENTRY_POINT(vkFlushMappedMemoryRanges);
-	ADD_DVC_ENTRY_POINT(vkInvalidateMappedMemoryRanges);
-	ADD_DVC_ENTRY_POINT(vkGetDeviceMemoryCommitment);
-	ADD_DVC_ENTRY_POINT(vkBindBufferMemory);
-	ADD_DVC_ENTRY_POINT(vkBindImageMemory);
-	ADD_DVC_ENTRY_POINT(vkGetBufferMemoryRequirements);
-	ADD_DVC_ENTRY_POINT(vkGetImageMemoryRequirements);
-	ADD_DVC_ENTRY_POINT(vkGetImageSparseMemoryRequirements);
-	ADD_DVC_ENTRY_POINT(vkQueueBindSparse);
-	ADD_DVC_ENTRY_POINT(vkCreateFence);
-	ADD_DVC_ENTRY_POINT(vkDestroyFence);
-	ADD_DVC_ENTRY_POINT(vkResetFences);
-	ADD_DVC_ENTRY_POINT(vkGetFenceStatus);
-	ADD_DVC_ENTRY_POINT(vkWaitForFences);
-	ADD_DVC_ENTRY_POINT(vkCreateSemaphore);
-	ADD_DVC_ENTRY_POINT(vkDestroySemaphore);
-	ADD_DVC_ENTRY_POINT(vkCreateEvent);
-	ADD_DVC_ENTRY_POINT(vkDestroyEvent);
-	ADD_DVC_ENTRY_POINT(vkGetEventStatus);
-	ADD_DVC_ENTRY_POINT(vkSetEvent);
-	ADD_DVC_ENTRY_POINT(vkResetEvent);
-	ADD_DVC_ENTRY_POINT(vkCreateQueryPool);
-	ADD_DVC_ENTRY_POINT(vkDestroyQueryPool);
-	ADD_DVC_ENTRY_POINT(vkGetQueryPoolResults);
-	ADD_DVC_ENTRY_POINT(vkCreateBuffer);
-	ADD_DVC_ENTRY_POINT(vkDestroyBuffer);
-	ADD_DVC_ENTRY_POINT(vkCreateBufferView);
-	ADD_DVC_ENTRY_POINT(vkDestroyBufferView);
-	ADD_DVC_ENTRY_POINT(vkCreateImage);
-	ADD_DVC_ENTRY_POINT(vkDestroyImage);
-	ADD_DVC_ENTRY_POINT(vkGetImageSubresourceLayout);
-	ADD_DVC_ENTRY_POINT(vkCreateImageView);
-	ADD_DVC_ENTRY_POINT(vkDestroyImageView);
-	ADD_DVC_ENTRY_POINT(vkCreateShaderModule);
-	ADD_DVC_ENTRY_POINT(vkDestroyShaderModule);
-	ADD_DVC_ENTRY_POINT(vkCreatePipelineCache);
-	ADD_DVC_ENTRY_POINT(vkDestroyPipelineCache);
-	ADD_DVC_ENTRY_POINT(vkGetPipelineCacheData);
-	ADD_DVC_ENTRY_POINT(vkMergePipelineCaches);
-	ADD_DVC_ENTRY_POINT(vkCreateGraphicsPipelines);
-	ADD_DVC_ENTRY_POINT(vkCreateComputePipelines);
-	ADD_DVC_ENTRY_POINT(vkDestroyPipeline);
-	ADD_DVC_ENTRY_POINT(vkCreatePipelineLayout);
-	ADD_DVC_ENTRY_POINT(vkDestroyPipelineLayout);
-	ADD_DVC_ENTRY_POINT(vkCreateSampler);
-	ADD_DVC_ENTRY_POINT(vkDestroySampler);
-	ADD_DVC_ENTRY_POINT(vkCreateDescriptorSetLayout);
-	ADD_DVC_ENTRY_POINT(vkDestroyDescriptorSetLayout);
-	ADD_DVC_ENTRY_POINT(vkCreateDescriptorPool);
-	ADD_DVC_ENTRY_POINT(vkDestroyDescriptorPool);
-	ADD_DVC_ENTRY_POINT(vkResetDescriptorPool);
-	ADD_DVC_ENTRY_POINT(vkAllocateDescriptorSets);
-	ADD_DVC_ENTRY_POINT(vkFreeDescriptorSets);
-	ADD_DVC_ENTRY_POINT(vkUpdateDescriptorSets);
-	ADD_DVC_ENTRY_POINT(vkCreateFramebuffer);
-	ADD_DVC_ENTRY_POINT(vkDestroyFramebuffer);
-	ADD_DVC_ENTRY_POINT(vkCreateRenderPass);
-	ADD_DVC_ENTRY_POINT(vkDestroyRenderPass);
-	ADD_DVC_ENTRY_POINT(vkGetRenderAreaGranularity);
-	ADD_DVC_ENTRY_POINT(vkCreateCommandPool);
-	ADD_DVC_ENTRY_POINT(vkDestroyCommandPool);
-	ADD_DVC_ENTRY_POINT(vkResetCommandPool);
-	ADD_DVC_ENTRY_POINT(vkAllocateCommandBuffers);
-	ADD_DVC_ENTRY_POINT(vkFreeCommandBuffers);
-	ADD_DVC_ENTRY_POINT(vkBeginCommandBuffer);
-	ADD_DVC_ENTRY_POINT(vkEndCommandBuffer);
-	ADD_DVC_ENTRY_POINT(vkResetCommandBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdBindPipeline);
-	ADD_DVC_ENTRY_POINT(vkCmdSetViewport);
-	ADD_DVC_ENTRY_POINT(vkCmdSetScissor);
-	ADD_DVC_ENTRY_POINT(vkCmdSetLineWidth);
-	ADD_DVC_ENTRY_POINT(vkCmdSetDepthBias);
-	ADD_DVC_ENTRY_POINT(vkCmdSetBlendConstants);
-	ADD_DVC_ENTRY_POINT(vkCmdSetDepthBounds);
-	ADD_DVC_ENTRY_POINT(vkCmdSetStencilCompareMask);
-	ADD_DVC_ENTRY_POINT(vkCmdSetStencilWriteMask);
-	ADD_DVC_ENTRY_POINT(vkCmdSetStencilReference);
-	ADD_DVC_ENTRY_POINT(vkCmdBindDescriptorSets);
-	ADD_DVC_ENTRY_POINT(vkCmdBindIndexBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdBindVertexBuffers);
-	ADD_DVC_ENTRY_POINT(vkCmdDraw);
-	ADD_DVC_ENTRY_POINT(vkCmdDrawIndexed);
-	ADD_DVC_ENTRY_POINT(vkCmdDrawIndirect);
-	ADD_DVC_ENTRY_POINT(vkCmdDrawIndexedIndirect);
-	ADD_DVC_ENTRY_POINT(vkCmdDispatch);
-	ADD_DVC_ENTRY_POINT(vkCmdDispatchIndirect);
-	ADD_DVC_ENTRY_POINT(vkCmdCopyBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdCopyImage);
-	ADD_DVC_ENTRY_POINT(vkCmdBlitImage);
-	ADD_DVC_ENTRY_POINT(vkCmdCopyBufferToImage);
-	ADD_DVC_ENTRY_POINT(vkCmdCopyImageToBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdUpdateBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdFillBuffer);
-	ADD_DVC_ENTRY_POINT(vkCmdClearColorImage);
-	ADD_DVC_ENTRY_POINT(vkCmdClearDepthStencilImage);
-	ADD_DVC_ENTRY_POINT(vkCmdClearAttachments);
-	ADD_DVC_ENTRY_POINT(vkCmdResolveImage);
-	ADD_DVC_ENTRY_POINT(vkCmdSetEvent);
-	ADD_DVC_ENTRY_POINT(vkCmdResetEvent);
-	ADD_DVC_ENTRY_POINT(vkCmdWaitEvents);
-	ADD_DVC_ENTRY_POINT(vkCmdPipelineBarrier);
-	ADD_DVC_ENTRY_POINT(vkCmdBeginQuery);
-	ADD_DVC_ENTRY_POINT(vkCmdEndQuery);
-	ADD_DVC_ENTRY_POINT(vkCmdResetQueryPool);
-	ADD_DVC_ENTRY_POINT(vkCmdWriteTimestamp);
-	ADD_DVC_ENTRY_POINT(vkCmdCopyQueryPoolResults);
-	ADD_DVC_ENTRY_POINT(vkCmdPushConstants);
-	ADD_DVC_ENTRY_POINT(vkCmdBeginRenderPass);
-	ADD_DVC_ENTRY_POINT(vkCmdNextSubpass);
-	ADD_DVC_ENTRY_POINT(vkCmdEndRenderPass);
-	ADD_DVC_ENTRY_POINT(vkCmdExecuteCommands);
+    // Device functions.
+    ADD_DVC_ENTRY_POINT(vkGetDeviceProcAddr);
+    ADD_DVC_ENTRY_POINT(vkDestroyDevice);
+    ADD_DVC_ENTRY_POINT(vkGetDeviceQueue);
+    ADD_DVC_ENTRY_POINT(vkQueueSubmit);
+    ADD_DVC_ENTRY_POINT(vkQueueWaitIdle);
+    ADD_DVC_ENTRY_POINT(vkDeviceWaitIdle);
+    ADD_DVC_ENTRY_POINT(vkAllocateMemory);
+    ADD_DVC_ENTRY_POINT(vkFreeMemory);
+    ADD_DVC_ENTRY_POINT(vkMapMemory);
+    ADD_DVC_ENTRY_POINT(vkUnmapMemory);
+    ADD_DVC_ENTRY_POINT(vkFlushMappedMemoryRanges);
+    ADD_DVC_ENTRY_POINT(vkInvalidateMappedMemoryRanges);
+    ADD_DVC_ENTRY_POINT(vkGetDeviceMemoryCommitment);
+    ADD_DVC_ENTRY_POINT(vkBindBufferMemory);
+    ADD_DVC_ENTRY_POINT(vkBindImageMemory);
+    ADD_DVC_ENTRY_POINT(vkGetBufferMemoryRequirements);
+    ADD_DVC_ENTRY_POINT(vkGetImageMemoryRequirements);
+    ADD_DVC_ENTRY_POINT(vkGetImageSparseMemoryRequirements);
+    ADD_DVC_ENTRY_POINT(vkQueueBindSparse);
+    ADD_DVC_ENTRY_POINT(vkCreateFence);
+    ADD_DVC_ENTRY_POINT(vkDestroyFence);
+    ADD_DVC_ENTRY_POINT(vkResetFences);
+    ADD_DVC_ENTRY_POINT(vkGetFenceStatus);
+    ADD_DVC_ENTRY_POINT(vkWaitForFences);
+    ADD_DVC_ENTRY_POINT(vkCreateSemaphore);
+    ADD_DVC_ENTRY_POINT(vkDestroySemaphore);
+    ADD_DVC_ENTRY_POINT(vkCreateEvent);
+    ADD_DVC_ENTRY_POINT(vkDestroyEvent);
+    ADD_DVC_ENTRY_POINT(vkGetEventStatus);
+    ADD_DVC_ENTRY_POINT(vkSetEvent);
+    ADD_DVC_ENTRY_POINT(vkResetEvent);
+    ADD_DVC_ENTRY_POINT(vkCreateQueryPool);
+    ADD_DVC_ENTRY_POINT(vkDestroyQueryPool);
+    ADD_DVC_ENTRY_POINT(vkGetQueryPoolResults);
+    ADD_DVC_ENTRY_POINT(vkCreateBuffer);
+    ADD_DVC_ENTRY_POINT(vkDestroyBuffer);
+    ADD_DVC_ENTRY_POINT(vkCreateBufferView);
+    ADD_DVC_ENTRY_POINT(vkDestroyBufferView);
+    ADD_DVC_ENTRY_POINT(vkCreateImage);
+    ADD_DVC_ENTRY_POINT(vkDestroyImage);
+    ADD_DVC_ENTRY_POINT(vkGetImageSubresourceLayout);
+    ADD_DVC_ENTRY_POINT(vkCreateImageView);
+    ADD_DVC_ENTRY_POINT(vkDestroyImageView);
+    ADD_DVC_ENTRY_POINT(vkCreateShaderModule);
+    ADD_DVC_ENTRY_POINT(vkDestroyShaderModule);
+    ADD_DVC_ENTRY_POINT(vkCreatePipelineCache);
+    ADD_DVC_ENTRY_POINT(vkDestroyPipelineCache);
+    ADD_DVC_ENTRY_POINT(vkGetPipelineCacheData);
+    ADD_DVC_ENTRY_POINT(vkMergePipelineCaches);
+    ADD_DVC_ENTRY_POINT(vkCreateGraphicsPipelines);
+    ADD_DVC_ENTRY_POINT(vkCreateComputePipelines);
+    ADD_DVC_ENTRY_POINT(vkDestroyPipeline);
+    ADD_DVC_ENTRY_POINT(vkCreatePipelineLayout);
+    ADD_DVC_ENTRY_POINT(vkDestroyPipelineLayout);
+    ADD_DVC_ENTRY_POINT(vkCreateSampler);
+    ADD_DVC_ENTRY_POINT(vkDestroySampler);
+    ADD_DVC_ENTRY_POINT(vkCreateDescriptorSetLayout);
+    ADD_DVC_ENTRY_POINT(vkDestroyDescriptorSetLayout);
+    ADD_DVC_ENTRY_POINT(vkCreateDescriptorPool);
+    ADD_DVC_ENTRY_POINT(vkDestroyDescriptorPool);
+    ADD_DVC_ENTRY_POINT(vkResetDescriptorPool);
+    ADD_DVC_ENTRY_POINT(vkAllocateDescriptorSets);
+    ADD_DVC_ENTRY_POINT(vkFreeDescriptorSets);
+    ADD_DVC_ENTRY_POINT(vkUpdateDescriptorSets);
+    ADD_DVC_ENTRY_POINT(vkCreateFramebuffer);
+    ADD_DVC_ENTRY_POINT(vkDestroyFramebuffer);
+    ADD_DVC_ENTRY_POINT(vkCreateRenderPass);
+    ADD_DVC_ENTRY_POINT(vkDestroyRenderPass);
+    ADD_DVC_ENTRY_POINT(vkGetRenderAreaGranularity);
+    ADD_DVC_ENTRY_POINT(vkCreateCommandPool);
+    ADD_DVC_ENTRY_POINT(vkDestroyCommandPool);
+    ADD_DVC_ENTRY_POINT(vkResetCommandPool);
+    ADD_DVC_ENTRY_POINT(vkAllocateCommandBuffers);
+    ADD_DVC_ENTRY_POINT(vkFreeCommandBuffers);
+    ADD_DVC_ENTRY_POINT(vkBeginCommandBuffer);
+    ADD_DVC_ENTRY_POINT(vkEndCommandBuffer);
+    ADD_DVC_ENTRY_POINT(vkResetCommandBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdBindPipeline);
+    ADD_DVC_ENTRY_POINT(vkCmdSetViewport);
+    ADD_DVC_ENTRY_POINT(vkCmdSetScissor);
+    ADD_DVC_ENTRY_POINT(vkCmdSetLineWidth);
+    ADD_DVC_ENTRY_POINT(vkCmdSetDepthBias);
+    ADD_DVC_ENTRY_POINT(vkCmdSetBlendConstants);
+    ADD_DVC_ENTRY_POINT(vkCmdSetDepthBounds);
+    ADD_DVC_ENTRY_POINT(vkCmdSetStencilCompareMask);
+    ADD_DVC_ENTRY_POINT(vkCmdSetStencilWriteMask);
+    ADD_DVC_ENTRY_POINT(vkCmdSetStencilReference);
+    ADD_DVC_ENTRY_POINT(vkCmdBindDescriptorSets);
+    ADD_DVC_ENTRY_POINT(vkCmdBindIndexBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdBindVertexBuffers);
+    ADD_DVC_ENTRY_POINT(vkCmdDraw);
+    ADD_DVC_ENTRY_POINT(vkCmdDrawIndexed);
+    ADD_DVC_ENTRY_POINT(vkCmdDrawIndirect);
+    ADD_DVC_ENTRY_POINT(vkCmdDrawIndexedIndirect);
+    ADD_DVC_ENTRY_POINT(vkCmdDispatch);
+    ADD_DVC_ENTRY_POINT(vkCmdDispatchIndirect);
+    ADD_DVC_ENTRY_POINT(vkCmdCopyBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdCopyImage);
+    ADD_DVC_ENTRY_POINT(vkCmdBlitImage);
+    ADD_DVC_ENTRY_POINT(vkCmdCopyBufferToImage);
+    ADD_DVC_ENTRY_POINT(vkCmdCopyImageToBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdUpdateBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdFillBuffer);
+    ADD_DVC_ENTRY_POINT(vkCmdClearColorImage);
+    ADD_DVC_ENTRY_POINT(vkCmdClearDepthStencilImage);
+    ADD_DVC_ENTRY_POINT(vkCmdClearAttachments);
+    ADD_DVC_ENTRY_POINT(vkCmdResolveImage);
+    ADD_DVC_ENTRY_POINT(vkCmdSetEvent);
+    ADD_DVC_ENTRY_POINT(vkCmdResetEvent);
+    ADD_DVC_ENTRY_POINT(vkCmdWaitEvents);
+    ADD_DVC_ENTRY_POINT(vkCmdPipelineBarrier);
+    ADD_DVC_ENTRY_POINT(vkCmdBeginQuery);
+    ADD_DVC_ENTRY_POINT(vkCmdEndQuery);
+    ADD_DVC_ENTRY_POINT(vkCmdResetQueryPool);
+    ADD_DVC_ENTRY_POINT(vkCmdWriteTimestamp);
+    ADD_DVC_ENTRY_POINT(vkCmdCopyQueryPoolResults);
+    ADD_DVC_ENTRY_POINT(vkCmdPushConstants);
+    ADD_DVC_ENTRY_POINT(vkCmdBeginRenderPass);
+    ADD_DVC_ENTRY_POINT(vkCmdNextSubpass);
+    ADD_DVC_ENTRY_POINT(vkCmdEndRenderPass);
+    ADD_DVC_ENTRY_POINT(vkCmdExecuteCommands);
 
-	ADD_DVC_1_1_ENTRY_POINT(vkGetDeviceQueue2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindBufferMemory2, KHR_BIND_MEMORY_2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindImageMemory2, KHR_BIND_MEMORY_2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetBufferMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageSparseMemoryRequirements2, KHR_GET_MEMORY_REQUIREMENTS_2);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDeviceGroupPeerMemoryFeatures, KHR_DEVICE_GROUP);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateDescriptorUpdateTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroyDescriptorUpdateTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkUpdateDescriptorSetWithTemplate, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDescriptorSetLayoutSupport, KHR_MAINTENANCE3);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateSamplerYcbcrConversion, KHR_SAMPLER_YCBCR_CONVERSION);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroySamplerYcbcrConversion, KHR_SAMPLER_YCBCR_CONVERSION);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkTrimCommandPool, KHR_MAINTENANCE1);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdSetDeviceMask, KHR_DEVICE_GROUP);
-	ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdDispatchBase, KHR_DEVICE_GROUP);
+    ADD_DVC_1_1_ENTRY_POINT(vkGetDeviceQueue2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindBufferMemory2, KHR_BIND_MEMORY_2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkBindImageMemory2, KHR_BIND_MEMORY_2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetBufferMemoryRequirements2,
+                                     KHR_GET_MEMORY_REQUIREMENTS_2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageMemoryRequirements2,
+                                     KHR_GET_MEMORY_REQUIREMENTS_2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetImageSparseMemoryRequirements2,
+                                     KHR_GET_MEMORY_REQUIREMENTS_2);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDeviceGroupPeerMemoryFeatures,
+                                     KHR_DEVICE_GROUP);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateDescriptorUpdateTemplate,
+                                     KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroyDescriptorUpdateTemplate,
+                                     KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkUpdateDescriptorSetWithTemplate,
+                                     KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkGetDescriptorSetLayoutSupport,
+                                     KHR_MAINTENANCE3);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCreateSamplerYcbcrConversion,
+                                     KHR_SAMPLER_YCBCR_CONVERSION);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkDestroySamplerYcbcrConversion,
+                                     KHR_SAMPLER_YCBCR_CONVERSION);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkTrimCommandPool, KHR_MAINTENANCE1);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdSetDeviceMask, KHR_DEVICE_GROUP);
+    ADD_DVC_1_1_PROMOTED_ENTRY_POINT(vkCmdDispatchBase, KHR_DEVICE_GROUP);
 
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdBeginRenderPass2, KHR, KHR_CREATE_RENDERPASS_2);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdDrawIndexedIndirectCount, KHR, KHR_DRAW_INDIRECT_COUNT);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdDrawIndirectCount, KHR, KHR_DRAW_INDIRECT_COUNT);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdEndRenderPass2, KHR, KHR_CREATE_RENDERPASS_2);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdNextSubpass2, KHR, KHR_CREATE_RENDERPASS_2);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCreateRenderPass2, KHR, KHR_CREATE_RENDERPASS_2);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferDeviceAddress, KHR, KHR_BUFFER_DEVICE_ADDRESS);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferOpaqueCaptureAddress, KHR, KHR_BUFFER_DEVICE_ADDRESS);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetDeviceMemoryOpaqueCaptureAddress, KHR, KHR_BUFFER_DEVICE_ADDRESS);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetSemaphoreCounterValue, KHR, KHR_TIMELINE_SEMAPHORE);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferDeviceAddress, EXT, EXT_BUFFER_DEVICE_ADDRESS);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkResetQueryPool, EXT, EXT_HOST_QUERY_RESET);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkSignalSemaphore, KHR, KHR_TIMELINE_SEMAPHORE);
-	ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkWaitSemaphores, KHR, KHR_TIMELINE_SEMAPHORE);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdBeginRenderPass2, KHR,
+                                     KHR_CREATE_RENDERPASS_2);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdDrawIndexedIndirectCount, KHR,
+                                     KHR_DRAW_INDIRECT_COUNT);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdDrawIndirectCount, KHR,
+                                     KHR_DRAW_INDIRECT_COUNT);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdEndRenderPass2, KHR,
+                                     KHR_CREATE_RENDERPASS_2);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCmdNextSubpass2, KHR,
+                                     KHR_CREATE_RENDERPASS_2);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkCreateRenderPass2, KHR,
+                                     KHR_CREATE_RENDERPASS_2);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferDeviceAddress, KHR,
+                                     KHR_BUFFER_DEVICE_ADDRESS);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferOpaqueCaptureAddress, KHR,
+                                     KHR_BUFFER_DEVICE_ADDRESS);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetDeviceMemoryOpaqueCaptureAddress, KHR,
+                                     KHR_BUFFER_DEVICE_ADDRESS);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetSemaphoreCounterValue, KHR,
+                                     KHR_TIMELINE_SEMAPHORE);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkGetBufferDeviceAddress, EXT,
+                                     EXT_BUFFER_DEVICE_ADDRESS);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkResetQueryPool, EXT,
+                                     EXT_HOST_QUERY_RESET);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkSignalSemaphore, KHR,
+                                     KHR_TIMELINE_SEMAPHORE);
+    ADD_DVC_1_2_PROMOTED_ENTRY_POINT(vkWaitSemaphores, KHR,
+                                     KHR_TIMELINE_SEMAPHORE);
 
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBeginRendering, KHR, KHR_DYNAMIC_RENDERING);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBindVertexBuffers2, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBlitImage2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyBuffer2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyBufferToImage2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyImage2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyImageToBuffer2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdEndRendering, KHR, KHR_DYNAMIC_RENDERING);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdPipelineBarrier2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdResetEvent2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdResolveImage2, KHR, KHR_COPY_COMMANDS_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetCullMode, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthBiasEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthBoundsTestEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthCompareOp, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthTestEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthWriteEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetEvent2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetFrontFace, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetPrimitiveRestartEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetPrimitiveTopology, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetRasterizerDiscardEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetScissorWithCount, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetStencilOp, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetStencilTestEnable, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetViewportWithCount, EXT, EXT_EXTENDED_DYNAMIC_STATE);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdWaitEvents2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdWriteTimestamp2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCreatePrivateDataSlot, EXT, EXT_PRIVATE_DATA);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkDestroyPrivateDataSlot, EXT, EXT_PRIVATE_DATA);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceBufferMemoryRequirements, KHR, KHR_MAINTENANCE_4);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceImageMemoryRequirements, KHR, KHR_MAINTENANCE_4);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceImageSparseMemoryRequirements, KHR, KHR_MAINTENANCE_4);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetPrivateData, EXT, EXT_PRIVATE_DATA);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkQueueSubmit2, KHR, KHR_SYNCHRONIZATION_2);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkSetPrivateData, EXT, EXT_PRIVATE_DATA);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBeginRendering, KHR,
+                                     KHR_DYNAMIC_RENDERING);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBindVertexBuffers2, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdBlitImage2, KHR, KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyBuffer2, KHR,
+                                     KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyBufferToImage2, KHR,
+                                     KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyImage2, KHR, KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdCopyImageToBuffer2, KHR,
+                                     KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdEndRendering, KHR,
+                                     KHR_DYNAMIC_RENDERING);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdPipelineBarrier2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdResetEvent2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdResolveImage2, KHR,
+                                     KHR_COPY_COMMANDS_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetCullMode, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthBiasEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthBoundsTestEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthCompareOp, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthTestEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetDepthWriteEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetEvent2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetFrontFace, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetPrimitiveRestartEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetPrimitiveTopology, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetRasterizerDiscardEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetScissorWithCount, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetStencilOp, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetStencilTestEnable, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdSetViewportWithCount, EXT,
+                                     EXT_EXTENDED_DYNAMIC_STATE);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdWaitEvents2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCmdWriteTimestamp2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkCreatePrivateDataSlot, EXT,
+                                     EXT_PRIVATE_DATA);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkDestroyPrivateDataSlot, EXT,
+                                     EXT_PRIVATE_DATA);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceBufferMemoryRequirements, KHR,
+                                     KHR_MAINTENANCE_4);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceImageMemoryRequirements, KHR,
+                                     KHR_MAINTENANCE_4);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetDeviceImageSparseMemoryRequirements,
+                                     KHR, KHR_MAINTENANCE_4);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetPrivateData, EXT, EXT_PRIVATE_DATA);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkQueueSubmit2, KHR,
+                                     KHR_SYNCHRONIZATION_2);
+    ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkSetPrivateData, EXT, EXT_PRIVATE_DATA);
 
-	// Device extension functions.
-	ADD_DVC_EXT_ENTRY_POINT(vkGetCalibratedTimestampsKHR, KHR_CALIBRATED_TIMESTAMPS);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR, KHR_CALIBRATED_TIMESTAMPS);
-    ADD_DVC_EXT_ENTRY_POINT(vkCreateDeferredOperationKHR, KHR_DEFERRED_HOST_OPERATIONS);
-    ADD_DVC_EXT_ENTRY_POINT(vkDeferredOperationJoinKHR, KHR_DEFERRED_HOST_OPERATIONS);
-    ADD_DVC_EXT_ENTRY_POINT(vkDestroyDeferredOperationKHR, KHR_DEFERRED_HOST_OPERATIONS);
-    ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationMaxConcurrencyKHR, KHR_DEFERRED_HOST_OPERATIONS);
-    ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationResultKHR, KHR_DEFERRED_HOST_OPERATIONS);
-	ADD_DVC_EXT_ENTRY_POINT(vkMapMemory2KHR, KHR_MAP_MEMORY_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkUnmapMemory2KHR, KHR_MAP_MEMORY_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdPushDescriptorSetKHR, KHR_PUSH_DESCRIPTOR);
-	ADD_DVC_EXT2_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplateKHR, 1_1, KHR_PUSH_DESCRIPTOR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
-	ADD_DVC_EXT_ENTRY_POINT(vkCreateSwapchainKHR, KHR_SWAPCHAIN);
-	ADD_DVC_EXT_ENTRY_POINT(vkDestroySwapchainKHR, KHR_SWAPCHAIN);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetSwapchainImagesKHR, KHR_SWAPCHAIN);
-	ADD_DVC_EXT_ENTRY_POINT(vkAcquireNextImageKHR, KHR_SWAPCHAIN);
-	ADD_DVC_EXT_ENTRY_POINT(vkQueuePresentKHR, KHR_SWAPCHAIN);
-	ADD_DVC_EXT2_ENTRY_POINT(vkGetDeviceGroupPresentCapabilitiesKHR, 1_1, KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT2_ENTRY_POINT(vkGetDeviceGroupSurfacePresentModesKHR, 1_1, KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT2_ENTRY_POINT(vkGetPhysicalDevicePresentRectanglesKHR, 1_1, KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT2_ENTRY_POINT(vkAcquireNextImage2KHR, 1_1, KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
-	ADD_DVC_EXT_ENTRY_POINT_ALIAS(vkGetCalibratedTimestampsEXT, vkGetCalibratedTimestampsKHR, EXT_CALIBRATED_TIMESTAMPS);
-	ADD_DVC_EXT_ENTRY_POINT_ALIAS(vkGetPhysicalDeviceCalibrateableTimeDomainsEXT, vkGetPhysicalDeviceCalibrateableTimeDomainsKHR, EXT_CALIBRATED_TIMESTAMPS);
-	ADD_DVC_EXT_ENTRY_POINT(vkDebugMarkerSetObjectTagEXT, EXT_DEBUG_MARKER);
-	ADD_DVC_EXT_ENTRY_POINT(vkDebugMarkerSetObjectNameEXT, EXT_DEBUG_MARKER);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerBeginEXT, EXT_DEBUG_MARKER);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerEndEXT, EXT_DEBUG_MARKER);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerInsertEXT, EXT_DEBUG_MARKER);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetMemoryHostPointerPropertiesEXT, EXT_EXTERNAL_MEMORY_HOST);
-	ADD_DVC_EXT_ENTRY_POINT(vkSetHdrMetadataEXT, EXT_HDR_METADATA);
-	ADD_DVC_EXT_ENTRY_POINT(vkExportMetalObjectsEXT, EXT_METAL_OBJECTS);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetPhysicalDeviceMultisamplePropertiesEXT, EXT_SAMPLE_LOCATIONS);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleLocationsEXT, EXT_SAMPLE_LOCATIONS);
-	ADD_DVC_EXT_ENTRY_POINT(vkReleaseSwapchainImagesEXT, EXT_SWAPCHAIN_MAINTENANCE_1);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetRefreshCycleDurationGOOGLE, GOOGLE_DISPLAY_TIMING);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetPastPresentationTimingGOOGLE, GOOGLE_DISPLAY_TIMING);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLogicOpEXT, EXT_EXTENDED_DYNAMIC_STATE_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetPatchControlPointsEXT, EXT_EXTENDED_DYNAMIC_STATE_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetAlphaToCoverageEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetAlphaToOneEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendAdvancedEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendEquationEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorWriteMaskEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetConservativeRasterizationModeEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClampEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClipEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClipNegativeOneToOneEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetExtraPrimitiveOverestimationSizeEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLineRasterizationModeEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLineStippleEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLogicOpEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetPolygonModeEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetProvokingVertexModeEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetRasterizationSamplesEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetRasterizationStreamEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleLocationsEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleMaskEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetTessellationDomainOriginEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToImageEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToMemoryEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyMemoryToImageEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetImageSubresourceLayout2EXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkTransitionImageLayoutEXT, EXT_HOST_IMAGE_COPY);
+    // Device extension functions.
+    ADD_DVC_EXT_ENTRY_POINT(vkGetCalibratedTimestampsKHR,
+                            KHR_CALIBRATED_TIMESTAMPS);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR,
+                            KHR_CALIBRATED_TIMESTAMPS);
+    ADD_DVC_EXT_ENTRY_POINT(vkCreateDeferredOperationKHR,
+                            KHR_DEFERRED_HOST_OPERATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkDeferredOperationJoinKHR,
+                            KHR_DEFERRED_HOST_OPERATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkDestroyDeferredOperationKHR,
+                            KHR_DEFERRED_HOST_OPERATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationMaxConcurrencyKHR,
+                            KHR_DEFERRED_HOST_OPERATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationResultKHR,
+                            KHR_DEFERRED_HOST_OPERATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkMapMemory2KHR, KHR_MAP_MEMORY_2);
+    ADD_DVC_EXT_ENTRY_POINT(vkUnmapMemory2KHR, KHR_MAP_MEMORY_2);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdPushDescriptorSetKHR, KHR_PUSH_DESCRIPTOR);
+    ADD_DVC_EXT2_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplateKHR, 1_1,
+                             KHR_PUSH_DESCRIPTOR,
+                             KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+    ADD_DVC_EXT_ENTRY_POINT(vkCreateSwapchainKHR, KHR_SWAPCHAIN);
+    ADD_DVC_EXT_ENTRY_POINT(vkDestroySwapchainKHR, KHR_SWAPCHAIN);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetSwapchainImagesKHR, KHR_SWAPCHAIN);
+    ADD_DVC_EXT_ENTRY_POINT(vkAcquireNextImageKHR, KHR_SWAPCHAIN);
+    ADD_DVC_EXT_ENTRY_POINT(vkQueuePresentKHR, KHR_SWAPCHAIN);
+    ADD_DVC_EXT2_ENTRY_POINT(vkGetDeviceGroupPresentCapabilitiesKHR, 1_1,
+                             KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
+    ADD_DVC_EXT2_ENTRY_POINT(vkGetDeviceGroupSurfacePresentModesKHR, 1_1,
+                             KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
+    ADD_DVC_EXT2_ENTRY_POINT(vkGetPhysicalDevicePresentRectanglesKHR, 1_1,
+                             KHR_SWAPCHAIN, KHR_DEVICE_GROUP);
+    ADD_DVC_EXT2_ENTRY_POINT(vkAcquireNextImage2KHR, 1_1, KHR_SWAPCHAIN,
+                             KHR_DEVICE_GROUP);
+    ADD_DVC_EXT_ENTRY_POINT_ALIAS(vkGetCalibratedTimestampsEXT,
+                                  vkGetCalibratedTimestampsKHR,
+                                  EXT_CALIBRATED_TIMESTAMPS);
+    ADD_DVC_EXT_ENTRY_POINT_ALIAS(
+        vkGetPhysicalDeviceCalibrateableTimeDomainsEXT,
+        vkGetPhysicalDeviceCalibrateableTimeDomainsKHR,
+        EXT_CALIBRATED_TIMESTAMPS);
+    ADD_DVC_EXT_ENTRY_POINT(vkDebugMarkerSetObjectTagEXT, EXT_DEBUG_MARKER);
+    ADD_DVC_EXT_ENTRY_POINT(vkDebugMarkerSetObjectNameEXT, EXT_DEBUG_MARKER);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerBeginEXT, EXT_DEBUG_MARKER);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerEndEXT, EXT_DEBUG_MARKER);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdDebugMarkerInsertEXT, EXT_DEBUG_MARKER);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetMemoryHostPointerPropertiesEXT,
+                            EXT_EXTERNAL_MEMORY_HOST);
+    ADD_DVC_EXT_ENTRY_POINT(vkSetHdrMetadataEXT, EXT_HDR_METADATA);
+    ADD_DVC_EXT_ENTRY_POINT(vkExportMetalObjectsEXT, EXT_METAL_OBJECTS);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetPhysicalDeviceMultisamplePropertiesEXT,
+                            EXT_SAMPLE_LOCATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleLocationsEXT, EXT_SAMPLE_LOCATIONS);
+    ADD_DVC_EXT_ENTRY_POINT(vkReleaseSwapchainImagesEXT,
+                            EXT_SWAPCHAIN_MAINTENANCE_1);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetRefreshCycleDurationGOOGLE,
+                            GOOGLE_DISPLAY_TIMING);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetPastPresentationTimingGOOGLE,
+                            GOOGLE_DISPLAY_TIMING);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLogicOpEXT, EXT_EXTENDED_DYNAMIC_STATE_2);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetPatchControlPointsEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_2);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetAlphaToCoverageEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetAlphaToOneEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendAdvancedEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorBlendEquationEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetColorWriteMaskEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetConservativeRasterizationModeEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClampEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClipEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetDepthClipNegativeOneToOneEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetExtraPrimitiveOverestimationSizeEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLineRasterizationModeEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLineStippleEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetLogicOpEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetPolygonModeEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetProvokingVertexModeEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetRasterizationSamplesEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetRasterizationStreamEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleLocationsEnableEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleMaskEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCmdSetTessellationDomainOriginEXT,
+                            EXT_EXTENDED_DYNAMIC_STATE_3);
+    ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToImageEXT, EXT_HOST_IMAGE_COPY);
+    ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToMemoryEXT, EXT_HOST_IMAGE_COPY);
+    ADD_DVC_EXT_ENTRY_POINT(vkCopyMemoryToImageEXT, EXT_HOST_IMAGE_COPY);
+    ADD_DVC_EXT_ENTRY_POINT(vkGetImageSubresourceLayout2EXT,
+                            EXT_HOST_IMAGE_COPY);
+    ADD_DVC_EXT_ENTRY_POINT(vkTransitionImageLayoutEXT, EXT_HOST_IMAGE_COPY);
 }
 
 void MVKInstance::logVersions() {
-	static_assert(string_view(MVK_STRINGIFY(MVK_FRAMEWORK_VERSION)) == MVK_VERSION_STRING, "Xcode build setting CURRENT_PROJECT_VERSION must be identical to the MoltenVK version (MVK_VERSION_STRING).");
+    static_assert(string_view(MVK_STRINGIFY(MVK_FRAMEWORK_VERSION)) ==
+                      MVK_VERSION_STRING,
+                  "Xcode build setting CURRENT_PROJECT_VERSION must be "
+                  "identical to the MoltenVK version "
+                  "(MVK_VERSION_STRING).");
 
-	MVKExtensionList allExtns(this, true);
-	MVKLogInfo("MoltenVK version %s, supporting Vulkan version %s.\n\tThe following %d Vulkan extensions are supported:%s",
-			   MVK_VERSION_STRING,
-			   mvkGetVulkanVersionString(getMVKConfig().apiVersionToAdvertise).c_str(),
-			   allExtns.getEnabledCount(),
-			   allExtns.enabledNamesString("\n\t", true).c_str());
+    MVKExtensionList allExtns(this, true);
+    MVKLogInfo("MoltenVK version %s, supporting Vulkan version %s.\n\tThe "
+               "following %d Vulkan extensions are "
+               "supported:%s",
+               MVK_VERSION_STRING,
+               mvkGetVulkanVersionString(getMVKConfig().apiVersionToAdvertise)
+                   .c_str(),
+               allExtns.getEnabledCount(),
+               allExtns.enabledNamesString("\n\t", true).c_str());
 }
 
 VkResult MVKInstance::verifyLayers(uint32_t count, const char* const* names) {
     VkResult result = VK_SUCCESS;
     for (uint32_t i = 0; i < count; i++) {
-        if ( !getLayerManager()->getLayerNamed(names[i]) ) {
-            result = reportError(VK_ERROR_LAYER_NOT_PRESENT, "Vulkan layer %s is not supported.", names[i]);
+        if (!getLayerManager()->getLayerNamed(names[i])) {
+            result = reportError(VK_ERROR_LAYER_NOT_PRESENT,
+                                 "Vulkan layer %s is not supported.", names[i]);
         }
     }
     return result;
 }
 
 MVKInstance::~MVKInstance() {
-	_useCreationCallbacks = true;
-	mvkDestroyContainerContents(_physicalDevices);
+    _useCreationCallbacks = true;
+    mvkDestroyContainerContents(_physicalDevices);
 
-	// Since this message may invoke debug callbacks, do it before locking callbacks.
-	MVKLogInfo("Destroying VkInstance for Vulkan version %s with %d Vulkan extensions enabled.",
-			   mvkGetVulkanVersionString(_appInfo.apiVersion).c_str(),
-			   _enabledExtensions.getEnabledCount());
+    // Since this message may invoke debug callbacks, do it before locking
+    // callbacks.
+    MVKLogInfo("Destroying VkInstance for Vulkan version %s with %d Vulkan "
+               "extensions enabled.",
+               mvkGetVulkanVersionString(_appInfo.apiVersion).c_str(),
+               _enabledExtensions.getEnabledCount());
 
-	lock_guard<mutex> lock(_dcbLock);
-	mvkDestroyContainerContents(_debugReportCallbacks);
-	mvkDestroyContainerContents(_debugUtilMessengers);
+    lock_guard<mutex> lock(_dcbLock);
+    mvkDestroyContainerContents(_debugReportCallbacks);
+    mvkDestroyContainerContents(_debugUtilMessengers);
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,71 +35,76 @@
 class MVKCommandEncoder;
 class MVKPipelineCache;
 
-
 #pragma mark -
 #pragma mark MVKPipelineLayout
 
 struct MVKShaderImplicitRezBinding {
-	uint32_t stages[kMVKShaderStageCount];
+    uint32_t stages[kMVKShaderStageCount];
 };
 
 /** Represents a Vulkan pipeline layout. */
 class MVKPipelineLayout : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_PIPELINE_LAYOUT;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PIPELINE_LAYOUT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT; }
-
-	/** Binds descriptor sets to a command encoder. */
+    /** Binds descriptor sets to a command encoder. */
     void bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
-							VkPipelineBindPoint pipelineBindPoint,
+                            VkPipelineBindPoint pipelineBindPoint,
                             MVKArrayRef<MVKDescriptorSet*> descriptorSets,
                             uint32_t firstSet,
                             MVKArrayRef<uint32_t> dynamicOffsets);
 
-	/** Updates a descriptor set in a command encoder. */
-	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-						   VkPipelineBindPoint pipelineBindPoint,
-						   MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
-						   uint32_t set);
+    /** Updates a descriptor set in a command encoder. */
+    void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                           VkPipelineBindPoint pipelineBindPoint,
+                           MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
+                           uint32_t set);
 
-	/** Updates a descriptor set from a template in a command encoder. */
-	void pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-						   MVKDescriptorUpdateTemplate* descriptorUpdateTemplate,
-						   uint32_t set,
-						   const void* pData);
+    /** Updates a descriptor set from a template in a command encoder. */
+    void
+    pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
+                      MVKDescriptorUpdateTemplate* descriptorUpdateTemplate,
+                      uint32_t set, const void* pData);
 
-	/** Populates the specified shader conversion config. */
-	void populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig);
+    /** Populates the specified shader conversion config. */
+    void populateShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig);
 
-	/** Returns the descriptor set layout. */
-	MVKDescriptorSetLayout* getDescriptorSetLayout(uint32_t descSetIndex) { return _descriptorSetLayouts[descSetIndex]; }
+    /** Returns the descriptor set layout. */
+    MVKDescriptorSetLayout* getDescriptorSetLayout(uint32_t descSetIndex) {
+        return _descriptorSetLayouts[descSetIndex];
+    }
 
-	/** Returns a text description of this layout. */
-	std::string getLogDescription(std::string indent = "");
+    /** Returns a text description of this layout. */
+    std::string getLogDescription(std::string indent = "");
 
-	/** Constructs an instance for the specified device. */
-	MVKPipelineLayout(MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo);
+    /** Constructs an instance for the specified device. */
+    MVKPipelineLayout(MVKDevice* device,
+                      const VkPipelineLayoutCreateInfo* pCreateInfo);
 
-	~MVKPipelineLayout() override;
+    ~MVKPipelineLayout() override;
 
-protected:
-	friend class MVKPipeline;
+  protected:
+    friend class MVKPipeline;
 
-	void propagateDebugName() override {}
-	bool stageUsesPushConstants(MVKShaderStage mvkStage);
+    void propagateDebugName() override {}
+    bool stageUsesPushConstants(MVKShaderStage mvkStage);
 
-	MVKSmallVector<MVKDescriptorSetLayout*, 1> _descriptorSetLayouts;
-	MVKSmallVector<MVKShaderResourceBinding, 1> _dslMTLResourceIndexOffsets;
-	MVKSmallVector<VkPushConstantRange> _pushConstants;
-	MVKShaderResourceBinding _mtlResourceCounts;
-	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
+    MVKSmallVector<MVKDescriptorSetLayout*, 1> _descriptorSetLayouts;
+    MVKSmallVector<MVKShaderResourceBinding, 1> _dslMTLResourceIndexOffsets;
+    MVKSmallVector<VkPushConstantRange> _pushConstants;
+    MVKShaderResourceBinding _mtlResourceCounts;
+    MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
 };
-
 
 #pragma mark -
 #pragma mark MVKPipeline
@@ -115,86 +120,99 @@ static const uint32_t kMVKTessEvalLevelBufferBinding = 2;
 /** Represents an abstract Vulkan pipeline. */
 class MVKPipeline : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PIPELINE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PIPELINE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT; }
+    /** Called when the pipeline has been bound to the command encoder. */
+    virtual void wasBound(MVKCommandEncoder* cmdEncoder) {}
 
-	/** Called when the pipeline has been bound to the command encoder. */
-	virtual void wasBound(MVKCommandEncoder* cmdEncoder) {}
+    /** Encodes this pipeline to the command encoder. */
+    virtual void encode(MVKCommandEncoder* cmdEncoder, uint32_t stage = 0) = 0;
 
-	/** Encodes this pipeline to the command encoder. */
-	virtual void encode(MVKCommandEncoder* cmdEncoder, uint32_t stage = 0) = 0;
+    /** Binds the push constants to a command encoder. */
+    void bindPushConstants(MVKCommandEncoder* cmdEncoder);
 
-	/** Binds the push constants to a command encoder. */
-	void bindPushConstants(MVKCommandEncoder* cmdEncoder);
+    /** Returns the current indirect parameter buffer bindings. */
+    const MVKShaderImplicitRezBinding& getIndirectParamsIndex() {
+        return _indirectParamsIndex;
+    }
 
-	/** Returns the current indirect parameter buffer bindings. */
-	const MVKShaderImplicitRezBinding& getIndirectParamsIndex() { return _indirectParamsIndex; }
+    /** Returns whether or not full image view swizzling is enabled for this
+     * pipeline. */
+    bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
 
-	/** Returns whether or not full image view swizzling is enabled for this pipeline. */
-	bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
+    /** Returns whether all internal Metal pipeline states are valid. */
+    bool hasValidMTLPipelineStates() { return _hasValidMTLPipelineStates; }
 
-	/** Returns whether all internal Metal pipeline states are valid. */
-	bool hasValidMTLPipelineStates() { return _hasValidMTLPipelineStates; }
+    /** Returns the array of descriptor binding use for the descriptor set. */
+    virtual MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex,
+                                                 MVKShaderStage stage) = 0;
 
-	/** Returns the array of descriptor binding use for the descriptor set. */
-	virtual MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex, MVKShaderStage stage) = 0;
+    /** Returns the number of descriptor sets in this pipeline layout. */
+    uint32_t getDescriptorSetCount() { return _descriptorSetCount; }
 
-	/** Returns the number of descriptor sets in this pipeline layout. */
-	uint32_t getDescriptorSetCount() { return _descriptorSetCount; }
+    /** Returns the pipeline cache used by this pipeline. */
+    MVKPipelineCache* getPipelineCache() { return _pipelineCache; }
 
-	/** Returns the pipeline cache used by this pipeline. */
-	MVKPipelineCache* getPipelineCache() { return _pipelineCache; }
+    /** Returns whether the pipeline creation fail if a pipeline compile is
+     * required. */
+    bool shouldFailOnPipelineCompileRequired() {
+        return (getEnabledPipelineCreationCacheControlFeatures()
+                    .pipelineCreationCacheControl &&
+                mvkIsAnyFlagEnabled(
+                    _flags,
+                    VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT));
+    }
 
-	/** Returns whether the pipeline creation fail if a pipeline compile is required. */
-	bool shouldFailOnPipelineCompileRequired() {
-		return (getEnabledPipelineCreationCacheControlFeatures().pipelineCreationCacheControl &&
-				mvkIsAnyFlagEnabled(_flags, VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT));
-	}
+    /** Returns whether the shader for the stage uses physical storage buffer
+     * addresses. */
+    virtual bool
+    usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) = 0;
 
-	/** Returns whether the shader for the stage uses physical storage buffer addresses. */
-	virtual bool usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) = 0;
+    /** Constructs an instance for the device. layout, and parent (which may be
+     * NULL). */
+    MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache,
+                MVKPipelineLayout* layout, VkPipelineCreateFlags flags,
+                MVKPipeline* parent);
 
-	/** Constructs an instance for the device. layout, and parent (which may be NULL). */
-	MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipelineLayout* layout,
-				VkPipelineCreateFlags flags, MVKPipeline* parent);
+  protected:
+    void propagateDebugName() override {}
+    template <typename CreateInfo>
+    void populateDescriptorSetBindingUse(
+        MVKMTLFunction& mvkMTLFunc, const CreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        MVKShaderStage stage);
 
-protected:
-	void propagateDebugName() override {}
-	template<typename CreateInfo> void populateDescriptorSetBindingUse(MVKMTLFunction& mvkMTLFunc,
-																	   const CreateInfo* pCreateInfo,
-                                     mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-																	   MVKShaderStage stage);
-
-	MVKPipelineCache* _pipelineCache;
-	MVKShaderImplicitRezBinding _descriptorBufferCounts;
-	MVKShaderImplicitRezBinding _swizzleBufferIndex;
-	MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
-	MVKShaderImplicitRezBinding _dynamicOffsetBufferIndex;
-	MVKShaderImplicitRezBinding _indirectParamsIndex;
-	MVKShaderImplicitRezBinding _pushConstantsBufferIndex;
-	VkPipelineCreateFlags _flags;
-	uint32_t _descriptorSetCount;
-	bool _stageUsesPushConstants[kMVKShaderStageCount];
-	bool _fullImageViewSwizzle;
-	bool _hasValidMTLPipelineStates = true;
-
+    MVKPipelineCache* _pipelineCache;
+    MVKShaderImplicitRezBinding _descriptorBufferCounts;
+    MVKShaderImplicitRezBinding _swizzleBufferIndex;
+    MVKShaderImplicitRezBinding _bufferSizeBufferIndex;
+    MVKShaderImplicitRezBinding _dynamicOffsetBufferIndex;
+    MVKShaderImplicitRezBinding _indirectParamsIndex;
+    MVKShaderImplicitRezBinding _pushConstantsBufferIndex;
+    VkPipelineCreateFlags _flags;
+    uint32_t _descriptorSetCount;
+    bool _stageUsesPushConstants[kMVKShaderStageCount];
+    bool _fullImageViewSwizzle;
+    bool _hasValidMTLPipelineStates = true;
 };
-
 
 #pragma mark -
 #pragma mark MVKGraphicsPipeline
 
-/** Describes a buffer binding to accommodate vertex attributes with offsets greater than the stride. */
+/** Describes a buffer binding to accommodate vertex attributes with offsets
+ * greater than the stride. */
 struct MVKTranslatedVertexBinding {
-	uint16_t binding;
-	uint16_t translationBinding;
-	uint32_t translationOffset;
-	uint32_t mappedAttributeCount;
+    uint16_t binding;
+    uint16_t translationBinding;
+    uint32_t translationOffset;
+    uint32_t mappedAttributeCount;
 };
 
 /** Describes a vertex buffer binding whose divisor is zero. */
@@ -203,73 +221,92 @@ typedef std::pair<uint32_t, uint32_t> MVKZeroDivisorVertexBinding;
 typedef MVKSmallVector<MVKGraphicsStage, 4> MVKPiplineStages;
 
 struct MVKStagedDescriptorBindingUse {
-	MVKBitArray stages[4] = {};
+    MVKBitArray stages[4] = {};
 };
 
 /** Enumeration identifying different state content types. */
 enum MVKRenderStateType {
-	Unknown = 0,
-	BlendConstants,
-	CullMode,
-	DepthBias,
-	DepthBiasEnable,
-	DepthBounds,
-	DepthBoundsTestEnable,
-	DepthClipEnable,
-	DepthCompareOp,
-	DepthTestEnable,
-	DepthWriteEnable,
-	FrontFace,
-	LineWidth,
-	LogicOp,
-	LogicOpEnable,
-	PatchControlPoints,
-	PolygonMode,
-	PrimitiveRestartEnable,
-	PrimitiveTopology,
-	RasterizerDiscardEnable,
-	SampleLocations,
-	SampleLocationsEnable,
-	Scissors,
-	StencilCompareMask,
-	StencilOp,
-	StencilReference,
-	StencilTestEnable,
-	StencilWriteMask,
-	VertexStride,
-	Viewports,
-	MVKRenderStateTypeCount
+    Unknown = 0,
+    BlendConstants,
+    CullMode,
+    DepthBias,
+    DepthBiasEnable,
+    DepthBounds,
+    DepthBoundsTestEnable,
+    DepthClipEnable,
+    DepthCompareOp,
+    DepthTestEnable,
+    DepthWriteEnable,
+    FrontFace,
+    LineWidth,
+    LogicOp,
+    LogicOpEnable,
+    PatchControlPoints,
+    PolygonMode,
+    PrimitiveRestartEnable,
+    PrimitiveTopology,
+    RasterizerDiscardEnable,
+    SampleLocations,
+    SampleLocationsEnable,
+    Scissors,
+    StencilCompareMask,
+    StencilOp,
+    StencilReference,
+    StencilTestEnable,
+    StencilWriteMask,
+    VertexStride,
+    Viewports,
+    MVKRenderStateTypeCount
 };
 
 /** Boolean tracking of rendering state. */
 struct MVKRenderStateFlags {
-	void enable(MVKRenderStateType rs) { if (rs) { mvkEnableFlags(_stateFlags, getFlagMask(rs)); } }
-	void disable(MVKRenderStateType rs) { if (rs) { mvkDisableFlags(_stateFlags, getFlagMask(rs)); } }
-	void set(MVKRenderStateType rs, bool val) { val? enable(rs) : disable(rs); }
-	void enableAll() { mvkEnableAllFlags(_stateFlags); }
-	void disableAll() { mvkDisableAllFlags(_stateFlags); }
-	bool isEnabled(MVKRenderStateType rs) { return mvkIsAnyFlagEnabled(_stateFlags, getFlagMask(rs)); }
-protected:
-	uint32_t getFlagMask(MVKRenderStateType rs) { return rs ? (1u << (rs - 1u)) : 0; }	 // Ignore Unknown type
-	
-	uint32_t _stateFlags = 0;
-	static_assert(sizeof(_stateFlags) * 8 >= MVKRenderStateTypeCount - 1, "_stateFlags is too small to support the number of flags in MVKRenderStateType."); // Ignore Unknown type
+    void enable(MVKRenderStateType rs) {
+        if (rs) {
+            mvkEnableFlags(_stateFlags, getFlagMask(rs));
+        }
+    }
+    void disable(MVKRenderStateType rs) {
+        if (rs) {
+            mvkDisableFlags(_stateFlags, getFlagMask(rs));
+        }
+    }
+    void set(MVKRenderStateType rs, bool val) {
+        val ? enable(rs) : disable(rs);
+    }
+    void enableAll() { mvkEnableAllFlags(_stateFlags); }
+    void disableAll() { mvkDisableAllFlags(_stateFlags); }
+    bool isEnabled(MVKRenderStateType rs) {
+        return mvkIsAnyFlagEnabled(_stateFlags, getFlagMask(rs));
+    }
+
+  protected:
+    uint32_t getFlagMask(MVKRenderStateType rs) {
+        return rs ? (1u << (rs - 1u)) : 0;
+    } // Ignore Unknown type
+
+    uint32_t _stateFlags = 0;
+    static_assert(sizeof(_stateFlags) * 8 >= MVKRenderStateTypeCount - 1,
+                  "_stateFlags is too small to support the number of flags in "
+                  "MVKRenderStateType."); // Ignore Unknown type
 };
 
 /** Represents an Vulkan graphics pipeline. */
 class MVKGraphicsPipeline : public MVKPipeline {
 
-public:
+  public:
+    /** Returns the number and order of stages in this pipeline. Draws commands
+     * must encode this pipeline once per stage. */
+    void getStages(MVKPiplineStages& stages);
 
-	/** Returns the number and order of stages in this pipeline. Draws commands must encode this pipeline once per stage. */
-	void getStages(MVKPiplineStages& stages);
+    virtual void wasBound(MVKCommandEncoder* cmdEncoder) override;
 
-	virtual void wasBound(MVKCommandEncoder* cmdEncoder) override;
-
-	void encode(MVKCommandEncoder* cmdEncoder, uint32_t stage = 0) override;
+    void encode(MVKCommandEncoder* cmdEncoder, uint32_t stage = 0) override;
 
     /** Returns whether this pipeline permits dynamic setting of the state. */
-	bool isDynamicState(MVKRenderStateType state) { return _dynamicState.isEnabled(state); }
+    bool isDynamicState(MVKRenderStateType state) {
+        return _dynamicState.isEnabled(state);
+    }
 
     /** Returns whether this pipeline has tessellation shaders. */
     bool isTessellationPipeline() { return _isTessellationPipeline; }
@@ -277,168 +314,316 @@ public:
     /** Returns the number of output tessellation patch control points. */
     uint32_t getOutputControlPointCount() { return _outputControlPointCount; }
 
-	/** Returns the current captured output buffer bindings. */
-	const MVKShaderImplicitRezBinding& getOutputBufferIndex() { return _outputBufferIndex; }
+    /** Returns the current captured output buffer bindings. */
+    const MVKShaderImplicitRezBinding& getOutputBufferIndex() {
+        return _outputBufferIndex;
+    }
 
-	/** Returns the current captured per-patch output buffer binding for the tess. control shader. */
-	uint32_t getTessCtlPatchOutputBufferIndex() { return _tessCtlPatchOutputBufferIndex; }
+    /** Returns the current captured per-patch output buffer binding for the
+     * tess. control shader. */
+    uint32_t getTessCtlPatchOutputBufferIndex() {
+        return _tessCtlPatchOutputBufferIndex;
+    }
 
-	/** Returns the current tessellation level buffer binding for the tess. control shader. */
-	uint32_t getTessCtlLevelBufferIndex() { return _tessCtlLevelBufferIndex; }
+    /** Returns the current tessellation level buffer binding for the tess.
+     * control shader. */
+    uint32_t getTessCtlLevelBufferIndex() { return _tessCtlLevelBufferIndex; }
 
-	/** Returns the MTLComputePipelineState object for the vertex stage of a tessellated draw with no indices. */
-	id<MTLComputePipelineState> getTessVertexStageState() { return _mtlTessVertexStageState; }
+    /** Returns the MTLComputePipelineState object for the vertex stage of a
+     * tessellated draw with no indices. */
+    id<MTLComputePipelineState> getTessVertexStageState() {
+        return _mtlTessVertexStageState;
+    }
 
-	/** Returns the MTLComputePipelineState object for the vertex stage of a tessellated draw with 16-bit indices. */
-	id<MTLComputePipelineState> getTessVertexStageIndex16State() { return _mtlTessVertexStageIndex16State; }
+    /** Returns the MTLComputePipelineState object for the vertex stage of a
+     * tessellated draw with 16-bit indices. */
+    id<MTLComputePipelineState> getTessVertexStageIndex16State() {
+        return _mtlTessVertexStageIndex16State;
+    }
 
-	/** Returns the MTLComputePipelineState object for the vertex stage of a tessellated draw with 32-bit indices. */
-	id<MTLComputePipelineState> getTessVertexStageIndex32State() { return _mtlTessVertexStageIndex32State; }
+    /** Returns the MTLComputePipelineState object for the vertex stage of a
+     * tessellated draw with 32-bit indices. */
+    id<MTLComputePipelineState> getTessVertexStageIndex32State() {
+        return _mtlTessVertexStageIndex32State;
+    }
 
-	/** Returns the MTLComputePipelineState object for the tessellation control stage of a tessellated draw. */
-	id<MTLComputePipelineState> getTessControlStageState() { return _mtlTessControlStageState; }
+    /** Returns the MTLComputePipelineState object for the tessellation control
+     * stage of a tessellated draw. */
+    id<MTLComputePipelineState> getTessControlStageState() {
+        return _mtlTessControlStageState;
+    }
 
-	/** Returns true if the vertex shader needs a buffer to store its output. */
-	bool needsVertexOutputBuffer() { return _needsVertexOutputBuffer; }
+    /** Returns true if the vertex shader needs a buffer to store its output. */
+    bool needsVertexOutputBuffer() { return _needsVertexOutputBuffer; }
 
-	/** Returns true if the tessellation control shader needs a buffer to store its per-vertex output. */
-	bool needsTessCtlOutputBuffer() { return _needsTessCtlOutputBuffer; }
+    /** Returns true if the tessellation control shader needs a buffer to store
+     * its per-vertex output. */
+    bool needsTessCtlOutputBuffer() { return _needsTessCtlOutputBuffer; }
 
-	/** Returns true if the tessellation control shader needs a buffer to store its per-patch output. */
-	bool needsTessCtlPatchOutputBuffer() { return _needsTessCtlPatchOutputBuffer; }
+    /** Returns true if the tessellation control shader needs a buffer to store
+     * its per-patch output. */
+    bool needsTessCtlPatchOutputBuffer() {
+        return _needsTessCtlPatchOutputBuffer;
+    }
 
-	/** Returns the Vulkan primitive topology. */
-	VkPrimitiveTopology getVkPrimitiveTopology() { return _vkPrimitiveTopology; }
+    /** Returns the Vulkan primitive topology. */
+    VkPrimitiveTopology getVkPrimitiveTopology() {
+        return _vkPrimitiveTopology;
+    }
 
-	bool usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) override;
+    bool
+    usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) override;
 
-	/**
-	 * Returns whether the MTLBuffer vertex shader buffer index is valid for a stage of this pipeline.
-	 * It is if it is a descriptor binding within the descriptor binding range,
-	 * or a vertex attribute binding above any implicit buffer bindings.
-	 */
-	bool isValidVertexBufferIndex(MVKShaderStage stage, uint32_t mtlBufferIndex);
+    /**
+     * Returns whether the MTLBuffer vertex shader buffer index is valid for a
+     * stage of this pipeline. It is if it is a descriptor binding within the
+     * descriptor binding range, or a vertex attribute binding above any
+     * implicit buffer bindings.
+     */
+    bool isValidVertexBufferIndex(MVKShaderStage stage,
+                                  uint32_t mtlBufferIndex);
 
-	/** Returns the Metal vertex buffer index to use for the specified vertex attribute binding number.  */
-	uint32_t getMetalBufferIndexForVertexAttributeBinding(uint32_t binding) { return _device->getMetalBufferIndexForVertexAttributeBinding(binding); }
+    /** Returns the Metal vertex buffer index to use for the specified vertex
+     * attribute binding number.  */
+    uint32_t getMetalBufferIndexForVertexAttributeBinding(uint32_t binding) {
+        return _device->getMetalBufferIndexForVertexAttributeBinding(binding);
+    }
 
-	/** Returns the collection of translated vertex bindings. */
-	MVKArrayRef<MVKTranslatedVertexBinding> getTranslatedVertexBindings() { return _translatedVertexBindings.contents(); }
+    /** Returns the collection of translated vertex bindings. */
+    MVKArrayRef<MVKTranslatedVertexBinding> getTranslatedVertexBindings() {
+        return _translatedVertexBindings.contents();
+    }
 
-	/** Returns the collection of instance-rate vertex bindings whose divisor is zero, along with their strides. */
-	MVKArrayRef<MVKZeroDivisorVertexBinding> getZeroDivisorVertexBindings() { return _zeroDivisorVertexBindings.contents(); }
+    /** Returns the collection of instance-rate vertex bindings whose divisor is
+     * zero, along with their strides. */
+    MVKArrayRef<MVKZeroDivisorVertexBinding> getZeroDivisorVertexBindings() {
+        return _zeroDivisorVertexBindings.contents();
+    }
 
-	/** Returns the array of descriptor binding use for the descriptor set. */
-	MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex, MVKShaderStage stage) override { return _descriptorBindingUse[descSetIndex].stages[stage]; }
+    /** Returns the array of descriptor binding use for the descriptor set. */
+    MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex,
+                                         MVKShaderStage stage) override {
+        return _descriptorBindingUse[descSetIndex].stages[stage];
+    }
 
-	/** Constructs an instance for the device and parent (which may be NULL). */
-	MVKGraphicsPipeline(MVKDevice* device,
-						MVKPipelineCache* pipelineCache,
-						MVKPipeline* parent,
-						const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    /** Constructs an instance for the device and parent (which may be NULL). */
+    MVKGraphicsPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache,
+                        MVKPipeline* parent,
+                        const VkGraphicsPipelineCreateInfo* pCreateInfo);
 
-	~MVKGraphicsPipeline() override;
+    ~MVKGraphicsPipeline() override;
 
-protected:
-	typedef MVKSmallVector<mvk::SPIRVShaderInterfaceVariable, 32> SPIRVShaderOutputs;
-	typedef MVKSmallVector<mvk::SPIRVShaderInterfaceVariable, 32> SPIRVShaderInputs;
+  protected:
+    typedef MVKSmallVector<mvk::SPIRVShaderInterfaceVariable, 32>
+        SPIRVShaderOutputs;
+    typedef MVKSmallVector<mvk::SPIRVShaderInterfaceVariable, 32>
+        SPIRVShaderInputs;
 
-    id<MTLRenderPipelineState> getOrCompilePipeline(MTLRenderPipelineDescriptor* plDesc, id<MTLRenderPipelineState>& plState);
-    id<MTLComputePipelineState> getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc, id<MTLComputePipelineState>& plState, const char* compilerType);
-	bool compileTessVertexStageState(MTLComputePipelineDescriptor* vtxPLDesc, MVKMTLFunction* pVtxFunctions, VkPipelineCreationFeedback* pVertexFB);
-	bool compileTessControlStageState(MTLComputePipelineDescriptor* tcPLDesc, VkPipelineCreationFeedback* pTessCtlFB);
-	void initDynamicState(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-	void initSampleLocations(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-    void initMTLRenderPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData, VkPipelineCreationFeedback* pPipelineFB, const VkPipelineShaderStageCreateInfo* pVertexSS, VkPipelineCreationFeedback* pVertexFB, const VkPipelineShaderStageCreateInfo* pTessCtlSS, VkPipelineCreationFeedback* pTessCtlFB, const VkPipelineShaderStageCreateInfo* pTessEvalSS, VkPipelineCreationFeedback* pTessEvalFB, const VkPipelineShaderStageCreateInfo* pFragmentSS, VkPipelineCreationFeedback* pFragmentFB);
-    void initShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData);
-	void initReservedVertexAttributeBufferCount(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-    void addVertexInputToShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkGraphicsPipelineCreateInfo* pCreateInfo);
-    void addNextStageInputToShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderInputs& inputs);
-    void addPrevStageOutputToShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& outputs);
-    MTLRenderPipelineDescriptor* newMTLRenderPipelineDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData, const VkPipelineShaderStageCreateInfo* pVertexSS, VkPipelineCreationFeedback* pVertexFB, const VkPipelineShaderStageCreateInfo* pFragmentSS, VkPipelineCreationFeedback* pFragmentFB);
-    MTLComputePipelineDescriptor* newMTLTessVertexStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkPipelineShaderStageCreateInfo* pVertexSS, VkPipelineCreationFeedback* pVertexFB, const VkPipelineShaderStageCreateInfo* pTessCtlSS, MVKMTLFunction* pVtxFunctions);
-	MTLComputePipelineDescriptor* newMTLTessControlStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkPipelineShaderStageCreateInfo* pTessCtlSS, VkPipelineCreationFeedback* pTessCtlFB, const VkPipelineShaderStageCreateInfo* pVertexSS, const VkPipelineShaderStageCreateInfo* pTessEvalSS);
-	MTLRenderPipelineDescriptor* newMTLTessRasterStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo, const mvk::SPIRVTessReflectionData& reflectData, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkPipelineShaderStageCreateInfo* pTessEvalSS, VkPipelineCreationFeedback* pTessEvalFB, const VkPipelineShaderStageCreateInfo* pFragmentSS, VkPipelineCreationFeedback* pFragmentFB, const VkPipelineShaderStageCreateInfo* pTessCtlSS);
-	bool addVertexShaderToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const VkPipelineShaderStageCreateInfo* pVertexSS, VkPipelineCreationFeedback* pVertexFB, const VkPipelineShaderStageCreateInfo*& pFragmentSS);
-	bool addVertexShaderToPipeline(MTLComputePipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderInputs& nextInputs, const VkPipelineShaderStageCreateInfo* pVertexSS, VkPipelineCreationFeedback* pVertexFB, MVKMTLFunction* pVtxFunctions);
-	bool addTessCtlShaderToPipeline(MTLComputePipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& prevOutput, SPIRVShaderInputs& nextInputs, const VkPipelineShaderStageCreateInfo* pTessCtlSS, VkPipelineCreationFeedback* pTessCtlFB);
-	bool addTessEvalShaderToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& prevOutput, const VkPipelineShaderStageCreateInfo* pTessEvalSS, VkPipelineCreationFeedback* pTessEvalFB, const VkPipelineShaderStageCreateInfo*& pFragmentSS);
-    bool addFragmentShaderToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& prevOutput, const VkPipelineShaderStageCreateInfo* pFragmentSS, VkPipelineCreationFeedback* pFragmentFB);
-	template<class T>
-	bool addVertexInputToPipeline(T* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, const mvk::SPIRVToMSLConversionConfiguration& shaderConfig);
-	void adjustVertexInputForMultiview(MTLVertexDescriptor* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, uint32_t viewCount, uint32_t oldViewCount = 1);
-    void addTessellationToPipeline(MTLRenderPipelineDescriptor* plDesc, const mvk::SPIRVTessReflectionData& reflectData, const VkPipelineTessellationStateCreateInfo* pTS);
-    void addFragmentOutputToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    id<MTLRenderPipelineState>
+    getOrCompilePipeline(MTLRenderPipelineDescriptor* plDesc,
+                         id<MTLRenderPipelineState>& plState);
+    id<MTLComputePipelineState>
+    getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc,
+                         id<MTLComputePipelineState>& plState,
+                         const char* compilerType);
+    bool compileTessVertexStageState(MTLComputePipelineDescriptor* vtxPLDesc,
+                                     MVKMTLFunction* pVtxFunctions,
+                                     VkPipelineCreationFeedback* pVertexFB);
+    bool compileTessControlStageState(MTLComputePipelineDescriptor* tcPLDesc,
+                                      VkPipelineCreationFeedback* pTessCtlFB);
+    void initDynamicState(const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    void initSampleLocations(const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    void initMTLRenderPipelineState(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData,
+        VkPipelineCreationFeedback* pPipelineFB,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        VkPipelineCreationFeedback* pVertexFB,
+        const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+        VkPipelineCreationFeedback* pTessCtlFB,
+        const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+        VkPipelineCreationFeedback* pTessEvalFB,
+        const VkPipelineShaderStageCreateInfo* pFragmentSS,
+        VkPipelineCreationFeedback* pFragmentFB);
+    void initShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData);
+    void initReservedVertexAttributeBufferCount(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    void addVertexInputToShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    void addNextStageInputToShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderInputs& inputs);
+    void addPrevStageOutputToShaderConversionConfig(
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderOutputs& outputs);
+    MTLRenderPipelineDescriptor* newMTLRenderPipelineDescriptor(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        VkPipelineCreationFeedback* pVertexFB,
+        const VkPipelineShaderStageCreateInfo* pFragmentSS,
+        VkPipelineCreationFeedback* pFragmentFB);
+    MTLComputePipelineDescriptor* newMTLTessVertexStageDescriptor(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        VkPipelineCreationFeedback* pVertexFB,
+        const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+        MVKMTLFunction* pVtxFunctions);
+    MTLComputePipelineDescriptor* newMTLTessControlStageDescriptor(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+        VkPipelineCreationFeedback* pTessCtlFB,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        const VkPipelineShaderStageCreateInfo* pTessEvalSS);
+    MTLRenderPipelineDescriptor* newMTLTessRasterStageDescriptor(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        const mvk::SPIRVTessReflectionData& reflectData,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+        VkPipelineCreationFeedback* pTessEvalFB,
+        const VkPipelineShaderStageCreateInfo* pFragmentSS,
+        VkPipelineCreationFeedback* pFragmentFB,
+        const VkPipelineShaderStageCreateInfo* pTessCtlSS);
+    bool addVertexShaderToPipeline(
+        MTLRenderPipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        VkPipelineCreationFeedback* pVertexFB,
+        const VkPipelineShaderStageCreateInfo*& pFragmentSS);
+    bool addVertexShaderToPipeline(
+        MTLComputePipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderInputs& nextInputs,
+        const VkPipelineShaderStageCreateInfo* pVertexSS,
+        VkPipelineCreationFeedback* pVertexFB, MVKMTLFunction* pVtxFunctions);
+    bool addTessCtlShaderToPipeline(
+        MTLComputePipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderOutputs& prevOutput, SPIRVShaderInputs& nextInputs,
+        const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+        VkPipelineCreationFeedback* pTessCtlFB);
+    bool addTessEvalShaderToPipeline(
+        MTLRenderPipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderOutputs& prevOutput,
+        const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+        VkPipelineCreationFeedback* pTessEvalFB,
+        const VkPipelineShaderStageCreateInfo*& pFragmentSS);
+    bool addFragmentShaderToPipeline(
+        MTLRenderPipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo,
+        mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+        SPIRVShaderOutputs& prevOutput,
+        const VkPipelineShaderStageCreateInfo* pFragmentSS,
+        VkPipelineCreationFeedback* pFragmentFB);
+    template <class T>
+    bool addVertexInputToPipeline(
+        T* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI,
+        const mvk::SPIRVToMSLConversionConfiguration& shaderConfig);
+    void adjustVertexInputForMultiview(
+        MTLVertexDescriptor* inputDesc,
+        const VkPipelineVertexInputStateCreateInfo* pVI, uint32_t viewCount,
+        uint32_t oldViewCount = 1);
+    void
+    addTessellationToPipeline(MTLRenderPipelineDescriptor* plDesc,
+                              const mvk::SPIRVTessReflectionData& reflectData,
+                              const VkPipelineTessellationStateCreateInfo* pTS);
+    void addFragmentOutputToPipeline(
+        MTLRenderPipelineDescriptor* plDesc,
+        const VkGraphicsPipelineCreateInfo* pCreateInfo);
     bool isRenderingPoints(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-    bool isRasterizationDisabled(const VkGraphicsPipelineCreateInfo* pCreateInfo);
-	bool verifyImplicitBuffer(bool needsBuffer, MVKShaderImplicitRezBinding& index, MVKShaderStage stage, const char* name);
-	uint32_t getTranslatedVertexBinding(uint32_t binding, uint32_t translationOffset, uint32_t maxBinding);
-	uint32_t getImplicitBufferIndex(MVKShaderStage stage, uint32_t bufferIndexOffset);
-	MVKMTLFunction getMTLFunction(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
-								  const VkPipelineShaderStageCreateInfo* pShaderStage,
-								  VkPipelineCreationFeedback* pStageFB,
-								  const char* pStageName);
-	void markIfUsingPhysicalStorageBufferAddressesCapability(mvk::SPIRVToMSLConversionResultInfo& resultsInfo,
-															 MVKShaderStage stage);
+    bool
+    isRasterizationDisabled(const VkGraphicsPipelineCreateInfo* pCreateInfo);
+    bool verifyImplicitBuffer(bool needsBuffer,
+                              MVKShaderImplicitRezBinding& index,
+                              MVKShaderStage stage, const char* name);
+    uint32_t getTranslatedVertexBinding(uint32_t binding,
+                                        uint32_t translationOffset,
+                                        uint32_t maxBinding);
+    uint32_t getImplicitBufferIndex(MVKShaderStage stage,
+                                    uint32_t bufferIndexOffset);
+    MVKMTLFunction
+    getMTLFunction(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
+                   const VkPipelineShaderStageCreateInfo* pShaderStage,
+                   VkPipelineCreationFeedback* pStageFB,
+                   const char* pStageName);
+    void markIfUsingPhysicalStorageBufferAddressesCapability(
+        mvk::SPIRVToMSLConversionResultInfo& resultsInfo, MVKShaderStage stage);
 
-	VkPipelineTessellationStateCreateInfo _tessInfo;
-	VkPipelineRasterizationStateCreateInfo _rasterInfo;
-	VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
-	MVKRenderStateFlags _dynamicState;
+    VkPipelineTessellationStateCreateInfo _tessInfo;
+    VkPipelineRasterizationStateCreateInfo _rasterInfo;
+    VkPipelineDepthStencilStateCreateInfo _depthStencilInfo;
+    MVKRenderStateFlags _dynamicState;
 
-	MVKSmallVector<VkViewport, kMVKMaxViewportScissorCount> _viewports;
-	MVKSmallVector<VkRect2D, kMVKMaxViewportScissorCount> _scissors;
-	MVKSmallVector<VkSampleLocationEXT> _sampleLocations;
-	MVKSmallVector<MVKTranslatedVertexBinding> _translatedVertexBindings;
-	MVKSmallVector<MVKZeroDivisorVertexBinding> _zeroDivisorVertexBindings;
-	MVKSmallVector<MVKStagedDescriptorBindingUse> _descriptorBindingUse;
-	MVKSmallVector<MVKShaderStage> _stagesUsingPhysicalStorageBufferAddressesCapability;
-	std::unordered_map<uint32_t, id<MTLRenderPipelineState>> _multiviewMTLPipelineStates;
+    MVKSmallVector<VkViewport, kMVKMaxViewportScissorCount> _viewports;
+    MVKSmallVector<VkRect2D, kMVKMaxViewportScissorCount> _scissors;
+    MVKSmallVector<VkSampleLocationEXT> _sampleLocations;
+    MVKSmallVector<MVKTranslatedVertexBinding> _translatedVertexBindings;
+    MVKSmallVector<MVKZeroDivisorVertexBinding> _zeroDivisorVertexBindings;
+    MVKSmallVector<MVKStagedDescriptorBindingUse> _descriptorBindingUse;
+    MVKSmallVector<MVKShaderStage>
+        _stagesUsingPhysicalStorageBufferAddressesCapability;
+    std::unordered_map<uint32_t, id<MTLRenderPipelineState>>
+        _multiviewMTLPipelineStates;
 
-	id<MTLComputePipelineState> _mtlTessVertexStageState = nil;
-	id<MTLComputePipelineState> _mtlTessVertexStageIndex16State = nil;
-	id<MTLComputePipelineState> _mtlTessVertexStageIndex32State = nil;
-	id<MTLComputePipelineState> _mtlTessControlStageState = nil;
-	id<MTLRenderPipelineState> _mtlPipelineState = nil;
+    id<MTLComputePipelineState> _mtlTessVertexStageState = nil;
+    id<MTLComputePipelineState> _mtlTessVertexStageIndex16State = nil;
+    id<MTLComputePipelineState> _mtlTessVertexStageIndex32State = nil;
+    id<MTLComputePipelineState> _mtlTessControlStageState = nil;
+    id<MTLRenderPipelineState> _mtlPipelineState = nil;
 
-	MVKColor32 _blendConstants = { 0.0, 0.0, 0.0, 1.0 };
-	MVKShaderImplicitRezBinding _reservedVertexAttributeBufferCount;
-	MVKShaderImplicitRezBinding _viewRangeBufferIndex;
-	MVKShaderImplicitRezBinding _outputBufferIndex;
-	VkPrimitiveTopology _vkPrimitiveTopology;
-	uint32_t _outputControlPointCount;
-	uint32_t _tessCtlPatchOutputBufferIndex = 0;
-	uint32_t _tessCtlLevelBufferIndex = 0;
+    MVKColor32 _blendConstants = {0.0, 0.0, 0.0, 1.0};
+    MVKShaderImplicitRezBinding _reservedVertexAttributeBufferCount;
+    MVKShaderImplicitRezBinding _viewRangeBufferIndex;
+    MVKShaderImplicitRezBinding _outputBufferIndex;
+    VkPrimitiveTopology _vkPrimitiveTopology;
+    uint32_t _outputControlPointCount;
+    uint32_t _tessCtlPatchOutputBufferIndex = 0;
+    uint32_t _tessCtlLevelBufferIndex = 0;
 
-	static constexpr uint32_t kMVKMaxVertexInputBindingBufferCount = 31u; // Taken from Metal Feature Set Table. Highest value out of all present GPUs
-	bool _isVertexInputBindingUsed[kMVKMaxVertexInputBindingBufferCount] = { false };
-	bool _primitiveRestartEnable = true;
-	bool _hasRasterInfo = false;
-	bool _needsVertexSwizzleBuffer = false;
-	bool _needsVertexBufferSizeBuffer = false;
-	bool _needsVertexDynamicOffsetBuffer = false;
-	bool _needsVertexViewRangeBuffer = false;
-	bool _needsVertexOutputBuffer = false;
-	bool _needsTessCtlSwizzleBuffer = false;
-	bool _needsTessCtlBufferSizeBuffer = false;
-	bool _needsTessCtlDynamicOffsetBuffer = false;
-	bool _needsTessCtlOutputBuffer = false;
-	bool _needsTessCtlPatchOutputBuffer = false;
-	bool _needsTessCtlInputBuffer = false;
-	bool _needsTessEvalSwizzleBuffer = false;
-	bool _needsTessEvalBufferSizeBuffer = false;
-	bool _needsTessEvalDynamicOffsetBuffer = false;
-	bool _needsFragmentSwizzleBuffer = false;
-	bool _needsFragmentBufferSizeBuffer = false;
-	bool _needsFragmentDynamicOffsetBuffer = false;
-	bool _needsFragmentViewRangeBuffer = false;
-	bool _isRasterizing = false;
-	bool _isRasterizingColor = false;
-	bool _sampleLocationsEnable = false;
-	bool _isTessellationPipeline = false;
-	bool _inputAttachmentIsDSAttachment = false;
+    static constexpr uint32_t kMVKMaxVertexInputBindingBufferCount =
+        31u; // Taken from Metal Feature Set Table. Highest value out of all
+             // present GPUs
+    bool _isVertexInputBindingUsed[kMVKMaxVertexInputBindingBufferCount] = {
+        false};
+    bool _primitiveRestartEnable = true;
+    bool _hasRasterInfo = false;
+    bool _needsVertexSwizzleBuffer = false;
+    bool _needsVertexBufferSizeBuffer = false;
+    bool _needsVertexDynamicOffsetBuffer = false;
+    bool _needsVertexViewRangeBuffer = false;
+    bool _needsVertexOutputBuffer = false;
+    bool _needsTessCtlSwizzleBuffer = false;
+    bool _needsTessCtlBufferSizeBuffer = false;
+    bool _needsTessCtlDynamicOffsetBuffer = false;
+    bool _needsTessCtlOutputBuffer = false;
+    bool _needsTessCtlPatchOutputBuffer = false;
+    bool _needsTessCtlInputBuffer = false;
+    bool _needsTessEvalSwizzleBuffer = false;
+    bool _needsTessEvalBufferSizeBuffer = false;
+    bool _needsTessEvalDynamicOffsetBuffer = false;
+    bool _needsFragmentSwizzleBuffer = false;
+    bool _needsFragmentBufferSizeBuffer = false;
+    bool _needsFragmentDynamicOffsetBuffer = false;
+    bool _needsFragmentViewRangeBuffer = false;
+    bool _isRasterizing = false;
+    bool _isRasterizingColor = false;
+    bool _sampleLocationsEnable = false;
+    bool _isTessellationPipeline = false;
+    bool _inputAttachmentIsDSAttachment = false;
 };
-
 
 #pragma mark -
 #pragma mark MVKComputePipeline
@@ -446,42 +631,45 @@ protected:
 /** Represents an Vulkan compute pipeline. */
 class MVKComputePipeline : public MVKPipeline {
 
-public:
+  public:
+    void encode(MVKCommandEncoder* cmdEncoder, uint32_t = 0) override;
 
-	void encode(MVKCommandEncoder* cmdEncoder, uint32_t = 0) override;
+    /** Returns if this pipeline allows non-zero dispatch bases in
+     * vkCmdDispatchBase(). */
+    bool allowsDispatchBase() { return _allowsDispatchBase; }
 
-	/** Returns if this pipeline allows non-zero dispatch bases in vkCmdDispatchBase(). */
-	bool allowsDispatchBase() { return _allowsDispatchBase; }
+    /** Returns the array of descriptor binding use for the descriptor set. */
+    MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex,
+                                         MVKShaderStage stage) override {
+        return _descriptorBindingUse[descSetIndex];
+    }
 
-	/** Returns the array of descriptor binding use for the descriptor set. */
-	MVKBitArray& getDescriptorBindingUse(uint32_t descSetIndex, MVKShaderStage stage) override { return _descriptorBindingUse[descSetIndex]; }
+    bool
+    usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) override;
 
-	bool usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) override;
+    /** Constructs an instance for the device and parent (which may be NULL). */
+    MVKComputePipeline(MVKDevice* device, MVKPipelineCache* pipelineCache,
+                       MVKPipeline* parent,
+                       const VkComputePipelineCreateInfo* pCreateInfo);
 
-	/** Constructs an instance for the device and parent (which may be NULL). */
-	MVKComputePipeline(MVKDevice* device,
-					   MVKPipelineCache* pipelineCache,
-					   MVKPipeline* parent,
-					   const VkComputePipelineCreateInfo* pCreateInfo);
+    ~MVKComputePipeline() override;
 
-	~MVKComputePipeline() override;
-
-protected:
-    MVKMTLFunction getMTLFunction(const VkComputePipelineCreateInfo* pCreateInfo,
-								  VkPipelineCreationFeedback* pStageFB);
-	uint32_t getImplicitBufferIndex(uint32_t bufferIndexOffset);
+  protected:
+    MVKMTLFunction
+    getMTLFunction(const VkComputePipelineCreateInfo* pCreateInfo,
+                   VkPipelineCreationFeedback* pStageFB);
+    uint32_t getImplicitBufferIndex(uint32_t bufferIndexOffset);
 
     id<MTLComputePipelineState> _mtlPipelineState;
-	MVKSmallVector<MVKBitArray> _descriptorBindingUse;
+    MVKSmallVector<MVKBitArray> _descriptorBindingUse;
     MTLSize _mtlThreadgroupSize;
     bool _needsSwizzleBuffer = false;
     bool _needsBufferSizeBuffer = false;
-	bool _needsDynamicOffsetBuffer = false;
+    bool _needsDynamicOffsetBuffer = false;
     bool _needsDispatchBaseBuffer = false;
     bool _allowsDispatchBase = false;
-	bool _usesPhysicalStorageBufferAddressesCapability = false;
+    bool _usesPhysicalStorageBufferAddressesCapability = false;
 };
-
 
 #pragma mark -
 #pragma mark MVKPipelineCache
@@ -489,61 +677,68 @@ protected:
 /** Represents a Vulkan pipeline cache. */
 class MVKPipelineCache : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_PIPELINE_CACHE;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_PIPELINE_CACHE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT; }
+    /**
+     * If pData is not null, serializes at most pDataSize bytes of the contents
+     * of the cache into that memory location, and returns the number of bytes
+     * serialized in pDataSize. If pData is null, returns the number of bytes
+     * required to serialize the contents of this pipeline cache.
+     */
+    VkResult writeData(size_t* pDataSize, void* pData);
 
-	/** 
-	 * If pData is not null, serializes at most pDataSize bytes of the contents of the cache into that
-	 * memory location, and returns the number of bytes serialized in pDataSize. If pData is null,
-	 * returns the number of bytes required to serialize the contents of this pipeline cache.
-	 */
-	VkResult writeData(size_t* pDataSize, void* pData);
+    /**
+     * Return a shader library for the shader conversion configuration, from the
+     * pipeline's pipeline cache, or compiled from source in the shader module.
+     */
+    MVKShaderLibrary*
+    getShaderLibrary(mvk::SPIRVToMSLConversionConfiguration* pContext,
+                     MVKShaderModule* shaderModule, MVKPipeline* pipeline,
+                     VkPipelineCreationFeedback* pShaderFeedback = nullptr,
+                     uint64_t startTime = 0);
 
-	/**
-	 * Return a shader library for the shader conversion configuration, from the
-	 * pipeline's pipeline cache, or compiled from source in the shader module.
-	 */
-	MVKShaderLibrary* getShaderLibrary(mvk::SPIRVToMSLConversionConfiguration* pContext,
-									   MVKShaderModule* shaderModule,
-									   MVKPipeline* pipeline,
-									   VkPipelineCreationFeedback* pShaderFeedback = nullptr,
-									   uint64_t startTime = 0);
-
-	/** Merges the contents of the specified number of pipeline caches into this cache. */
-	VkResult mergePipelineCaches(uint32_t srcCacheCount, const VkPipelineCache* pSrcCaches);
+    /** Merges the contents of the specified number of pipeline caches into this
+     * cache. */
+    VkResult mergePipelineCaches(uint32_t srcCacheCount,
+                                 const VkPipelineCache* pSrcCaches);
 
 #pragma mark Construction
 
-	/** Constructs an instance for the specified device. */
-	MVKPipelineCache(MVKDevice* device, const VkPipelineCacheCreateInfo* pCreateInfo);
+    /** Constructs an instance for the specified device. */
+    MVKPipelineCache(MVKDevice* device,
+                     const VkPipelineCacheCreateInfo* pCreateInfo);
 
-	~MVKPipelineCache() override;
+    ~MVKPipelineCache() override;
 
-protected:
-	void propagateDebugName() override {}
-	MVKShaderLibraryCache* getShaderLibraryCache(MVKShaderModuleKey smKey);
-	void readData(const VkPipelineCacheCreateInfo* pCreateInfo);
-	void writeData(std::ostream& outstream, bool isCounting = false);
-	MVKShaderLibrary* getShaderLibraryImpl(mvk::SPIRVToMSLConversionConfiguration* pContext,
-										   MVKShaderModule* shaderModule,
-										   MVKPipeline* pipeline,
-										   VkPipelineCreationFeedback* pShaderFeedback,
-										   uint64_t startTime);
-	VkResult writeDataImpl(size_t* pDataSize, void* pData);
-	VkResult mergePipelineCachesImpl(uint32_t srcCacheCount, const VkPipelineCache* pSrcCaches);
-	void markDirty();
+  protected:
+    void propagateDebugName() override {}
+    MVKShaderLibraryCache* getShaderLibraryCache(MVKShaderModuleKey smKey);
+    void readData(const VkPipelineCacheCreateInfo* pCreateInfo);
+    void writeData(std::ostream& outstream, bool isCounting = false);
+    MVKShaderLibrary*
+    getShaderLibraryImpl(mvk::SPIRVToMSLConversionConfiguration* pContext,
+                         MVKShaderModule* shaderModule, MVKPipeline* pipeline,
+                         VkPipelineCreationFeedback* pShaderFeedback,
+                         uint64_t startTime);
+    VkResult writeDataImpl(size_t* pDataSize, void* pData);
+    VkResult mergePipelineCachesImpl(uint32_t srcCacheCount,
+                                     const VkPipelineCache* pSrcCaches);
+    void markDirty();
 
-	std::unordered_map<MVKShaderModuleKey, MVKShaderLibraryCache*> _shaderCache;
-	size_t _dataSize = 0;
-	std::mutex _shaderCacheLock;
-	bool _isExternallySynchronized = false;
+    std::unordered_map<MVKShaderModuleKey, MVKShaderLibraryCache*> _shaderCache;
+    size_t _dataSize = 0;
+    std::mutex _shaderCacheLock;
+    bool _isExternallySynchronized = false;
 };
-
 
 #pragma mark -
 #pragma mark MVKRenderPipelineCompiler
@@ -551,36 +746,40 @@ protected:
 /**
  * Creates a MTLRenderPipelineState from a descriptor.
  *
- * Instances of this class are one-shot, and can only be used for a single pipeline compilation.
+ * Instances of this class are one-shot, and can only be used for a single
+ * pipeline compilation.
  */
 class MVKRenderPipelineCompiler : public MVKMetalCompiler {
 
-public:
-
-	/**
-	 * Returns a new (retained) MTLRenderPipelineState object compiled from the descriptor.
-	 *
-	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLRenderPipelineState> newMTLRenderPipelineState(MTLRenderPipelineDescriptor* mtlRPLDesc);
-
+  public:
+    /**
+     * Returns a new (retained) MTLRenderPipelineState object compiled from the
+     * descriptor.
+     *
+     * If the Metal pipeline compiler does not return within
+     * MVKConfiguration::metalCompileTimeout nanoseconds, an error will be
+     * generated and logged, and nil will be returned.
+     */
+    id<MTLRenderPipelineState>
+    newMTLRenderPipelineState(MTLRenderPipelineDescriptor* mtlRPLDesc);
 
 #pragma mark Construction
 
-	MVKRenderPipelineCompiler(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
-		_compilerType = "Render pipeline";
-		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.pipelineCompile;
-	}
+    MVKRenderPipelineCompiler(MVKVulkanAPIDeviceObject* owner)
+        : MVKMetalCompiler(owner) {
+        _compilerType = "Render pipeline";
+        _pPerformanceTracker =
+            &getPerformanceStats().shaderCompilation.pipelineCompile;
+    }
 
-	~MVKRenderPipelineCompiler() override;
+    ~MVKRenderPipelineCompiler() override;
 
-protected:
-	bool compileComplete(id<MTLRenderPipelineState> pipelineState, NSError *error);
+  protected:
+    bool compileComplete(id<MTLRenderPipelineState> pipelineState,
+                         NSError* error);
 
-	id<MTLRenderPipelineState> _mtlRenderPipelineState = nil;
+    id<MTLRenderPipelineState> _mtlRenderPipelineState = nil;
 };
-
 
 #pragma mark -
 #pragma mark MVKComputePipelineCompiler
@@ -588,40 +787,49 @@ protected:
 /**
  * Creates a MTLComputePipelineState from a MTLFunction.
  *
- * Instances of this class are one-shot, and can only be used for a single pipeline compilation.
+ * Instances of this class are one-shot, and can only be used for a single
+ * pipeline compilation.
  */
 class MVKComputePipelineCompiler : public MVKMetalCompiler {
 
-public:
+  public:
+    /**
+     * Returns a new (retained) MTLComputePipelineState object compiled from the
+     * MTLFunction.
+     *
+     * If the Metal pipeline compiler does not return within
+     * MVKConfiguration::metalCompileTimeout nanoseconds, an error will be
+     * generated and logged, and nil will be returned.
+     */
+    id<MTLComputePipelineState>
+    newMTLComputePipelineState(id<MTLFunction> mtlFunction);
 
-	/**
-	 * Returns a new (retained) MTLComputePipelineState object compiled from the MTLFunction.
-	 *
-	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLComputePipelineState> newMTLComputePipelineState(id<MTLFunction> mtlFunction);
-
-	/**
-	 * Returns a new (retained) MTLComputePipelineState object compiled from the MTLComputePipelineDescriptor.
-	 *
-	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLComputePipelineState> newMTLComputePipelineState(MTLComputePipelineDescriptor* plDesc);
-
+    /**
+     * Returns a new (retained) MTLComputePipelineState object compiled from the
+     * MTLComputePipelineDescriptor.
+     *
+     * If the Metal pipeline compiler does not return within
+     * MVKConfiguration::metalCompileTimeout nanoseconds, an error will be
+     * generated and logged, and nil will be returned.
+     */
+    id<MTLComputePipelineState>
+    newMTLComputePipelineState(MTLComputePipelineDescriptor* plDesc);
 
 #pragma mark Construction
 
-	MVKComputePipelineCompiler(MVKVulkanAPIDeviceObject* owner, const char* compilerType = nullptr) : MVKMetalCompiler(owner) {
-		_compilerType = compilerType ? compilerType : "Compute pipeline";
-		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.pipelineCompile;
-	}
+    MVKComputePipelineCompiler(MVKVulkanAPIDeviceObject* owner,
+                               const char* compilerType = nullptr)
+        : MVKMetalCompiler(owner) {
+        _compilerType = compilerType ? compilerType : "Compute pipeline";
+        _pPerformanceTracker =
+            &getPerformanceStats().shaderCompilation.pipelineCompile;
+    }
 
-	~MVKComputePipelineCompiler() override;
+    ~MVKComputePipelineCompiler() override;
 
-protected:
-	bool compileComplete(id<MTLComputePipelineState> pipelineState, NSError *error);
+  protected:
+    bool compileComplete(id<MTLComputePipelineState> pipelineState,
+                         NSError* error);
 
-	id<MTLComputePipelineState> _mtlComputePipelineState = nil;
+    id<MTLComputePipelineState> _mtlComputePipelineState = nil;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,210 +43,247 @@ using namespace std;
 using namespace mvk;
 using namespace SPIRV_CROSS_NAMESPACE;
 
-
 #pragma mark MVKPipelineLayout
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKPipelineLayout::bindDescriptorSets(MVKCommandEncoder* cmdEncoder,
-										   VkPipelineBindPoint pipelineBindPoint,
-                                           MVKArrayRef<MVKDescriptorSet*> descriptorSets,
-                                           uint32_t firstSet,
-                                           MVKArrayRef<uint32_t> dynamicOffsets) {
-	if (!cmdEncoder) { clearConfigurationResult(); }
-	uint32_t dynamicOffsetIndex = 0;
-	size_t dsCnt = descriptorSets.size();
-	for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
-		MVKDescriptorSet* descSet = descriptorSets[dsIdx];
-		uint32_t dslIdx = firstSet + dsIdx;
-		MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[dslIdx];
-		dsl->bindDescriptorSet(cmdEncoder, pipelineBindPoint,
-							   dslIdx, descSet,
-							   _dslMTLResourceIndexOffsets[dslIdx],
-							   dynamicOffsets, dynamicOffsetIndex);
-		if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
-	}
+void MVKPipelineLayout::bindDescriptorSets(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKArrayRef<MVKDescriptorSet*> descriptorSets, uint32_t firstSet,
+    MVKArrayRef<uint32_t> dynamicOffsets) {
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
+    uint32_t dynamicOffsetIndex = 0;
+    size_t dsCnt = descriptorSets.size();
+    for (uint32_t dsIdx = 0; dsIdx < dsCnt; dsIdx++) {
+        MVKDescriptorSet* descSet = descriptorSets[dsIdx];
+        uint32_t dslIdx = firstSet + dsIdx;
+        MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[dslIdx];
+        dsl->bindDescriptorSet(cmdEncoder, pipelineBindPoint, dslIdx, descSet,
+                               _dslMTLResourceIndexOffsets[dslIdx],
+                               dynamicOffsets, dynamicOffsetIndex);
+        if (!cmdEncoder) {
+            setConfigurationResult(dsl->getConfigurationResult());
+        }
+    }
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKPipelineLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-                                          VkPipelineBindPoint pipelineBindPoint,
-                                          MVKArrayRef<VkWriteDescriptorSet> descriptorWrites,
-                                          uint32_t set) {
-	if (!cmdEncoder) { clearConfigurationResult(); }
-	MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
-	dsl->pushDescriptorSet(cmdEncoder, pipelineBindPoint, descriptorWrites, _dslMTLResourceIndexOffsets[set]);
-	if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
+void MVKPipelineLayout::pushDescriptorSet(
+    MVKCommandEncoder* cmdEncoder, VkPipelineBindPoint pipelineBindPoint,
+    MVKArrayRef<VkWriteDescriptorSet> descriptorWrites, uint32_t set) {
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
+    MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
+    dsl->pushDescriptorSet(cmdEncoder, pipelineBindPoint, descriptorWrites,
+                           _dslMTLResourceIndexOffsets[set]);
+    if (!cmdEncoder) {
+        setConfigurationResult(dsl->getConfigurationResult());
+    }
 }
 
 // A null cmdEncoder can be passed to perform a validation pass
-void MVKPipelineLayout::pushDescriptorSet(MVKCommandEncoder* cmdEncoder,
-                                          MVKDescriptorUpdateTemplate* descUpdateTemplate,
-                                          uint32_t set,
-                                          const void* pData) {
-	if (!cmdEncoder) { clearConfigurationResult(); }
-	MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
-	dsl->pushDescriptorSet(cmdEncoder, descUpdateTemplate, pData, _dslMTLResourceIndexOffsets[set]);
-	if (!cmdEncoder) { setConfigurationResult(dsl->getConfigurationResult()); }
+void MVKPipelineLayout::pushDescriptorSet(
+    MVKCommandEncoder* cmdEncoder,
+    MVKDescriptorUpdateTemplate* descUpdateTemplate, uint32_t set,
+    const void* pData) {
+    if (!cmdEncoder) {
+        clearConfigurationResult();
+    }
+    MVKDescriptorSetLayout* dsl = _descriptorSetLayouts[set];
+    dsl->pushDescriptorSet(cmdEncoder, descUpdateTemplate, pData,
+                           _dslMTLResourceIndexOffsets[set]);
+    if (!cmdEncoder) {
+        setConfigurationResult(dsl->getConfigurationResult());
+    }
 }
 
-void MVKPipelineLayout::populateShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig) {
-	shaderConfig.resourceBindings.clear();
-	shaderConfig.discreteDescriptorSets.clear();
-	shaderConfig.dynamicBufferDescriptors.clear();
+void MVKPipelineLayout::populateShaderConversionConfig(
+    SPIRVToMSLConversionConfiguration& shaderConfig) {
+    shaderConfig.resourceBindings.clear();
+    shaderConfig.discreteDescriptorSets.clear();
+    shaderConfig.dynamicBufferDescriptors.clear();
 
-	// Add any resource bindings used by push-constants.
-	// Use VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT descriptor type as compatible with push constants in Metal.
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		if (stageUsesPushConstants((MVKShaderStage)stage)) {
-			mvkPopulateShaderConversionConfig(shaderConfig,
-											  _pushConstantsMTLResourceIndexes.stages[stage],
-											  MVKShaderStage(stage),
-											  kPushConstDescSet,
-											  kPushConstBinding,
-											  1,
-											  VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT,
-											  nullptr,
-											  getMetalFeatures().nativeTextureAtomics);
-		}
-	}
+    // Add any resource bindings used by push-constants.
+    // Use VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT descriptor type as
+    // compatible with push constants in Metal.
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        if (stageUsesPushConstants((MVKShaderStage)stage)) {
+            mvkPopulateShaderConversionConfig(
+                shaderConfig, _pushConstantsMTLResourceIndexes.stages[stage],
+                MVKShaderStage(stage), kPushConstDescSet, kPushConstBinding, 1,
+                VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT, nullptr,
+                getMetalFeatures().nativeTextureAtomics);
+        }
+    }
 
     // Add resource bindings defined in the descriptor set layouts
-	auto dslCnt = _descriptorSetLayouts.size();
-	for (uint32_t dslIdx = 0; dslIdx < dslCnt; dslIdx++) {
-		_descriptorSetLayouts[dslIdx]->populateShaderConversionConfig(shaderConfig,
-																	  _dslMTLResourceIndexOffsets[dslIdx],
-																	  dslIdx);
-	}
+    auto dslCnt = _descriptorSetLayouts.size();
+    for (uint32_t dslIdx = 0; dslIdx < dslCnt; dslIdx++) {
+        _descriptorSetLayouts[dslIdx]
+            ->populateShaderConversionConfig(shaderConfig,
+                                             _dslMTLResourceIndexOffsets
+                                                 [dslIdx],
+                                             dslIdx);
+    }
 }
 
 bool MVKPipelineLayout::stageUsesPushConstants(MVKShaderStage mvkStage) {
-	VkShaderStageFlagBits vkStage = mvkVkShaderStageFlagBitsFromMVKShaderStage(mvkStage);
-	for (auto pushConst : _pushConstants) {
-		if (mvkIsAnyFlagEnabled(pushConst.stageFlags, vkStage)) {
-			return true;
-		}
-	}
-	return false;
+    VkShaderStageFlagBits vkStage =
+        mvkVkShaderStageFlagBitsFromMVKShaderStage(mvkStage);
+    for (auto pushConst : _pushConstants) {
+        if (mvkIsAnyFlagEnabled(pushConst.stageFlags, vkStage)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::string MVKPipelineLayout::getLogDescription(std::string indent) {
-	std::stringstream descStr;
-	size_t dslCnt = _descriptorSetLayouts.size();
-	descStr << "VkPipelineLayout with " << dslCnt << " descriptor set layouts:";
-	auto descLayoutIndent = indent + "\t";
-	for (uint32_t dslIdx = 0; dslIdx < dslCnt; dslIdx++) {
-		descStr << "\n" << descLayoutIndent << dslIdx << ": " << _descriptorSetLayouts[dslIdx]->getLogDescription(descLayoutIndent);
-	}
-	return descStr.str();
+    std::stringstream descStr;
+    size_t dslCnt = _descriptorSetLayouts.size();
+    descStr << "VkPipelineLayout with " << dslCnt << " descriptor set layouts:";
+    auto descLayoutIndent = indent + "\t";
+    for (uint32_t dslIdx = 0; dslIdx < dslCnt; dslIdx++) {
+        descStr << "\n"
+                << descLayoutIndent << dslIdx << ": "
+                << _descriptorSetLayouts[dslIdx]->getLogDescription(
+                       descLayoutIndent);
+    }
+    return descStr.str();
 }
 
-MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
-                                     const VkPipelineLayoutCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
+MVKPipelineLayout::MVKPipelineLayout(
+    MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
 
-	// For pipeline layout compatibility (“compatible for set N”),
-	// consume the Metal resource indexes in this order:
-	//   - Fixed count of argument buffers for descriptor sets (if using Metal argument buffers).
-	//   - Push constants
-	//   - Descriptor set content
+    // For pipeline layout compatibility (“compatible for set N”),
+    // consume the Metal resource indexes in this order:
+    //   - Fixed count of argument buffers for descriptor sets (if using Metal
+    //   argument buffers).
+    //   - Push constants
+    //   - Descriptor set content
 
-	// If we are using Metal argument buffers, consume a fixed number
-	// of buffer indexes for the Metal argument buffers themselves.
-	if (isUsingMetalArgumentBuffers()) {
-		_mtlResourceCounts.addArgumentBuffers(kMVKMaxDescriptorSetCount);
-	}
+    // If we are using Metal argument buffers, consume a fixed number
+    // of buffer indexes for the Metal argument buffers themselves.
+    if (isUsingMetalArgumentBuffers()) {
+        _mtlResourceCounts.addArgumentBuffers(kMVKMaxDescriptorSetCount);
+    }
 
-	// Add push constants from config
-	_pushConstants.reserve(pCreateInfo->pushConstantRangeCount);
-	for (uint32_t i = 0; i < pCreateInfo->pushConstantRangeCount; i++) {
-		_pushConstants.push_back(pCreateInfo->pPushConstantRanges[i]);
-	}
+    // Add push constants from config
+    _pushConstants.reserve(pCreateInfo->pushConstantRangeCount);
+    for (uint32_t i = 0; i < pCreateInfo->pushConstantRangeCount; i++) {
+        _pushConstants.push_back(pCreateInfo->pPushConstantRanges[i]);
+    }
 
-	// Set push constant resource indexes, and consume a buffer index for any stage that uses a push constant buffer.
-	_pushConstantsMTLResourceIndexes = _mtlResourceCounts;
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		if (stageUsesPushConstants((MVKShaderStage)stage)) {
-			_mtlResourceCounts.stages[stage].bufferIndex++;
-		}
-	}
+    // Set push constant resource indexes, and consume a buffer index for any
+    // stage that uses a push constant buffer.
+    _pushConstantsMTLResourceIndexes = _mtlResourceCounts;
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        if (stageUsesPushConstants((MVKShaderStage)stage)) {
+            _mtlResourceCounts.stages[stage].bufferIndex++;
+        }
+    }
 
-	// Add descriptor set layouts, accumulating the resource index offsets used by the corresponding DSL,
-	// and associating the current accumulated resource index offsets with each DSL as it is added.
-	uint32_t dslCnt = pCreateInfo->setLayoutCount;
-	_descriptorSetLayouts.reserve(dslCnt);
-	for (uint32_t i = 0; i < dslCnt; i++) {
-		MVKDescriptorSetLayout* pDescSetLayout = (MVKDescriptorSetLayout*)pCreateInfo->pSetLayouts[i];
-		pDescSetLayout->retain();
-		_descriptorSetLayouts.push_back(pDescSetLayout);
+    // Add descriptor set layouts, accumulating the resource index offsets used
+    // by the corresponding DSL, and associating the current accumulated
+    // resource index offsets with each DSL as it is added.
+    uint32_t dslCnt = pCreateInfo->setLayoutCount;
+    _descriptorSetLayouts.reserve(dslCnt);
+    for (uint32_t i = 0; i < dslCnt; i++) {
+        MVKDescriptorSetLayout* pDescSetLayout =
+            (MVKDescriptorSetLayout*)pCreateInfo->pSetLayouts[i];
+        pDescSetLayout->retain();
+        _descriptorSetLayouts.push_back(pDescSetLayout);
 
-		MVKShaderResourceBinding adjstdDSLRezOfsts = _mtlResourceCounts;
-		MVKShaderResourceBinding adjstdDSLRezCnts = pDescSetLayout->_mtlResourceCounts;
-		if (pDescSetLayout->isUsingMetalArgumentBuffers()) {
-			adjstdDSLRezOfsts.clearArgumentBufferResources();
-			adjstdDSLRezCnts.clearArgumentBufferResources();
-		}
-		_dslMTLResourceIndexOffsets.push_back(adjstdDSLRezOfsts);
-		_mtlResourceCounts += adjstdDSLRezCnts;
-	}
+        MVKShaderResourceBinding adjstdDSLRezOfsts = _mtlResourceCounts;
+        MVKShaderResourceBinding adjstdDSLRezCnts =
+            pDescSetLayout->_mtlResourceCounts;
+        if (pDescSetLayout->isUsingMetalArgumentBuffers()) {
+            adjstdDSLRezOfsts.clearArgumentBufferResources();
+            adjstdDSLRezCnts.clearArgumentBufferResources();
+        }
+        _dslMTLResourceIndexOffsets.push_back(adjstdDSLRezOfsts);
+        _mtlResourceCounts += adjstdDSLRezCnts;
+    }
 
-	MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n", getLogDescription().c_str());
+    MVKLogDebugIf(getMVKConfig().debugMode, "Created %s\n",
+                  getLogDescription().c_str());
 }
 
 MVKPipelineLayout::~MVKPipelineLayout() {
-	for (auto dsl : _descriptorSetLayouts) { dsl->release(); }
+    for (auto dsl : _descriptorSetLayouts) {
+        dsl->release();
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKPipeline
 
 void MVKPipeline::bindPushConstants(MVKCommandEncoder* cmdEncoder) {
-	for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-		if (cmdEncoder) {
-			auto* pcState = cmdEncoder->getPushConstants(mvkVkShaderStageFlagBitsFromMVKShaderStage(MVKShaderStage(stage)));
-			pcState->setMTLBufferIndex(_pushConstantsBufferIndex.stages[stage], _stageUsesPushConstants[stage]);
-		}
-	}
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        if (cmdEncoder) {
+            auto* pcState = cmdEncoder->getPushConstants(
+                mvkVkShaderStageFlagBitsFromMVKShaderStage(
+                    MVKShaderStage(stage)));
+            pcState->setMTLBufferIndex(_pushConstantsBufferIndex.stages[stage],
+                                       _stageUsesPushConstants[stage]);
+        }
+    }
 }
 
-// For each descriptor set, populate the descriptor bindings used by the shader for this stage.
-template<typename CreateInfo>
-void MVKPipeline::populateDescriptorSetBindingUse(MVKMTLFunction& mvkMTLFunc,
-												  const CreateInfo* pCreateInfo,
-												  SPIRVToMSLConversionConfiguration& shaderConfig,
-												  MVKShaderStage stage) {
-	if (isUsingMetalArgumentBuffers()) {
-		for (uint32_t dsIdx = 0; dsIdx < _descriptorSetCount; dsIdx++) {
-			auto* dsLayout = ((MVKPipelineLayout*)pCreateInfo->layout)->getDescriptorSetLayout(dsIdx);
-			dsLayout->populateBindingUse(getDescriptorBindingUse(dsIdx, stage), shaderConfig, stage, dsIdx);
-		}
-	}
+// For each descriptor set, populate the descriptor bindings used by the shader
+// for this stage.
+template <typename CreateInfo>
+void MVKPipeline::populateDescriptorSetBindingUse(
+    MVKMTLFunction& mvkMTLFunc, const CreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig, MVKShaderStage stage) {
+    if (isUsingMetalArgumentBuffers()) {
+        for (uint32_t dsIdx = 0; dsIdx < _descriptorSetCount; dsIdx++) {
+            auto* dsLayout = ((MVKPipelineLayout*)pCreateInfo->layout)
+                                 ->getDescriptorSetLayout(dsIdx);
+            dsLayout->populateBindingUse(getDescriptorBindingUse(dsIdx, stage),
+                                         shaderConfig, stage, dsIdx);
+        }
+    }
 }
 
-MVKPipeline::MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipelineLayout* layout,
-						 VkPipelineCreateFlags flags, MVKPipeline* parent) :
-	MVKVulkanAPIDeviceObject(device),
-	_pipelineCache(pipelineCache),
-	_flags(flags),
-	_descriptorSetCount(uint32_t(layout->_descriptorSetLayouts.size())),
-	_fullImageViewSwizzle(getMVKConfig().fullImageViewSwizzle) {
+MVKPipeline::MVKPipeline(MVKDevice* device, MVKPipelineCache* pipelineCache,
+                         MVKPipelineLayout* layout, VkPipelineCreateFlags flags,
+                         MVKPipeline* parent)
+    : MVKVulkanAPIDeviceObject(device), _pipelineCache(pipelineCache),
+      _flags(flags),
+      _descriptorSetCount(uint32_t(layout->_descriptorSetLayouts.size())),
+      _fullImageViewSwizzle(getMVKConfig().fullImageViewSwizzle) {
 
-		// Establish descriptor counts and push constants use.
-		for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount; stage++) {
-			_descriptorBufferCounts.stages[stage] = layout->_mtlResourceCounts.stages[stage].bufferIndex;
-			_pushConstantsBufferIndex.stages[stage] = layout->_pushConstantsMTLResourceIndexes.stages[stage].bufferIndex;
-			_stageUsesPushConstants[stage] = layout->stageUsesPushConstants((MVKShaderStage)stage);
-		}
-	}
-
+    // Establish descriptor counts and push constants use.
+    for (uint32_t stage = kMVKShaderStageVertex; stage < kMVKShaderStageCount;
+         stage++) {
+        _descriptorBufferCounts.stages[stage] =
+            layout->_mtlResourceCounts.stages[stage].bufferIndex;
+        _pushConstantsBufferIndex.stages[stage] =
+            layout->_pushConstantsMTLResourceIndexes.stages[stage].bufferIndex;
+        _stageUsesPushConstants[stage] =
+            layout->stageUsesPushConstants((MVKShaderStage)stage);
+    }
+}
 
 #pragma mark -
 #pragma mark MVKGraphicsPipeline
 
-// Set retrieve-only rendering state when pipeline is bound, as it's too late at draw command.
+// Set retrieve-only rendering state when pipeline is bound, as it's too late at
+// draw command.
 void MVKGraphicsPipeline::wasBound(MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->_renderingState.setPatchControlPoints(_tessInfo.patchControlPoints, false);
-	cmdEncoder->_renderingState.setSampleLocations(_sampleLocations.contents(), false);
-	cmdEncoder->_renderingState.setSampleLocationsEnable(_sampleLocationsEnable, false);
+    cmdEncoder->_renderingState
+        .setPatchControlPoints(_tessInfo.patchControlPoints, false);
+    cmdEncoder->_renderingState.setSampleLocations(_sampleLocations.contents(),
+                                                   false);
+    cmdEncoder->_renderingState.setSampleLocationsEnable(_sampleLocationsEnable,
+                                                         false);
 }
 
 void MVKGraphicsPipeline::getStages(MVKPiplineStages& stages) {
@@ -257,1180 +294,1701 @@ void MVKGraphicsPipeline::getStages(MVKPiplineStages& stages) {
     stages.push_back(kMVKGraphicsStageRasterization);
 }
 
-void MVKGraphicsPipeline::encode(MVKCommandEncoder* cmdEncoder, uint32_t stage) {
-	if ( !_hasValidMTLPipelineStates ) { return; }
+void MVKGraphicsPipeline::encode(MVKCommandEncoder* cmdEncoder,
+                                 uint32_t stage) {
+    if (!_hasValidMTLPipelineStates) {
+        return;
+    }
 
     id<MTLRenderCommandEncoder> mtlCmdEnc = cmdEncoder->_mtlRenderEncoder;
-	id<MTLComputeCommandEncoder> tessCtlEnc;
-    if ( stage == kMVKGraphicsStageRasterization && !mtlCmdEnc ) { return; }   // Pre-renderpass. Come back later.
+    id<MTLComputeCommandEncoder> tessCtlEnc;
+    if (stage == kMVKGraphicsStageRasterization && !mtlCmdEnc) {
+        return;
+    } // Pre-renderpass. Come back later.
 
     switch (stage) {
 
-		case kMVKGraphicsStageVertex: {
-			// Stage 1 of a tessellated draw: compute pipeline to run the vertex shader.
-			// N.B. This will prematurely terminate the current subpass. We'll have to remember to start it back up again.
-			// Due to yet another impedance mismatch between Metal and Vulkan, which pipeline
-			// state we use depends on whether or not we have an index buffer, and if we do,
-			// the kind of indices in it.
+    case kMVKGraphicsStageVertex: {
+        // Stage 1 of a tessellated draw: compute pipeline to run the vertex
+        // shader. N.B. This will prematurely terminate the current subpass.
+        // We'll have to remember to start it back up again. Due to yet another
+        // impedance mismatch between Metal and Vulkan, which pipeline state we
+        // use depends on whether or not we have an index buffer, and if we do,
+        // the kind of indices in it.
 
-            id<MTLComputePipelineState> plState;
-			const MVKIndexMTLBufferBinding& indexBuff = cmdEncoder->_graphicsResourcesState._mtlIndexBufferBinding;
-            if (!cmdEncoder->_isIndexedDraw) {
-                plState = getTessVertexStageState();
-            } else if (indexBuff.mtlIndexType == MTLIndexTypeUInt16) {
-                plState = getTessVertexStageIndex16State();
-            } else {
-                plState = getTessVertexStageIndex32State();
-            }
-
-			if ( !_hasValidMTLPipelineStates ) { return; }
-
-            tessCtlEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
-            [tessCtlEnc setComputePipelineState: plState];
-            break;
-		}
-
-        case kMVKGraphicsStageTessControl: {
-			// Stage 2 of a tessellated draw: compute pipeline to run the tess. control shader.
-			if ( !_mtlTessControlStageState ) { return; }		// Abort if pipeline could not be created.
-
-            tessCtlEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseTessellationVertexTessCtl);
-            [tessCtlEnc setComputePipelineState: _mtlTessControlStageState];
-            break;
+        id<MTLComputePipelineState> plState;
+        const MVKIndexMTLBufferBinding& indexBuff =
+            cmdEncoder->_graphicsResourcesState._mtlIndexBufferBinding;
+        if (!cmdEncoder->_isIndexedDraw) {
+            plState = getTessVertexStageState();
+        } else if (indexBuff.mtlIndexType == MTLIndexTypeUInt16) {
+            plState = getTessVertexStageIndex16State();
+        } else {
+            plState = getTessVertexStageIndex32State();
         }
 
-        case kMVKGraphicsStageRasterization:
-			// Stage 3 of a tessellated draw:
+        if (!_hasValidMTLPipelineStates) {
+            return;
+        }
 
-			if ( !_mtlPipelineState ) { return; }		// Abort if pipeline could not be created.
-            // Render pipeline state
-			if (cmdEncoder->getSubpass()->isMultiview() && !isTessellationPipeline() && !_multiviewMTLPipelineStates.empty()) {
-				[mtlCmdEnc setRenderPipelineState: _multiviewMTLPipelineStates[cmdEncoder->getSubpass()->getViewCountInMetalPass(cmdEncoder->getMultiviewPassIndex())]];
-			} else {
-				[mtlCmdEnc setRenderPipelineState: _mtlPipelineState];
-			}
-
-            // Depth stencil state - Cleared _depthStencilInfo values will disable depth testing
-			cmdEncoder->_depthStencilState.setDepthStencilState(_depthStencilInfo);
-
-            // Rasterization
-			cmdEncoder->_renderingState.setPrimitiveTopology(_vkPrimitiveTopology, false);
-			cmdEncoder->_renderingState.setPrimitiveRestartEnable(_primitiveRestartEnable, false);
-			cmdEncoder->_renderingState.setBlendConstants(_blendConstants, false);
-			cmdEncoder->_renderingState.setDepthBounds({_depthStencilInfo.minDepthBounds, _depthStencilInfo.maxDepthBounds}, false);
-			cmdEncoder->_renderingState.setStencilReferenceValues(_depthStencilInfo);
-            cmdEncoder->_renderingState.setViewports(_viewports.contents(), 0, false);
-            cmdEncoder->_renderingState.setScissors(_scissors.contents(), 0, false);
-			if (_hasRasterInfo) {
-				cmdEncoder->_renderingState.setCullMode(_rasterInfo.cullMode, false);
-				cmdEncoder->_renderingState.setFrontFace(_rasterInfo.frontFace, false);
-				cmdEncoder->_renderingState.setPolygonMode(_rasterInfo.polygonMode, false);
-				cmdEncoder->_renderingState.setLineWidth(_rasterInfo.lineWidth, false);
-				cmdEncoder->_renderingState.setDepthBias(_rasterInfo);
-				cmdEncoder->_renderingState.setDepthClipEnable( !_rasterInfo.depthClampEnable, false );
-			}
-            break;
+        tessCtlEnc = cmdEncoder->getMTLComputeEncoder(
+            kMVKCommandUseTessellationVertexTessCtl);
+        [tessCtlEnc setComputePipelineState:plState];
+        break;
     }
 
-	cmdEncoder->_graphicsResourcesState.markOverriddenBufferIndexesDirty();
-    cmdEncoder->_graphicsResourcesState.bindSwizzleBuffer(_swizzleBufferIndex, _needsVertexSwizzleBuffer, _needsTessCtlSwizzleBuffer, _needsTessEvalSwizzleBuffer, _needsFragmentSwizzleBuffer);
-    cmdEncoder->_graphicsResourcesState.bindBufferSizeBuffer(_bufferSizeBufferIndex, _needsVertexBufferSizeBuffer, _needsTessCtlBufferSizeBuffer, _needsTessEvalBufferSizeBuffer, _needsFragmentBufferSizeBuffer);
-	cmdEncoder->_graphicsResourcesState.bindDynamicOffsetBuffer(_dynamicOffsetBufferIndex, _needsVertexDynamicOffsetBuffer, _needsTessCtlDynamicOffsetBuffer, _needsTessEvalDynamicOffsetBuffer, _needsFragmentDynamicOffsetBuffer);
-    cmdEncoder->_graphicsResourcesState.bindViewRangeBuffer(_viewRangeBufferIndex, _needsVertexViewRangeBuffer, _needsFragmentViewRangeBuffer);
+    case kMVKGraphicsStageTessControl: {
+        // Stage 2 of a tessellated draw: compute pipeline to run the tess.
+        // control shader.
+        if (!_mtlTessControlStageState) {
+            return;
+        } // Abort if pipeline could not be created.
+
+        tessCtlEnc = cmdEncoder->getMTLComputeEncoder(
+            kMVKCommandUseTessellationVertexTessCtl);
+        [tessCtlEnc setComputePipelineState:_mtlTessControlStageState];
+        break;
+    }
+
+    case kMVKGraphicsStageRasterization:
+        // Stage 3 of a tessellated draw:
+
+        if (!_mtlPipelineState) {
+            return;
+        } // Abort if pipeline could not be created.
+          // Render pipeline state
+        if (cmdEncoder->getSubpass()->isMultiview() &&
+            !isTessellationPipeline() && !_multiviewMTLPipelineStates.empty()) {
+            [mtlCmdEnc
+                setRenderPipelineState:
+                    _multiviewMTLPipelineStates
+                        [cmdEncoder->getSubpass()->getViewCountInMetalPass(
+                            cmdEncoder->getMultiviewPassIndex())]];
+        } else {
+            [mtlCmdEnc setRenderPipelineState:_mtlPipelineState];
+        }
+
+        // Depth stencil state - Cleared _depthStencilInfo values will disable
+        // depth testing
+        cmdEncoder->_depthStencilState.setDepthStencilState(_depthStencilInfo);
+
+        // Rasterization
+        cmdEncoder->_renderingState.setPrimitiveTopology(_vkPrimitiveTopology,
+                                                         false);
+        cmdEncoder->_renderingState
+            .setPrimitiveRestartEnable(_primitiveRestartEnable, false);
+        cmdEncoder->_renderingState.setBlendConstants(_blendConstants, false);
+        cmdEncoder->_renderingState
+            .setDepthBounds({_depthStencilInfo.minDepthBounds,
+                             _depthStencilInfo.maxDepthBounds},
+                            false);
+        cmdEncoder->_renderingState.setStencilReferenceValues(
+            _depthStencilInfo);
+        cmdEncoder->_renderingState.setViewports(_viewports.contents(), 0,
+                                                 false);
+        cmdEncoder->_renderingState.setScissors(_scissors.contents(), 0, false);
+        if (_hasRasterInfo) {
+            cmdEncoder->_renderingState.setCullMode(_rasterInfo.cullMode,
+                                                    false);
+            cmdEncoder->_renderingState.setFrontFace(_rasterInfo.frontFace,
+                                                     false);
+            cmdEncoder->_renderingState.setPolygonMode(_rasterInfo.polygonMode,
+                                                       false);
+            cmdEncoder->_renderingState.setLineWidth(_rasterInfo.lineWidth,
+                                                     false);
+            cmdEncoder->_renderingState.setDepthBias(_rasterInfo);
+            cmdEncoder->_renderingState
+                .setDepthClipEnable(!_rasterInfo.depthClampEnable, false);
+        }
+        break;
+    }
+
+    cmdEncoder->_graphicsResourcesState.markOverriddenBufferIndexesDirty();
+    cmdEncoder->_graphicsResourcesState
+        .bindSwizzleBuffer(_swizzleBufferIndex, _needsVertexSwizzleBuffer,
+                           _needsTessCtlSwizzleBuffer,
+                           _needsTessEvalSwizzleBuffer,
+                           _needsFragmentSwizzleBuffer);
+    cmdEncoder->_graphicsResourcesState
+        .bindBufferSizeBuffer(_bufferSizeBufferIndex,
+                              _needsVertexBufferSizeBuffer,
+                              _needsTessCtlBufferSizeBuffer,
+                              _needsTessEvalBufferSizeBuffer,
+                              _needsFragmentBufferSizeBuffer);
+    cmdEncoder->_graphicsResourcesState
+        .bindDynamicOffsetBuffer(_dynamicOffsetBufferIndex,
+                                 _needsVertexDynamicOffsetBuffer,
+                                 _needsTessCtlDynamicOffsetBuffer,
+                                 _needsTessEvalDynamicOffsetBuffer,
+                                 _needsFragmentDynamicOffsetBuffer);
+    cmdEncoder->_graphicsResourcesState
+        .bindViewRangeBuffer(_viewRangeBufferIndex, _needsVertexViewRangeBuffer,
+                             _needsFragmentViewRangeBuffer);
 }
 
 static const char vtxCompilerType[] = "Vertex stage pipeline for tessellation";
 
-bool MVKGraphicsPipeline::compileTessVertexStageState(MTLComputePipelineDescriptor* vtxPLDesc,
-													  MVKMTLFunction* pVtxFunctions,
-													  VkPipelineCreationFeedback* pVertexFB) {
-	uint64_t startTime = 0;
+bool MVKGraphicsPipeline::compileTessVertexStageState(
+    MTLComputePipelineDescriptor* vtxPLDesc, MVKMTLFunction* pVtxFunctions,
+    VkPipelineCreationFeedback* pVertexFB) {
+    uint64_t startTime = 0;
     if (pVertexFB) {
-		startTime = mvkGetTimestamp();
-	}
-	vtxPLDesc.computeFunction = pVtxFunctions[0].getMTLFunction();
-    bool res = !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageState, vtxCompilerType);
+        startTime = mvkGetTimestamp();
+    }
+    vtxPLDesc.computeFunction = pVtxFunctions[0].getMTLFunction();
+    bool res = !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageState,
+                                      vtxCompilerType);
 
-	vtxPLDesc.computeFunction = pVtxFunctions[1].getMTLFunction();
+    vtxPLDesc.computeFunction = pVtxFunctions[1].getMTLFunction();
     vtxPLDesc.stageInputDescriptor.indexType = MTLIndexTypeUInt16;
     for (uint32_t i = 0; i < 31; i++) {
-		MTLBufferLayoutDescriptor* blDesc = vtxPLDesc.stageInputDescriptor.layouts[i];
+        MTLBufferLayoutDescriptor* blDesc =
+            vtxPLDesc.stageInputDescriptor.layouts[i];
         if (blDesc.stepFunction == MTLStepFunctionThreadPositionInGridX) {
-                blDesc.stepFunction = MTLStepFunctionThreadPositionInGridXIndexed;
+            blDesc.stepFunction = MTLStepFunctionThreadPositionInGridXIndexed;
         }
     }
-    res |= !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageIndex16State, vtxCompilerType);
+    res |= !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageIndex16State,
+                                  vtxCompilerType);
 
-	vtxPLDesc.computeFunction = pVtxFunctions[2].getMTLFunction();
+    vtxPLDesc.computeFunction = pVtxFunctions[2].getMTLFunction();
     vtxPLDesc.stageInputDescriptor.indexType = MTLIndexTypeUInt32;
-    res |= !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageIndex32State, vtxCompilerType);
+    res |= !!getOrCompilePipeline(vtxPLDesc, _mtlTessVertexStageIndex32State,
+                                  vtxCompilerType);
 
-	if (pVertexFB) {
-		if (!res) {
-			// Compilation of the shader will have enabled the flag, so I need to turn it off.
-			mvkDisableFlags(pVertexFB->flags, VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
-		}
-		pVertexFB->duration += mvkGetElapsedNanoseconds(startTime);
-	}
-	return res;
+    if (pVertexFB) {
+        if (!res) {
+            // Compilation of the shader will have enabled the flag, so I need
+            // to turn it off.
+            mvkDisableFlags(pVertexFB->flags,
+                            VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
+        }
+        pVertexFB->duration += mvkGetElapsedNanoseconds(startTime);
+    }
+    return res;
 }
 
-bool MVKGraphicsPipeline::compileTessControlStageState(MTLComputePipelineDescriptor* tcPLDesc,
-													   VkPipelineCreationFeedback* pTessCtlFB) {
-	uint64_t startTime = 0;
+bool MVKGraphicsPipeline::compileTessControlStageState(
+    MTLComputePipelineDescriptor* tcPLDesc,
+    VkPipelineCreationFeedback* pTessCtlFB) {
+    uint64_t startTime = 0;
     if (pTessCtlFB) {
-		startTime = mvkGetTimestamp();
-	}
-    bool res = !!getOrCompilePipeline(tcPLDesc, _mtlTessControlStageState, "Tessellation control");
-	if (pTessCtlFB) {
-		if (!res) {
-			mvkDisableFlags(pTessCtlFB->flags, VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
-		}
-		pTessCtlFB->duration += mvkGetElapsedNanoseconds(startTime);
-	}
-	return res;
+        startTime = mvkGetTimestamp();
+    }
+    bool res = !!getOrCompilePipeline(tcPLDesc, _mtlTessControlStageState,
+                                      "Tessellation control");
+    if (pTessCtlFB) {
+        if (!res) {
+            mvkDisableFlags(pTessCtlFB->flags,
+                            VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
+        }
+        pTessCtlFB->duration += mvkGetElapsedNanoseconds(startTime);
+    }
+    return res;
 }
-
 
 #pragma mark Construction
 
-// Extracts and returns a VkPipelineRenderingCreateInfo from the renderPass or pNext
-// chain of pCreateInfo, or returns an empty struct if neither of those are found.
-// Although the Vulkan spec is vague and unclear, there are CTS that set both renderPass
-// and VkPipelineRenderingCreateInfo to null in VkGraphicsPipelineCreateInfo.
-static const VkPipelineRenderingCreateInfo* getRenderingCreateInfo(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	if (pCreateInfo->renderPass) {
-		return ((MVKRenderPass*)pCreateInfo->renderPass)->getSubpass(pCreateInfo->subpass)->getPipelineRenderingCreateInfo();
-	}
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO: return (VkPipelineRenderingCreateInfo*)next;
-			default: break;
-		}
-	}
-	static VkPipelineRenderingCreateInfo emptyRendInfo = { .sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO };
-	return &emptyRendInfo;
+// Extracts and returns a VkPipelineRenderingCreateInfo from the renderPass or
+// pNext chain of pCreateInfo, or returns an empty struct if neither of those
+// are found. Although the Vulkan spec is vague and unclear, there are CTS that
+// set both renderPass and VkPipelineRenderingCreateInfo to null in
+// VkGraphicsPipelineCreateInfo.
+static const VkPipelineRenderingCreateInfo*
+getRenderingCreateInfo(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    if (pCreateInfo->renderPass) {
+        return ((MVKRenderPass*)pCreateInfo->renderPass)
+            ->getSubpass(pCreateInfo->subpass)
+            ->getPipelineRenderingCreateInfo();
+    }
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO:
+            return (VkPipelineRenderingCreateInfo*)next;
+        default:
+            break;
+        }
+    }
+    static VkPipelineRenderingCreateInfo emptyRendInfo = {
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    return &emptyRendInfo;
 }
 
-MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
-										 MVKPipelineCache* pipelineCache,
-										 MVKPipeline* parent,
-										 const VkGraphicsPipelineCreateInfo* pCreateInfo) :
-	MVKPipeline(device, pipelineCache, (MVKPipelineLayout*)pCreateInfo->layout, pCreateInfo->flags, parent) {
+MVKGraphicsPipeline::MVKGraphicsPipeline(
+    MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipeline* parent,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo)
+    : MVKPipeline(device, pipelineCache,
+                  (MVKPipelineLayout*)pCreateInfo->layout, pCreateInfo->flags,
+                  parent) {
 
+    // Extract dynamic state first, as it can affect many configurations.
+    initDynamicState(pCreateInfo);
 
-	// Extract dynamic state first, as it can affect many configurations.
-	initDynamicState(pCreateInfo);
+    // Determine rasterization early, as various other structs are validated and
+    // interpreted in this context.
+    const VkPipelineRenderingCreateInfo* pRendInfo =
+        getRenderingCreateInfo(pCreateInfo);
+    _isRasterizing = !isRasterizationDisabled(pCreateInfo);
+    _isRasterizingColor = _isRasterizing && mvkHasColorAttachments(pRendInfo);
 
-	// Determine rasterization early, as various other structs are validated and interpreted in this context.
-	const VkPipelineRenderingCreateInfo* pRendInfo = getRenderingCreateInfo(pCreateInfo);
-	_isRasterizing = !isRasterizationDisabled(pCreateInfo);
-	_isRasterizingColor = _isRasterizing && mvkHasColorAttachments(pRendInfo);
+    const VkPipelineCreationFeedbackCreateInfo* pFeedbackInfo = nullptr;
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
+            pFeedbackInfo = (VkPipelineCreationFeedbackCreateInfo*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	const VkPipelineCreationFeedbackCreateInfo* pFeedbackInfo = nullptr;
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
-				pFeedbackInfo = (VkPipelineCreationFeedbackCreateInfo*)next;
-				break;
-			default:
-				break;
-		}
-	}
+    // Initialize feedback. The VALID bit must be initialized, either set or
+    // cleared. We'll set the VALID bits later, after successful compilation.
+    VkPipelineCreationFeedback* pPipelineFB = nullptr;
+    if (pFeedbackInfo) {
+        pPipelineFB = pFeedbackInfo->pPipelineCreationFeedback;
+        // n.b. Do *NOT* use mvkClear(). That would also clear the sType and
+        // pNext fields.
+        pPipelineFB->flags = 0;
+        pPipelineFB->duration = 0;
+        for (uint32_t i = 0;
+             i < pFeedbackInfo->pipelineStageCreationFeedbackCount; ++i) {
+            pFeedbackInfo->pPipelineStageCreationFeedbacks[i].flags = 0;
+            pFeedbackInfo->pPipelineStageCreationFeedbacks[i].duration = 0;
+        }
+    }
 
-	// Initialize feedback. The VALID bit must be initialized, either set or cleared.
-	// We'll set the VALID bits later, after successful compilation.
-	VkPipelineCreationFeedback* pPipelineFB = nullptr;
-	if (pFeedbackInfo) {
-		pPipelineFB = pFeedbackInfo->pPipelineCreationFeedback;
-		// n.b. Do *NOT* use mvkClear(). That would also clear the sType and pNext fields.
-		pPipelineFB->flags = 0;
-		pPipelineFB->duration = 0;
-		for (uint32_t i = 0; i < pFeedbackInfo->pipelineStageCreationFeedbackCount; ++i) {
-			pFeedbackInfo->pPipelineStageCreationFeedbacks[i].flags = 0;
-			pFeedbackInfo->pPipelineStageCreationFeedbacks[i].duration = 0;
-		}
-	}
+    // Get the shader stages. Do this now, because we need to extract
+    // reflection data from them that informs everything else.
+    const VkPipelineShaderStageCreateInfo* pVertexSS = nullptr;
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS = nullptr;
+    const VkPipelineShaderStageCreateInfo* pTessEvalSS = nullptr;
+    const VkPipelineShaderStageCreateInfo* pFragmentSS = nullptr;
+    VkPipelineCreationFeedback* pVertexFB = nullptr;
+    VkPipelineCreationFeedback* pTessCtlFB = nullptr;
+    VkPipelineCreationFeedback* pTessEvalFB = nullptr;
+    VkPipelineCreationFeedback* pFragmentFB = nullptr;
+    for (uint32_t i = 0; i < pCreateInfo->stageCount; i++) {
+        const auto* pSS = &pCreateInfo->pStages[i];
+        switch (pSS->stage) {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+            pVertexSS = pSS;
+            if (pFeedbackInfo &&
+                pFeedbackInfo->pPipelineStageCreationFeedbacks) {
+                pVertexFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
+            }
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            pTessCtlSS = pSS;
+            if (pFeedbackInfo &&
+                pFeedbackInfo->pPipelineStageCreationFeedbacks) {
+                pTessCtlFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
+            }
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            pTessEvalSS = pSS;
+            if (pFeedbackInfo &&
+                pFeedbackInfo->pPipelineStageCreationFeedbacks) {
+                pTessEvalFB =
+                    &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
+            }
+            break;
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            pFragmentSS = pSS;
+            if (pFeedbackInfo &&
+                pFeedbackInfo->pPipelineStageCreationFeedbacks) {
+                pFragmentFB =
+                    &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
+            }
+            break;
+        default:
+            break;
+        }
+    }
 
-	// Get the shader stages. Do this now, because we need to extract
-	// reflection data from them that informs everything else.
-	const VkPipelineShaderStageCreateInfo* pVertexSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* pTessCtlSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* pTessEvalSS = nullptr;
-	const VkPipelineShaderStageCreateInfo* pFragmentSS = nullptr;
-	VkPipelineCreationFeedback* pVertexFB = nullptr;
-	VkPipelineCreationFeedback* pTessCtlFB = nullptr;
-	VkPipelineCreationFeedback* pTessEvalFB = nullptr;
-	VkPipelineCreationFeedback* pFragmentFB = nullptr;
-	for (uint32_t i = 0; i < pCreateInfo->stageCount; i++) {
-		const auto* pSS = &pCreateInfo->pStages[i];
-		switch (pSS->stage) {
-			case VK_SHADER_STAGE_VERTEX_BIT:
-				pVertexSS = pSS;
-				if (pFeedbackInfo && pFeedbackInfo->pPipelineStageCreationFeedbacks) {
-					pVertexFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
-				}
-				break;
-			case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
-				pTessCtlSS = pSS;
-				if (pFeedbackInfo && pFeedbackInfo->pPipelineStageCreationFeedbacks) {
-					pTessCtlFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
-				}
-				break;
-			case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
-				pTessEvalSS = pSS;
-				if (pFeedbackInfo && pFeedbackInfo->pPipelineStageCreationFeedbacks) {
-					pTessEvalFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
-				}
-				break;
-			case VK_SHADER_STAGE_FRAGMENT_BIT:
-				pFragmentSS = pSS;
-				if (pFeedbackInfo && pFeedbackInfo->pPipelineStageCreationFeedbacks) {
-					pFragmentFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[i];
-				}
-				break;
-			default:
-				break;
-		}
-	}
+    // Get the tessellation parameters from the shaders.
+    SPIRVTessReflectionData reflectData;
+    std::string reflectErrorLog;
+    if (pTessCtlSS && pTessEvalSS) {
+        _isTessellationPipeline = true;
 
-	// Get the tessellation parameters from the shaders.
-	SPIRVTessReflectionData reflectData;
-	std::string reflectErrorLog;
-	if (pTessCtlSS && pTessEvalSS) {
-		_isTessellationPipeline = true;
+        if (!getTessReflectionData(((MVKShaderModule*)pTessCtlSS->module)
+                                       ->getSPIRV(),
+                                   pTessCtlSS->pName,
+                                   ((MVKShaderModule*)pTessEvalSS->module)
+                                       ->getSPIRV(),
+                                   pTessEvalSS->pName, reflectData,
+                                   reflectErrorLog)) {
+            setConfigurationResult(
+                reportError(VK_ERROR_INITIALIZATION_FAILED,
+                            "Failed to reflect tessellation shaders: %s",
+                            reflectErrorLog.c_str()));
+            return;
+        }
+        // Unfortunately, we can't support line tessellation at this time.
+        if (reflectData.patchKind == spv::ExecutionModeIsolines) {
+            setConfigurationResult(
+                reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                            "Metal does not support isoline tessellation."));
+            return;
+        }
+    }
 
-		if (!getTessReflectionData(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(), pTessCtlSS->pName, ((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(), pTessEvalSS->pName, reflectData, reflectErrorLog) ) {
-			setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to reflect tessellation shaders: %s", reflectErrorLog.c_str()));
-			return;
-		}
-		// Unfortunately, we can't support line tessellation at this time.
-		if (reflectData.patchKind == spv::ExecutionModeIsolines) {
-			setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "Metal does not support isoline tessellation."));
-			return;
-		}
-	}
+    // Tessellation - must ignore allowed bad pTessellationState pointer if not
+    // tess pipeline
+    _outputControlPointCount = reflectData.numControlPoints;
+    mvkSetOrClear(&_tessInfo, _isTessellationPipeline
+                                  ? pCreateInfo->pTessellationState
+                                  : nullptr);
 
-	// Tessellation - must ignore allowed bad pTessellationState pointer if not tess pipeline
-	_outputControlPointCount = reflectData.numControlPoints;
-	mvkSetOrClear(&_tessInfo, _isTessellationPipeline ? pCreateInfo->pTessellationState : nullptr);
+    // Handles depth attachment being used as input attachment. However, it does
+    // not solve the issue when the pipeline is created without render pass
+    // (dynamic rendering) since we won't be able to know which resources will
+    // be used when rendering. Needs to be done before we do shaders Potential
+    // solution would be to generate 2 pipelines, one with the workaround for
+    // the Metal issue and one without it, and decide at bind time once we know
+    // the resources which one to use.
+    if (pCreateInfo->renderPass) {
+        MVKRenderSubpass* subpass = ((MVKRenderPass*)pCreateInfo->renderPass)
+                                        ->getSubpass(pCreateInfo->subpass);
+        _inputAttachmentIsDSAttachment =
+            subpass->isInputAttachmentDepthStencilAttachment();
+    }
 
-	// Handles depth attachment being used as input attachment. However, it does not solve the issue when
-	// the pipeline is created without render pass (dynamic rendering) since we won't be able to know
-	// which resources will be used when rendering. Needs to be done before we do shaders
-	// Potential solution would be to generate 2 pipelines, one with the workaround for the Metal issue
-	// and one without it, and decide at bind time once we know the resources which one to use.
-	if (pCreateInfo->renderPass) {
-		MVKRenderSubpass* subpass = ((MVKRenderPass*)pCreateInfo->renderPass)->getSubpass(pCreateInfo->subpass);
-		_inputAttachmentIsDSAttachment = subpass->isInputAttachmentDepthStencilAttachment();
-	}
+    // Render pipeline state. Do this as early as possible, to fail fast if
+    // pipeline requires a fail on cache-miss.
+    initMTLRenderPipelineState(pCreateInfo, reflectData, pPipelineFB, pVertexSS,
+                               pVertexFB, pTessCtlSS, pTessCtlFB, pTessEvalSS,
+                               pTessEvalFB, pFragmentSS, pFragmentFB);
+    if (!_hasValidMTLPipelineStates) {
+        return;
+    }
 
-	// Render pipeline state. Do this as early as possible, to fail fast if pipeline requires a fail on cache-miss.
-	initMTLRenderPipelineState(pCreateInfo, reflectData, pPipelineFB, pVertexSS, pVertexFB, pTessCtlSS, pTessCtlFB, pTessEvalSS, pTessEvalFB, pFragmentSS, pFragmentFB);
-	if ( !_hasValidMTLPipelineStates ) { return; }
+    // Blending - must ignore allowed bad pColorBlendState pointer if
+    // rasterization disabled or no color attachments
+    if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
+        mvkCopy(_blendConstants.float32,
+                pCreateInfo->pColorBlendState->blendConstants, 4);
+    }
 
-	// Blending - must ignore allowed bad pColorBlendState pointer if rasterization disabled or no color attachments
-	if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
-		mvkCopy(_blendConstants.float32, pCreateInfo->pColorBlendState->blendConstants, 4);
-	}
+    // Topology
+    _vkPrimitiveTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    _primitiveRestartEnable = true; // Always enabled in Metal
+    if (pCreateInfo->pInputAssemblyState) {
+        _vkPrimitiveTopology = pCreateInfo->pInputAssemblyState->topology;
+        _primitiveRestartEnable =
+            pCreateInfo->pInputAssemblyState->primitiveRestartEnable;
+    }
 
-	// Topology
-	_vkPrimitiveTopology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-	_primitiveRestartEnable = true;			// Always enabled in Metal
-	if (pCreateInfo->pInputAssemblyState) {
-		_vkPrimitiveTopology = pCreateInfo->pInputAssemblyState->topology;
-		_primitiveRestartEnable = pCreateInfo->pInputAssemblyState->primitiveRestartEnable;
-	}
+    // In Metal, primitive restart cannot be disabled, so issue a warning if the
+    // app has disabled it statically, or indicates that it might do so
+    // dynamically. Just issue a warning here, as it is very likely the app is
+    // not actually expecting to use primitive restart at all, and is disabling
+    // it "just-in-case". As such, forcing an error here would be unexpected to
+    // the app (including CTS). BTW, although Metal docs avoid mentioning it,
+    // testing shows that Metal does not support primitive restart for list
+    // topologies, meaning VK_EXT_primitive_topology_list_restart cannot be
+    // supported.
+    if ((!_primitiveRestartEnable || isDynamicState(PrimitiveRestartEnable)) &&
+        (_vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP ||
+         _vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP ||
+         _vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN ||
+         isDynamicState(PrimitiveTopology))) {
+        reportWarning(VK_ERROR_FEATURE_NOT_PRESENT,
+                      "Metal does not support disabling primitive restart.");
+    }
 
-	// In Metal, primitive restart cannot be disabled, so issue a warning if the app
-	// has disabled it statically, or indicates that it might do so dynamically.
-	// Just issue a warning here, as it is very likely the app is not actually
-	// expecting to use primitive restart at all, and is disabling it "just-in-case".
-	// As such, forcing an error here would be unexpected to the app (including CTS).
-	// BTW, although Metal docs avoid mentioning it, testing shows that Metal does not support primitive
-	// restart for list topologies, meaning VK_EXT_primitive_topology_list_restart cannot be supported.
-	if (( !_primitiveRestartEnable || isDynamicState(PrimitiveRestartEnable)) &&
-		 (_vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP ||
-		  _vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP ||
-		  _vkPrimitiveTopology == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN ||
-		  isDynamicState(PrimitiveTopology))) {
-		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Metal does not support disabling primitive restart.");
-	}
+    // Rasterization
+    _hasRasterInfo =
+        mvkSetOrClear(&_rasterInfo, pCreateInfo->pRasterizationState);
 
-	// Rasterization
-	_hasRasterInfo = mvkSetOrClear(&_rasterInfo, pCreateInfo->pRasterizationState);
+    // Must run after _isRasterizing and _dynamicState are populated
+    initSampleLocations(pCreateInfo);
 
-	// Must run after _isRasterizing and _dynamicState are populated
-	initSampleLocations(pCreateInfo);
+    // Depth stencil content - clearing will disable depth and stencil testing
+    // Must ignore allowed bad pDepthStencilState pointer if rasterization
+    // disabled or no depth or stencil attachment format
+    bool isRasterizingDepthStencil =
+        _isRasterizing && (pRendInfo->depthAttachmentFormat ||
+                           pRendInfo->stencilAttachmentFormat);
+    mvkSetOrClear(&_depthStencilInfo, isRasterizingDepthStencil
+                                          ? pCreateInfo->pDepthStencilState
+                                          : nullptr);
 
-	// Depth stencil content - clearing will disable depth and stencil testing
-	// Must ignore allowed bad pDepthStencilState pointer if rasterization disabled or no depth or stencil attachment format
-	bool isRasterizingDepthStencil = _isRasterizing && (pRendInfo->depthAttachmentFormat || pRendInfo->stencilAttachmentFormat);
-	mvkSetOrClear(&_depthStencilInfo, isRasterizingDepthStencil ? pCreateInfo->pDepthStencilState : nullptr);
+    // Viewports and scissors - must ignore allowed bad pViewportState pointer
+    // if rasterization is disabled
+    auto pVPState = _isRasterizing ? pCreateInfo->pViewportState : nullptr;
+    if (pVPState) {
 
-	// Viewports and scissors - must ignore allowed bad pViewportState pointer if rasterization is disabled
-	auto pVPState = _isRasterizing ? pCreateInfo->pViewportState : nullptr;
-	if (pVPState) {
+        // If viewports are dynamic, ignore them here.
+        uint32_t vpCnt = (pVPState->pViewports && !isDynamicState(Viewports))
+                             ? pVPState->viewportCount
+                             : 0;
+        _viewports.reserve(vpCnt);
+        for (uint32_t vpIdx = 0; vpIdx < vpCnt; vpIdx++) {
+            _viewports.push_back(pVPState->pViewports[vpIdx]);
+        }
 
-		// If viewports are dynamic, ignore them here.
-		uint32_t vpCnt = (pVPState->pViewports && !isDynamicState(Viewports)) ? pVPState->viewportCount : 0;
-		_viewports.reserve(vpCnt);
-		for (uint32_t vpIdx = 0; vpIdx < vpCnt; vpIdx++) {
-			_viewports.push_back(pVPState->pViewports[vpIdx]);
-		}
-
-		// If scissors are dynamic, ignore them here.
-		uint32_t sCnt = (pVPState->pScissors && !isDynamicState(Scissors)) ? pVPState->scissorCount : 0;
-		_scissors.reserve(sCnt);
-		for (uint32_t sIdx = 0; sIdx < sCnt; sIdx++) {
-			_scissors.push_back(pVPState->pScissors[sIdx]);
-		}
-	}
+        // If scissors are dynamic, ignore them here.
+        uint32_t sCnt = (pVPState->pScissors && !isDynamicState(Scissors))
+                            ? pVPState->scissorCount
+                            : 0;
+        _scissors.reserve(sCnt);
+        for (uint32_t sIdx = 0; sIdx < sCnt; sIdx++) {
+            _scissors.push_back(pVPState->pScissors[sIdx]);
+        }
+    }
 }
 
 static MVKRenderStateType getRenderStateType(VkDynamicState vkDynamicState) {
-	switch (vkDynamicState) {
-		case VK_DYNAMIC_STATE_BLEND_CONSTANTS:             return BlendConstants;
-		case VK_DYNAMIC_STATE_CULL_MODE:                   return CullMode;
-		case VK_DYNAMIC_STATE_DEPTH_BIAS:                  return DepthBias;
-		case VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE:           return DepthBiasEnable;
-		case VK_DYNAMIC_STATE_DEPTH_BOUNDS:                return DepthBounds;
-		case VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE:    return DepthBoundsTestEnable;
-		case VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT:      return DepthClipEnable;
-		case VK_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT:       return DepthClipEnable;
-		case VK_DYNAMIC_STATE_DEPTH_COMPARE_OP:            return DepthCompareOp;
-		case VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE:           return DepthTestEnable;
-		case VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE:          return DepthWriteEnable;
-		case VK_DYNAMIC_STATE_FRONT_FACE:                  return FrontFace;
-		case VK_DYNAMIC_STATE_LINE_WIDTH:                  return LineWidth;
-		case VK_DYNAMIC_STATE_LOGIC_OP_EXT:                return LogicOp;
-		case VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT:         return LogicOpEnable;
-		case VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT:    return PatchControlPoints;
-		case VK_DYNAMIC_STATE_POLYGON_MODE_EXT:            return PolygonMode;
-		case VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE:    return PrimitiveRestartEnable;
-		case VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY:          return PrimitiveTopology;
-		case VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE:   return RasterizerDiscardEnable;
-		case VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT:        return SampleLocations;
-		case VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT: return SampleLocationsEnable;
-		case VK_DYNAMIC_STATE_SCISSOR:                     return Scissors;
-		case VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT:          return Scissors;
-		case VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK:        return StencilCompareMask;
-		case VK_DYNAMIC_STATE_STENCIL_OP:                  return StencilOp;
-		case VK_DYNAMIC_STATE_STENCIL_REFERENCE:           return StencilReference;
-		case VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE:         return StencilTestEnable;
-		case VK_DYNAMIC_STATE_STENCIL_WRITE_MASK:          return StencilWriteMask;
-		case VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE: return VertexStride;
-		case VK_DYNAMIC_STATE_VIEWPORT:                    return Viewports;
-		case VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT:         return Viewports;
-		default:                                           return Unknown;
-	}
+    switch (vkDynamicState) {
+    case VK_DYNAMIC_STATE_BLEND_CONSTANTS:
+        return BlendConstants;
+    case VK_DYNAMIC_STATE_CULL_MODE:
+        return CullMode;
+    case VK_DYNAMIC_STATE_DEPTH_BIAS:
+        return DepthBias;
+    case VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE:
+        return DepthBiasEnable;
+    case VK_DYNAMIC_STATE_DEPTH_BOUNDS:
+        return DepthBounds;
+    case VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE:
+        return DepthBoundsTestEnable;
+    case VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT:
+        return DepthClipEnable;
+    case VK_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT:
+        return DepthClipEnable;
+    case VK_DYNAMIC_STATE_DEPTH_COMPARE_OP:
+        return DepthCompareOp;
+    case VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE:
+        return DepthTestEnable;
+    case VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE:
+        return DepthWriteEnable;
+    case VK_DYNAMIC_STATE_FRONT_FACE:
+        return FrontFace;
+    case VK_DYNAMIC_STATE_LINE_WIDTH:
+        return LineWidth;
+    case VK_DYNAMIC_STATE_LOGIC_OP_EXT:
+        return LogicOp;
+    case VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT:
+        return LogicOpEnable;
+    case VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT:
+        return PatchControlPoints;
+    case VK_DYNAMIC_STATE_POLYGON_MODE_EXT:
+        return PolygonMode;
+    case VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE:
+        return PrimitiveRestartEnable;
+    case VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY:
+        return PrimitiveTopology;
+    case VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE:
+        return RasterizerDiscardEnable;
+    case VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT:
+        return SampleLocations;
+    case VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT:
+        return SampleLocationsEnable;
+    case VK_DYNAMIC_STATE_SCISSOR:
+        return Scissors;
+    case VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT:
+        return Scissors;
+    case VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK:
+        return StencilCompareMask;
+    case VK_DYNAMIC_STATE_STENCIL_OP:
+        return StencilOp;
+    case VK_DYNAMIC_STATE_STENCIL_REFERENCE:
+        return StencilReference;
+    case VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE:
+        return StencilTestEnable;
+    case VK_DYNAMIC_STATE_STENCIL_WRITE_MASK:
+        return StencilWriteMask;
+    case VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE:
+        return VertexStride;
+    case VK_DYNAMIC_STATE_VIEWPORT:
+        return Viewports;
+    case VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT:
+        return Viewports;
+    default:
+        return Unknown;
+    }
 }
 
-// This is executed first during pipeline creation. Do not depend on any internal state here.
-void MVKGraphicsPipeline::initDynamicState(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	const auto* pDS = pCreateInfo->pDynamicState;
-	if ( !pDS ) { return; }
+// This is executed first during pipeline creation. Do not depend on any
+// internal state here.
+void MVKGraphicsPipeline::initDynamicState(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    const auto* pDS = pCreateInfo->pDynamicState;
+    if (!pDS) {
+        return;
+    }
 
-	for (uint32_t i = 0; i < pDS->dynamicStateCount; i++) {
-		auto dynStateType = getRenderStateType(pDS->pDynamicStates[i]);
-		bool isDynamic = true;
+    for (uint32_t i = 0; i < pDS->dynamicStateCount; i++) {
+        auto dynStateType = getRenderStateType(pDS->pDynamicStates[i]);
+        bool isDynamic = true;
 
-		// Some dynamic states have other restrictions
-		switch (dynStateType) {
-			case VertexStride:
-				isDynamic = getMetalFeatures().dynamicVertexStride;
-				if ( !isDynamic ) { setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "This device and platform does not support VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE (macOS 14.0 or iOS/tvOS 17.0, plus either Apple4 or Mac2 GPU).")); }
-				break;
-			default:
-				break;
-		}
+        // Some dynamic states have other restrictions
+        switch (dynStateType) {
+        case VertexStride:
+            isDynamic = getMetalFeatures().dynamicVertexStride;
+            if (!isDynamic) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                                "This device and platform does not support "
+                                "VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE "
+                                "(macOS 14.0 or "
+                                "iOS/tvOS 17.0, plus either Apple4 or Mac2 "
+                                "GPU)."));
+            }
+            break;
+        default:
+            break;
+        }
 
-		if (isDynamic) { _dynamicState.enable(dynStateType); }
-	}
+        if (isDynamic) {
+            _dynamicState.enable(dynStateType);
+        }
+    }
 }
 
 // Either returns an existing pipeline state or compiles a new one.
-id<MTLRenderPipelineState> MVKGraphicsPipeline::getOrCompilePipeline(MTLRenderPipelineDescriptor* plDesc,
-																	 id<MTLRenderPipelineState>& plState) {
-	if ( !plState ) {
-		MVKRenderPipelineCompiler* plc = new MVKRenderPipelineCompiler(this);
-		plState = plc->newMTLRenderPipelineState(plDesc);	// retained
-		plc->destroy();
-		if ( !plState ) { _hasValidMTLPipelineStates = false; }
-	}
-	return plState;
+id<MTLRenderPipelineState>
+MVKGraphicsPipeline::getOrCompilePipeline(MTLRenderPipelineDescriptor* plDesc,
+                                          id<MTLRenderPipelineState>& plState) {
+    if (!plState) {
+        MVKRenderPipelineCompiler* plc = new MVKRenderPipelineCompiler(this);
+        plState = plc->newMTLRenderPipelineState(plDesc); // retained
+        plc->destroy();
+        if (!plState) {
+            _hasValidMTLPipelineStates = false;
+        }
+    }
+    return plState;
 }
 
 // Either returns an existing pipeline state or compiles a new one.
-id<MTLComputePipelineState> MVKGraphicsPipeline::getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc,
-																	  id<MTLComputePipelineState>& plState,
-																	  const char* compilerType) {
-	if ( !plState ) {
-		MVKComputePipelineCompiler* plc = new MVKComputePipelineCompiler(this, compilerType);
-		plState = plc->newMTLComputePipelineState(plDesc);	// retained
-		plc->destroy();
-		if ( !plState ) { _hasValidMTLPipelineStates = false; }
-	}
-	return plState;
+id<MTLComputePipelineState>
+MVKGraphicsPipeline::getOrCompilePipeline(MTLComputePipelineDescriptor* plDesc,
+                                          id<MTLComputePipelineState>& plState,
+                                          const char* compilerType) {
+    if (!plState) {
+        MVKComputePipelineCompiler* plc =
+            new MVKComputePipelineCompiler(this, compilerType);
+        plState = plc->newMTLComputePipelineState(plDesc); // retained
+        plc->destroy();
+        if (!plState) {
+            _hasValidMTLPipelineStates = false;
+        }
+    }
+    return plState;
 }
 
 // Must run after _isRasterizing and _dynamicState are populated
-void MVKGraphicsPipeline::initSampleLocations(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+void MVKGraphicsPipeline::initSampleLocations(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
 
-	// Must ignore allowed bad pMultisampleState pointer if rasterization disabled
-	if ( !(_isRasterizing && pCreateInfo->pMultisampleState) ) { return; }
+    // Must ignore allowed bad pMultisampleState pointer if rasterization
+    // disabled
+    if (!(_isRasterizing && pCreateInfo->pMultisampleState)) {
+        return;
+    }
 
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pMultisampleState->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT: {
-				auto* pSampLocnsCreateInfo = (VkPipelineSampleLocationsStateCreateInfoEXT*)next;
-				_sampleLocationsEnable = pSampLocnsCreateInfo->sampleLocationsEnable;
-				for (uint32_t slIdx = 0; slIdx < pSampLocnsCreateInfo->sampleLocationsInfo.sampleLocationsCount; slIdx++) {
-					_sampleLocations.push_back(pSampLocnsCreateInfo->sampleLocationsInfo.pSampleLocations[slIdx]);
-				}
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    for (const auto* next =
+             (VkBaseInStructure*)pCreateInfo->pMultisampleState->pNext;
+         next; next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT: {
+            auto* pSampLocnsCreateInfo =
+                (VkPipelineSampleLocationsStateCreateInfoEXT*)next;
+            _sampleLocationsEnable =
+                pSampLocnsCreateInfo->sampleLocationsEnable;
+            for (uint32_t slIdx = 0;
+                 slIdx <
+                 pSampLocnsCreateInfo->sampleLocationsInfo.sampleLocationsCount;
+                 slIdx++) {
+                _sampleLocations.push_back(
+                    pSampLocnsCreateInfo->sampleLocationsInfo
+                        .pSampleLocations[slIdx]);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
 }
 
 // Constructs the underlying Metal render pipeline.
-void MVKGraphicsPipeline::initMTLRenderPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													 const SPIRVTessReflectionData& reflectData,
-													 VkPipelineCreationFeedback* pPipelineFB,
-													 const VkPipelineShaderStageCreateInfo* pVertexSS,
-													 VkPipelineCreationFeedback* pVertexFB,
-													 const VkPipelineShaderStageCreateInfo* pTessCtlSS,
-													 VkPipelineCreationFeedback* pTessCtlFB,
-													 const VkPipelineShaderStageCreateInfo* pTessEvalSS,
-													 VkPipelineCreationFeedback* pTessEvalFB,
-													 const VkPipelineShaderStageCreateInfo* pFragmentSS,
-													 VkPipelineCreationFeedback* pFragmentFB) {
-	_mtlTessVertexStageState = nil;
-	_mtlTessVertexStageIndex16State = nil;
-	_mtlTessVertexStageIndex32State = nil;
-	_mtlTessControlStageState = nil;
-	_mtlPipelineState = nil;
+void MVKGraphicsPipeline::initMTLRenderPipelineState(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData,
+    VkPipelineCreationFeedback* pPipelineFB,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    VkPipelineCreationFeedback* pVertexFB,
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+    VkPipelineCreationFeedback* pTessCtlFB,
+    const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+    VkPipelineCreationFeedback* pTessEvalFB,
+    const VkPipelineShaderStageCreateInfo* pFragmentSS,
+    VkPipelineCreationFeedback* pFragmentFB) {
+    _mtlTessVertexStageState = nil;
+    _mtlTessVertexStageIndex16State = nil;
+    _mtlTessVertexStageIndex32State = nil;
+    _mtlTessControlStageState = nil;
+    _mtlPipelineState = nil;
 
-	uint64_t pipelineStart = 0;
-	if (pPipelineFB) {
-		pipelineStart = mvkGetTimestamp();
-	}
+    uint64_t pipelineStart = 0;
+    if (pPipelineFB) {
+        pipelineStart = mvkGetTimestamp();
+    }
 
-	if (isUsingMetalArgumentBuffers()) { _descriptorBindingUse.resize(_descriptorSetCount); }
+    if (isUsingMetalArgumentBuffers()) {
+        _descriptorBindingUse.resize(_descriptorSetCount);
+    }
 
-	const char* dumpDir = getMVKConfig().shaderDumpDir;
-	if (dumpDir && *dumpDir) {
-		char filename[PATH_MAX];
-		char text[1024];
-		char* ptext = text;
-		size_t full_hash = 0;
-		const char* type = pTessCtlSS && pTessEvalSS ? "-tess" : "";
-		auto addShader = [&](const char* type, const VkPipelineShaderStageCreateInfo* ss) {
-			if (!ss) {
-				return;
-			}
-			size_t hash = reinterpret_cast<MVKShaderModule*>(ss->module)->getKey().codeHash;
-			full_hash = full_hash * 33 ^ hash;
-			ptext = std::min(ptext + snprintf(ptext, std::end(text) - ptext, "%s: %016zx\n", type, hash), std::end(text) - 1);
-		};
-		addShader(" VS", pVertexSS);
-		addShader("TCS", pTessCtlSS);
-		addShader("TES", pTessEvalSS);
-		addShader(" FS", pFragmentSS);
-		mkdir(dumpDir, 0755);
-		snprintf(filename, sizeof(filename), "%s/pipeline%s-%016zx.txt", dumpDir, type, full_hash);
-		FILE* file = fopen(filename, "w");
-		if (file) {
-			fwrite(text, 1, ptext - text, file);
-			fclose(file);
-		}
-	}
+    const char* dumpDir = getMVKConfig().shaderDumpDir;
+    if (dumpDir && *dumpDir) {
+        char filename[PATH_MAX];
+        char text[1024];
+        char* ptext = text;
+        size_t full_hash = 0;
+        const char* type = pTessCtlSS && pTessEvalSS ? "-tess" : "";
+        auto addShader = [&](const char* type,
+                             const VkPipelineShaderStageCreateInfo* ss) {
+            if (!ss) {
+                return;
+            }
+            size_t hash = reinterpret_cast<MVKShaderModule*>(ss->module)
+                              ->getKey()
+                              .codeHash;
+            full_hash = full_hash * 33 ^ hash;
+            ptext = std::min(ptext + snprintf(ptext, std::end(text) - ptext,
+                                              "%s: %016zx\n", type, hash),
+                             std::end(text) - 1);
+        };
+        addShader(" VS", pVertexSS);
+        addShader("TCS", pTessCtlSS);
+        addShader("TES", pTessEvalSS);
+        addShader(" FS", pFragmentSS);
+        mkdir(dumpDir, 0755);
+        snprintf(filename, sizeof(filename), "%s/pipeline%s-%016zx.txt",
+                 dumpDir, type, full_hash);
+        FILE* file = fopen(filename, "w");
+        if (file) {
+            fwrite(text, 1, ptext - text, file);
+            fclose(file);
+        }
+    }
 
-	if (!isTessellationPipeline()) {
-		MTLRenderPipelineDescriptor* plDesc = newMTLRenderPipelineDescriptor(pCreateInfo, reflectData, pVertexSS, pVertexFB, pFragmentSS, pFragmentFB);	// temp retain
-		if (plDesc) {
-			const VkPipelineRenderingCreateInfo* pRendInfo = getRenderingCreateInfo(pCreateInfo);
-			if (pRendInfo && mvkIsMultiview(pRendInfo->viewMask)) {
-				// We need to adjust the step rate for per-instance attributes to account for the
-				// extra instances needed to render all views. But, there's a problem: vertex input
-				// descriptions are static pipeline state. If we need multiple passes, and some have
-				// different numbers of views to render than others, then the step rate must be different
-				// for these passes. We'll need to make a pipeline for every pass view count we can see
-				// in the render pass. This really sucks.
-				std::unordered_set<uint32_t> viewCounts;
-				for (uint32_t passIdx = 0; passIdx < getDevice()->getMultiviewMetalPassCount(pRendInfo->viewMask); ++passIdx) {
-					viewCounts.insert(getDevice()->getViewCountInMetalPass(pRendInfo->viewMask, passIdx));
-				}
-				auto count = viewCounts.cbegin();
-				adjustVertexInputForMultiview(plDesc.vertexDescriptor, pCreateInfo->pVertexInputState, *count);
-				getOrCompilePipeline(plDesc, _mtlPipelineState);
-				if (viewCounts.size() > 1) {
-					_multiviewMTLPipelineStates[*count] = _mtlPipelineState;
-					uint32_t oldCount = *count++;
-					for (auto last = viewCounts.cend(); count != last; ++count) {
-						if (_multiviewMTLPipelineStates.count(*count)) { continue; }
-						adjustVertexInputForMultiview(plDesc.vertexDescriptor, pCreateInfo->pVertexInputState, *count, oldCount);
-						getOrCompilePipeline(plDesc, _multiviewMTLPipelineStates[*count]);
-						oldCount = *count;
-					}
-				}
-			} else {
-				getOrCompilePipeline(plDesc, _mtlPipelineState);
-			}
-			[plDesc release];																				// temp release
-		} else {
-			_hasValidMTLPipelineStates = false;
-		}
-	} else {
-		// In this case, we need to create three render pipelines. But, the way Metal handles
-		// index buffers for compute stage-in means we have to create three pipelines for
-		// stage 1 (five pipelines in total).
-		SPIRVToMSLConversionConfiguration shaderConfig;
-		initShaderConversionConfig(shaderConfig, pCreateInfo, reflectData);
+    if (!isTessellationPipeline()) {
+        MTLRenderPipelineDescriptor* plDesc =
+            newMTLRenderPipelineDescriptor(pCreateInfo, reflectData, pVertexSS,
+                                           pVertexFB, pFragmentSS,
+                                           pFragmentFB); // temp retain
+        if (plDesc) {
+            const VkPipelineRenderingCreateInfo* pRendInfo =
+                getRenderingCreateInfo(pCreateInfo);
+            if (pRendInfo && mvkIsMultiview(pRendInfo->viewMask)) {
+                // We need to adjust the step rate for per-instance attributes
+                // to account for the extra instances needed to render all
+                // views. But, there's a problem: vertex input descriptions are
+                // static pipeline state. If we need multiple passes, and some
+                // have different numbers of views to render than others, then
+                // the step rate must be different for these passes. We'll need
+                // to make a pipeline for every pass view count we can see in
+                // the render pass. This really sucks.
+                std::unordered_set<uint32_t> viewCounts;
+                for (uint32_t passIdx = 0;
+                     passIdx < getDevice()->getMultiviewMetalPassCount(
+                                   pRendInfo->viewMask);
+                     ++passIdx) {
+                    viewCounts.insert(
+                        getDevice()
+                            ->getViewCountInMetalPass(pRendInfo->viewMask,
+                                                      passIdx));
+                }
+                auto count = viewCounts.cbegin();
+                adjustVertexInputForMultiview(plDesc.vertexDescriptor,
+                                              pCreateInfo->pVertexInputState,
+                                              *count);
+                getOrCompilePipeline(plDesc, _mtlPipelineState);
+                if (viewCounts.size() > 1) {
+                    _multiviewMTLPipelineStates[*count] = _mtlPipelineState;
+                    uint32_t oldCount = *count++;
+                    for (auto last = viewCounts.cend(); count != last;
+                         ++count) {
+                        if (_multiviewMTLPipelineStates.count(*count)) {
+                            continue;
+                        }
+                        adjustVertexInputForMultiview(plDesc.vertexDescriptor,
+                                                      pCreateInfo
+                                                          ->pVertexInputState,
+                                                      *count, oldCount);
+                        getOrCompilePipeline(plDesc, _multiviewMTLPipelineStates
+                                                         [*count]);
+                        oldCount = *count;
+                    }
+                }
+            } else {
+                getOrCompilePipeline(plDesc, _mtlPipelineState);
+            }
+            [plDesc release]; // temp release
+        } else {
+            _hasValidMTLPipelineStates = false;
+        }
+    } else {
+        // In this case, we need to create three render pipelines. But, the way
+        // Metal handles index buffers for compute stage-in means we have to
+        // create three pipelines for stage 1 (five pipelines in total).
+        SPIRVToMSLConversionConfiguration shaderConfig;
+        initShaderConversionConfig(shaderConfig, pCreateInfo, reflectData);
 
-		MVKMTLFunction vtxFunctions[3] = {};
-		MTLComputePipelineDescriptor* vtxPLDesc = newMTLTessVertexStageDescriptor(pCreateInfo, reflectData, shaderConfig, pVertexSS, pVertexFB, pTessCtlSS, vtxFunctions);					// temp retained
-		MTLComputePipelineDescriptor* tcPLDesc = newMTLTessControlStageDescriptor(pCreateInfo, reflectData, shaderConfig, pTessCtlSS, pTessCtlFB, pVertexSS, pTessEvalSS);					// temp retained
-		MTLRenderPipelineDescriptor* rastPLDesc = newMTLTessRasterStageDescriptor(pCreateInfo, reflectData, shaderConfig, pTessEvalSS, pTessEvalFB, pFragmentSS, pFragmentFB, pTessCtlSS);	// temp retained
-		if (vtxPLDesc && tcPLDesc && rastPLDesc) {
-			if (compileTessVertexStageState(vtxPLDesc, vtxFunctions, pVertexFB)) {
-				if (compileTessControlStageState(tcPLDesc, pTessCtlFB)) {
-					getOrCompilePipeline(rastPLDesc, _mtlPipelineState);
-				}
-			}
-		} else {
-			_hasValidMTLPipelineStates = false;
-		}
-		[vtxPLDesc release];	// temp release
-		[tcPLDesc release];		// temp release
-		[rastPLDesc release];	// temp release
-	}
+        MVKMTLFunction vtxFunctions[3] = {};
+        MTLComputePipelineDescriptor* vtxPLDesc =
+            newMTLTessVertexStageDescriptor(pCreateInfo, reflectData,
+                                            shaderConfig, pVertexSS, pVertexFB,
+                                            pTessCtlSS,
+                                            vtxFunctions); // temp retained
+        MTLComputePipelineDescriptor* tcPLDesc =
+            newMTLTessControlStageDescriptor(pCreateInfo, reflectData,
+                                             shaderConfig, pTessCtlSS,
+                                             pTessCtlFB, pVertexSS,
+                                             pTessEvalSS); // temp retained
+        MTLRenderPipelineDescriptor* rastPLDesc =
+            newMTLTessRasterStageDescriptor(pCreateInfo, reflectData,
+                                            shaderConfig, pTessEvalSS,
+                                            pTessEvalFB, pFragmentSS,
+                                            pFragmentFB,
+                                            pTessCtlSS); // temp retained
+        if (vtxPLDesc && tcPLDesc && rastPLDesc) {
+            if (compileTessVertexStageState(vtxPLDesc, vtxFunctions,
+                                            pVertexFB)) {
+                if (compileTessControlStageState(tcPLDesc, pTessCtlFB)) {
+                    getOrCompilePipeline(rastPLDesc, _mtlPipelineState);
+                }
+            }
+        } else {
+            _hasValidMTLPipelineStates = false;
+        }
+        [vtxPLDesc release];  // temp release
+        [tcPLDesc release];   // temp release
+        [rastPLDesc release]; // temp release
+    }
 
-	if (pPipelineFB) {
-		if ( _hasValidMTLPipelineStates ) {
-			mvkEnableFlags(pPipelineFB->flags, VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
-		}
-		pPipelineFB->duration = mvkGetElapsedNanoseconds(pipelineStart);
-	}
+    if (pPipelineFB) {
+        if (_hasValidMTLPipelineStates) {
+            mvkEnableFlags(pPipelineFB->flags,
+                           VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
+        }
+        pPipelineFB->duration = mvkGetElapsedNanoseconds(pipelineStart);
+    }
 }
 
-// Returns a retained MTLRenderPipelineDescriptor constructed from this instance, or nil if an error occurs.
-// It is the responsibility of the caller to release the returned descriptor.
-MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLRenderPipelineDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-																				 const SPIRVTessReflectionData& reflectData,
-																				 const VkPipelineShaderStageCreateInfo* pVertexSS,
-																				 VkPipelineCreationFeedback* pVertexFB,
-																				 const VkPipelineShaderStageCreateInfo* pFragmentSS,
-																				 VkPipelineCreationFeedback* pFragmentFB) {
-	SPIRVToMSLConversionConfiguration shaderConfig;
-	initShaderConversionConfig(shaderConfig, pCreateInfo, reflectData);
+// Returns a retained MTLRenderPipelineDescriptor constructed from this
+// instance, or nil if an error occurs. It is the responsibility of the caller
+// to release the returned descriptor.
+MTLRenderPipelineDescriptor*
+MVKGraphicsPipeline::newMTLRenderPipelineDescriptor(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    VkPipelineCreationFeedback* pVertexFB,
+    const VkPipelineShaderStageCreateInfo* pFragmentSS,
+    VkPipelineCreationFeedback* pFragmentFB) {
+    SPIRVToMSLConversionConfiguration shaderConfig;
+    initShaderConversionConfig(shaderConfig, pCreateInfo, reflectData);
 
-	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// retained
+    MTLRenderPipelineDescriptor* plDesc =
+        [MTLRenderPipelineDescriptor new]; // retained
 
-	SPIRVShaderOutputs vtxOutputs;
-	std::string errorLog;
-	if (!getShaderOutputs(((MVKShaderModule*)pVertexSS->module)->getSPIRV(), spv::ExecutionModelVertex, pVertexSS->pName, vtxOutputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get vertex outputs: %s", errorLog.c_str()));
-		return nil;
-	}
+    SPIRVShaderOutputs vtxOutputs;
+    std::string errorLog;
+    if (!getShaderOutputs(((MVKShaderModule*)pVertexSS->module)->getSPIRV(),
+                          spv::ExecutionModelVertex, pVertexSS->pName,
+                          vtxOutputs, errorLog)) {
+        setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                           "Failed to get vertex outputs: %s",
+                                           errorLog.c_str()));
+        return nil;
+    }
 
-	// Add shader stages. Compile vertex shader before others just in case conversion changes anything...like rasterizaion disable.
-	if (!addVertexShaderToPipeline(plDesc, pCreateInfo, shaderConfig, pVertexSS, pVertexFB, pFragmentSS)) { return nil; }
+    // Add shader stages. Compile vertex shader before others just in case
+    // conversion changes anything...like rasterizaion disable.
+    if (!addVertexShaderToPipeline(plDesc, pCreateInfo, shaderConfig, pVertexSS,
+                                   pVertexFB, pFragmentSS)) {
+        return nil;
+    }
 
-	// Vertex input
-	// This needs to happen before compiling the fragment shader, or we'll lose information on vertex attributes.
-	if (!addVertexInputToPipeline(plDesc.vertexDescriptor, pCreateInfo->pVertexInputState, shaderConfig)) { return nil; }
+    // Vertex input
+    // This needs to happen before compiling the fragment shader, or we'll lose
+    // information on vertex attributes.
+    if (!addVertexInputToPipeline(plDesc.vertexDescriptor,
+                                  pCreateInfo->pVertexInputState,
+                                  shaderConfig)) {
+        return nil;
+    }
 
-	// Fragment shader - only add if rasterization is enabled
-	if (!addFragmentShaderToPipeline(plDesc, pCreateInfo, shaderConfig, vtxOutputs, pFragmentSS, pFragmentFB)) { return nil; }
+    // Fragment shader - only add if rasterization is enabled
+    if (!addFragmentShaderToPipeline(plDesc, pCreateInfo, shaderConfig,
+                                     vtxOutputs, pFragmentSS, pFragmentFB)) {
+        return nil;
+    }
 
-	// Output
-	addFragmentOutputToPipeline(plDesc, pCreateInfo);
+    // Output
+    addFragmentOutputToPipeline(plDesc, pCreateInfo);
 
-	// Metal does not allow the name of the pipeline to be changed after it has been created,
-	// and we need to create the Metal pipeline immediately to provide error feedback to app.
-	// The best we can do at this point is set the pipeline name from the layout.
-	setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
+    // Metal does not allow the name of the pipeline to be changed after it has
+    // been created, and we need to create the Metal pipeline immediately to
+    // provide error feedback to app. The best we can do at this point is set
+    // the pipeline name from the layout.
+    setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)
+                                    ->getDebugName());
 
-	return plDesc;
+    return plDesc;
 }
 
-// Returns a retained MTLComputePipelineDescriptor for the vertex stage of a tessellated draw constructed from this instance, or nil if an error occurs.
+// Returns a retained MTLComputePipelineDescriptor for the vertex stage of a
+// tessellated draw constructed from this instance, or nil if an error occurs.
 // It is the responsibility of the caller to release the returned descriptor.
-MTLComputePipelineDescriptor* MVKGraphicsPipeline::newMTLTessVertexStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-																				   const SPIRVTessReflectionData& reflectData,
-																				   SPIRVToMSLConversionConfiguration& shaderConfig,
-																				   const VkPipelineShaderStageCreateInfo* pVertexSS,
-																				   VkPipelineCreationFeedback* pVertexFB,
-																				   const VkPipelineShaderStageCreateInfo* pTessCtlSS,
-																				   MVKMTLFunction* pVtxFunctions) {
-	MTLComputePipelineDescriptor* plDesc = [MTLComputePipelineDescriptor new];	// retained
+MTLComputePipelineDescriptor*
+MVKGraphicsPipeline::newMTLTessVertexStageDescriptor(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    VkPipelineCreationFeedback* pVertexFB,
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+    MVKMTLFunction* pVtxFunctions) {
+    MTLComputePipelineDescriptor* plDesc =
+        [MTLComputePipelineDescriptor new]; // retained
 
-	SPIRVShaderInputs tcInputs;
-	std::string errorLog;
-	if (!getShaderInputs(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(), spv::ExecutionModelTessellationControl, pTessCtlSS->pName, tcInputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get tessellation control inputs: %s", errorLog.c_str()));
-		return nil;
-	}
+    SPIRVShaderInputs tcInputs;
+    std::string errorLog;
+    if (!getShaderInputs(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(),
+                         spv::ExecutionModelTessellationControl,
+                         pTessCtlSS->pName, tcInputs, errorLog)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "Failed to get tessellation control inputs: %s",
+                        errorLog.c_str()));
+        return nil;
+    }
 
-	// Filter out anything but builtins. We couldn't do this before because we needed to make sure
-	// locations were assigned correctly.
-	tcInputs.erase(std::remove_if(tcInputs.begin(), tcInputs.end(), [](const SPIRVShaderInterfaceVariable& var) {
-		return var.builtin != spv::BuiltInPosition && var.builtin != spv::BuiltInPointSize && var.builtin != spv::BuiltInClipDistance && var.builtin != spv::BuiltInCullDistance;
-	}), tcInputs.end());
+    // Filter out anything but builtins. We couldn't do this before because we
+    // needed to make sure locations were assigned correctly.
+    tcInputs.erase(std::remove_if(tcInputs.begin(), tcInputs.end(),
+                                  [](const SPIRVShaderInterfaceVariable& var) {
+                                      return var.builtin !=
+                                                 spv::BuiltInPosition &&
+                                             var.builtin !=
+                                                 spv::BuiltInPointSize &&
+                                             var.builtin !=
+                                                 spv::BuiltInClipDistance &&
+                                             var.builtin !=
+                                                 spv::BuiltInCullDistance;
+                                  }),
+                   tcInputs.end());
 
-	// Add shader stages.
-	if (!addVertexShaderToPipeline(plDesc, pCreateInfo, shaderConfig, tcInputs, pVertexSS, pVertexFB, pVtxFunctions)) { return nil; }
+    // Add shader stages.
+    if (!addVertexShaderToPipeline(plDesc, pCreateInfo, shaderConfig, tcInputs,
+                                   pVertexSS, pVertexFB, pVtxFunctions)) {
+        return nil;
+    }
 
-	// Vertex input
-	plDesc.stageInputDescriptor = [MTLStageInputOutputDescriptor stageInputOutputDescriptor];
-	if (!addVertexInputToPipeline(plDesc.stageInputDescriptor, pCreateInfo->pVertexInputState, shaderConfig)) { return nil; }
-	plDesc.stageInputDescriptor.indexBufferIndex = _indirectParamsIndex.stages[kMVKShaderStageVertex];
+    // Vertex input
+    plDesc.stageInputDescriptor =
+        [MTLStageInputOutputDescriptor stageInputOutputDescriptor];
+    if (!addVertexInputToPipeline(plDesc.stageInputDescriptor,
+                                  pCreateInfo->pVertexInputState,
+                                  shaderConfig)) {
+        return nil;
+    }
+    plDesc.stageInputDescriptor.indexBufferIndex =
+        _indirectParamsIndex.stages[kMVKShaderStageVertex];
 
-	plDesc.threadGroupSizeIsMultipleOfThreadExecutionWidth = YES;
+    plDesc.threadGroupSizeIsMultipleOfThreadExecutionWidth = YES;
 
-	// Metal does not allow the name of the pipeline to be changed after it has been created,
-	// and we need to create the Metal pipeline immediately to provide error feedback to app.
-	// The best we can do at this point is set the pipeline name from the layout.
-	setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
+    // Metal does not allow the name of the pipeline to be changed after it has
+    // been created, and we need to create the Metal pipeline immediately to
+    // provide error feedback to app. The best we can do at this point is set
+    // the pipeline name from the layout.
+    setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)
+                                    ->getDebugName());
 
-	return plDesc;
+    return plDesc;
 }
 
 static VkFormat mvkFormatFromOutput(const SPIRVShaderOutput& output) {
-	switch (output.baseType) {
-		case SPIRType::SByte:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R8_SINT;
-				case 2: return VK_FORMAT_R8G8_SINT;
-				case 3: return VK_FORMAT_R8G8B8_SINT;
-				case 4: return VK_FORMAT_R8G8B8A8_SINT;
-			}
-			break;
-		case SPIRType::UByte:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R8_UINT;
-				case 2: return VK_FORMAT_R8G8_UINT;
-				case 3: return VK_FORMAT_R8G8B8_UINT;
-				case 4: return VK_FORMAT_R8G8B8A8_UINT;
-			}
-			break;
-		case SPIRType::Short:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_SINT;
-				case 2: return VK_FORMAT_R16G16_SINT;
-				case 3: return VK_FORMAT_R16G16B16_SINT;
-				case 4: return VK_FORMAT_R16G16B16A16_SINT;
-			}
-			break;
-		case SPIRType::UShort:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_UINT;
-				case 2: return VK_FORMAT_R16G16_UINT;
-				case 3: return VK_FORMAT_R16G16B16_UINT;
-				case 4: return VK_FORMAT_R16G16B16A16_UINT;
-			}
-			break;
-		case SPIRType::Half:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_SFLOAT;
-				case 2: return VK_FORMAT_R16G16_SFLOAT;
-				case 3: return VK_FORMAT_R16G16B16_SFLOAT;
-				case 4: return VK_FORMAT_R16G16B16A16_SFLOAT;
-			}
-			break;
-		case SPIRType::Int:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_SINT;
-				case 2: return VK_FORMAT_R32G32_SINT;
-				case 3: return VK_FORMAT_R32G32B32_SINT;
-				case 4: return VK_FORMAT_R32G32B32A32_SINT;
-			}
-			break;
-		case SPIRType::UInt:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_UINT;
-				case 2: return VK_FORMAT_R32G32_UINT;
-				case 3: return VK_FORMAT_R32G32B32_UINT;
-				case 4: return VK_FORMAT_R32G32B32A32_UINT;
-			}
-			break;
-		case SPIRType::Float:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_SFLOAT;
-				case 2: return VK_FORMAT_R32G32_SFLOAT;
-				case 3: return VK_FORMAT_R32G32B32_SFLOAT;
-				case 4: return VK_FORMAT_R32G32B32A32_SFLOAT;
-			}
-			break;
-		default:
-			break;
-	}
-	return VK_FORMAT_UNDEFINED;
+    switch (output.baseType) {
+    case SPIRType::SByte:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R8_SINT;
+        case 2:
+            return VK_FORMAT_R8G8_SINT;
+        case 3:
+            return VK_FORMAT_R8G8B8_SINT;
+        case 4:
+            return VK_FORMAT_R8G8B8A8_SINT;
+        }
+        break;
+    case SPIRType::UByte:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R8_UINT;
+        case 2:
+            return VK_FORMAT_R8G8_UINT;
+        case 3:
+            return VK_FORMAT_R8G8B8_UINT;
+        case 4:
+            return VK_FORMAT_R8G8B8A8_UINT;
+        }
+        break;
+    case SPIRType::Short:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R16_SINT;
+        case 2:
+            return VK_FORMAT_R16G16_SINT;
+        case 3:
+            return VK_FORMAT_R16G16B16_SINT;
+        case 4:
+            return VK_FORMAT_R16G16B16A16_SINT;
+        }
+        break;
+    case SPIRType::UShort:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R16_UINT;
+        case 2:
+            return VK_FORMAT_R16G16_UINT;
+        case 3:
+            return VK_FORMAT_R16G16B16_UINT;
+        case 4:
+            return VK_FORMAT_R16G16B16A16_UINT;
+        }
+        break;
+    case SPIRType::Half:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R16_SFLOAT;
+        case 2:
+            return VK_FORMAT_R16G16_SFLOAT;
+        case 3:
+            return VK_FORMAT_R16G16B16_SFLOAT;
+        case 4:
+            return VK_FORMAT_R16G16B16A16_SFLOAT;
+        }
+        break;
+    case SPIRType::Int:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R32_SINT;
+        case 2:
+            return VK_FORMAT_R32G32_SINT;
+        case 3:
+            return VK_FORMAT_R32G32B32_SINT;
+        case 4:
+            return VK_FORMAT_R32G32B32A32_SINT;
+        }
+        break;
+    case SPIRType::UInt:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R32_UINT;
+        case 2:
+            return VK_FORMAT_R32G32_UINT;
+        case 3:
+            return VK_FORMAT_R32G32B32_UINT;
+        case 4:
+            return VK_FORMAT_R32G32B32A32_UINT;
+        }
+        break;
+    case SPIRType::Float:
+        switch (output.vecWidth) {
+        case 1:
+            return VK_FORMAT_R32_SFLOAT;
+        case 2:
+            return VK_FORMAT_R32G32_SFLOAT;
+        case 3:
+            return VK_FORMAT_R32G32B32_SFLOAT;
+        case 4:
+            return VK_FORMAT_R32G32B32A32_SFLOAT;
+        }
+        break;
+    default:
+        break;
+    }
+    return VK_FORMAT_UNDEFINED;
 }
 
-// Returns a format of the same base type with vector length adjusted to fit size.
-static MTLVertexFormat mvkAdjustFormatVectorToSize(MTLVertexFormat format, uint32_t size) {
-#define MVK_ADJUST_FORMAT_CASE(size_1, type, suffix) \
-	case MTLVertexFormat##type##4##suffix: if (size >= 4 * (size_1)) { return MTLVertexFormat##type##4##suffix; } \
-	case MTLVertexFormat##type##3##suffix: if (size >= 3 * (size_1)) { return MTLVertexFormat##type##3##suffix; } \
-	case MTLVertexFormat##type##2##suffix: if (size >= 2 * (size_1)) { return MTLVertexFormat##type##2##suffix; } \
-	case MTLVertexFormat##type##suffix:    if (size >= 1 * (size_1)) { return MTLVertexFormat##type##suffix; } \
-	return MTLVertexFormatInvalid;
+// Returns a format of the same base type with vector length adjusted to fit
+// size.
+static MTLVertexFormat mvkAdjustFormatVectorToSize(MTLVertexFormat format,
+                                                   uint32_t size) {
+#define MVK_ADJUST_FORMAT_CASE(size_1, type, suffix)                           \
+    case MTLVertexFormat##type##4##suffix:                                     \
+        if (size >= 4 * (size_1)) {                                            \
+            return MTLVertexFormat##type##4##suffix;                           \
+        }                                                                      \
+    case MTLVertexFormat##type##3##suffix:                                     \
+        if (size >= 3 * (size_1)) {                                            \
+            return MTLVertexFormat##type##3##suffix;                           \
+        }                                                                      \
+    case MTLVertexFormat##type##2##suffix:                                     \
+        if (size >= 2 * (size_1)) {                                            \
+            return MTLVertexFormat##type##2##suffix;                           \
+        }                                                                      \
+    case MTLVertexFormat##type##suffix:                                        \
+        if (size >= 1 * (size_1)) {                                            \
+            return MTLVertexFormat##type##suffix;                              \
+        }                                                                      \
+        return MTLVertexFormatInvalid;
 
-	switch (format) {
-		MVK_ADJUST_FORMAT_CASE(1, UChar, )
-		MVK_ADJUST_FORMAT_CASE(1, Char, )
-		MVK_ADJUST_FORMAT_CASE(1, UChar, Normalized)
-		MVK_ADJUST_FORMAT_CASE(1, Char, Normalized)
-		MVK_ADJUST_FORMAT_CASE(2, UShort, )
-		MVK_ADJUST_FORMAT_CASE(2, Short, )
-		MVK_ADJUST_FORMAT_CASE(2, UShort, Normalized)
-		MVK_ADJUST_FORMAT_CASE(2, Short, Normalized)
-		MVK_ADJUST_FORMAT_CASE(2, Half, )
-		MVK_ADJUST_FORMAT_CASE(4, Float, )
-		MVK_ADJUST_FORMAT_CASE(4, UInt, )
-		MVK_ADJUST_FORMAT_CASE(4, Int, )
-		default: return format;
-	}
+    switch (format) {
+        MVK_ADJUST_FORMAT_CASE(1, UChar, )
+        MVK_ADJUST_FORMAT_CASE(1, Char, )
+        MVK_ADJUST_FORMAT_CASE(1, UChar, Normalized)
+        MVK_ADJUST_FORMAT_CASE(1, Char, Normalized)
+        MVK_ADJUST_FORMAT_CASE(2, UShort, )
+        MVK_ADJUST_FORMAT_CASE(2, Short, )
+        MVK_ADJUST_FORMAT_CASE(2, UShort, Normalized)
+        MVK_ADJUST_FORMAT_CASE(2, Short, Normalized)
+        MVK_ADJUST_FORMAT_CASE(2, Half, )
+        MVK_ADJUST_FORMAT_CASE(4, Float, )
+        MVK_ADJUST_FORMAT_CASE(4, UInt, )
+        MVK_ADJUST_FORMAT_CASE(4, Int, )
+    default:
+        return format;
+    }
 #undef MVK_ADJUST_FORMAT_CASE
 }
 
-// Returns a retained MTLComputePipelineDescriptor for the tess. control stage of a tessellated draw constructed from this instance, or nil if an error occurs.
-// It is the responsibility of the caller to release the returned descriptor.
-MTLComputePipelineDescriptor* MVKGraphicsPipeline::newMTLTessControlStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-																					const SPIRVTessReflectionData& reflectData,
-																					SPIRVToMSLConversionConfiguration& shaderConfig,
-																					const VkPipelineShaderStageCreateInfo* pTessCtlSS,
-																					VkPipelineCreationFeedback* pTessCtlFB,
-																					const VkPipelineShaderStageCreateInfo* pVertexSS,
-																					const VkPipelineShaderStageCreateInfo* pTessEvalSS) {
-	MTLComputePipelineDescriptor* plDesc = [MTLComputePipelineDescriptor new];		// retained
+// Returns a retained MTLComputePipelineDescriptor for the tess. control stage
+// of a tessellated draw constructed from this instance, or nil if an error
+// occurs. It is the responsibility of the caller to release the returned
+// descriptor.
+MTLComputePipelineDescriptor*
+MVKGraphicsPipeline::newMTLTessControlStageDescriptor(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+    VkPipelineCreationFeedback* pTessCtlFB,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    const VkPipelineShaderStageCreateInfo* pTessEvalSS) {
+    MTLComputePipelineDescriptor* plDesc =
+        [MTLComputePipelineDescriptor new]; // retained
 
-	SPIRVShaderOutputs vtxOutputs;
-	SPIRVShaderInputs teInputs;
-	std::string errorLog;
-	if (!getShaderOutputs(((MVKShaderModule*)pVertexSS->module)->getSPIRV(), spv::ExecutionModelVertex, pVertexSS->pName, vtxOutputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get vertex outputs: %s", errorLog.c_str()));
-		return nil;
-	}
-	if (!getShaderInputs(((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(), spv::ExecutionModelTessellationEvaluation, pTessEvalSS->pName, teInputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get tessellation evaluation inputs: %s", errorLog.c_str()));
-		return nil;
-	}
+    SPIRVShaderOutputs vtxOutputs;
+    SPIRVShaderInputs teInputs;
+    std::string errorLog;
+    if (!getShaderOutputs(((MVKShaderModule*)pVertexSS->module)->getSPIRV(),
+                          spv::ExecutionModelVertex, pVertexSS->pName,
+                          vtxOutputs, errorLog)) {
+        setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                           "Failed to get vertex outputs: %s",
+                                           errorLog.c_str()));
+        return nil;
+    }
+    if (!getShaderInputs(((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(),
+                         spv::ExecutionModelTessellationEvaluation,
+                         pTessEvalSS->pName, teInputs, errorLog)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "Failed to get tessellation evaluation inputs: %s",
+                        errorLog.c_str()));
+        return nil;
+    }
 
-	// Filter out anything but builtins. We couldn't do this before because we needed to make sure
-	// locations were assigned correctly.
-	teInputs.erase(std::remove_if(teInputs.begin(), teInputs.end(), [](const SPIRVShaderInterfaceVariable& var) {
-		return var.builtin != spv::BuiltInPosition && var.builtin != spv::BuiltInPointSize && var.builtin != spv::BuiltInClipDistance && var.builtin != spv::BuiltInCullDistance;
-	}), teInputs.end());
+    // Filter out anything but builtins. We couldn't do this before because we
+    // needed to make sure locations were assigned correctly.
+    teInputs.erase(std::remove_if(teInputs.begin(), teInputs.end(),
+                                  [](const SPIRVShaderInterfaceVariable& var) {
+                                      return var.builtin !=
+                                                 spv::BuiltInPosition &&
+                                             var.builtin !=
+                                                 spv::BuiltInPointSize &&
+                                             var.builtin !=
+                                                 spv::BuiltInClipDistance &&
+                                             var.builtin !=
+                                                 spv::BuiltInCullDistance;
+                                  }),
+                   teInputs.end());
 
-	// Add shader stages.
-	if (!addTessCtlShaderToPipeline(plDesc, pCreateInfo, shaderConfig, vtxOutputs, teInputs, pTessCtlSS, pTessCtlFB)) {
-		[plDesc release];
-		return nil;
-	}
+    // Add shader stages.
+    if (!addTessCtlShaderToPipeline(plDesc, pCreateInfo, shaderConfig,
+                                    vtxOutputs, teInputs, pTessCtlSS,
+                                    pTessCtlFB)) {
+        [plDesc release];
+        return nil;
+    }
 
-	// Metal does not allow the name of the pipeline to be changed after it has been created,
-	// and we need to create the Metal pipeline immediately to provide error feedback to app.
-	// The best we can do at this point is set the pipeline name from the layout.
-	setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
+    // Metal does not allow the name of the pipeline to be changed after it has
+    // been created, and we need to create the Metal pipeline immediately to
+    // provide error feedback to app. The best we can do at this point is set
+    // the pipeline name from the layout.
+    setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)
+                                    ->getDebugName());
 
-	return plDesc;
+    return plDesc;
 }
 
-// Returns a retained MTLRenderPipelineDescriptor for the last stage of a tessellated draw constructed from this instance, or nil if an error occurs.
+// Returns a retained MTLRenderPipelineDescriptor for the last stage of a
+// tessellated draw constructed from this instance, or nil if an error occurs.
 // It is the responsibility of the caller to release the returned descriptor.
-MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLTessRasterStageDescriptor(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-																				  const SPIRVTessReflectionData& reflectData,
-																				  SPIRVToMSLConversionConfiguration& shaderConfig,
-																				  const VkPipelineShaderStageCreateInfo* pTessEvalSS,
-																				  VkPipelineCreationFeedback* pTessEvalFB,
-																				  const VkPipelineShaderStageCreateInfo* pFragmentSS,
-																				  VkPipelineCreationFeedback* pFragmentFB,
-																				  const VkPipelineShaderStageCreateInfo* pTessCtlSS) {
-	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// retained
+MTLRenderPipelineDescriptor*
+MVKGraphicsPipeline::newMTLTessRasterStageDescriptor(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+    VkPipelineCreationFeedback* pTessEvalFB,
+    const VkPipelineShaderStageCreateInfo* pFragmentSS,
+    VkPipelineCreationFeedback* pFragmentFB,
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS) {
+    MTLRenderPipelineDescriptor* plDesc =
+        [MTLRenderPipelineDescriptor new]; // retained
 
-	SPIRVShaderOutputs tcOutputs, teOutputs;
-	SPIRVShaderInputs teInputs;
-	std::string errorLog;
-	if (!getShaderOutputs(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(), spv::ExecutionModelTessellationControl, pTessCtlSS->pName, tcOutputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get tessellation control outputs: %s", errorLog.c_str()));
-		return nil;
-	}
-	if (!getShaderOutputs(((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(), spv::ExecutionModelTessellationEvaluation, pTessEvalSS->pName, teOutputs, errorLog) ) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get tessellation evaluation outputs: %s", errorLog.c_str()));
-		return nil;
-	}
+    SPIRVShaderOutputs tcOutputs, teOutputs;
+    SPIRVShaderInputs teInputs;
+    std::string errorLog;
+    if (!getShaderOutputs(((MVKShaderModule*)pTessCtlSS->module)->getSPIRV(),
+                          spv::ExecutionModelTessellationControl,
+                          pTessCtlSS->pName, tcOutputs, errorLog)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "Failed to get tessellation control outputs: %s",
+                        errorLog.c_str()));
+        return nil;
+    }
+    if (!getShaderOutputs(((MVKShaderModule*)pTessEvalSS->module)->getSPIRV(),
+                          spv::ExecutionModelTessellationEvaluation,
+                          pTessEvalSS->pName, teOutputs, errorLog)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "Failed to get tessellation evaluation outputs: %s",
+                        errorLog.c_str()));
+        return nil;
+    }
 
-	// Add shader stages. Compile tessellation evaluation shader before others just in case conversion changes anything...like rasterizaion disable.
-	if (!addTessEvalShaderToPipeline(plDesc, pCreateInfo, shaderConfig, tcOutputs, pTessEvalSS, pTessEvalFB, pFragmentSS)) {
-		[plDesc release];
-		return nil;
-	}
+    // Add shader stages. Compile tessellation evaluation shader before others
+    // just in case conversion changes anything...like rasterizaion disable.
+    if (!addTessEvalShaderToPipeline(plDesc, pCreateInfo, shaderConfig,
+                                     tcOutputs, pTessEvalSS, pTessEvalFB,
+                                     pFragmentSS)) {
+        [plDesc release];
+        return nil;
+    }
 
-	// Fragment shader - only add if rasterization is enabled
-	if (!addFragmentShaderToPipeline(plDesc, pCreateInfo, shaderConfig, teOutputs, pFragmentSS, pFragmentFB)) {
-		[plDesc release];
-		return nil;
-	}
+    // Fragment shader - only add if rasterization is enabled
+    if (!addFragmentShaderToPipeline(plDesc, pCreateInfo, shaderConfig,
+                                     teOutputs, pFragmentSS, pFragmentFB)) {
+        [plDesc release];
+        return nil;
+    }
 
-	// Tessellation state
-	addTessellationToPipeline(plDesc, reflectData, pCreateInfo->pTessellationState);
+    // Tessellation state
+    addTessellationToPipeline(plDesc, reflectData,
+                              pCreateInfo->pTessellationState);
 
-	// Output
-	addFragmentOutputToPipeline(plDesc, pCreateInfo);
+    // Output
+    addFragmentOutputToPipeline(plDesc, pCreateInfo);
 
-	return plDesc;
+    return plDesc;
 }
 
-bool MVKGraphicsPipeline::verifyImplicitBuffer(bool needsBuffer, MVKShaderImplicitRezBinding& index, MVKShaderStage stage, const char* name) {
-	const char* stageNames[] = {
-		"Vertex",
-		"Tessellation control",
-		"Tessellation evaluation",
-		"Fragment"
-	};
-	if (needsBuffer && index.stages[stage] < _descriptorBufferCounts.stages[stage]) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "%s shader requires %s buffer, but there is no free slot to pass it.", stageNames[stage], name));
-		return false;
-	}
-	return true;
+bool MVKGraphicsPipeline::verifyImplicitBuffer(
+    bool needsBuffer, MVKShaderImplicitRezBinding& index, MVKShaderStage stage,
+    const char* name) {
+    const char* stageNames[] = {"Vertex", "Tessellation control",
+                                "Tessellation evaluation", "Fragment"};
+    if (needsBuffer &&
+        index.stages[stage] < _descriptorBufferCounts.stages[stage]) {
+        setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV,
+                                           "%s shader requires %s buffer, but "
+                                           "there is no free slot to pass it.",
+                                           stageNames[stage], name));
+        return false;
+    }
+    return true;
 }
 
 // Adds a vertex shader to the pipeline description.
-bool MVKGraphicsPipeline::addVertexShaderToPipeline(MTLRenderPipelineDescriptor* plDesc,
-													const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													SPIRVToMSLConversionConfiguration& shaderConfig,
-													const VkPipelineShaderStageCreateInfo* pVertexSS,
-													VkPipelineCreationFeedback* pVertexFB,
-													const VkPipelineShaderStageCreateInfo*& pFragmentSS) {
-	shaderConfig.options.entryPointStage = spv::ExecutionModelVertex;
-	shaderConfig.options.entryPointName = pVertexSS->pName;
-	shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.indirect_params_buffer_index = _indirectParamsIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.shader_output_buffer_index = _outputBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.view_mask_buffer_index = _viewRangeBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.capture_output_to_buffer = false;
-	shaderConfig.options.mslOptions.disable_rasterization = !_isRasterizing;
+bool MVKGraphicsPipeline::addVertexShaderToPipeline(
+    MTLRenderPipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    VkPipelineCreationFeedback* pVertexFB,
+    const VkPipelineShaderStageCreateInfo*& pFragmentSS) {
+    shaderConfig.options.entryPointStage = spv::ExecutionModelVertex;
+    shaderConfig.options.entryPointName = pVertexSS->pName;
+    shaderConfig.options.mslOptions.swizzle_buffer_index =
+        _swizzleBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.indirect_params_buffer_index =
+        _indirectParamsIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.shader_output_buffer_index =
+        _outputBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.buffer_size_buffer_index =
+        _bufferSizeBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.view_mask_buffer_index =
+        _viewRangeBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.capture_output_to_buffer = false;
+    shaderConfig.options.mslOptions.disable_rasterization = !_isRasterizing;
     addVertexInputToShaderConversionConfig(shaderConfig, pCreateInfo);
 
-	MVKMTLFunction func = getMTLFunction(shaderConfig, pVertexSS, pVertexFB, "Vertex");
-	id<MTLFunction> mtlFunc = func.getMTLFunction();
-	plDesc.vertexFunction = mtlFunc;
-	if ( !mtlFunc ) { return false; }
+    MVKMTLFunction func =
+        getMTLFunction(shaderConfig, pVertexSS, pVertexFB, "Vertex");
+    id<MTLFunction> mtlFunc = func.getMTLFunction();
+    plDesc.vertexFunction = mtlFunc;
+    if (!mtlFunc) {
+        return false;
+    }
 
-	auto& funcRslts = func.shaderConversionResults;
-	plDesc.rasterizationEnabled = !funcRslts.isRasterizationDisabled;
-	_needsVertexSwizzleBuffer = funcRslts.needsSwizzleBuffer;
-	_needsVertexBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-	_needsVertexDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
-	_needsVertexViewRangeBuffer = funcRslts.needsViewRangeBuffer;
-	_needsVertexOutputBuffer = funcRslts.needsOutputBuffer;
-	markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts, kMVKShaderStageVertex);
+    auto& funcRslts = func.shaderConversionResults;
+    plDesc.rasterizationEnabled = !funcRslts.isRasterizationDisabled;
+    _needsVertexSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+    _needsVertexBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
+    _needsVertexDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+    _needsVertexViewRangeBuffer = funcRslts.needsViewRangeBuffer;
+    _needsVertexOutputBuffer = funcRslts.needsOutputBuffer;
+    markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts,
+                                                        kMVKShaderStageVertex);
 
-	populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageVertex);
+    populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                    kMVKShaderStageVertex);
 
-	if (funcRslts.isRasterizationDisabled) {
-		pFragmentSS = nullptr;
-	}
+    if (funcRslts.isRasterizationDisabled) {
+        pFragmentSS = nullptr;
+    }
 
-	// If we need the swizzle buffer and there's no place to put it, we're in serious trouble.
-	if (!verifyImplicitBuffer(_needsVertexSwizzleBuffer, _swizzleBufferIndex, kMVKShaderStageVertex, "swizzle")) {
-		return false;
-	}
-	// Ditto buffer size buffer.
-	if (!verifyImplicitBuffer(_needsVertexBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageVertex, "buffer size")) {
-		return false;
-	}
-	// Ditto dynamic offset buffer.
-	if (!verifyImplicitBuffer(_needsVertexDynamicOffsetBuffer, _dynamicOffsetBufferIndex, kMVKShaderStageVertex, "dynamic offset")) {
-		return false;
-	}
-	// Ditto captured output buffer.
-	if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _outputBufferIndex, kMVKShaderStageVertex, "output")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _indirectParamsIndex, kMVKShaderStageVertex, "indirect parameters")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsVertexViewRangeBuffer, _viewRangeBufferIndex, kMVKShaderStageVertex, "view range")) {
-		return false;
-	}
-	return true;
+    // If we need the swizzle buffer and there's no place to put it, we're in
+    // serious trouble.
+    if (!verifyImplicitBuffer(_needsVertexSwizzleBuffer, _swizzleBufferIndex,
+                              kMVKShaderStageVertex, "swizzle")) {
+        return false;
+    }
+    // Ditto buffer size buffer.
+    if (!verifyImplicitBuffer(_needsVertexBufferSizeBuffer,
+                              _bufferSizeBufferIndex, kMVKShaderStageVertex,
+                              "buffer size")) {
+        return false;
+    }
+    // Ditto dynamic offset buffer.
+    if (!verifyImplicitBuffer(_needsVertexDynamicOffsetBuffer,
+                              _dynamicOffsetBufferIndex, kMVKShaderStageVertex,
+                              "dynamic offset")) {
+        return false;
+    }
+    // Ditto captured output buffer.
+    if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _outputBufferIndex,
+                              kMVKShaderStageVertex, "output")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _indirectParamsIndex,
+                              kMVKShaderStageVertex, "indirect parameters")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsVertexViewRangeBuffer,
+                              _viewRangeBufferIndex, kMVKShaderStageVertex,
+                              "view range")) {
+        return false;
+    }
+    return true;
 }
 
-// Adds a vertex shader compiled as a compute kernel to the pipeline description.
-bool MVKGraphicsPipeline::addVertexShaderToPipeline(MTLComputePipelineDescriptor* plDesc,
-													const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													SPIRVToMSLConversionConfiguration& shaderConfig,
-													SPIRVShaderInputs& tcInputs,
-													const VkPipelineShaderStageCreateInfo* pVertexSS,
-													VkPipelineCreationFeedback* pVertexFB,
-													MVKMTLFunction* pVtxFunctions) {
-	shaderConfig.options.entryPointStage = spv::ExecutionModelVertex;
-	shaderConfig.options.entryPointName = pVertexSS->pName;
-	shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.shader_index_buffer_index = _indirectParamsIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.shader_output_buffer_index = _outputBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageVertex];
-	shaderConfig.options.mslOptions.capture_output_to_buffer = true;
-	shaderConfig.options.mslOptions.vertex_for_tessellation = true;
-	shaderConfig.options.mslOptions.disable_rasterization = true;
+// Adds a vertex shader compiled as a compute kernel to the pipeline
+// description.
+bool MVKGraphicsPipeline::addVertexShaderToPipeline(
+    MTLComputePipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderInputs& tcInputs,
+    const VkPipelineShaderStageCreateInfo* pVertexSS,
+    VkPipelineCreationFeedback* pVertexFB, MVKMTLFunction* pVtxFunctions) {
+    shaderConfig.options.entryPointStage = spv::ExecutionModelVertex;
+    shaderConfig.options.entryPointName = pVertexSS->pName;
+    shaderConfig.options.mslOptions.swizzle_buffer_index =
+        _swizzleBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.shader_index_buffer_index =
+        _indirectParamsIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.shader_output_buffer_index =
+        _outputBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.buffer_size_buffer_index =
+        _bufferSizeBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageVertex];
+    shaderConfig.options.mslOptions.capture_output_to_buffer = true;
+    shaderConfig.options.mslOptions.vertex_for_tessellation = true;
+    shaderConfig.options.mslOptions.disable_rasterization = true;
     addVertexInputToShaderConversionConfig(shaderConfig, pCreateInfo);
-	addNextStageInputToShaderConversionConfig(shaderConfig, tcInputs);
+    addNextStageInputToShaderConversionConfig(shaderConfig, tcInputs);
 
-	// We need to compile this function three times, with no indexing, 16-bit indices, and 32-bit indices.
-	static const CompilerMSL::Options::IndexType indexTypes[] = {
-		CompilerMSL::Options::IndexType::None,
-		CompilerMSL::Options::IndexType::UInt16,
-		CompilerMSL::Options::IndexType::UInt32,
-	};
-	MVKMTLFunction func;
-	for (uint32_t i = 0; i < sizeof(indexTypes)/sizeof(indexTypes[0]); i++) {
-		shaderConfig.options.mslOptions.vertex_index_type = indexTypes[i];
-		func = getMTLFunction(shaderConfig, pVertexSS, pVertexFB, "Vertex");
-		if ( !func.getMTLFunction() ) { return false; }
+    // We need to compile this function three times, with no indexing, 16-bit
+    // indices, and 32-bit indices.
+    static const CompilerMSL::Options::IndexType indexTypes[] = {
+        CompilerMSL::Options::IndexType::None,
+        CompilerMSL::Options::IndexType::UInt16,
+        CompilerMSL::Options::IndexType::UInt32,
+    };
+    MVKMTLFunction func;
+    for (uint32_t i = 0; i < sizeof(indexTypes) / sizeof(indexTypes[0]); i++) {
+        shaderConfig.options.mslOptions.vertex_index_type = indexTypes[i];
+        func = getMTLFunction(shaderConfig, pVertexSS, pVertexFB, "Vertex");
+        if (!func.getMTLFunction()) {
+            return false;
+        }
 
-		pVtxFunctions[i] = func;
+        pVtxFunctions[i] = func;
 
-		auto& funcRslts = func.shaderConversionResults;
-		_needsVertexSwizzleBuffer = funcRslts.needsSwizzleBuffer;
-		_needsVertexBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-		_needsVertexDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
-		_needsVertexOutputBuffer = funcRslts.needsOutputBuffer;
-		markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts, kMVKShaderStageVertex);
-	}
+        auto& funcRslts = func.shaderConversionResults;
+        _needsVertexSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+        _needsVertexBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
+        _needsVertexDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+        _needsVertexOutputBuffer = funcRslts.needsOutputBuffer;
+        markIfUsingPhysicalStorageBufferAddressesCapability(
+            funcRslts, kMVKShaderStageVertex);
+    }
 
-	populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageVertex);
+    populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                    kMVKShaderStageVertex);
 
-	// If we need the swizzle buffer and there's no place to put it, we're in serious trouble.
-	if (!verifyImplicitBuffer(_needsVertexSwizzleBuffer, _swizzleBufferIndex, kMVKShaderStageVertex, "swizzle")) {
-		return false;
-	}
-	// Ditto buffer size buffer.
-	if (!verifyImplicitBuffer(_needsVertexBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageVertex, "buffer size")) {
-		return false;
-	}
-	// Ditto dynamic offset buffer.
-	if (!verifyImplicitBuffer(_needsVertexDynamicOffsetBuffer, _dynamicOffsetBufferIndex, kMVKShaderStageVertex, "dynamic offset")) {
-		return false;
-	}
-	// Ditto captured output buffer.
-	if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _outputBufferIndex, kMVKShaderStageVertex, "output")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(!shaderConfig.shaderInputs.empty(), _indirectParamsIndex, kMVKShaderStageVertex, "index")) {
-		return false;
-	}
-	return true;
+    // If we need the swizzle buffer and there's no place to put it, we're in
+    // serious trouble.
+    if (!verifyImplicitBuffer(_needsVertexSwizzleBuffer, _swizzleBufferIndex,
+                              kMVKShaderStageVertex, "swizzle")) {
+        return false;
+    }
+    // Ditto buffer size buffer.
+    if (!verifyImplicitBuffer(_needsVertexBufferSizeBuffer,
+                              _bufferSizeBufferIndex, kMVKShaderStageVertex,
+                              "buffer size")) {
+        return false;
+    }
+    // Ditto dynamic offset buffer.
+    if (!verifyImplicitBuffer(_needsVertexDynamicOffsetBuffer,
+                              _dynamicOffsetBufferIndex, kMVKShaderStageVertex,
+                              "dynamic offset")) {
+        return false;
+    }
+    // Ditto captured output buffer.
+    if (!verifyImplicitBuffer(_needsVertexOutputBuffer, _outputBufferIndex,
+                              kMVKShaderStageVertex, "output")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(!shaderConfig.shaderInputs.empty(),
+                              _indirectParamsIndex, kMVKShaderStageVertex,
+                              "index")) {
+        return false;
+    }
+    return true;
 }
 
-bool MVKGraphicsPipeline::addTessCtlShaderToPipeline(MTLComputePipelineDescriptor* plDesc,
-													 const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													 SPIRVToMSLConversionConfiguration& shaderConfig,
-													 SPIRVShaderOutputs& vtxOutputs,
-													 SPIRVShaderInputs& teInputs,
-													 const VkPipelineShaderStageCreateInfo* pTessCtlSS,
-													 VkPipelineCreationFeedback* pTessCtlFB) {
-	shaderConfig.options.entryPointStage = spv::ExecutionModelTessellationControl;
-	shaderConfig.options.entryPointName = pTessCtlSS->pName;
-	shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageTessCtl];
-	shaderConfig.options.mslOptions.indirect_params_buffer_index = _indirectParamsIndex.stages[kMVKShaderStageTessCtl];
-	shaderConfig.options.mslOptions.shader_input_buffer_index = getMetalBufferIndexForVertexAttributeBinding(kMVKTessCtlInputBufferBinding);
-	shaderConfig.options.mslOptions.shader_output_buffer_index = _outputBufferIndex.stages[kMVKShaderStageTessCtl];
-	shaderConfig.options.mslOptions.shader_patch_output_buffer_index = _tessCtlPatchOutputBufferIndex;
-	shaderConfig.options.mslOptions.shader_tess_factor_buffer_index = _tessCtlLevelBufferIndex;
-	shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageTessCtl];
-	shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageTessCtl];
-	shaderConfig.options.mslOptions.capture_output_to_buffer = true;
-	shaderConfig.options.mslOptions.multi_patch_workgroup = true;
-	shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pTessCtlSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) ? 0 : getMetalFeatures().maxSubgroupSize;
-	addPrevStageOutputToShaderConversionConfig(shaderConfig, vtxOutputs);
-	addNextStageInputToShaderConversionConfig(shaderConfig, teInputs);
+bool MVKGraphicsPipeline::addTessCtlShaderToPipeline(
+    MTLComputePipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderOutputs& vtxOutputs, SPIRVShaderInputs& teInputs,
+    const VkPipelineShaderStageCreateInfo* pTessCtlSS,
+    VkPipelineCreationFeedback* pTessCtlFB) {
+    shaderConfig.options.entryPointStage =
+        spv::ExecutionModelTessellationControl;
+    shaderConfig.options.entryPointName = pTessCtlSS->pName;
+    shaderConfig.options.mslOptions.swizzle_buffer_index =
+        _swizzleBufferIndex.stages[kMVKShaderStageTessCtl];
+    shaderConfig.options.mslOptions.indirect_params_buffer_index =
+        _indirectParamsIndex.stages[kMVKShaderStageTessCtl];
+    shaderConfig.options.mslOptions.shader_input_buffer_index =
+        getMetalBufferIndexForVertexAttributeBinding(
+            kMVKTessCtlInputBufferBinding);
+    shaderConfig.options.mslOptions.shader_output_buffer_index =
+        _outputBufferIndex.stages[kMVKShaderStageTessCtl];
+    shaderConfig.options.mslOptions.shader_patch_output_buffer_index =
+        _tessCtlPatchOutputBufferIndex;
+    shaderConfig.options.mslOptions.shader_tess_factor_buffer_index =
+        _tessCtlLevelBufferIndex;
+    shaderConfig.options.mslOptions.buffer_size_buffer_index =
+        _bufferSizeBufferIndex.stages[kMVKShaderStageTessCtl];
+    shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageTessCtl];
+    shaderConfig.options.mslOptions.capture_output_to_buffer = true;
+    shaderConfig.options.mslOptions.multi_patch_workgroup = true;
+    shaderConfig.options.mslOptions.fixed_subgroup_size =
+        mvkIsAnyFlagEnabled(
+            pTessCtlSS->flags,
+            VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT)
+            ? 0
+            : getMetalFeatures().maxSubgroupSize;
+    addPrevStageOutputToShaderConversionConfig(shaderConfig, vtxOutputs);
+    addNextStageInputToShaderConversionConfig(shaderConfig, teInputs);
 
-	MVKMTLFunction func = getMTLFunction(shaderConfig, pTessCtlSS, pTessCtlFB, "Tessellation control");
-	id<MTLFunction> mtlFunc = func.getMTLFunction();
-	if ( !mtlFunc ) { return false; }
-	plDesc.computeFunction = mtlFunc;
+    MVKMTLFunction func = getMTLFunction(shaderConfig, pTessCtlSS, pTessCtlFB,
+                                         "Tessellation control");
+    id<MTLFunction> mtlFunc = func.getMTLFunction();
+    if (!mtlFunc) {
+        return false;
+    }
+    plDesc.computeFunction = mtlFunc;
 
-	auto& funcRslts = func.shaderConversionResults;
-	_needsTessCtlSwizzleBuffer = funcRslts.needsSwizzleBuffer;
-	_needsTessCtlBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-	_needsTessCtlDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
-	_needsTessCtlOutputBuffer = funcRslts.needsOutputBuffer;
-	_needsTessCtlPatchOutputBuffer = funcRslts.needsPatchOutputBuffer;
-	_needsTessCtlInputBuffer = funcRslts.needsInputThreadgroupMem;
-	markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts, kMVKShaderStageTessCtl);
+    auto& funcRslts = func.shaderConversionResults;
+    _needsTessCtlSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+    _needsTessCtlBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
+    _needsTessCtlDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+    _needsTessCtlOutputBuffer = funcRslts.needsOutputBuffer;
+    _needsTessCtlPatchOutputBuffer = funcRslts.needsPatchOutputBuffer;
+    _needsTessCtlInputBuffer = funcRslts.needsInputThreadgroupMem;
+    markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts,
+                                                        kMVKShaderStageTessCtl);
 
-	populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageTessCtl);
+    populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                    kMVKShaderStageTessCtl);
 
-	if (!verifyImplicitBuffer(_needsTessCtlSwizzleBuffer, _swizzleBufferIndex, kMVKShaderStageTessCtl, "swizzle")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsTessCtlBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageTessCtl, "buffer size")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsTessCtlDynamicOffsetBuffer, _dynamicOffsetBufferIndex, kMVKShaderStageTessCtl, "dynamic offset")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(true, _indirectParamsIndex, kMVKShaderStageTessCtl, "indirect parameters")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsTessCtlOutputBuffer, _outputBufferIndex, kMVKShaderStageTessCtl, "per-vertex output")) {
-		return false;
-	}
-	if (_needsTessCtlPatchOutputBuffer && _tessCtlPatchOutputBufferIndex < _descriptorBufferCounts.stages[kMVKShaderStageTessCtl]) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Tessellation control shader requires per-patch output buffer, but there is no free slot to pass it."));
-		return false;
-	}
-	if (_tessCtlLevelBufferIndex < _descriptorBufferCounts.stages[kMVKShaderStageTessCtl]) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Tessellation control shader requires tessellation level output buffer, but there is no free slot to pass it."));
-		return false;
-	}
-	return true;
+    if (!verifyImplicitBuffer(_needsTessCtlSwizzleBuffer, _swizzleBufferIndex,
+                              kMVKShaderStageTessCtl, "swizzle")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsTessCtlBufferSizeBuffer,
+                              _bufferSizeBufferIndex, kMVKShaderStageTessCtl,
+                              "buffer size")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsTessCtlDynamicOffsetBuffer,
+                              _dynamicOffsetBufferIndex, kMVKShaderStageTessCtl,
+                              "dynamic offset")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(true, _indirectParamsIndex,
+                              kMVKShaderStageTessCtl, "indirect parameters")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsTessCtlOutputBuffer, _outputBufferIndex,
+                              kMVKShaderStageTessCtl, "per-vertex output")) {
+        return false;
+    }
+    if (_needsTessCtlPatchOutputBuffer &&
+        _tessCtlPatchOutputBufferIndex <
+            _descriptorBufferCounts.stages[kMVKShaderStageTessCtl]) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Tessellation control shader requires per-patch output "
+                        "buffer, but "
+                        "there is no free slot to pass it."));
+        return false;
+    }
+    if (_tessCtlLevelBufferIndex <
+        _descriptorBufferCounts.stages[kMVKShaderStageTessCtl]) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Tessellation control shader requires tessellation "
+                        "level output "
+                        "buffer, but there is no free slot to pass it."));
+        return false;
+    }
+    return true;
 }
 
-bool MVKGraphicsPipeline::addTessEvalShaderToPipeline(MTLRenderPipelineDescriptor* plDesc,
-													  const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													  SPIRVToMSLConversionConfiguration& shaderConfig,
-													  SPIRVShaderOutputs& tcOutputs,
-													  const VkPipelineShaderStageCreateInfo* pTessEvalSS,
-													  VkPipelineCreationFeedback* pTessEvalFB,
-													  const VkPipelineShaderStageCreateInfo*& pFragmentSS) {
-	shaderConfig.options.entryPointStage = spv::ExecutionModelTessellationEvaluation;
-	shaderConfig.options.entryPointName = pTessEvalSS->pName;
-	shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageTessEval];
-	shaderConfig.options.mslOptions.shader_input_buffer_index = getMetalBufferIndexForVertexAttributeBinding(kMVKTessEvalInputBufferBinding);
-	shaderConfig.options.mslOptions.shader_patch_input_buffer_index = getMetalBufferIndexForVertexAttributeBinding(kMVKTessEvalPatchInputBufferBinding);
-	shaderConfig.options.mslOptions.shader_tess_factor_buffer_index = getMetalBufferIndexForVertexAttributeBinding(kMVKTessEvalLevelBufferBinding);
-	shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageTessEval];
-	shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageTessEval];
-	shaderConfig.options.mslOptions.capture_output_to_buffer = false;
-	shaderConfig.options.mslOptions.raw_buffer_tese_input = true;
-	shaderConfig.options.mslOptions.disable_rasterization = !_isRasterizing;
-	addPrevStageOutputToShaderConversionConfig(shaderConfig, tcOutputs);
+bool MVKGraphicsPipeline::addTessEvalShaderToPipeline(
+    MTLRenderPipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderOutputs& tcOutputs,
+    const VkPipelineShaderStageCreateInfo* pTessEvalSS,
+    VkPipelineCreationFeedback* pTessEvalFB,
+    const VkPipelineShaderStageCreateInfo*& pFragmentSS) {
+    shaderConfig.options.entryPointStage =
+        spv::ExecutionModelTessellationEvaluation;
+    shaderConfig.options.entryPointName = pTessEvalSS->pName;
+    shaderConfig.options.mslOptions.swizzle_buffer_index =
+        _swizzleBufferIndex.stages[kMVKShaderStageTessEval];
+    shaderConfig.options.mslOptions.shader_input_buffer_index =
+        getMetalBufferIndexForVertexAttributeBinding(
+            kMVKTessEvalInputBufferBinding);
+    shaderConfig.options.mslOptions.shader_patch_input_buffer_index =
+        getMetalBufferIndexForVertexAttributeBinding(
+            kMVKTessEvalPatchInputBufferBinding);
+    shaderConfig.options.mslOptions.shader_tess_factor_buffer_index =
+        getMetalBufferIndexForVertexAttributeBinding(
+            kMVKTessEvalLevelBufferBinding);
+    shaderConfig.options.mslOptions.buffer_size_buffer_index =
+        _bufferSizeBufferIndex.stages[kMVKShaderStageTessEval];
+    shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageTessEval];
+    shaderConfig.options.mslOptions.capture_output_to_buffer = false;
+    shaderConfig.options.mslOptions.raw_buffer_tese_input = true;
+    shaderConfig.options.mslOptions.disable_rasterization = !_isRasterizing;
+    addPrevStageOutputToShaderConversionConfig(shaderConfig, tcOutputs);
 
-	MVKMTLFunction func = getMTLFunction(shaderConfig, pTessEvalSS, pTessEvalFB, "Tessellation evaluation");
-	id<MTLFunction> mtlFunc = func.getMTLFunction();
-	plDesc.vertexFunction = mtlFunc;	// Yeah, you read that right. Tess. eval functions are a kind of vertex function in Metal.
-	if ( !mtlFunc ) { return false; }
+    MVKMTLFunction func = getMTLFunction(shaderConfig, pTessEvalSS, pTessEvalFB,
+                                         "Tessellation evaluation");
+    id<MTLFunction> mtlFunc = func.getMTLFunction();
+    plDesc.vertexFunction =
+        mtlFunc; // Yeah, you read that right. Tess. eval functions are a kind
+                 // of vertex function in Metal.
+    if (!mtlFunc) {
+        return false;
+    }
 
-	auto& funcRslts = func.shaderConversionResults;
-	plDesc.rasterizationEnabled = !funcRslts.isRasterizationDisabled;
-	_needsTessEvalSwizzleBuffer = funcRslts.needsSwizzleBuffer;
-	_needsTessEvalBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-	_needsTessEvalDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
-	markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts, kMVKShaderStageTessEval);
+    auto& funcRslts = func.shaderConversionResults;
+    plDesc.rasterizationEnabled = !funcRslts.isRasterizationDisabled;
+    _needsTessEvalSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+    _needsTessEvalBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
+    _needsTessEvalDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+    markIfUsingPhysicalStorageBufferAddressesCapability(
+        funcRslts, kMVKShaderStageTessEval);
 
-	populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageTessEval);
+    populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                    kMVKShaderStageTessEval);
 
-	if (funcRslts.isRasterizationDisabled) {
-		pFragmentSS = nullptr;
-	}
+    if (funcRslts.isRasterizationDisabled) {
+        pFragmentSS = nullptr;
+    }
 
-	if (!verifyImplicitBuffer(_needsTessEvalSwizzleBuffer, _swizzleBufferIndex, kMVKShaderStageTessEval, "swizzle")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsTessEvalBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageTessEval, "buffer size")) {
-		return false;
-	}
-	if (!verifyImplicitBuffer(_needsTessEvalDynamicOffsetBuffer, _dynamicOffsetBufferIndex, kMVKShaderStageTessEval, "dynamic offset")) {
-		return false;
-	}
-	return true;
+    if (!verifyImplicitBuffer(_needsTessEvalSwizzleBuffer, _swizzleBufferIndex,
+                              kMVKShaderStageTessEval, "swizzle")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsTessEvalBufferSizeBuffer,
+                              _bufferSizeBufferIndex, kMVKShaderStageTessEval,
+                              "buffer size")) {
+        return false;
+    }
+    if (!verifyImplicitBuffer(_needsTessEvalDynamicOffsetBuffer,
+                              _dynamicOffsetBufferIndex,
+                              kMVKShaderStageTessEval, "dynamic offset")) {
+        return false;
+    }
+    return true;
 }
 
-bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescriptor* plDesc,
-													  const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													  SPIRVToMSLConversionConfiguration& shaderConfig,
-													  SPIRVShaderOutputs& shaderOutputs,
-													  const VkPipelineShaderStageCreateInfo* pFragmentSS,
-													  VkPipelineCreationFeedback* pFragmentFB) {
-	auto& mtlFeats = getMetalFeatures();
-	if (pFragmentSS) {
-		shaderConfig.options.entryPointStage = spv::ExecutionModelFragment;
-		shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageFragment];
-		shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageFragment];
-		shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageFragment];
-		shaderConfig.options.mslOptions.view_mask_buffer_index = _viewRangeBufferIndex.stages[kMVKShaderStageFragment];
-		shaderConfig.options.entryPointName = pFragmentSS->pName;
-		shaderConfig.options.mslOptions.capture_output_to_buffer = false;
-		shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pFragmentSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) ? 0 : mtlFeats.maxSubgroupSize;
-		shaderConfig.options.mslOptions.check_discarded_frag_stores = true;
-		/* Enabling makes dEQP-VK.fragment_shader_interlock.basic.discard.image.pixel_ordered.1xaa.no_sample_shading.1024x1024 and similar tests fail. Requires investigation */
-		shaderConfig.options.mslOptions.force_fragment_with_side_effects_execution = false;
-		shaderConfig.options.mslOptions.input_attachment_is_ds_attachment = _inputAttachmentIsDSAttachment;
-		if (mtlFeats.needsSampleDrefLodArrayWorkaround) {
-			shaderConfig.options.mslOptions.sample_dref_lod_array_as_grad = true;
-		}
-		if (_isRasterizing && pCreateInfo->pMultisampleState) {		// Must ignore allowed bad pMultisampleState pointer if rasterization disabled
+bool MVKGraphicsPipeline::addFragmentShaderToPipeline(
+    MTLRenderPipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderOutputs& shaderOutputs,
+    const VkPipelineShaderStageCreateInfo* pFragmentSS,
+    VkPipelineCreationFeedback* pFragmentFB) {
+    auto& mtlFeats = getMetalFeatures();
+    if (pFragmentSS) {
+        shaderConfig.options.entryPointStage = spv::ExecutionModelFragment;
+        shaderConfig.options.mslOptions.swizzle_buffer_index =
+            _swizzleBufferIndex.stages[kMVKShaderStageFragment];
+        shaderConfig.options.mslOptions.buffer_size_buffer_index =
+            _bufferSizeBufferIndex.stages[kMVKShaderStageFragment];
+        shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+            _dynamicOffsetBufferIndex.stages[kMVKShaderStageFragment];
+        shaderConfig.options.mslOptions.view_mask_buffer_index =
+            _viewRangeBufferIndex.stages[kMVKShaderStageFragment];
+        shaderConfig.options.entryPointName = pFragmentSS->pName;
+        shaderConfig.options.mslOptions.capture_output_to_buffer = false;
+        shaderConfig.options.mslOptions.fixed_subgroup_size =
+            mvkIsAnyFlagEnabled(
+                pFragmentSS->flags,
+                VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT)
+                ? 0
+                : mtlFeats.maxSubgroupSize;
+        shaderConfig.options.mslOptions.check_discarded_frag_stores = true;
+        /* Enabling makes
+         * dEQP-VK.fragment_shader_interlock.basic.discard.image.pixel_ordered.1xaa.no_sample_shading.1024x1024
+         * and similar tests fail. Requires investigation */
+        shaderConfig.options.mslOptions
+            .force_fragment_with_side_effects_execution = false;
+        shaderConfig.options.mslOptions.input_attachment_is_ds_attachment =
+            _inputAttachmentIsDSAttachment;
+        if (mtlFeats.needsSampleDrefLodArrayWorkaround) {
+            shaderConfig.options.mslOptions.sample_dref_lod_array_as_grad =
+                true;
+        }
+        if (_isRasterizing &&
+            pCreateInfo->pMultisampleState) { // Must ignore allowed bad
+                                              // pMultisampleState pointer if
+                                              // rasterization disabled
 #if MVK_USE_METAL_PRIVATE_API
-			if (!getMVKConfig().useMetalPrivateAPI) {
+            if (!getMVKConfig().useMetalPrivateAPI) {
 #endif
-				if (pCreateInfo->pMultisampleState->pSampleMask && pCreateInfo->pMultisampleState->pSampleMask[0] != 0xffffffff) {
-					shaderConfig.options.mslOptions.additional_fixed_sample_mask = pCreateInfo->pMultisampleState->pSampleMask[0];
-				}
+                if (pCreateInfo->pMultisampleState->pSampleMask &&
+                    pCreateInfo->pMultisampleState->pSampleMask[0] !=
+                        0xffffffff) {
+                    shaderConfig.options.mslOptions
+                        .additional_fixed_sample_mask =
+                        pCreateInfo->pMultisampleState->pSampleMask[0];
+                }
 #if MVK_USE_METAL_PRIVATE_API
-			}
+            }
 #endif
-			shaderConfig.options.mslOptions.force_sample_rate_shading = pCreateInfo->pMultisampleState->sampleShadingEnable && pCreateInfo->pMultisampleState->minSampleShading != 0.0f;
-		}
-		if (std::any_of(shaderOutputs.begin(), shaderOutputs.end(), [](const SPIRVShaderOutput& output) { return output.builtin == spv::BuiltInLayer; })) {
-			shaderConfig.options.mslOptions.arrayed_subpass_input = true;
-		}
-		addPrevStageOutputToShaderConversionConfig(shaderConfig, shaderOutputs);
+            shaderConfig.options.mslOptions.force_sample_rate_shading =
+                pCreateInfo->pMultisampleState->sampleShadingEnable &&
+                pCreateInfo->pMultisampleState->minSampleShading != 0.0f;
+        }
+        if (std::any_of(shaderOutputs.begin(), shaderOutputs.end(),
+                        [](const SPIRVShaderOutput& output) {
+                            return output.builtin == spv::BuiltInLayer;
+                        })) {
+            shaderConfig.options.mslOptions.arrayed_subpass_input = true;
+        }
+        addPrevStageOutputToShaderConversionConfig(shaderConfig, shaderOutputs);
 
-		MVKMTLFunction func = getMTLFunction(shaderConfig, pFragmentSS, pFragmentFB, "Fragment");
-		id<MTLFunction> mtlFunc = func.getMTLFunction();
-		plDesc.fragmentFunction = mtlFunc;
-		if ( !mtlFunc ) { return false; }
+        MVKMTLFunction func =
+            getMTLFunction(shaderConfig, pFragmentSS, pFragmentFB, "Fragment");
+        id<MTLFunction> mtlFunc = func.getMTLFunction();
+        plDesc.fragmentFunction = mtlFunc;
+        if (!mtlFunc) {
+            return false;
+        }
 
-		auto& funcRslts = func.shaderConversionResults;
-		_needsFragmentSwizzleBuffer = funcRslts.needsSwizzleBuffer;
-		_needsFragmentBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-		_needsFragmentDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
-		_needsFragmentViewRangeBuffer = funcRslts.needsViewRangeBuffer;
-		markIfUsingPhysicalStorageBufferAddressesCapability(funcRslts, kMVKShaderStageFragment);
+        auto& funcRslts = func.shaderConversionResults;
+        _needsFragmentSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+        _needsFragmentBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
+        _needsFragmentDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+        _needsFragmentViewRangeBuffer = funcRslts.needsViewRangeBuffer;
+        markIfUsingPhysicalStorageBufferAddressesCapability(
+            funcRslts, kMVKShaderStageFragment);
 
-		populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageFragment);
+        populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                        kMVKShaderStageFragment);
 
-		if (!verifyImplicitBuffer(_needsFragmentSwizzleBuffer, _swizzleBufferIndex, kMVKShaderStageFragment, "swizzle")) {
-			return false;
-		}
-		if (!verifyImplicitBuffer(_needsFragmentBufferSizeBuffer, _bufferSizeBufferIndex, kMVKShaderStageFragment, "buffer size")) {
-			return false;
-		}
-		if (!verifyImplicitBuffer(_needsFragmentDynamicOffsetBuffer, _dynamicOffsetBufferIndex, kMVKShaderStageFragment, "dynamic offset")) {
-			return false;
-		}
-		if (!verifyImplicitBuffer(_needsFragmentViewRangeBuffer, _viewRangeBufferIndex, kMVKShaderStageFragment, "view range")) {
-			return false;
-		}
-	}
-	return true;
+        if (!verifyImplicitBuffer(_needsFragmentSwizzleBuffer,
+                                  _swizzleBufferIndex, kMVKShaderStageFragment,
+                                  "swizzle")) {
+            return false;
+        }
+        if (!verifyImplicitBuffer(_needsFragmentBufferSizeBuffer,
+                                  _bufferSizeBufferIndex,
+                                  kMVKShaderStageFragment, "buffer size")) {
+            return false;
+        }
+        if (!verifyImplicitBuffer(_needsFragmentDynamicOffsetBuffer,
+                                  _dynamicOffsetBufferIndex,
+                                  kMVKShaderStageFragment, "dynamic offset")) {
+            return false;
+        }
+        if (!verifyImplicitBuffer(_needsFragmentViewRangeBuffer,
+                                  _viewRangeBufferIndex,
+                                  kMVKShaderStageFragment, "view range")) {
+            return false;
+        }
+    }
+    return true;
 }
 
 #if !MVK_XCODE_15
 static const NSUInteger MTLBufferLayoutStrideDynamic = NSUIntegerMax;
 #endif
 
-template<class T>
-bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
-												   const VkPipelineVertexInputStateCreateInfo* pVI,
-												   const SPIRVToMSLConversionConfiguration& shaderConfig) {
+template <class T>
+bool MVKGraphicsPipeline::addVertexInputToPipeline(
+    T* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI,
+    const SPIRVToMSLConversionConfiguration& shaderConfig) {
     // Collect extension structures
-    VkPipelineVertexInputDivisorStateCreateInfoEXT* pVertexInputDivisorState = nullptr;
-	for (const auto* next = (VkBaseInStructure*)pVI->pNext; next; next = next->pNext) {
+    VkPipelineVertexInputDivisorStateCreateInfoEXT* pVertexInputDivisorState =
+        nullptr;
+    for (const auto* next = (VkBaseInStructure*)pVI->pNext; next;
+         next = next->pNext) {
         switch (next->sType) {
         case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT:
-            pVertexInputDivisorState = (VkPipelineVertexInputDivisorStateCreateInfoEXT*)next;
+            pVertexInputDivisorState =
+                (VkPipelineVertexInputDivisorStateCreateInfoEXT*)next;
             break;
         default:
             break;
@@ -1438,34 +1996,49 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
     }
 
     // Vertex buffer bindings
-	bool isVtxStrideStatic = !isDynamicState(VertexStride);
-	uint32_t maxBinding = 0;
-	uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
+    bool isVtxStrideStatic = !isDynamicState(VertexStride);
+    uint32_t maxBinding = 0;
+    uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
     for (uint32_t i = 0; i < vbCnt; i++) {
-        const VkVertexInputBindingDescription* pVKVB = &pVI->pVertexBindingDescriptions[i];
+        const VkVertexInputBindingDescription* pVKVB =
+            &pVI->pVertexBindingDescriptions[i];
         if (shaderConfig.isVertexBufferUsed(pVKVB->binding)) {
 
-			// Vulkan allows any stride, but Metal requires multiples of 4 on older GPUs.
-            if (isVtxStrideStatic && (pVKVB->stride % getMetalFeatures().vertexStrideAlignment) != 0) {
-				setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Under Metal, vertex attribute binding strides must be aligned to %llu bytes.", getMetalFeatures().vertexStrideAlignment));
+            // Vulkan allows any stride, but Metal requires multiples of 4 on
+            // older GPUs.
+            if (isVtxStrideStatic &&
+                (pVKVB->stride % getMetalFeatures().vertexStrideAlignment) !=
+                    0) {
+                setConfigurationResult(
+                    reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                "Under Metal, vertex attribute binding strides "
+                                "must be aligned to %llu bytes.",
+                                getMetalFeatures().vertexStrideAlignment));
                 return false;
             }
 
-			maxBinding = max(pVKVB->binding, maxBinding);
-			uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
-			_isVertexInputBindingUsed[vbIdx] = true;
-			auto vbDesc = inputDesc.layouts[vbIdx];
-			if (isVtxStrideStatic && pVKVB->stride == 0) {
-				// Stride can't be 0, it will be set later to attributes' maximum offset + size
-				// to prevent it from being larger than the underlying buffer permits.
-				vbDesc.stride = 0;
-				vbDesc.stepFunction = (decltype(vbDesc.stepFunction))MTLStepFunctionConstant;
-				vbDesc.stepRate = 0;
-			} else {
-				vbDesc.stride = isVtxStrideStatic ? pVKVB->stride : MTLBufferLayoutStrideDynamic;
-				vbDesc.stepFunction = (decltype(vbDesc.stepFunction))mvkMTLStepFunctionFromVkVertexInputRate(pVKVB->inputRate, isTessellationPipeline());
-				vbDesc.stepRate = 1;
-			}
+            maxBinding = max(pVKVB->binding, maxBinding);
+            uint32_t vbIdx =
+                getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
+            _isVertexInputBindingUsed[vbIdx] = true;
+            auto vbDesc = inputDesc.layouts[vbIdx];
+            if (isVtxStrideStatic && pVKVB->stride == 0) {
+                // Stride can't be 0, it will be set later to attributes'
+                // maximum offset + size to prevent it from being larger than
+                // the underlying buffer permits.
+                vbDesc.stride = 0;
+                vbDesc.stepFunction =
+                    (decltype(vbDesc.stepFunction))MTLStepFunctionConstant;
+                vbDesc.stepRate = 0;
+            } else {
+                vbDesc.stride = isVtxStrideStatic
+                                    ? pVKVB->stride
+                                    : MTLBufferLayoutStrideDynamic;
+                vbDesc.stepFunction = (decltype(vbDesc.stepFunction))
+                    mvkMTLStepFunctionFromVkVertexInputRate(
+                        pVKVB->inputRate, isTessellationPipeline());
+                vbDesc.stepRate = 1;
+            }
         }
     }
 
@@ -1474,13 +2047,19 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
     if (pVertexInputDivisorState) {
         uint32_t vbdCnt = pVertexInputDivisorState->vertexBindingDivisorCount;
         for (uint32_t i = 0; i < vbdCnt; i++) {
-            const VkVertexInputBindingDivisorDescriptionEXT* pVKVB = &pVertexInputDivisorState->pVertexBindingDivisors[i];
+            const VkVertexInputBindingDivisorDescriptionEXT* pVKVB =
+                &pVertexInputDivisorState->pVertexBindingDivisors[i];
             if (shaderConfig.isVertexBufferUsed(pVKVB->binding)) {
-                uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
-                if ((NSUInteger)inputDesc.layouts[vbIdx].stepFunction == MTLStepFunctionPerInstance ||
-					(NSUInteger)inputDesc.layouts[vbIdx].stepFunction == MTLStepFunctionThreadPositionInGridY) {
+                uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(
+                    pVKVB->binding);
+                if ((NSUInteger)inputDesc.layouts[vbIdx].stepFunction ==
+                        MTLStepFunctionPerInstance ||
+                    (NSUInteger)inputDesc.layouts[vbIdx].stepFunction ==
+                        MTLStepFunctionThreadPositionInGridY) {
                     if (pVKVB->divisor == 0) {
-                        inputDesc.layouts[vbIdx].stepFunction = (decltype(inputDesc.layouts[vbIdx].stepFunction))MTLStepFunctionConstant;
+                        inputDesc.layouts[vbIdx].stepFunction =
+                            (decltype(inputDesc.layouts[vbIdx].stepFunction))
+                                MTLStepFunctionConstant;
                         zeroDivisorBindings.insert(pVKVB->binding);
                     }
                     inputDesc.layouts[vbIdx].stepRate = pVKVB->divisor;
@@ -1489,271 +2068,212 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
         }
     }
 
-	// Vertex attributes
-	uint32_t vaCnt = pVI->vertexAttributeDescriptionCount;
-	for (uint32_t i = 0; i < vaCnt; i++) {
-		const VkVertexInputAttributeDescription* pVKVA = &pVI->pVertexAttributeDescriptions[i];
-		if (shaderConfig.isShaderInputLocationUsed(pVKVA->location)) {
-			uint32_t vaBinding = pVKVA->binding;
-			uint32_t vaOffset = pVKVA->offset;
-			auto vaDesc = inputDesc.attributes[pVKVA->location];
-			auto mtlFormat = (decltype(vaDesc.format))getPixelFormats()->getMTLVertexFormat(pVKVA->format);
+    // Vertex attributes
+    uint32_t vaCnt = pVI->vertexAttributeDescriptionCount;
+    for (uint32_t i = 0; i < vaCnt; i++) {
+        const VkVertexInputAttributeDescription* pVKVA =
+            &pVI->pVertexAttributeDescriptions[i];
+        if (shaderConfig.isShaderInputLocationUsed(pVKVA->location)) {
+            uint32_t vaBinding = pVKVA->binding;
+            uint32_t vaOffset = pVKVA->offset;
+            auto vaDesc = inputDesc.attributes[pVKVA->location];
+            auto mtlFormat =
+                (decltype(vaDesc.format))getPixelFormats()->getMTLVertexFormat(
+                    pVKVA->format);
 
-			// Vulkan allows offsets to exceed the buffer stride, but Metal doesn't.
-			// If this is the case, fetch a translated artificial buffer binding, using the same MTLBuffer,
-			// but that is translated so that the reduced VA offset fits into the binding stride.
-			if (isVtxStrideStatic) {
-				const VkVertexInputBindingDescription* pVKVB = pVI->pVertexBindingDescriptions;
-				uint32_t attrSize = 0;
-				for (uint32_t j = 0; j < vbCnt; j++, pVKVB++) {
-					if (pVKVB->binding == pVKVA->binding) {
-						attrSize = getPixelFormats()->getBytesPerBlock(pVKVA->format);
-						if (pVKVB->stride == 0) {
-							// The step is set to constant, but we need to change stride to be non-zero for metal.
-							// Look for the maximum offset + size to set as the stride.
-							uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
-							auto vbDesc = inputDesc.layouts[vbIdx];
-							uint32_t strideLowBound = vaOffset + attrSize;
-							if (vbDesc.stride < strideLowBound) vbDesc.stride = strideLowBound;
-						} else if (vaOffset && vaOffset + attrSize > pVKVB->stride) {
-							// Move vertex attribute offset into the stride. This vertex attribute may be
-							// combined with other vertex attributes into the same translated buffer binding.
-							// But if the reduced offset combined with the vertex attribute size still won't
-							// fit into the buffer binding stride, force the vertex attribute offset to zero,
-							// effectively dedicating this vertex attribute to its own buffer binding.
-							uint32_t origOffset = vaOffset;
-							vaOffset %= pVKVB->stride;
-							if (vaOffset + attrSize > pVKVB->stride) {
-								vaOffset = 0;
-							}
-							vaBinding = getTranslatedVertexBinding(vaBinding, origOffset - vaOffset, maxBinding);
-							if (zeroDivisorBindings.count(pVKVB->binding)) {
-								zeroDivisorBindings.insert(vaBinding);
-							}
-						}
-						break;
-					}
-				}
-				if (pVKVB->stride && attrSize > pVKVB->stride) {
-					/* Metal does not support overlapping loads. Truncate format vector length to prevent an assertion
-					 * and hope it's not used by the shader. */
-					MTLVertexFormat newFormat = mvkAdjustFormatVectorToSize((MTLVertexFormat)mtlFormat, pVKVB->stride);
-					reportError(VK_SUCCESS, "Found attribute with size (%u) larger than it's binding's stride (%u). Changing descriptor format from %s to %s.",
-								attrSize, pVKVB->stride, getPixelFormats()->getName((MTLVertexFormat)mtlFormat), getPixelFormats()->getName(newFormat));
-					mtlFormat = (decltype(vaDesc.format))newFormat;
-				}
-			}
+            // Vulkan allows offsets to exceed the buffer stride, but Metal
+            // doesn't. If this is the case, fetch a translated artificial
+            // buffer binding, using the same MTLBuffer, but that is translated
+            // so that the reduced VA offset fits into the binding stride.
+            if (isVtxStrideStatic) {
+                const VkVertexInputBindingDescription* pVKVB =
+                    pVI->pVertexBindingDescriptions;
+                uint32_t attrSize = 0;
+                for (uint32_t j = 0; j < vbCnt; j++, pVKVB++) {
+                    if (pVKVB->binding == pVKVA->binding) {
+                        attrSize =
+                            getPixelFormats()->getBytesPerBlock(pVKVA->format);
+                        if (pVKVB->stride == 0) {
+                            // The step is set to constant, but we need to
+                            // change stride to be non-zero for metal. Look for
+                            // the maximum offset + size to set as the stride.
+                            uint32_t vbIdx =
+                                getMetalBufferIndexForVertexAttributeBinding(
+                                    pVKVB->binding);
+                            auto vbDesc = inputDesc.layouts[vbIdx];
+                            uint32_t strideLowBound = vaOffset + attrSize;
+                            if (vbDesc.stride < strideLowBound)
+                                vbDesc.stride = strideLowBound;
+                        } else if (vaOffset &&
+                                   vaOffset + attrSize > pVKVB->stride) {
+                            // Move vertex attribute offset into the stride.
+                            // This vertex attribute may be combined with other
+                            // vertex attributes into the same translated buffer
+                            // binding. But if the reduced offset combined with
+                            // the vertex attribute size still won't fit into
+                            // the buffer binding stride, force the vertex
+                            // attribute offset to zero, effectively dedicating
+                            // this vertex attribute to its own buffer binding.
+                            uint32_t origOffset = vaOffset;
+                            vaOffset %= pVKVB->stride;
+                            if (vaOffset + attrSize > pVKVB->stride) {
+                                vaOffset = 0;
+                            }
+                            vaBinding = getTranslatedVertexBinding(vaBinding,
+                                                                   origOffset -
+                                                                       vaOffset,
+                                                                   maxBinding);
+                            if (zeroDivisorBindings.count(pVKVB->binding)) {
+                                zeroDivisorBindings.insert(vaBinding);
+                            }
+                        }
+                        break;
+                    }
+                }
+                if (pVKVB->stride && attrSize > pVKVB->stride) {
+                    /* Metal does not support overlapping loads. Truncate format
+                     * vector length to prevent an assertion and hope it's not
+                     * used by the shader. */
+                    MTLVertexFormat newFormat =
+                        mvkAdjustFormatVectorToSize((MTLVertexFormat)mtlFormat,
+                                                    pVKVB->stride);
+                    reportError(VK_SUCCESS,
+                                "Found attribute with size (%u) larger than "
+                                "it's binding's stride (%u). Changing "
+                                "descriptor format from %s to %s.",
+                                attrSize, pVKVB->stride,
+                                getPixelFormats()->getName(
+                                    (MTLVertexFormat)mtlFormat),
+                                getPixelFormats()->getName(newFormat));
+                    mtlFormat = (decltype(vaDesc.format))newFormat;
+                }
+            }
 
-			vaDesc.format = mtlFormat;
-			vaDesc.bufferIndex = (decltype(vaDesc.bufferIndex))getMetalBufferIndexForVertexAttributeBinding(vaBinding);
-			vaDesc.offset = vaOffset;
-		}
-	}
+            vaDesc.format = mtlFormat;
+            vaDesc.bufferIndex = (decltype(vaDesc.bufferIndex))
+                getMetalBufferIndexForVertexAttributeBinding(vaBinding);
+            vaDesc.offset = vaOffset;
+        }
+    }
 
-	// Run through the vertex bindings. Add a new Metal vertex layout for each translated binding,
-	// identical to the original layout. The translated binding will index into the same MTLBuffer,
-	// but at an offset that is one or more strides away from the original.
-	for (uint32_t i = 0; i < vbCnt; i++) {
-		const VkVertexInputBindingDescription* pVKVB = &pVI->pVertexBindingDescriptions[i];
-		uint32_t vbVACnt = shaderConfig.countShaderInputsAt(pVKVB->binding);
-		if (vbVACnt > 0) {
-			uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
-			auto vbDesc = inputDesc.layouts[vbIdx];
+    // Run through the vertex bindings. Add a new Metal vertex layout for each
+    // translated binding, identical to the original layout. The translated
+    // binding will index into the same MTLBuffer, but at an offset that is one
+    // or more strides away from the original.
+    for (uint32_t i = 0; i < vbCnt; i++) {
+        const VkVertexInputBindingDescription* pVKVB =
+            &pVI->pVertexBindingDescriptions[i];
+        uint32_t vbVACnt = shaderConfig.countShaderInputsAt(pVKVB->binding);
+        if (vbVACnt > 0) {
+            uint32_t vbIdx =
+                getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
+            auto vbDesc = inputDesc.layouts[vbIdx];
 
-			uint32_t xldtVACnt = 0;
-			for (auto& xltdBind : _translatedVertexBindings) {
-				if (xltdBind.binding == pVKVB->binding) {
-					uint32_t vbXltdIdx = getMetalBufferIndexForVertexAttributeBinding(xltdBind.translationBinding);
-					auto vbXltdDesc = inputDesc.layouts[vbXltdIdx];
-					vbXltdDesc.stride = vbDesc.stride;
-					vbXltdDesc.stepFunction = vbDesc.stepFunction;
-					vbXltdDesc.stepRate = vbDesc.stepRate;
-					xldtVACnt += xltdBind.mappedAttributeCount;
-				}
-			}
+            uint32_t xldtVACnt = 0;
+            for (auto& xltdBind : _translatedVertexBindings) {
+                if (xltdBind.binding == pVKVB->binding) {
+                    uint32_t vbXltdIdx =
+                        getMetalBufferIndexForVertexAttributeBinding(
+                            xltdBind.translationBinding);
+                    auto vbXltdDesc = inputDesc.layouts[vbXltdIdx];
+                    vbXltdDesc.stride = vbDesc.stride;
+                    vbXltdDesc.stepFunction = vbDesc.stepFunction;
+                    vbXltdDesc.stepRate = vbDesc.stepRate;
+                    xldtVACnt += xltdBind.mappedAttributeCount;
+                }
+            }
 
-			// If all of the vertex attributes at this vertex buffer binding have been translated, remove it.
-			if (xldtVACnt == vbVACnt) { vbDesc.stride = 0; }
-		}
-	}
+            // If all of the vertex attributes at this vertex buffer binding
+            // have been translated, remove it.
+            if (xldtVACnt == vbVACnt) {
+                vbDesc.stride = 0;
+            }
+        }
+    }
 
-    // Collect all bindings with zero divisors. We need to remember them so we can offset
-    // the vertex buffers during a draw.
+    // Collect all bindings with zero divisors. We need to remember them so we
+    // can offset the vertex buffers during a draw.
     for (uint32_t binding : zeroDivisorBindings) {
-        uint32_t stride = (uint32_t)inputDesc.layouts[getMetalBufferIndexForVertexAttributeBinding(binding)].stride;
+        uint32_t stride =
+            (uint32_t)inputDesc
+                .layouts[getMetalBufferIndexForVertexAttributeBinding(binding)]
+                .stride;
         _zeroDivisorVertexBindings.emplace_back(binding, stride);
     }
 
-	return true;
+    return true;
 }
 
-// Adjusts step rates for per-instance vertex buffers based on the number of views to be drawn.
-void MVKGraphicsPipeline::adjustVertexInputForMultiview(MTLVertexDescriptor* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, uint32_t viewCount, uint32_t oldViewCount) {
-	uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
-	const VkVertexInputBindingDescription* pVKVB = pVI->pVertexBindingDescriptions;
-	for (uint32_t i = 0; i < vbCnt; ++i, ++pVKVB) {
-		uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
-		if (inputDesc.layouts[vbIdx].stepFunction == MTLVertexStepFunctionPerInstance) {
-			inputDesc.layouts[vbIdx].stepRate = inputDesc.layouts[vbIdx].stepRate / oldViewCount * viewCount;
-			for (auto& xltdBind : _translatedVertexBindings) {
-				if (xltdBind.binding == pVKVB->binding) {
-					uint32_t vbXltdIdx = getMetalBufferIndexForVertexAttributeBinding(xltdBind.translationBinding);
-					inputDesc.layouts[vbXltdIdx].stepRate = inputDesc.layouts[vbXltdIdx].stepRate / oldViewCount * viewCount;
-				}
-			}
-		}
-	}
-}
-
-// Returns a translated binding for the existing binding and translation offset, creating it if needed.
-uint32_t MVKGraphicsPipeline::getTranslatedVertexBinding(uint32_t binding, uint32_t translationOffset, uint32_t maxBinding) {
-	// See if a translated binding already exists (for example if more than one VA needs the same translation).
-	for (auto& xltdBind : _translatedVertexBindings) {
-		if (xltdBind.binding == binding && xltdBind.translationOffset == translationOffset) {
-			xltdBind.mappedAttributeCount++;
-			return xltdBind.translationBinding;
-		}
-	}
-
-	// Get next available binding point and add a translation binding description for it
-	uint16_t xltdBindPt = (uint16_t)(maxBinding + _translatedVertexBindings.size() + 1);
-	_translatedVertexBindings.push_back( {.binding = (uint16_t)binding, .translationBinding = xltdBindPt, .translationOffset = translationOffset, .mappedAttributeCount = 1u} );
-
-	return xltdBindPt;
-}
-
-void MVKGraphicsPipeline::addTessellationToPipeline(MTLRenderPipelineDescriptor* plDesc,
-													const SPIRVTessReflectionData& reflectData,
-													const VkPipelineTessellationStateCreateInfo* pTS) {
-
-	VkPipelineTessellationDomainOriginStateCreateInfo* pTessDomainOriginState = nullptr;
-	if (pTS && reflectData.patchKind == spv::ExecutionModeTriangles) {
-		for (const auto* next = (VkBaseInStructure*)pTS->pNext; next; next = next->pNext) {
-			switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
-				pTessDomainOriginState = (VkPipelineTessellationDomainOriginStateCreateInfo*)next;
-				break;
-			default:
-				break;
-			}
-		}
-	}
-
-	plDesc.maxTessellationFactor = getDeviceProperties().limits.maxTessellationGenerationLevel;
-	plDesc.tessellationFactorFormat = MTLTessellationFactorFormatHalf;  // FIXME Use Float when it becomes available
-	plDesc.tessellationFactorStepFunction = MTLTessellationFactorStepFunctionPerPatch;
-	plDesc.tessellationOutputWindingOrder = mvkMTLWindingFromSpvExecutionMode(reflectData.windingOrder);
-	if (pTessDomainOriginState && pTessDomainOriginState->domainOrigin == VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT) {
-		// Reverse the winding order for triangle patches with lower-left domains.
-		if (plDesc.tessellationOutputWindingOrder == MTLWindingClockwise) {
-			plDesc.tessellationOutputWindingOrder = MTLWindingCounterClockwise;
-		} else {
-			plDesc.tessellationOutputWindingOrder = MTLWindingClockwise;
-		}
-	}
-	plDesc.tessellationPartitionMode = mvkMTLTessellationPartitionModeFromSpvExecutionMode(reflectData.partitionMode);
-}
-
-void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescriptor* plDesc,
-													  const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	// Topology
-	if (pCreateInfo->pInputAssemblyState) {
-		plDesc.inputPrimitiveTopologyMVK = isRenderingPoints(pCreateInfo)
-												? MTLPrimitiveTopologyClassPoint
-												: mvkMTLPrimitiveTopologyClassFromVkPrimitiveTopology(pCreateInfo->pInputAssemblyState->topology);
-	}
-
-	const VkPipelineRenderingCreateInfo* pRendInfo = getRenderingCreateInfo(pCreateInfo);
-
-	// Color attachments - must ignore bad pColorBlendState pointer if rasterization is disabled or subpass has no color attachments
-    uint32_t caCnt = 0;
-    if (_isRasterizingColor && pRendInfo && pCreateInfo->pColorBlendState) {
-        for (uint32_t caIdx = 0; caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {
-            const VkPipelineColorBlendAttachmentState* pCA = &pCreateInfo->pColorBlendState->pAttachments[caIdx];
-
-			MTLPixelFormat mtlPixFmt = getPixelFormats()->getMTLPixelFormat(pRendInfo->pColorAttachmentFormats[caIdx]);
-			MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[caIdx];
-            colorDesc.pixelFormat = mtlPixFmt;
-            if (colorDesc.pixelFormat == MTLPixelFormatRGB9E5Float) {
-                // Metal doesn't allow disabling individual channels for a RGB9E5 render target.
-                // Either all must be disabled or none must be disabled.
-                // TODO: Use framebuffer fetch to support this anyway. I don't understand why Apple doesn't
-                // support it, given that the only GPUs that support this in Metal also support framebuffer fetch.
-                colorDesc.writeMask = pCA->colorWriteMask ? MTLColorWriteMaskAll : MTLColorWriteMaskNone;
-            } else {
-                colorDesc.writeMask = mvkMTLColorWriteMaskFromVkChannelFlags(pCA->colorWriteMask);
-            }
-            // Don't set the blend state if we're not using this attachment.
-            // The pixel format will be MTLPixelFormatInvalid in that case, and
-            // Metal asserts if we turn on blending with that pixel format.
-            if (mtlPixFmt) {
-                caCnt++;
-                colorDesc.blendingEnabled = pCA->blendEnable;
-                colorDesc.rgbBlendOperation = mvkMTLBlendOperationFromVkBlendOp(pCA->colorBlendOp);
-                colorDesc.sourceRGBBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->srcColorBlendFactor);
-                colorDesc.destinationRGBBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->dstColorBlendFactor);
-                colorDesc.alphaBlendOperation = mvkMTLBlendOperationFromVkBlendOp(pCA->alphaBlendOp);
-                colorDesc.sourceAlphaBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->srcAlphaBlendFactor);
-                colorDesc.destinationAlphaBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->dstAlphaBlendFactor);
-#if MVK_USE_METAL_PRIVATE_API
-				if (getMVKConfig().useMetalPrivateAPI) {
-					colorDesc.logicOpEnabledMVK = pCreateInfo->pColorBlendState->logicOpEnable;
-					colorDesc.logicOpMVK = mvkMTLLogicOperationFromVkLogicOp(pCreateInfo->pColorBlendState->logicOp);
-				}
-#endif
+// Adjusts step rates for per-instance vertex buffers based on the number of
+// views to be drawn.
+void MVKGraphicsPipeline::adjustVertexInputForMultiview(
+    MTLVertexDescriptor* inputDesc,
+    const VkPipelineVertexInputStateCreateInfo* pVI, uint32_t viewCount,
+    uint32_t oldViewCount) {
+    uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
+    const VkVertexInputBindingDescription* pVKVB =
+        pVI->pVertexBindingDescriptions;
+    for (uint32_t i = 0; i < vbCnt; ++i, ++pVKVB) {
+        uint32_t vbIdx =
+            getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
+        if (inputDesc.layouts[vbIdx].stepFunction ==
+            MTLVertexStepFunctionPerInstance) {
+            inputDesc.layouts[vbIdx].stepRate =
+                inputDesc.layouts[vbIdx].stepRate / oldViewCount * viewCount;
+            for (auto& xltdBind : _translatedVertexBindings) {
+                if (xltdBind.binding == pVKVB->binding) {
+                    uint32_t vbXltdIdx =
+                        getMetalBufferIndexForVertexAttributeBinding(
+                            xltdBind.translationBinding);
+                    inputDesc.layouts[vbXltdIdx].stepRate =
+                        inputDesc.layouts[vbXltdIdx].stepRate / oldViewCount *
+                        viewCount;
+                }
             }
         }
     }
-
-    // Depth & stencil attachment formats
-	MVKPixelFormats* pixFmts = getPixelFormats();
-
-	MTLPixelFormat mtlDepthPixFmt = pixFmts->getMTLPixelFormat(pRendInfo->depthAttachmentFormat);
-	if (pixFmts->isDepthFormat(mtlDepthPixFmt)) { plDesc.depthAttachmentPixelFormat = mtlDepthPixFmt; }
-
-	MTLPixelFormat mtlStencilPixFmt = pixFmts->getMTLPixelFormat(pRendInfo->stencilAttachmentFormat);
-	if (pixFmts->isStencilFormat(mtlStencilPixFmt)) { plDesc.stencilAttachmentPixelFormat = mtlStencilPixFmt; }
-
-	// In Vulkan, it's perfectly valid to render without any attachments. In Metal, if that
-	// isn't supported, and we have no attachments, then we have to add a dummy attachment.
-	if (!getMetalFeatures().renderWithoutAttachments &&
-		!caCnt && !pRendInfo->depthAttachmentFormat && !pRendInfo->stencilAttachmentFormat) {
-
-        MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[0];
-        colorDesc.pixelFormat = MTLPixelFormatR8Unorm;
-        colorDesc.writeMask = MTLColorWriteMaskNone;
-    }
-
-    // Multisampling - must ignore allowed bad pMultisampleState pointer if rasterization disabled
-    if (_isRasterizing && pCreateInfo->pMultisampleState) {
-        plDesc.rasterSampleCount = mvkSampleCountFromVkSampleCountFlagBits(pCreateInfo->pMultisampleState->rasterizationSamples);
-#if MVK_USE_METAL_PRIVATE_API
-        if (getMVKConfig().useMetalPrivateAPI && pCreateInfo->pMultisampleState->pSampleMask) {
-            plDesc.sampleMaskMVK = pCreateInfo->pMultisampleState->pSampleMask[0];
-        }
-#endif
-        plDesc.alphaToCoverageEnabled = pCreateInfo->pMultisampleState->alphaToCoverageEnable;
-        plDesc.alphaToOneEnabled = pCreateInfo->pMultisampleState->alphaToOneEnable;
-
-		// If the pipeline uses a specific render subpass, set its default sample count
-		if (pCreateInfo->renderPass) {
-			((MVKRenderPass*)pCreateInfo->renderPass)->getSubpass(pCreateInfo->subpass)->setDefaultSampleCount(pCreateInfo->pMultisampleState->rasterizationSamples);
-		}
-    }
 }
 
-// Initializes the shader conversion config used to prepare the MSL library used by this pipeline.
-void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig,
-													 const VkGraphicsPipelineCreateInfo* pCreateInfo,
-													 const SPIRVTessReflectionData& reflectData) {
+// Returns a translated binding for the existing binding and translation offset,
+// creating it if needed.
+uint32_t MVKGraphicsPipeline::getTranslatedVertexBinding(
+    uint32_t binding, uint32_t translationOffset, uint32_t maxBinding) {
+    // See if a translated binding already exists (for example if more than one
+    // VA needs the same translation).
+    for (auto& xltdBind : _translatedVertexBindings) {
+        if (xltdBind.binding == binding &&
+            xltdBind.translationOffset == translationOffset) {
+            xltdBind.mappedAttributeCount++;
+            return xltdBind.translationBinding;
+        }
+    }
 
-	// Tessellation - must ignore allowed bad pTessellationState pointer if not tess pipeline
-    VkPipelineTessellationDomainOriginStateCreateInfo* pTessDomainOriginState = nullptr;
-    if (isTessellationPipeline() && pCreateInfo->pTessellationState) {
-		for (const auto* next = (VkBaseInStructure*)pCreateInfo->pTessellationState->pNext; next; next = next->pNext) {
+    // Get next available binding point and add a translation binding
+    // description for it
+    uint16_t xltdBindPt =
+        (uint16_t)(maxBinding + _translatedVertexBindings.size() + 1);
+    _translatedVertexBindings.push_back({.binding = (uint16_t)binding,
+                                         .translationBinding = xltdBindPt,
+                                         .translationOffset = translationOffset,
+                                         .mappedAttributeCount = 1u});
+
+    return xltdBindPt;
+}
+
+void MVKGraphicsPipeline::addTessellationToPipeline(
+    MTLRenderPipelineDescriptor* plDesc,
+    const SPIRVTessReflectionData& reflectData,
+    const VkPipelineTessellationStateCreateInfo* pTS) {
+
+    VkPipelineTessellationDomainOriginStateCreateInfo* pTessDomainOriginState =
+        nullptr;
+    if (pTS && reflectData.patchKind == spv::ExecutionModeTriangles) {
+        for (const auto* next = (VkBaseInStructure*)pTS->pNext; next;
+             next = next->pNext) {
             switch (next->sType) {
             case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
-                pTessDomainOriginState = (VkPipelineTessellationDomainOriginStateCreateInfo*)next;
+                pTessDomainOriginState =
+                    (VkPipelineTessellationDomainOriginStateCreateInfo*)next;
                 break;
             default:
                 break;
@@ -1761,150 +2281,398 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
         }
     }
 
-	auto& mtlFeats = getMetalFeatures();
-    shaderConfig.options.mslOptions.msl_version = mtlFeats.mslVersion;
-    shaderConfig.options.mslOptions.texel_buffer_texture_width = mtlFeats.maxTextureDimension;
-    shaderConfig.options.mslOptions.r32ui_linear_texture_alignment = (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT, this);
-	shaderConfig.options.mslOptions.texture_buffer_native = mtlFeats.textureBuffers;
+    plDesc.maxTessellationFactor =
+        getDeviceProperties().limits.maxTessellationGenerationLevel;
+    plDesc.tessellationFactorFormat =
+        MTLTessellationFactorFormatHalf; // FIXME Use Float when it becomes
+                                         // available
+    plDesc.tessellationFactorStepFunction =
+        MTLTessellationFactorStepFunctionPerPatch;
+    plDesc.tessellationOutputWindingOrder =
+        mvkMTLWindingFromSpvExecutionMode(reflectData.windingOrder);
+    if (pTessDomainOriginState &&
+        pTessDomainOriginState->domainOrigin ==
+            VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT) {
+        // Reverse the winding order for triangle patches with lower-left
+        // domains.
+        if (plDesc.tessellationOutputWindingOrder == MTLWindingClockwise) {
+            plDesc.tessellationOutputWindingOrder = MTLWindingCounterClockwise;
+        } else {
+            plDesc.tessellationOutputWindingOrder = MTLWindingClockwise;
+        }
+    }
+    plDesc.tessellationPartitionMode =
+        mvkMTLTessellationPartitionModeFromSpvExecutionMode(
+            reflectData.partitionMode);
+}
 
-	bool useMetalArgBuff = isUsingMetalArgumentBuffers();
-	shaderConfig.options.mslOptions.argument_buffers = useMetalArgBuff;
-	shaderConfig.options.mslOptions.force_active_argument_buffer_resources = false;
-	shaderConfig.options.mslOptions.pad_argument_buffer_resources = useMetalArgBuff;
-	shaderConfig.options.mslOptions.argument_buffers_tier = (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)getMetalFeatures().argumentBuffersTier;
-	shaderConfig.options.mslOptions.agx_manual_cube_grad_fixup = mtlFeats.needsCubeGradWorkaround;
+void MVKGraphicsPipeline::addFragmentOutputToPipeline(
+    MTLRenderPipelineDescriptor* plDesc,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    // Topology
+    if (pCreateInfo->pInputAssemblyState) {
+        plDesc.inputPrimitiveTopologyMVK =
+            isRenderingPoints(pCreateInfo)
+                ? MTLPrimitiveTopologyClassPoint
+                : mvkMTLPrimitiveTopologyClassFromVkPrimitiveTopology(
+                      pCreateInfo->pInputAssemblyState->topology);
+    }
+
+    const VkPipelineRenderingCreateInfo* pRendInfo =
+        getRenderingCreateInfo(pCreateInfo);
+
+    // Color attachments - must ignore bad pColorBlendState pointer if
+    // rasterization is disabled or subpass has no color attachments
+    uint32_t caCnt = 0;
+    if (_isRasterizingColor && pRendInfo && pCreateInfo->pColorBlendState) {
+        for (uint32_t caIdx = 0;
+             caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {
+            const VkPipelineColorBlendAttachmentState* pCA =
+                &pCreateInfo->pColorBlendState->pAttachments[caIdx];
+
+            MTLPixelFormat mtlPixFmt = getPixelFormats()->getMTLPixelFormat(
+                pRendInfo->pColorAttachmentFormats[caIdx]);
+            MTLRenderPipelineColorAttachmentDescriptor* colorDesc =
+                plDesc.colorAttachments[caIdx];
+            colorDesc.pixelFormat = mtlPixFmt;
+            if (colorDesc.pixelFormat == MTLPixelFormatRGB9E5Float) {
+                // Metal doesn't allow disabling individual channels for a
+                // RGB9E5 render target. Either all must be disabled or none
+                // must be disabled.
+                // TODO: Use framebuffer fetch to support this anyway. I don't
+                // understand why Apple doesn't support it, given that the only
+                // GPUs that support this in Metal also support framebuffer
+                // fetch.
+                colorDesc.writeMask = pCA->colorWriteMask
+                                          ? MTLColorWriteMaskAll
+                                          : MTLColorWriteMaskNone;
+            } else {
+                colorDesc.writeMask =
+                    mvkMTLColorWriteMaskFromVkChannelFlags(pCA->colorWriteMask);
+            }
+            // Don't set the blend state if we're not using this attachment.
+            // The pixel format will be MTLPixelFormatInvalid in that case, and
+            // Metal asserts if we turn on blending with that pixel format.
+            if (mtlPixFmt) {
+                caCnt++;
+                colorDesc.blendingEnabled = pCA->blendEnable;
+                colorDesc.rgbBlendOperation =
+                    mvkMTLBlendOperationFromVkBlendOp(pCA->colorBlendOp);
+                colorDesc.sourceRGBBlendFactor =
+                    mvkMTLBlendFactorFromVkBlendFactor(
+                        pCA->srcColorBlendFactor);
+                colorDesc.destinationRGBBlendFactor =
+                    mvkMTLBlendFactorFromVkBlendFactor(
+                        pCA->dstColorBlendFactor);
+                colorDesc.alphaBlendOperation =
+                    mvkMTLBlendOperationFromVkBlendOp(pCA->alphaBlendOp);
+                colorDesc.sourceAlphaBlendFactor =
+                    mvkMTLBlendFactorFromVkBlendFactor(
+                        pCA->srcAlphaBlendFactor);
+                colorDesc.destinationAlphaBlendFactor =
+                    mvkMTLBlendFactorFromVkBlendFactor(
+                        pCA->dstAlphaBlendFactor);
+#if MVK_USE_METAL_PRIVATE_API
+                if (getMVKConfig().useMetalPrivateAPI) {
+                    colorDesc.logicOpEnabledMVK =
+                        pCreateInfo->pColorBlendState->logicOpEnable;
+                    colorDesc.logicOpMVK = mvkMTLLogicOperationFromVkLogicOp(
+                        pCreateInfo->pColorBlendState->logicOp);
+                }
+#endif
+            }
+        }
+    }
+
+    // Depth & stencil attachment formats
+    MVKPixelFormats* pixFmts = getPixelFormats();
+
+    MTLPixelFormat mtlDepthPixFmt =
+        pixFmts->getMTLPixelFormat(pRendInfo->depthAttachmentFormat);
+    if (pixFmts->isDepthFormat(mtlDepthPixFmt)) {
+        plDesc.depthAttachmentPixelFormat = mtlDepthPixFmt;
+    }
+
+    MTLPixelFormat mtlStencilPixFmt =
+        pixFmts->getMTLPixelFormat(pRendInfo->stencilAttachmentFormat);
+    if (pixFmts->isStencilFormat(mtlStencilPixFmt)) {
+        plDesc.stencilAttachmentPixelFormat = mtlStencilPixFmt;
+    }
+
+    // In Vulkan, it's perfectly valid to render without any attachments. In
+    // Metal, if that isn't supported, and we have no attachments, then we have
+    // to add a dummy attachment.
+    if (!getMetalFeatures().renderWithoutAttachments && !caCnt &&
+        !pRendInfo->depthAttachmentFormat &&
+        !pRendInfo->stencilAttachmentFormat) {
+
+        MTLRenderPipelineColorAttachmentDescriptor* colorDesc =
+            plDesc.colorAttachments[0];
+        colorDesc.pixelFormat = MTLPixelFormatR8Unorm;
+        colorDesc.writeMask = MTLColorWriteMaskNone;
+    }
+
+    // Multisampling - must ignore allowed bad pMultisampleState pointer if
+    // rasterization disabled
+    if (_isRasterizing && pCreateInfo->pMultisampleState) {
+        plDesc.rasterSampleCount = mvkSampleCountFromVkSampleCountFlagBits(
+            pCreateInfo->pMultisampleState->rasterizationSamples);
+#if MVK_USE_METAL_PRIVATE_API
+        if (getMVKConfig().useMetalPrivateAPI &&
+            pCreateInfo->pMultisampleState->pSampleMask) {
+            plDesc.sampleMaskMVK =
+                pCreateInfo->pMultisampleState->pSampleMask[0];
+        }
+#endif
+        plDesc.alphaToCoverageEnabled =
+            pCreateInfo->pMultisampleState->alphaToCoverageEnable;
+        plDesc.alphaToOneEnabled =
+            pCreateInfo->pMultisampleState->alphaToOneEnable;
+
+        // If the pipeline uses a specific render subpass, set its default
+        // sample count
+        if (pCreateInfo->renderPass) {
+            ((MVKRenderPass*)pCreateInfo->renderPass)
+                ->getSubpass(pCreateInfo->subpass)
+                ->setDefaultSampleCount(
+                    pCreateInfo->pMultisampleState->rasterizationSamples);
+        }
+    }
+}
+
+// Initializes the shader conversion config used to prepare the MSL library used
+// by this pipeline.
+void MVKGraphicsPipeline::initShaderConversionConfig(
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    const SPIRVTessReflectionData& reflectData) {
+
+    // Tessellation - must ignore allowed bad pTessellationState pointer if not
+    // tess pipeline
+    VkPipelineTessellationDomainOriginStateCreateInfo* pTessDomainOriginState =
+        nullptr;
+    if (isTessellationPipeline() && pCreateInfo->pTessellationState) {
+        for (const auto* next =
+                 (VkBaseInStructure*)pCreateInfo->pTessellationState->pNext;
+             next; next = next->pNext) {
+            switch (next->sType) {
+            case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
+                pTessDomainOriginState =
+                    (VkPipelineTessellationDomainOriginStateCreateInfo*)next;
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    auto& mtlFeats = getMetalFeatures();
+    shaderConfig.options.mslOptions.msl_version = mtlFeats.mslVersion;
+    shaderConfig.options.mslOptions.texel_buffer_texture_width =
+        mtlFeats.maxTextureDimension;
+    shaderConfig.options.mslOptions.r32ui_linear_texture_alignment =
+        (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT,
+                                                           this);
+    shaderConfig.options.mslOptions.texture_buffer_native =
+        mtlFeats.textureBuffers;
+
+    bool useMetalArgBuff = isUsingMetalArgumentBuffers();
+    shaderConfig.options.mslOptions.argument_buffers = useMetalArgBuff;
+    shaderConfig.options.mslOptions.force_active_argument_buffer_resources =
+        false;
+    shaderConfig.options.mslOptions.pad_argument_buffer_resources =
+        useMetalArgBuff;
+    shaderConfig.options.mslOptions.argument_buffers_tier =
+        (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)
+            getMetalFeatures()
+                .argumentBuffersTier;
+    shaderConfig.options.mslOptions.agx_manual_cube_grad_fixup =
+        mtlFeats.needsCubeGradWorkaround;
 
     MVKPipelineLayout* layout = (MVKPipelineLayout*)pCreateInfo->layout;
     layout->populateShaderConversionConfig(shaderConfig);
 
-	// Set implicit buffer indices
-	// FIXME: Many of these are optional. We shouldn't set the ones that aren't
-	// present--or at least, we should move the ones that are down to avoid running over
-	// the limit of available buffers. But we can't know that until we compile the shaders.
-	initReservedVertexAttributeBufferCount(pCreateInfo);
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		MVKShaderStage stage = (MVKShaderStage)i;
-		_dynamicOffsetBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 0);
-		_bufferSizeBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 1);
-		_swizzleBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 2);
-		_indirectParamsIndex.stages[stage] = getImplicitBufferIndex(stage, 3);
-		_outputBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 4);
-		if (stage == kMVKShaderStageTessCtl) {
-			_tessCtlPatchOutputBufferIndex = getImplicitBufferIndex(stage, 5);
-			_tessCtlLevelBufferIndex = getImplicitBufferIndex(stage, 6);
-		}
-	}
-	// Since we currently can't use multiview with tessellation or geometry shaders,
-	// to conserve the number of buffer bindings, use the same bindings for the
-	// view range buffer as for the indirect paramters buffer.
-	_viewRangeBufferIndex = _indirectParamsIndex;
+    // Set implicit buffer indices
+    // FIXME: Many of these are optional. We shouldn't set the ones that aren't
+    // present--or at least, we should move the ones that are down to avoid
+    // running over the limit of available buffers. But we can't know that until
+    // we compile the shaders.
+    initReservedVertexAttributeBufferCount(pCreateInfo);
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        MVKShaderStage stage = (MVKShaderStage)i;
+        _dynamicOffsetBufferIndex.stages[stage] =
+            getImplicitBufferIndex(stage, 0);
+        _bufferSizeBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 1);
+        _swizzleBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 2);
+        _indirectParamsIndex.stages[stage] = getImplicitBufferIndex(stage, 3);
+        _outputBufferIndex.stages[stage] = getImplicitBufferIndex(stage, 4);
+        if (stage == kMVKShaderStageTessCtl) {
+            _tessCtlPatchOutputBufferIndex = getImplicitBufferIndex(stage, 5);
+            _tessCtlLevelBufferIndex = getImplicitBufferIndex(stage, 6);
+        }
+    }
+    // Since we currently can't use multiview with tessellation or geometry
+    // shaders, to conserve the number of buffer bindings, use the same bindings
+    // for the view range buffer as for the indirect paramters buffer.
+    _viewRangeBufferIndex = _indirectParamsIndex;
 
-	const VkPipelineRenderingCreateInfo* pRendInfo = getRenderingCreateInfo(pCreateInfo);
-	MVKPixelFormats* pixFmts = getPixelFormats();
+    const VkPipelineRenderingCreateInfo* pRendInfo =
+        getRenderingCreateInfo(pCreateInfo);
+    MVKPixelFormats* pixFmts = getPixelFormats();
 
-	// Disable any unused color attachments, because Metal validation can complain if the
-	// fragment shader outputs a color value without a corresponding color attachment.
-	// However, if alpha-to-coverage is enabled, we must enable the fragment shader first color output,
-	// even without a color attachment present or in use, so that coverage can be calculated.
-	// Must ignore allowed bad pMultisampleState pointer if rasterization disabled
-	bool hasA2C = _isRasterizing && pCreateInfo->pMultisampleState && pCreateInfo->pMultisampleState->alphaToCoverageEnable;
-	shaderConfig.options.mslOptions.enable_frag_output_mask = hasA2C ? 1 : 0;
-	if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
-		for (uint32_t caIdx = 0; caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {
-			if (mvkIsColorAttachmentUsed(pRendInfo, caIdx)) {
-				mvkEnableFlags(shaderConfig.options.mslOptions.enable_frag_output_mask, 1 << caIdx);
-			}
-		}
-	}
+    // Disable any unused color attachments, because Metal validation can
+    // complain if the fragment shader outputs a color value without a
+    // corresponding color attachment. However, if alpha-to-coverage is enabled,
+    // we must enable the fragment shader first color output, even without a
+    // color attachment present or in use, so that coverage can be calculated.
+    // Must ignore allowed bad pMultisampleState pointer if rasterization
+    // disabled
+    bool hasA2C = _isRasterizing && pCreateInfo->pMultisampleState &&
+                  pCreateInfo->pMultisampleState->alphaToCoverageEnable;
+    shaderConfig.options.mslOptions.enable_frag_output_mask = hasA2C ? 1 : 0;
+    if (_isRasterizingColor && pCreateInfo->pColorBlendState) {
+        for (uint32_t caIdx = 0;
+             caIdx < pCreateInfo->pColorBlendState->attachmentCount; caIdx++) {
+            if (mvkIsColorAttachmentUsed(pRendInfo, caIdx)) {
+                mvkEnableFlags(shaderConfig.options.mslOptions
+                                   .enable_frag_output_mask,
+                               1 << caIdx);
+            }
+        }
+    }
 
-	shaderConfig.options.mslOptions.ios_support_base_vertex_instance = mtlFeats.baseVertexInstanceDrawing;
-	shaderConfig.options.mslOptions.texture_1D_as_2D = getMVKConfig().texture1DAs2D;
-    shaderConfig.options.mslOptions.enable_point_size_builtin = isRenderingPoints(pCreateInfo) || reflectData.pointMode;
-	shaderConfig.options.mslOptions.enable_frag_depth_builtin = pixFmts->isDepthFormat(pixFmts->getMTLPixelFormat(pRendInfo->depthAttachmentFormat));
-	shaderConfig.options.mslOptions.enable_frag_stencil_ref_builtin = pixFmts->isStencilFormat(pixFmts->getMTLPixelFormat(pRendInfo->stencilAttachmentFormat));
-    shaderConfig.options.shouldFlipVertexY = getMVKConfig().shaderConversionFlipVertexY;
-    shaderConfig.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !mtlFeats.nativeTextureSwizzle;
-    shaderConfig.options.mslOptions.tess_domain_origin_lower_left = pTessDomainOriginState && pTessDomainOriginState->domainOrigin == VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
-    shaderConfig.options.mslOptions.multiview = mvkIsMultiview(pRendInfo->viewMask);
-    shaderConfig.options.mslOptions.multiview_layered_rendering = getPhysicalDevice()->canUseInstancingForMultiview();
-    shaderConfig.options.mslOptions.view_index_from_device_index = mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT);
-	shaderConfig.options.mslOptions.replace_recursive_inputs = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
+    shaderConfig.options.mslOptions.ios_support_base_vertex_instance =
+        mtlFeats.baseVertexInstanceDrawing;
+    shaderConfig.options.mslOptions.texture_1D_as_2D =
+        getMVKConfig().texture1DAs2D;
+    shaderConfig.options.mslOptions.enable_point_size_builtin =
+        isRenderingPoints(pCreateInfo) || reflectData.pointMode;
+    shaderConfig.options.mslOptions.enable_frag_depth_builtin =
+        pixFmts->isDepthFormat(
+            pixFmts->getMTLPixelFormat(pRendInfo->depthAttachmentFormat));
+    shaderConfig.options.mslOptions.enable_frag_stencil_ref_builtin =
+        pixFmts->isStencilFormat(
+            pixFmts->getMTLPixelFormat(pRendInfo->stencilAttachmentFormat));
+    shaderConfig.options.shouldFlipVertexY =
+        getMVKConfig().shaderConversionFlipVertexY;
+    shaderConfig.options.mslOptions.swizzle_texture_samples =
+        _fullImageViewSwizzle && !mtlFeats.nativeTextureSwizzle;
+    shaderConfig.options.mslOptions.tess_domain_origin_lower_left =
+        pTessDomainOriginState && pTessDomainOriginState->domainOrigin ==
+                                      VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
+    shaderConfig.options.mslOptions.multiview =
+        mvkIsMultiview(pRendInfo->viewMask);
+    shaderConfig.options.mslOptions.multiview_layered_rendering =
+        getPhysicalDevice()->canUseInstancingForMultiview();
+    shaderConfig.options.mslOptions.view_index_from_device_index =
+        mvkAreAllFlagsEnabled(
+            pCreateInfo->flags,
+            VK_PIPELINE_CREATE_VIEW_INDEX_FROM_DEVICE_INDEX_BIT);
+    shaderConfig.options.mslOptions.replace_recursive_inputs =
+        mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
 #if MVK_MACOS
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
 #endif
 #if MVK_IOS_OR_TVOS
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
-    shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;
+    shaderConfig.options.mslOptions.ios_use_simdgroup_functions =
+        !!mtlFeats.simdPermute;
 #endif
 
     shaderConfig.options.tessPatchKind = reflectData.patchKind;
     shaderConfig.options.numTessControlPoints = reflectData.numControlPoints;
 }
 
-uint32_t MVKGraphicsPipeline::getImplicitBufferIndex(MVKShaderStage stage, uint32_t bufferIndexOffset) {
-	return getMetalBufferIndexForVertexAttributeBinding(_reservedVertexAttributeBufferCount.stages[stage] + bufferIndexOffset);
+uint32_t
+MVKGraphicsPipeline::getImplicitBufferIndex(MVKShaderStage stage,
+                                            uint32_t bufferIndexOffset) {
+    return getMetalBufferIndexForVertexAttributeBinding(
+        _reservedVertexAttributeBufferCount.stages[stage] + bufferIndexOffset);
 }
 
-// Set the number of vertex attribute buffers consumed by this pipeline at each stage.
-// Any implicit buffers needed by this pipeline will be assigned indexes below the range
-// defined by this count below the max number of Metal buffer bindings per stage.
-// Must be called before any calls to getImplicitBufferIndex().
-void MVKGraphicsPipeline::initReservedVertexAttributeBufferCount(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	int32_t maxBinding = -1;
-	uint32_t xltdBuffCnt = 0;
+// Set the number of vertex attribute buffers consumed by this pipeline at each
+// stage. Any implicit buffers needed by this pipeline will be assigned indexes
+// below the range defined by this count below the max number of Metal buffer
+// bindings per stage. Must be called before any calls to
+// getImplicitBufferIndex().
+void MVKGraphicsPipeline::initReservedVertexAttributeBufferCount(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    int32_t maxBinding = -1;
+    uint32_t xltdBuffCnt = 0;
 
-	const VkPipelineVertexInputStateCreateInfo* pVI = pCreateInfo->pVertexInputState;
-	uint32_t vaCnt = pVI->vertexAttributeDescriptionCount;
-	uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
+    const VkPipelineVertexInputStateCreateInfo* pVI =
+        pCreateInfo->pVertexInputState;
+    uint32_t vaCnt = pVI->vertexAttributeDescriptionCount;
+    uint32_t vbCnt = pVI->vertexBindingDescriptionCount;
 
-	// Determine the highest binding number used by the vertex buffers
-	for (uint32_t vbIdx = 0; vbIdx < vbCnt; vbIdx++) {
-		const VkVertexInputBindingDescription* pVKVB = &pVI->pVertexBindingDescriptions[vbIdx];
-		maxBinding = max<int32_t>(pVKVB->binding, maxBinding);
+    // Determine the highest binding number used by the vertex buffers
+    for (uint32_t vbIdx = 0; vbIdx < vbCnt; vbIdx++) {
+        const VkVertexInputBindingDescription* pVKVB =
+            &pVI->pVertexBindingDescriptions[vbIdx];
+        maxBinding = max<int32_t>(pVKVB->binding, maxBinding);
 
-		// Iterate through the vertex attributes and determine if any need a synthetic binding buffer to
-		// accommodate offsets that are outside the stride, which Vulkan supports, but Metal does not.
-		// This value will be worst case, as some synthetic buffers may end up being shared.
-		for (uint32_t vaIdx = 0; vaIdx < vaCnt; vaIdx++) {
-			const VkVertexInputAttributeDescription* pVKVA = &pVI->pVertexAttributeDescriptions[vaIdx];
-			if ((pVKVA->binding == pVKVB->binding) && (pVKVA->offset + getPixelFormats()->getBytesPerBlock(pVKVA->format) > pVKVB->stride)) {
-				xltdBuffCnt++;
-			}
-		}
-	}
+        // Iterate through the vertex attributes and determine if any need a
+        // synthetic binding buffer to accommodate offsets that are outside the
+        // stride, which Vulkan supports, but Metal does not. This value will be
+        // worst case, as some synthetic buffers may end up being shared.
+        for (uint32_t vaIdx = 0; vaIdx < vaCnt; vaIdx++) {
+            const VkVertexInputAttributeDescription* pVKVA =
+                &pVI->pVertexAttributeDescriptions[vaIdx];
+            if ((pVKVA->binding == pVKVB->binding) &&
+                (pVKVA->offset +
+                     getPixelFormats()->getBytesPerBlock(pVKVA->format) >
+                 pVKVB->stride)) {
+                xltdBuffCnt++;
+            }
+        }
+    }
 
-	// The number of reserved bindings we need for the vertex stage is determined from the largest vertex
-	// attribute binding number, plus any synthetic buffer bindings created to support translated offsets.
-	mvkClear<uint32_t>(_reservedVertexAttributeBufferCount.stages, kMVKShaderStageCount);
-	_reservedVertexAttributeBufferCount.stages[kMVKShaderStageVertex] = (maxBinding + 1) + xltdBuffCnt;
-	_reservedVertexAttributeBufferCount.stages[kMVKShaderStageTessCtl] = kMVKTessCtlNumReservedBuffers;
-	_reservedVertexAttributeBufferCount.stages[kMVKShaderStageTessEval] = kMVKTessEvalNumReservedBuffers;
+    // The number of reserved bindings we need for the vertex stage is
+    // determined from the largest vertex attribute binding number, plus any
+    // synthetic buffer bindings created to support translated offsets.
+    mvkClear<uint32_t>(_reservedVertexAttributeBufferCount.stages,
+                       kMVKShaderStageCount);
+    _reservedVertexAttributeBufferCount.stages[kMVKShaderStageVertex] =
+        (maxBinding + 1) + xltdBuffCnt;
+    _reservedVertexAttributeBufferCount.stages[kMVKShaderStageTessCtl] =
+        kMVKTessCtlNumReservedBuffers;
+    _reservedVertexAttributeBufferCount.stages[kMVKShaderStageTessEval] =
+        kMVKTessEvalNumReservedBuffers;
 }
 
-bool MVKGraphicsPipeline::isValidVertexBufferIndex(MVKShaderStage stage, uint32_t mtlBufferIndex) {
-	return _isVertexInputBindingUsed[mtlBufferIndex] || mtlBufferIndex < _descriptorBufferCounts.stages[stage] || mtlBufferIndex > getImplicitBufferIndex(stage, 0);
+bool MVKGraphicsPipeline::isValidVertexBufferIndex(MVKShaderStage stage,
+                                                   uint32_t mtlBufferIndex) {
+    return _isVertexInputBindingUsed[mtlBufferIndex] ||
+           mtlBufferIndex < _descriptorBufferCounts.stages[stage] ||
+           mtlBufferIndex > getImplicitBufferIndex(stage, 0);
 }
 
 // Initializes the vertex attributes in a shader conversion configuration.
-void MVKGraphicsPipeline::addVertexInputToShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig,
-                                                                 const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+void MVKGraphicsPipeline::addVertexInputToShaderConversionConfig(
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
     // Set the shader conversion config vertex attribute information
     shaderConfig.shaderInputs.clear();
-    uint32_t vaCnt = pCreateInfo->pVertexInputState->vertexAttributeDescriptionCount;
+    uint32_t vaCnt =
+        pCreateInfo->pVertexInputState->vertexAttributeDescriptionCount;
     for (uint32_t vaIdx = 0; vaIdx < vaCnt; vaIdx++) {
-        const VkVertexInputAttributeDescription* pVKVA = &pCreateInfo->pVertexInputState->pVertexAttributeDescriptions[vaIdx];
+        const VkVertexInputAttributeDescription* pVKVA =
+            &pCreateInfo->pVertexInputState
+                 ->pVertexAttributeDescriptions[vaIdx];
 
         // Set binding and offset from Vulkan vertex attribute
         mvk::MSLShaderInput si;
         si.shaderVar.location = pVKVA->location;
         si.binding = pVKVA->binding;
 
-        // Metal can't do signedness conversions on vertex buffers (rdar://45922847). If the shader
-        // and the vertex attribute have mismatched signedness, we have to fix the shader
-        // to match the vertex attribute. So tell SPIRV-Cross if we're expecting an unsigned format.
-        // Only do this if the attribute could be reasonably expected to fit in the shader's
-        // declared type. Programs that try to invoke undefined behavior are on their own.
-        switch (getPixelFormats()->getFormatType(pVKVA->format) ) {
+        // Metal can't do signedness conversions on vertex buffers
+        // (rdar://45922847). If the shader and the vertex attribute have
+        // mismatched signedness, we have to fix the shader to match the vertex
+        // attribute. So tell SPIRV-Cross if we're expecting an unsigned format.
+        // Only do this if the attribute could be reasonably expected to fit in
+        // the shader's declared type. Programs that try to invoke undefined
+        // behavior are on their own.
+        switch (getPixelFormats()->getFormatType(pVKVA->format)) {
         case kMVKFormatColorUInt8:
             si.shaderVar.format = MSL_VERTEX_FORMAT_UINT8;
             break;
@@ -1930,398 +2698,520 @@ void MVKGraphicsPipeline::addVertexInputToShaderConversionConfig(SPIRVToMSLConve
 
         default:
             break;
-
         }
 
         shaderConfig.shaderInputs.push_back(si);
     }
 }
 
-// Initializes the shader outputs in a shader conversion config from the next stage input.
-void MVKGraphicsPipeline::addNextStageInputToShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig,
-                                                                    SPIRVShaderInputs& shaderInputs) {
+// Initializes the shader outputs in a shader conversion config from the next
+// stage input.
+void MVKGraphicsPipeline::addNextStageInputToShaderConversionConfig(
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderInputs& shaderInputs) {
     // Set the shader conversion configuration output variable information
     shaderConfig.shaderOutputs.clear();
     uint32_t soCnt = (uint32_t)shaderInputs.size();
     for (uint32_t soIdx = 0; soIdx < soCnt; soIdx++) {
-		if (!shaderInputs[soIdx].isUsed) { continue; }
+        if (!shaderInputs[soIdx].isUsed) {
+            continue;
+        }
 
         mvk::MSLShaderInterfaceVariable so;
         so.shaderVar.location = shaderInputs[soIdx].location;
-		so.shaderVar.component = shaderInputs[soIdx].component;
+        so.shaderVar.component = shaderInputs[soIdx].component;
         so.shaderVar.builtin = shaderInputs[soIdx].builtin;
         so.shaderVar.vecsize = shaderInputs[soIdx].vecWidth;
-		so.shaderVar.rate = shaderInputs[soIdx].perPatch ? MSL_SHADER_VARIABLE_RATE_PER_PATCH : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
+        so.shaderVar.rate = shaderInputs[soIdx].perPatch
+                                ? MSL_SHADER_VARIABLE_RATE_PER_PATCH
+                                : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
 
-        switch (getPixelFormats()->getFormatType(mvkFormatFromOutput(shaderInputs[soIdx]) ) ) {
-            case kMVKFormatColorUInt8:
-                so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT8;
-                break;
+        switch (getPixelFormats()->getFormatType(
+            mvkFormatFromOutput(shaderInputs[soIdx]))) {
+        case kMVKFormatColorUInt8:
+            so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT8;
+            break;
 
-            case kMVKFormatColorUInt16:
-                so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT16;
-                break;
+        case kMVKFormatColorUInt16:
+            so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT16;
+            break;
 
-			case kMVKFormatColorHalf:
-			case kMVKFormatColorInt16:
-				so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY16;
-				break;
+        case kMVKFormatColorHalf:
+        case kMVKFormatColorInt16:
+            so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY16;
+            break;
 
-			case kMVKFormatColorFloat:
-			case kMVKFormatColorInt32:
-			case kMVKFormatColorUInt32:
-				so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY32;
-				break;
+        case kMVKFormatColorFloat:
+        case kMVKFormatColorInt32:
+        case kMVKFormatColorUInt32:
+            so.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY32;
+            break;
 
-            default:
-                break;
+        default:
+            break;
         }
 
         shaderConfig.shaderOutputs.push_back(so);
     }
 }
 
-// Initializes the shader inputs in a shader conversion config from the previous stage output.
-void MVKGraphicsPipeline::addPrevStageOutputToShaderConversionConfig(SPIRVToMSLConversionConfiguration& shaderConfig,
-                                                                     SPIRVShaderOutputs& shaderOutputs) {
+// Initializes the shader inputs in a shader conversion config from the previous
+// stage output.
+void MVKGraphicsPipeline::addPrevStageOutputToShaderConversionConfig(
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    SPIRVShaderOutputs& shaderOutputs) {
     // Set the shader conversion configuration input variable information
     shaderConfig.shaderInputs.clear();
     uint32_t siCnt = (uint32_t)shaderOutputs.size();
     for (uint32_t siIdx = 0; siIdx < siCnt; siIdx++) {
-		if (!shaderOutputs[siIdx].isUsed) { continue; }
+        if (!shaderOutputs[siIdx].isUsed) {
+            continue;
+        }
 
         mvk::MSLShaderInput si;
         si.shaderVar.location = shaderOutputs[siIdx].location;
-		si.shaderVar.component = shaderOutputs[siIdx].component;
+        si.shaderVar.component = shaderOutputs[siIdx].component;
         si.shaderVar.builtin = shaderOutputs[siIdx].builtin;
         si.shaderVar.vecsize = shaderOutputs[siIdx].vecWidth;
-		si.shaderVar.rate = shaderOutputs[siIdx].perPatch ? MSL_SHADER_VARIABLE_RATE_PER_PATCH : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
+        si.shaderVar.rate = shaderOutputs[siIdx].perPatch
+                                ? MSL_SHADER_VARIABLE_RATE_PER_PATCH
+                                : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
 
-        switch (getPixelFormats()->getFormatType(mvkFormatFromOutput(shaderOutputs[siIdx]) ) ) {
-            case kMVKFormatColorUInt8:
-                si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT8;
-                break;
+        switch (getPixelFormats()->getFormatType(
+            mvkFormatFromOutput(shaderOutputs[siIdx]))) {
+        case kMVKFormatColorUInt8:
+            si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT8;
+            break;
 
-            case kMVKFormatColorUInt16:
-                si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT16;
-                break;
+        case kMVKFormatColorUInt16:
+            si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_UINT16;
+            break;
 
-			case kMVKFormatColorHalf:
-			case kMVKFormatColorInt16:
-				si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY16;
-				break;
+        case kMVKFormatColorHalf:
+        case kMVKFormatColorInt16:
+            si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY16;
+            break;
 
-			case kMVKFormatColorFloat:
-			case kMVKFormatColorInt32:
-			case kMVKFormatColorUInt32:
-				si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY32;
-				break;
+        case kMVKFormatColorFloat:
+        case kMVKFormatColorInt32:
+        case kMVKFormatColorUInt32:
+            si.shaderVar.format = MSL_SHADER_INPUT_FORMAT_ANY32;
+            break;
 
-            default:
-                break;
+        default:
+            break;
         }
 
         shaderConfig.shaderInputs.push_back(si);
     }
 }
 
-// We render points if either the static topology or static polygon-mode dictate it.
-// The topology class must be the same between static and dynamic, so point topology
-// in static also implies point topology in dynamic.
-// Metal does not support VK_POLYGON_MODE_POINT, but it can be emulated if the polygon mode
-// is static, which allows both the topology and the pipeline topology-class to be set to points.
-// This cannot be accomplished if the dynamic polygon mode has been changed to points when the
-// pipeline is expecting triangles or lines, because the pipeline topology class will be incorrect.
-bool MVKGraphicsPipeline::isRenderingPoints(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	return ((pCreateInfo->pInputAssemblyState &&
-			 (pCreateInfo->pInputAssemblyState->topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST)) ||
-			(pCreateInfo->pRasterizationState && 
-			 (pCreateInfo->pRasterizationState->polygonMode == VK_POLYGON_MODE_POINT) &&
-			 !isDynamicState(PolygonMode)));
+// We render points if either the static topology or static polygon-mode dictate
+// it. The topology class must be the same between static and dynamic, so point
+// topology in static also implies point topology in dynamic. Metal does not
+// support VK_POLYGON_MODE_POINT, but it can be emulated if the polygon mode is
+// static, which allows both the topology and the pipeline topology-class to be
+// set to points. This cannot be accomplished if the dynamic polygon mode has
+// been changed to points when the pipeline is expecting triangles or lines,
+// because the pipeline topology class will be incorrect.
+bool MVKGraphicsPipeline::isRenderingPoints(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    return ((pCreateInfo->pInputAssemblyState &&
+             (pCreateInfo->pInputAssemblyState->topology ==
+              VK_PRIMITIVE_TOPOLOGY_POINT_LIST)) ||
+            (pCreateInfo->pRasterizationState &&
+             (pCreateInfo->pRasterizationState->polygonMode ==
+              VK_POLYGON_MODE_POINT) &&
+             !isDynamicState(PolygonMode)));
 }
 
-// We disable rasterization if either static rasterizerDiscard is enabled or the static cull mode dictates it.
-bool MVKGraphicsPipeline::isRasterizationDisabled(const VkGraphicsPipelineCreateInfo* pCreateInfo) {
-	return (pCreateInfo->pRasterizationState &&
-			((pCreateInfo->pRasterizationState->rasterizerDiscardEnable && !isDynamicState(RasterizerDiscardEnable)) ||
-			 ((pCreateInfo->pRasterizationState->cullMode == VK_CULL_MODE_FRONT_AND_BACK) && !isDynamicState(CullMode) &&
-			  pCreateInfo->pInputAssemblyState &&
-			  (mvkMTLPrimitiveTopologyClassFromVkPrimitiveTopology(pCreateInfo->pInputAssemblyState->topology) == MTLPrimitiveTopologyClassTriangle))));
+// We disable rasterization if either static rasterizerDiscard is enabled or the
+// static cull mode dictates it.
+bool MVKGraphicsPipeline::isRasterizationDisabled(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo) {
+    return (pCreateInfo->pRasterizationState &&
+            ((pCreateInfo->pRasterizationState->rasterizerDiscardEnable &&
+              !isDynamicState(RasterizerDiscardEnable)) ||
+             ((pCreateInfo->pRasterizationState->cullMode ==
+               VK_CULL_MODE_FRONT_AND_BACK) &&
+              !isDynamicState(CullMode) && pCreateInfo->pInputAssemblyState &&
+              (mvkMTLPrimitiveTopologyClassFromVkPrimitiveTopology(
+                   pCreateInfo->pInputAssemblyState->topology) ==
+               MTLPrimitiveTopologyClassTriangle))));
 }
 
-MVKMTLFunction MVKGraphicsPipeline::getMTLFunction(SPIRVToMSLConversionConfiguration& shaderConfig,
-												   const VkPipelineShaderStageCreateInfo* pShaderStage,
-												   VkPipelineCreationFeedback* pStageFB,
-												   const char* pStageName) {
-	MVKShaderModule* shaderModule = (MVKShaderModule*)pShaderStage->module;
-	MVKMTLFunction func = shaderModule->getMTLFunction(&shaderConfig,
-													   pShaderStage->pSpecializationInfo,
-													   this,
-													   pStageFB);
-	if ( !func.getMTLFunction() ) {
-		if (shouldFailOnPipelineCompileRequired()) {
-			setConfigurationResult(VK_PIPELINE_COMPILE_REQUIRED);
-		} else {
-			setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "%s shader function could not be compiled into pipeline. See previous logged error.", pStageName));
-		}
-	}
-	return func;
+MVKMTLFunction MVKGraphicsPipeline::getMTLFunction(
+    SPIRVToMSLConversionConfiguration& shaderConfig,
+    const VkPipelineShaderStageCreateInfo* pShaderStage,
+    VkPipelineCreationFeedback* pStageFB, const char* pStageName) {
+    MVKShaderModule* shaderModule = (MVKShaderModule*)pShaderStage->module;
+    MVKMTLFunction func =
+        shaderModule->getMTLFunction(&shaderConfig,
+                                     pShaderStage->pSpecializationInfo, this,
+                                     pStageFB);
+    if (!func.getMTLFunction()) {
+        if (shouldFailOnPipelineCompileRequired()) {
+            setConfigurationResult(VK_PIPELINE_COMPILE_REQUIRED);
+        } else {
+            setConfigurationResult(
+                reportError(VK_ERROR_INVALID_SHADER_NV,
+                            "%s shader function could not be compiled into "
+                            "pipeline. See previous logged error.",
+                            pStageName));
+        }
+    }
+    return func;
 }
 
-void MVKGraphicsPipeline::markIfUsingPhysicalStorageBufferAddressesCapability(SPIRVToMSLConversionResultInfo& resultsInfo,
-																			  MVKShaderStage stage) {
-	if (resultsInfo.usesPhysicalStorageBufferAddressesCapability) {
-		_stagesUsingPhysicalStorageBufferAddressesCapability.push_back(stage);
-	}
+void MVKGraphicsPipeline::markIfUsingPhysicalStorageBufferAddressesCapability(
+    SPIRVToMSLConversionResultInfo& resultsInfo, MVKShaderStage stage) {
+    if (resultsInfo.usesPhysicalStorageBufferAddressesCapability) {
+        _stagesUsingPhysicalStorageBufferAddressesCapability.push_back(stage);
+    }
 }
 
-bool MVKGraphicsPipeline::usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) {
-	return mvkContains(_stagesUsingPhysicalStorageBufferAddressesCapability, stage);
+bool MVKGraphicsPipeline::usesPhysicalStorageBufferAddressesCapability(
+    MVKShaderStage stage) {
+    return mvkContains(_stagesUsingPhysicalStorageBufferAddressesCapability,
+                       stage);
 }
 
 MVKGraphicsPipeline::~MVKGraphicsPipeline() {
-	@synchronized (getMTLDevice()) {
-		[_mtlTessVertexStageState release];
-		[_mtlTessVertexStageIndex16State release];
-		[_mtlTessVertexStageIndex32State release];
-		[_mtlTessControlStageState release];
-		[_mtlPipelineState release];
-	}
+    @synchronized(getMTLDevice()) {
+        [_mtlTessVertexStageState release];
+        [_mtlTessVertexStageIndex16State release];
+        [_mtlTessVertexStageIndex32State release];
+        [_mtlTessControlStageState release];
+        [_mtlPipelineState release];
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKComputePipeline
 
 void MVKComputePipeline::encode(MVKCommandEncoder* cmdEncoder, uint32_t) {
-	if ( !_hasValidMTLPipelineStates ) { return; }
+    if (!_hasValidMTLPipelineStates) {
+        return;
+    }
 
-	[cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch) setComputePipelineState: _mtlPipelineState];
+    [cmdEncoder->getMTLComputeEncoder(kMVKCommandUseDispatch)
+        setComputePipelineState:_mtlPipelineState];
     cmdEncoder->_mtlThreadgroupSize = _mtlThreadgroupSize;
 
-	cmdEncoder->_computeResourcesState.markOverriddenBufferIndexesDirty();
-	cmdEncoder->_computeResourcesState.bindSwizzleBuffer(_swizzleBufferIndex, _needsSwizzleBuffer);
-	cmdEncoder->_computeResourcesState.bindBufferSizeBuffer(_bufferSizeBufferIndex, _needsBufferSizeBuffer);
-	cmdEncoder->_computeResourcesState.bindDynamicOffsetBuffer(_dynamicOffsetBufferIndex, _needsDynamicOffsetBuffer);
+    cmdEncoder->_computeResourcesState.markOverriddenBufferIndexesDirty();
+    cmdEncoder->_computeResourcesState.bindSwizzleBuffer(_swizzleBufferIndex,
+                                                         _needsSwizzleBuffer);
+    cmdEncoder->_computeResourcesState
+        .bindBufferSizeBuffer(_bufferSizeBufferIndex, _needsBufferSizeBuffer);
+    cmdEncoder->_computeResourcesState
+        .bindDynamicOffsetBuffer(_dynamicOffsetBufferIndex,
+                                 _needsDynamicOffsetBuffer);
 }
 
-MVKComputePipeline::MVKComputePipeline(MVKDevice* device,
-									   MVKPipelineCache* pipelineCache,
-									   MVKPipeline* parent,
-									   const VkComputePipelineCreateInfo* pCreateInfo) :
-	MVKPipeline(device, pipelineCache, (MVKPipelineLayout*)pCreateInfo->layout, pCreateInfo->flags, parent) {
+MVKComputePipeline::MVKComputePipeline(
+    MVKDevice* device, MVKPipelineCache* pipelineCache, MVKPipeline* parent,
+    const VkComputePipelineCreateInfo* pCreateInfo)
+    : MVKPipeline(device, pipelineCache,
+                  (MVKPipelineLayout*)pCreateInfo->layout, pCreateInfo->flags,
+                  parent) {
 
-	_allowsDispatchBase = mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_PIPELINE_CREATE_DISPATCH_BASE_BIT);
+    _allowsDispatchBase =
+        mvkAreAllFlagsEnabled(pCreateInfo->flags,
+                              VK_PIPELINE_CREATE_DISPATCH_BASE_BIT);
 
-	if (isUsingMetalArgumentBuffers()) { _descriptorBindingUse.resize(_descriptorSetCount); }
+    if (isUsingMetalArgumentBuffers()) {
+        _descriptorBindingUse.resize(_descriptorSetCount);
+    }
 
-	const VkPipelineCreationFeedbackCreateInfo* pFeedbackInfo = nullptr;
-	for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
-				pFeedbackInfo = (VkPipelineCreationFeedbackCreateInfo*)next;
-				break;
-			default:
-				break;
-		}
-	}
+    const VkPipelineCreationFeedbackCreateInfo* pFeedbackInfo = nullptr;
+    for (const auto* next = (VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
+            pFeedbackInfo = (VkPipelineCreationFeedbackCreateInfo*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	// Initialize feedback. The VALID bit must be initialized, either set or cleared.
-	// We'll set the VALID bit on the stage feedback when we compile it.
-	VkPipelineCreationFeedback* pPipelineFB = nullptr;
-	VkPipelineCreationFeedback* pStageFB = nullptr;
-	uint64_t pipelineStart = 0;
-	if (pFeedbackInfo) {
-		pPipelineFB = pFeedbackInfo->pPipelineCreationFeedback;
-		// n.b. Do *NOT* use mvkClear().
-		pPipelineFB->flags = 0;
-		pPipelineFB->duration = 0;
-		for (uint32_t i = 0; i < pFeedbackInfo->pipelineStageCreationFeedbackCount; ++i) {
-			pFeedbackInfo->pPipelineStageCreationFeedbacks[i].flags = 0;
-			pFeedbackInfo->pPipelineStageCreationFeedbacks[i].duration = 0;
-		}
-		pStageFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[0];
-		pipelineStart = mvkGetTimestamp();
-	}
+    // Initialize feedback. The VALID bit must be initialized, either set or
+    // cleared. We'll set the VALID bit on the stage feedback when we compile
+    // it.
+    VkPipelineCreationFeedback* pPipelineFB = nullptr;
+    VkPipelineCreationFeedback* pStageFB = nullptr;
+    uint64_t pipelineStart = 0;
+    if (pFeedbackInfo) {
+        pPipelineFB = pFeedbackInfo->pPipelineCreationFeedback;
+        // n.b. Do *NOT* use mvkClear().
+        pPipelineFB->flags = 0;
+        pPipelineFB->duration = 0;
+        for (uint32_t i = 0;
+             i < pFeedbackInfo->pipelineStageCreationFeedbackCount; ++i) {
+            pFeedbackInfo->pPipelineStageCreationFeedbacks[i].flags = 0;
+            pFeedbackInfo->pPipelineStageCreationFeedbacks[i].duration = 0;
+        }
+        pStageFB = &pFeedbackInfo->pPipelineStageCreationFeedbacks[0];
+        pipelineStart = mvkGetTimestamp();
+    }
 
-	MVKMTLFunction func = getMTLFunction(pCreateInfo, pStageFB);
-	_mtlThreadgroupSize = func.threadGroupSize;
-	_mtlPipelineState = nil;
+    MVKMTLFunction func = getMTLFunction(pCreateInfo, pStageFB);
+    _mtlThreadgroupSize = func.threadGroupSize;
+    _mtlPipelineState = nil;
 
-	id<MTLFunction> mtlFunc = func.getMTLFunction();
-	if (mtlFunc) {
-		MTLComputePipelineDescriptor* plDesc = [MTLComputePipelineDescriptor new];	// temp retain
-		plDesc.computeFunction = mtlFunc;
-		// Only available macOS 10.14+
-		if ([plDesc respondsToSelector:@selector(setMaxTotalThreadsPerThreadgroup:)]) {
-			plDesc.maxTotalThreadsPerThreadgroup = _mtlThreadgroupSize.width * _mtlThreadgroupSize.height * _mtlThreadgroupSize.depth;
-		}
-		plDesc.threadGroupSizeIsMultipleOfThreadExecutionWidth = mvkIsAnyFlagEnabled(pCreateInfo->stage.flags, VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT);
+    id<MTLFunction> mtlFunc = func.getMTLFunction();
+    if (mtlFunc) {
+        MTLComputePipelineDescriptor* plDesc =
+            [MTLComputePipelineDescriptor new]; // temp retain
+        plDesc.computeFunction = mtlFunc;
+        // Only available macOS 10.14+
+        if ([plDesc respondsToSelector:@selector
+                    (setMaxTotalThreadsPerThreadgroup:)]) {
+            plDesc.maxTotalThreadsPerThreadgroup = _mtlThreadgroupSize.width *
+                                                   _mtlThreadgroupSize.height *
+                                                   _mtlThreadgroupSize.depth;
+        }
+        plDesc.threadGroupSizeIsMultipleOfThreadExecutionWidth =
+            mvkIsAnyFlagEnabled(
+                pCreateInfo->stage.flags,
+                VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT);
 
-		// Metal does not allow the name of the pipeline to be changed after it has been created,
-		// and we need to create the Metal pipeline immediately to provide error feedback to app.
-		// The best we can do at this point is set the pipeline name from the layout.
-		setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)->getDebugName());
+        // Metal does not allow the name of the pipeline to be changed after it
+        // has been created, and we need to create the Metal pipeline
+        // immediately to provide error feedback to app. The best we can do at
+        // this point is set the pipeline name from the layout.
+        setMetalObjectLabel(plDesc, ((MVKPipelineLayout*)pCreateInfo->layout)
+                                        ->getDebugName());
 
-		MVKComputePipelineCompiler* plc = new MVKComputePipelineCompiler(this);
-		_mtlPipelineState = plc->newMTLComputePipelineState(plDesc);	// retained
-		plc->destroy();
-		[plDesc release];															// temp release
+        MVKComputePipelineCompiler* plc = new MVKComputePipelineCompiler(this);
+        _mtlPipelineState = plc->newMTLComputePipelineState(plDesc); // retained
+        plc->destroy();
+        [plDesc release]; // temp release
 
-		if ( !_mtlPipelineState ) { _hasValidMTLPipelineStates = false; }
-	} else {
-		_hasValidMTLPipelineStates = false;
-	}
-	if (pPipelineFB) {
-		if (_hasValidMTLPipelineStates) { mvkEnableFlags(pPipelineFB->flags, VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT); }
-		pPipelineFB->duration = mvkGetElapsedNanoseconds(pipelineStart);
-	}
+        if (!_mtlPipelineState) {
+            _hasValidMTLPipelineStates = false;
+        }
+    } else {
+        _hasValidMTLPipelineStates = false;
+    }
+    if (pPipelineFB) {
+        if (_hasValidMTLPipelineStates) {
+            mvkEnableFlags(pPipelineFB->flags,
+                           VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
+        }
+        pPipelineFB->duration = mvkGetElapsedNanoseconds(pipelineStart);
+    }
 
-	auto& mtlFeats = getMetalFeatures();
-	if (_needsSwizzleBuffer && _swizzleBufferIndex.stages[kMVKShaderStageCompute] > mtlFeats.maxPerStageBufferCount) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Compute shader requires swizzle buffer, but there is no free slot to pass it."));
-	}
-	if (_needsBufferSizeBuffer && _bufferSizeBufferIndex.stages[kMVKShaderStageCompute] > mtlFeats.maxPerStageBufferCount) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Compute shader requires buffer size buffer, but there is no free slot to pass it."));
-	}
-	if (_needsDynamicOffsetBuffer && _dynamicOffsetBufferIndex.stages[kMVKShaderStageCompute] > mtlFeats.maxPerStageBufferCount) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Compute shader requires dynamic offset buffer, but there is no free slot to pass it."));
-	}
-	if (_needsDispatchBaseBuffer && _indirectParamsIndex.stages[kMVKShaderStageCompute] > mtlFeats.maxPerStageBufferCount) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Compute shader requires dispatch base buffer, but there is no free slot to pass it."));
-	}
+    auto& mtlFeats = getMetalFeatures();
+    if (_needsSwizzleBuffer &&
+        _swizzleBufferIndex.stages[kMVKShaderStageCompute] >
+            mtlFeats.maxPerStageBufferCount) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Compute shader requires swizzle buffer, but there is "
+                        "no free slot to pass it."));
+    }
+    if (_needsBufferSizeBuffer &&
+        _bufferSizeBufferIndex.stages[kMVKShaderStageCompute] >
+            mtlFeats.maxPerStageBufferCount) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Compute shader requires buffer size buffer, but there "
+                        "is no free slot to pass it."));
+    }
+    if (_needsDynamicOffsetBuffer &&
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageCompute] >
+            mtlFeats.maxPerStageBufferCount) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Compute shader requires dynamic offset buffer, but "
+                        "there is no free slot to pass it."));
+    }
+    if (_needsDispatchBaseBuffer &&
+        _indirectParamsIndex.stages[kMVKShaderStageCompute] >
+            mtlFeats.maxPerStageBufferCount) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Compute shader requires dispatch base buffer, but "
+                        "there is no free slot to pass it."));
+    }
 }
 
 // Returns a MTLFunction to use when creating the MTLComputePipelineState.
-MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateInfo* pCreateInfo,
-												  VkPipelineCreationFeedback* pStageFB) {
+MVKMTLFunction MVKComputePipeline::getMTLFunction(
+    const VkComputePipelineCreateInfo* pCreateInfo,
+    VkPipelineCreationFeedback* pStageFB) {
 
     const VkPipelineShaderStageCreateInfo* pSS = &pCreateInfo->stage;
-    if ( !mvkAreAllFlagsEnabled(pSS->stage, VK_SHADER_STAGE_COMPUTE_BIT) ) { return MVKMTLFunctionNull; }
+    if (!mvkAreAllFlagsEnabled(pSS->stage, VK_SHADER_STAGE_COMPUTE_BIT)) {
+        return MVKMTLFunctionNull;
+    }
 
-	auto& mtlFeats = getMetalFeatures();
+    auto& mtlFeats = getMetalFeatures();
     SPIRVToMSLConversionConfiguration shaderConfig;
-	shaderConfig.options.entryPointName = pCreateInfo->stage.pName;
-	shaderConfig.options.entryPointStage = spv::ExecutionModelGLCompute;
+    shaderConfig.options.entryPointName = pCreateInfo->stage.pName;
+    shaderConfig.options.entryPointStage = spv::ExecutionModelGLCompute;
     shaderConfig.options.mslOptions.msl_version = mtlFeats.mslVersion;
-    shaderConfig.options.mslOptions.texel_buffer_texture_width = mtlFeats.maxTextureDimension;
-    shaderConfig.options.mslOptions.r32ui_linear_texture_alignment = (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT, this);
-	shaderConfig.options.mslOptions.swizzle_texture_samples = _fullImageViewSwizzle && !mtlFeats.nativeTextureSwizzle;
-	shaderConfig.options.mslOptions.texture_buffer_native = mtlFeats.textureBuffers;
-	shaderConfig.options.mslOptions.dispatch_base = _allowsDispatchBase;
-	shaderConfig.options.mslOptions.texture_1D_as_2D = getMVKConfig().texture1DAs2D;
-    shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) ? 0 : mtlFeats.maxSubgroupSize;
+    shaderConfig.options.mslOptions.texel_buffer_texture_width =
+        mtlFeats.maxTextureDimension;
+    shaderConfig.options.mslOptions.r32ui_linear_texture_alignment =
+        (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT,
+                                                           this);
+    shaderConfig.options.mslOptions.swizzle_texture_samples =
+        _fullImageViewSwizzle && !mtlFeats.nativeTextureSwizzle;
+    shaderConfig.options.mslOptions.texture_buffer_native =
+        mtlFeats.textureBuffers;
+    shaderConfig.options.mslOptions.dispatch_base = _allowsDispatchBase;
+    shaderConfig.options.mslOptions.texture_1D_as_2D =
+        getMVKConfig().texture1DAs2D;
+    shaderConfig.options.mslOptions.fixed_subgroup_size =
+        mvkIsAnyFlagEnabled(
+            pSS->flags,
+            VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT)
+            ? 0
+            : mtlFeats.maxSubgroupSize;
 
-	bool useMetalArgBuff = isUsingMetalArgumentBuffers();
-	shaderConfig.options.mslOptions.argument_buffers = useMetalArgBuff;
-	shaderConfig.options.mslOptions.force_active_argument_buffer_resources = false;
-	shaderConfig.options.mslOptions.pad_argument_buffer_resources = useMetalArgBuff;
-	shaderConfig.options.mslOptions.argument_buffers_tier = (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)getMetalFeatures().argumentBuffersTier;
+    bool useMetalArgBuff = isUsingMetalArgumentBuffers();
+    shaderConfig.options.mslOptions.argument_buffers = useMetalArgBuff;
+    shaderConfig.options.mslOptions.force_active_argument_buffer_resources =
+        false;
+    shaderConfig.options.mslOptions.pad_argument_buffer_resources =
+        useMetalArgBuff;
+    shaderConfig.options.mslOptions.argument_buffers_tier =
+        (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)
+            getMetalFeatures()
+                .argumentBuffersTier;
 
 #if MVK_MACOS
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
 #endif
 #if MVK_IOS_OR_TVOS
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
-    shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;
+    shaderConfig.options.mslOptions.ios_use_simdgroup_functions =
+        !!mtlFeats.simdPermute;
 #endif
 
     MVKPipelineLayout* layout = (MVKPipelineLayout*)pCreateInfo->layout;
     layout->populateShaderConversionConfig(shaderConfig);
 
-	// Set implicit buffer indices
-	// FIXME: Many of these are optional. We shouldn't set the ones that aren't
-	// present--or at least, we should move the ones that are down to avoid running over
-	// the limit of available buffers. But we can't know that until we compile the shaders.
-	for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
-		MVKShaderStage stage = (MVKShaderStage)i;
-		_dynamicOffsetBufferIndex.stages[stage] = getImplicitBufferIndex(0);
-		_bufferSizeBufferIndex.stages[stage] = getImplicitBufferIndex(1);
-		_swizzleBufferIndex.stages[stage] = getImplicitBufferIndex(2);
-		_indirectParamsIndex.stages[stage] = getImplicitBufferIndex(3);
-	}
+    // Set implicit buffer indices
+    // FIXME: Many of these are optional. We shouldn't set the ones that aren't
+    // present--or at least, we should move the ones that are down to avoid
+    // running over the limit of available buffers. But we can't know that until
+    // we compile the shaders.
+    for (uint32_t i = kMVKShaderStageVertex; i < kMVKShaderStageCount; i++) {
+        MVKShaderStage stage = (MVKShaderStage)i;
+        _dynamicOffsetBufferIndex.stages[stage] = getImplicitBufferIndex(0);
+        _bufferSizeBufferIndex.stages[stage] = getImplicitBufferIndex(1);
+        _swizzleBufferIndex.stages[stage] = getImplicitBufferIndex(2);
+        _indirectParamsIndex.stages[stage] = getImplicitBufferIndex(3);
+    }
 
-    shaderConfig.options.mslOptions.swizzle_buffer_index = _swizzleBufferIndex.stages[kMVKShaderStageCompute];
-    shaderConfig.options.mslOptions.buffer_size_buffer_index = _bufferSizeBufferIndex.stages[kMVKShaderStageCompute];
-	shaderConfig.options.mslOptions.dynamic_offsets_buffer_index = _dynamicOffsetBufferIndex.stages[kMVKShaderStageCompute];
-    shaderConfig.options.mslOptions.indirect_params_buffer_index = _indirectParamsIndex.stages[kMVKShaderStageCompute];
-	shaderConfig.options.mslOptions.replace_recursive_inputs = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
+    shaderConfig.options.mslOptions.swizzle_buffer_index =
+        _swizzleBufferIndex.stages[kMVKShaderStageCompute];
+    shaderConfig.options.mslOptions.buffer_size_buffer_index =
+        _bufferSizeBufferIndex.stages[kMVKShaderStageCompute];
+    shaderConfig.options.mslOptions.dynamic_offsets_buffer_index =
+        _dynamicOffsetBufferIndex.stages[kMVKShaderStageCompute];
+    shaderConfig.options.mslOptions.indirect_params_buffer_index =
+        _indirectParamsIndex.stages[kMVKShaderStageCompute];
+    shaderConfig.options.mslOptions.replace_recursive_inputs =
+        mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
 
-    MVKMTLFunction func = ((MVKShaderModule*)pSS->module)->getMTLFunction(&shaderConfig, pSS->pSpecializationInfo, this, pStageFB);
-	if ( !func.getMTLFunction() ) {
-		if (shouldFailOnPipelineCompileRequired()) {
-			setConfigurationResult(VK_PIPELINE_COMPILE_REQUIRED);
-		} else {
-			setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "Compute shader function could not be compiled into pipeline. See previous logged error."));
-		}
-	}
-	auto& funcRslts = func.shaderConversionResults;
-	_needsSwizzleBuffer = funcRslts.needsSwizzleBuffer;
+    MVKMTLFunction func =
+        ((MVKShaderModule*)pSS->module)
+            ->getMTLFunction(&shaderConfig, pSS->pSpecializationInfo, this,
+                             pStageFB);
+    if (!func.getMTLFunction()) {
+        if (shouldFailOnPipelineCompileRequired()) {
+            setConfigurationResult(VK_PIPELINE_COMPILE_REQUIRED);
+        } else {
+            setConfigurationResult(
+                reportError(VK_ERROR_INVALID_SHADER_NV,
+                            "Compute shader function could not be compiled "
+                            "into pipeline. See previous logged error."));
+        }
+    }
+    auto& funcRslts = func.shaderConversionResults;
+    _needsSwizzleBuffer = funcRslts.needsSwizzleBuffer;
     _needsBufferSizeBuffer = funcRslts.needsBufferSizeBuffer;
-	_needsDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
+    _needsDynamicOffsetBuffer = funcRslts.needsDynamicOffsetBuffer;
     _needsDispatchBaseBuffer = funcRslts.needsDispatchBaseBuffer;
-	_usesPhysicalStorageBufferAddressesCapability = funcRslts.usesPhysicalStorageBufferAddressesCapability;
+    _usesPhysicalStorageBufferAddressesCapability =
+        funcRslts.usesPhysicalStorageBufferAddressesCapability;
 
-	populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig, kMVKShaderStageCompute);
+    populateDescriptorSetBindingUse(func, pCreateInfo, shaderConfig,
+                                    kMVKShaderStageCompute);
 
-	return func;
+    return func;
 }
 
-uint32_t MVKComputePipeline::getImplicitBufferIndex(uint32_t bufferIndexOffset) {
-	return getMetalFeatures().maxPerStageBufferCount - (bufferIndexOffset + 1);
+uint32_t
+MVKComputePipeline::getImplicitBufferIndex(uint32_t bufferIndexOffset) {
+    return getMetalFeatures().maxPerStageBufferCount - (bufferIndexOffset + 1);
 }
 
-bool MVKComputePipeline::usesPhysicalStorageBufferAddressesCapability(MVKShaderStage stage) {
-	return _usesPhysicalStorageBufferAddressesCapability;
+bool MVKComputePipeline::usesPhysicalStorageBufferAddressesCapability(
+    MVKShaderStage stage) {
+    return _usesPhysicalStorageBufferAddressesCapability;
 }
 
 MVKComputePipeline::~MVKComputePipeline() {
-	@synchronized (getMTLDevice()) {
-		[_mtlPipelineState release];
-	}
+    @synchronized(getMTLDevice()) {
+        [_mtlPipelineState release];
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKPipelineCache
 
-// Return a shader library from the specified shader conversion configuration sourced from the specified shader module.
-MVKShaderLibrary* MVKPipelineCache::getShaderLibrary(SPIRVToMSLConversionConfiguration* pContext,
-													 MVKShaderModule* shaderModule,
-													 MVKPipeline* pipeline,
-													 VkPipelineCreationFeedback* pShaderFeedback,
-													 uint64_t startTime) {
-	if (_isExternallySynchronized) {
-		return getShaderLibraryImpl(pContext, shaderModule, pipeline, pShaderFeedback, startTime);
-	} else {
-		lock_guard<mutex> lock(_shaderCacheLock);
-		return getShaderLibraryImpl(pContext, shaderModule, pipeline, pShaderFeedback, startTime);
-	}
+// Return a shader library from the specified shader conversion configuration
+// sourced from the specified shader module.
+MVKShaderLibrary* MVKPipelineCache::getShaderLibrary(
+    SPIRVToMSLConversionConfiguration* pContext, MVKShaderModule* shaderModule,
+    MVKPipeline* pipeline, VkPipelineCreationFeedback* pShaderFeedback,
+    uint64_t startTime) {
+    if (_isExternallySynchronized) {
+        return getShaderLibraryImpl(pContext, shaderModule, pipeline,
+                                    pShaderFeedback, startTime);
+    } else {
+        lock_guard<mutex> lock(_shaderCacheLock);
+        return getShaderLibraryImpl(pContext, shaderModule, pipeline,
+                                    pShaderFeedback, startTime);
+    }
 }
 
-MVKShaderLibrary* MVKPipelineCache::getShaderLibraryImpl(SPIRVToMSLConversionConfiguration* pContext,
-														 MVKShaderModule* shaderModule,
-														 MVKPipeline* pipeline,
-														 VkPipelineCreationFeedback* pShaderFeedback,
-														 uint64_t startTime) {
-	bool wasAdded = false;
-	MVKShaderLibraryCache* slCache = getShaderLibraryCache(shaderModule->getKey());
-	MVKShaderLibrary* shLib = slCache->getShaderLibrary(pContext, shaderModule, pipeline, &wasAdded, pShaderFeedback, startTime);
-	if (wasAdded) { markDirty(); }
-	else if (pShaderFeedback) { mvkEnableFlags(pShaderFeedback->flags, VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT); }
-	return shLib;
+MVKShaderLibrary* MVKPipelineCache::getShaderLibraryImpl(
+    SPIRVToMSLConversionConfiguration* pContext, MVKShaderModule* shaderModule,
+    MVKPipeline* pipeline, VkPipelineCreationFeedback* pShaderFeedback,
+    uint64_t startTime) {
+    bool wasAdded = false;
+    MVKShaderLibraryCache* slCache =
+        getShaderLibraryCache(shaderModule->getKey());
+    MVKShaderLibrary* shLib =
+        slCache->getShaderLibrary(pContext, shaderModule, pipeline, &wasAdded,
+                                  pShaderFeedback, startTime);
+    if (wasAdded) {
+        markDirty();
+    } else if (pShaderFeedback) {
+        mvkEnableFlags(
+            pShaderFeedback->flags,
+            VK_PIPELINE_CREATION_FEEDBACK_APPLICATION_PIPELINE_CACHE_HIT_BIT);
+    }
+    return shLib;
 }
 
-// Returns a shader library cache for the specified shader module key, creating it if necessary.
-MVKShaderLibraryCache* MVKPipelineCache::getShaderLibraryCache(MVKShaderModuleKey smKey) {
-	MVKShaderLibraryCache* slCache = _shaderCache[smKey];
-	if ( !slCache ) {
-		slCache = new MVKShaderLibraryCache(this);
-		_shaderCache[smKey] = slCache;
-	}
-	return slCache;
+// Returns a shader library cache for the specified shader module key, creating
+// it if necessary.
+MVKShaderLibraryCache*
+MVKPipelineCache::getShaderLibraryCache(MVKShaderModuleKey smKey) {
+    MVKShaderLibraryCache* slCache = _shaderCache[smKey];
+    if (!slCache) {
+        slCache = new MVKShaderLibraryCache(this);
+        _shaderCache[smKey] = slCache;
+    }
+    return slCache;
 }
-
 
 #pragma mark Streaming pipeline cache to and from offline memory
 
@@ -2331,542 +3221,533 @@ static uint32_t kDataHeaderSize = (sizeof(uint32_t) * 4) + VK_UUID_SIZE;
 
 // Entry type markers to be inserted into data stream
 typedef enum {
-	MVKPipelineCacheEntryTypeEOF = 0,
-	MVKPipelineCacheEntryTypeShaderLibrary = 1,
+    MVKPipelineCacheEntryTypeEOF = 0,
+    MVKPipelineCacheEntryTypeShaderLibrary = 1,
 } MVKPipelineCacheEntryType;
 
-// Helper class to iterate through the shader libraries in a shader library cache in order to serialize them.
-// Needs to support input of null shader library cache.
+// Helper class to iterate through the shader libraries in a shader library
+// cache in order to serialize them. Needs to support input of null shader
+// library cache.
 class MVKShaderCacheIterator : public MVKBaseObject {
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _pSLCache->getVulkanAPIObject(); };
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _pSLCache->getVulkanAPIObject();
+    };
 
-protected:
-	friend MVKPipelineCache;
+  protected:
+    friend MVKPipelineCache;
 
-	bool next() { return (++_index < (_pSLCache ? _pSLCache->_shaderLibraries.size() : 0)); }
-	SPIRVToMSLConversionConfiguration& getShaderConversionConfig() { return _pSLCache->_shaderLibraries[_index].first; }
-	MVKCompressor<std::string>& getCompressedMSL() { return _pSLCache->_shaderLibraries[_index].second->getCompressedMSL(); }
-	SPIRVToMSLConversionResultInfo& getShaderConversionResultInfo() { return _pSLCache->_shaderLibraries[_index].second->_shaderConversionResultInfo; }
-	MVKShaderCacheIterator(MVKShaderLibraryCache* pSLCache) : _pSLCache(pSLCache) {}
+    bool next() {
+        return (++_index <
+                (_pSLCache ? _pSLCache->_shaderLibraries.size() : 0));
+    }
+    SPIRVToMSLConversionConfiguration& getShaderConversionConfig() {
+        return _pSLCache->_shaderLibraries[_index].first;
+    }
+    MVKCompressor<std::string>& getCompressedMSL() {
+        return _pSLCache->_shaderLibraries[_index].second->getCompressedMSL();
+    }
+    SPIRVToMSLConversionResultInfo& getShaderConversionResultInfo() {
+        return _pSLCache->_shaderLibraries[_index]
+            .second->_shaderConversionResultInfo;
+    }
+    MVKShaderCacheIterator(MVKShaderLibraryCache* pSLCache)
+        : _pSLCache(pSLCache) {}
 
-	MVKShaderLibraryCache* _pSLCache;
-	size_t _count = 0;
-	int32_t _index = -1;
+    MVKShaderLibraryCache* _pSLCache;
+    size_t _count = 0;
+    int32_t _index = -1;
 };
 
 VkResult MVKPipelineCache::writeData(size_t* pDataSize, void* pData) {
-	if (_isExternallySynchronized) {
-		return writeDataImpl(pDataSize, pData);
-	} else {
-		lock_guard<mutex> lock(_shaderCacheLock);
-		return writeDataImpl(pDataSize, pData);
-	}
+    if (_isExternallySynchronized) {
+        return writeDataImpl(pDataSize, pData);
+    } else {
+        lock_guard<mutex> lock(_shaderCacheLock);
+        return writeDataImpl(pDataSize, pData);
+    }
 }
 
-// If pData is not null, serializes at most pDataSize bytes of the contents of the cache into that
-// memory location, and returns the number of bytes serialized in pDataSize. If pData is null,
-// returns the number of bytes required to serialize the contents of this pipeline cache.
-// This is the compliment of the readData() function. The two must be kept aligned.
+// If pData is not null, serializes at most pDataSize bytes of the contents of
+// the cache into that memory location, and returns the number of bytes
+// serialized in pDataSize. If pData is null, returns the number of bytes
+// required to serialize the contents of this pipeline cache. This is the
+// compliment of the readData() function. The two must be kept aligned.
 VkResult MVKPipelineCache::writeDataImpl(size_t* pDataSize, void* pData) {
 #if MVK_USE_CEREAL
-	try {
+    try {
 
-		if ( !pDataSize ) { return VK_SUCCESS; }
+        if (!pDataSize) {
+            return VK_SUCCESS;
+        }
 
-		if (pData) {
-			if (*pDataSize >= _dataSize) {
-				mvk::membuf mb((char*)pData, _dataSize);
-				ostream outStream(&mb);
-				writeData(outStream);
-				*pDataSize = _dataSize;
-				return VK_SUCCESS;
-			} else {
-				*pDataSize = 0;
-				return VK_INCOMPLETE;
-			}
-		} else {
-			if (_dataSize == 0) {
-				mvk::countbuf cb;
-				ostream outStream(&cb);
-				writeData(outStream, true);
-				_dataSize = cb.buffSize;
-			}
-			*pDataSize = _dataSize;
-			return VK_SUCCESS;
-		}
+        if (pData) {
+            if (*pDataSize >= _dataSize) {
+                mvk::membuf mb((char*)pData, _dataSize);
+                ostream outStream(&mb);
+                writeData(outStream);
+                *pDataSize = _dataSize;
+                return VK_SUCCESS;
+            } else {
+                *pDataSize = 0;
+                return VK_INCOMPLETE;
+            }
+        } else {
+            if (_dataSize == 0) {
+                mvk::countbuf cb;
+                ostream outStream(&cb);
+                writeData(outStream, true);
+                _dataSize = cb.buffSize;
+            }
+            *pDataSize = _dataSize;
+            return VK_SUCCESS;
+        }
 
-	} catch (cereal::Exception& ex) {
-		*pDataSize = 0;
-		return reportError(VK_INCOMPLETE, "Error writing pipeline cache data: %s", ex.what());
-	}
+    } catch (cereal::Exception& ex) {
+        *pDataSize = 0;
+        return reportError(VK_INCOMPLETE,
+                           "Error writing pipeline cache data: %s", ex.what());
+    }
 #else
-	*pDataSize = 0;
-	return reportError(VK_INCOMPLETE, "Pipeline cache serialization is unavailable. To enable pipeline cache serialization, build MoltenVK with MVK_USE_CEREAL=1 build setting.");
+    *pDataSize = 0;
+    return reportError(
+        VK_INCOMPLETE,
+        "Pipeline cache serialization is unavailable. To enable pipeline cache "
+        "serialization, build MoltenVK with MVK_USE_CEREAL=1 build setting.");
 #endif
 }
 
 // Serializes the data in this cache to a stream
 void MVKPipelineCache::writeData(ostream& outstream, bool isCounting) {
 #if MVK_USE_CEREAL
-	MVKPerformanceTracker& perfTracker = isCounting
-		? getPerformanceStats().pipelineCache.sizePipelineCache
-		: getPerformanceStats().pipelineCache.writePipelineCache;
+    MVKPerformanceTracker& perfTracker =
+        isCounting ? getPerformanceStats().pipelineCache.sizePipelineCache
+                   : getPerformanceStats().pipelineCache.writePipelineCache;
 
-	uint32_t cacheEntryType;
-	cereal::BinaryOutputArchive writer(outstream);
+    uint32_t cacheEntryType;
+    cereal::BinaryOutputArchive writer(outstream);
 
-	// Write the data header...after ensuring correct byte-order.
-	auto& devProps = getDeviceProperties();
-	writer(NSSwapHostIntToLittle(kDataHeaderSize));
-	writer(NSSwapHostIntToLittle(VK_PIPELINE_CACHE_HEADER_VERSION_ONE));
-	writer(NSSwapHostIntToLittle(devProps.vendorID));
-	writer(NSSwapHostIntToLittle(devProps.deviceID));
-	writer(devProps.pipelineCacheUUID);
+    // Write the data header...after ensuring correct byte-order.
+    auto& devProps = getDeviceProperties();
+    writer(NSSwapHostIntToLittle(kDataHeaderSize));
+    writer(NSSwapHostIntToLittle(VK_PIPELINE_CACHE_HEADER_VERSION_ONE));
+    writer(NSSwapHostIntToLittle(devProps.vendorID));
+    writer(NSSwapHostIntToLittle(devProps.deviceID));
+    writer(devProps.pipelineCacheUUID);
 
-	// Shader libraries
-	// Output a cache entry for each shader library, including the shader module key in each entry.
-	cacheEntryType = MVKPipelineCacheEntryTypeShaderLibrary;
-	for (auto& scPair : _shaderCache) {
-		MVKShaderModuleKey smKey = scPair.first;
-		MVKShaderCacheIterator cacheIter(scPair.second);
-		while (cacheIter.next()) {
-			uint64_t startTime = getPerformanceTimestamp();
-			writer(cacheEntryType);
-			writer(smKey);
-			writer(cacheIter.getShaderConversionConfig());
-			writer(cacheIter.getShaderConversionResultInfo());
-			writer(cacheIter.getCompressedMSL());
-			addPerformanceInterval(perfTracker, startTime);
-		}
-	}
+    // Shader libraries
+    // Output a cache entry for each shader library, including the shader module
+    // key in each entry.
+    cacheEntryType = MVKPipelineCacheEntryTypeShaderLibrary;
+    for (auto& scPair : _shaderCache) {
+        MVKShaderModuleKey smKey = scPair.first;
+        MVKShaderCacheIterator cacheIter(scPair.second);
+        while (cacheIter.next()) {
+            uint64_t startTime = getPerformanceTimestamp();
+            writer(cacheEntryType);
+            writer(smKey);
+            writer(cacheIter.getShaderConversionConfig());
+            writer(cacheIter.getShaderConversionResultInfo());
+            writer(cacheIter.getCompressedMSL());
+            addPerformanceInterval(perfTracker, startTime);
+        }
+    }
 
-	// Mark the end of the archive
-	cacheEntryType = MVKPipelineCacheEntryTypeEOF;
-	writer(cacheEntryType);
+    // Mark the end of the archive
+    cacheEntryType = MVKPipelineCacheEntryTypeEOF;
+    writer(cacheEntryType);
 #else
-	MVKAssert(false, "Pipeline cache serialization is unavailable. To enable pipeline cache serialization, build MoltenVK with MVK_USE_CEREAL=1 build setting.");
+    MVKAssert(false, "Pipeline cache serialization is unavailable. To enable "
+                     "pipeline cache serialization, build "
+                     "MoltenVK with MVK_USE_CEREAL=1 build setting.");
 #endif
 }
 
 // Loads any data indicated by the creation info.
-// This is the compliment of the writeData() function. The two must be kept aligned.
+// This is the compliment of the writeData() function. The two must be kept
+// aligned.
 void MVKPipelineCache::readData(const VkPipelineCacheCreateInfo* pCreateInfo) {
 #if MVK_USE_CEREAL
-	try {
+    try {
 
-		size_t byteCount = pCreateInfo->initialDataSize;
-		uint32_t cacheEntryType;
+        size_t byteCount = pCreateInfo->initialDataSize;
+        uint32_t cacheEntryType;
 
-		// Must be able to read the header and at least one cache entry type.
-		if (byteCount < kDataHeaderSize + sizeof(cacheEntryType)) { return; }
+        // Must be able to read the header and at least one cache entry type.
+        if (byteCount < kDataHeaderSize + sizeof(cacheEntryType)) {
+            return;
+        }
 
-		mvk::membuf mb((char*)pCreateInfo->pInitialData, byteCount);
-		istream inStream(&mb);
-		cereal::BinaryInputArchive reader(inStream);
+        mvk::membuf mb((char*)pCreateInfo->pInitialData, byteCount);
+        istream inStream(&mb);
+        cereal::BinaryInputArchive reader(inStream);
 
-		// Read the data header...and ensure correct byte-order.
-		uint32_t hdrComponent;
-		uint8_t pcUUID[VK_UUID_SIZE];
-		auto& dvcProps = getDeviceProperties();
+        // Read the data header...and ensure correct byte-order.
+        uint32_t hdrComponent;
+        uint8_t pcUUID[VK_UUID_SIZE];
+        auto& dvcProps = getDeviceProperties();
 
-		reader(hdrComponent);	// Header size
-		if (NSSwapLittleIntToHost(hdrComponent) !=  kDataHeaderSize) { return; }
+        reader(hdrComponent); // Header size
+        if (NSSwapLittleIntToHost(hdrComponent) != kDataHeaderSize) {
+            return;
+        }
 
-		reader(hdrComponent);	// Header version
-		if (NSSwapLittleIntToHost(hdrComponent) !=  VK_PIPELINE_CACHE_HEADER_VERSION_ONE) { return; }
+        reader(hdrComponent); // Header version
+        if (NSSwapLittleIntToHost(hdrComponent) !=
+            VK_PIPELINE_CACHE_HEADER_VERSION_ONE) {
+            return;
+        }
 
-		reader(hdrComponent);	// Vendor ID
-		if (NSSwapLittleIntToHost(hdrComponent) !=  dvcProps.vendorID) { return; }
+        reader(hdrComponent); // Vendor ID
+        if (NSSwapLittleIntToHost(hdrComponent) != dvcProps.vendorID) {
+            return;
+        }
 
-		reader(hdrComponent);	// Device ID
-		if (NSSwapLittleIntToHost(hdrComponent) !=  dvcProps.deviceID) { return; }
+        reader(hdrComponent); // Device ID
+        if (NSSwapLittleIntToHost(hdrComponent) != dvcProps.deviceID) {
+            return;
+        }
 
-		reader(pcUUID);			// Pipeline cache UUID
-		if ( !mvkAreEqual(pcUUID, dvcProps.pipelineCacheUUID, VK_UUID_SIZE) ) { return; }
+        reader(pcUUID); // Pipeline cache UUID
+        if (!mvkAreEqual(pcUUID, dvcProps.pipelineCacheUUID, VK_UUID_SIZE)) {
+            return;
+        }
 
-		bool done = false;
-		while ( !done ) {
-			reader(cacheEntryType);
-			switch (cacheEntryType) {
-				case MVKPipelineCacheEntryTypeShaderLibrary: {
-					uint64_t startTime = getPerformanceTimestamp();
+        bool done = false;
+        while (!done) {
+            reader(cacheEntryType);
+            switch (cacheEntryType) {
+            case MVKPipelineCacheEntryTypeShaderLibrary: {
+                uint64_t startTime = getPerformanceTimestamp();
 
-					MVKShaderModuleKey smKey;
-					reader(smKey);
+                MVKShaderModuleKey smKey;
+                reader(smKey);
 
-					SPIRVToMSLConversionConfiguration shaderConversionConfig;
-					reader(shaderConversionConfig);
+                SPIRVToMSLConversionConfiguration shaderConversionConfig;
+                reader(shaderConversionConfig);
 
-					SPIRVToMSLConversionResultInfo resultInfo;
-					reader(resultInfo);
+                SPIRVToMSLConversionResultInfo resultInfo;
+                reader(resultInfo);
 
-					MVKCompressor<std::string> compressedMSL;
-					reader(compressedMSL);
+                MVKCompressor<std::string> compressedMSL;
+                reader(compressedMSL);
 
-					// Add the shader library to the staging cache.
-					MVKShaderLibraryCache* slCache = getShaderLibraryCache(smKey);
-					addPerformanceInterval(getPerformanceStats().pipelineCache.readPipelineCache, startTime);
-					slCache->addShaderLibrary(&shaderConversionConfig, resultInfo, compressedMSL);
+                // Add the shader library to the staging cache.
+                MVKShaderLibraryCache* slCache = getShaderLibraryCache(smKey);
+                addPerformanceInterval(getPerformanceStats()
+                                           .pipelineCache.readPipelineCache,
+                                       startTime);
+                slCache->addShaderLibrary(&shaderConversionConfig, resultInfo,
+                                          compressedMSL);
 
-					break;
-				}
+                break;
+            }
 
-				default: {
-					done = true;
-					break;
-				}
-			}
-		}
+            default: {
+                done = true;
+                break;
+            }
+            }
+        }
 
-	} catch (cereal::Exception& ex) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Error reading pipeline cache data: %s", ex.what()));
-	}
+    } catch (cereal::Exception& ex) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "Error reading pipeline cache data: %s", ex.what()));
+    }
 #else
-	setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Pipeline cache serialization is unavailable. To enable pipeline cache serialization, build MoltenVK with MVK_USE_CEREAL=1 build setting."));
+    setConfigurationResult(reportError(
+        VK_ERROR_INITIALIZATION_FAILED,
+        "Pipeline cache serialization is unavailable. To enable pipeline cache "
+        "serialization, build MoltenVK with MVK_USE_CEREAL=1 build setting."));
 #endif
 }
 
 // Mark the cache as dirty, so that existing streaming info is released
-void MVKPipelineCache::markDirty() {
-	_dataSize = 0;
+void MVKPipelineCache::markDirty() { _dataSize = 0; }
+
+VkResult
+MVKPipelineCache::mergePipelineCaches(uint32_t srcCacheCount,
+                                      const VkPipelineCache* pSrcCaches) {
+    if (_isExternallySynchronized) {
+        return mergePipelineCachesImpl(srcCacheCount, pSrcCaches);
+    } else {
+        lock_guard<mutex> lock(_shaderCacheLock);
+        return mergePipelineCachesImpl(srcCacheCount, pSrcCaches);
+    }
 }
 
-VkResult MVKPipelineCache::mergePipelineCaches(uint32_t srcCacheCount, const VkPipelineCache* pSrcCaches) {
-	if (_isExternallySynchronized) {
-		return mergePipelineCachesImpl(srcCacheCount, pSrcCaches);
-	} else {
-		lock_guard<mutex> lock(_shaderCacheLock);
-		return mergePipelineCachesImpl(srcCacheCount, pSrcCaches);
-	}
+VkResult
+MVKPipelineCache::mergePipelineCachesImpl(uint32_t srcCacheCount,
+                                          const VkPipelineCache* pSrcCaches) {
+    for (uint32_t srcIdx = 0; srcIdx < srcCacheCount; srcIdx++) {
+        MVKPipelineCache* srcPLC = (MVKPipelineCache*)pSrcCaches[srcIdx];
+        for (auto& srcPair : srcPLC->_shaderCache) {
+            getShaderLibraryCache(srcPair.first)->merge(srcPair.second);
+        }
+    }
+    markDirty();
+
+    return VK_SUCCESS;
 }
-
-VkResult MVKPipelineCache::mergePipelineCachesImpl(uint32_t srcCacheCount, const VkPipelineCache* pSrcCaches) {
-	for (uint32_t srcIdx = 0; srcIdx < srcCacheCount; srcIdx++) {
-		MVKPipelineCache* srcPLC = (MVKPipelineCache*)pSrcCaches[srcIdx];
-		for (auto& srcPair : srcPLC->_shaderCache) {
-			getShaderLibraryCache(srcPair.first)->merge(srcPair.second);
-		}
-	}
-	markDirty();
-
-	return VK_SUCCESS;
-}
-
 
 #pragma mark Cereal archive definitions
 
 namespace SPIRV_CROSS_NAMESPACE {
 
-	template<class Archive>
-	void serialize(Archive & archive, CompilerMSL::Options& opt) {
-		archive(opt.platform,
-				opt.msl_version,
-				opt.texel_buffer_texture_width,
-				opt.r32ui_linear_texture_alignment,
-				opt.swizzle_buffer_index,
-				opt.indirect_params_buffer_index,
-				opt.shader_output_buffer_index,
-				opt.shader_patch_output_buffer_index,
-				opt.shader_tess_factor_buffer_index,
-				opt.buffer_size_buffer_index,
-				opt.view_mask_buffer_index,
-				opt.dynamic_offsets_buffer_index,
-				opt.shader_input_buffer_index,
-				opt.shader_index_buffer_index,
-				opt.shader_patch_input_buffer_index,
-				opt.shader_input_wg_index,
-				opt.device_index,
-				opt.enable_frag_output_mask,
-				opt.additional_fixed_sample_mask,
-				opt.fixed_subgroup_size,
-				opt.enable_point_size_builtin,
-				opt.enable_frag_depth_builtin,
-				opt.enable_frag_stencil_ref_builtin,
-				opt.disable_rasterization,
-				opt.capture_output_to_buffer,
-				opt.swizzle_texture_samples,
-				opt.tess_domain_origin_lower_left,
-				opt.multiview,
-				opt.multiview_layered_rendering,
-				opt.view_index_from_device_index,
-				opt.dispatch_base,
-				opt.texture_1D_as_2D,
-				opt.argument_buffers,
-				opt.enable_base_index_zero,
-				opt.pad_fragment_output_components,
-				opt.ios_support_base_vertex_instance,
-				opt.use_framebuffer_fetch_subpasses,
-				opt.invariant_float_math,
-				opt.emulate_cube_array,
-				opt.enable_decoration_binding,
-				opt.texture_buffer_native,
-				opt.force_active_argument_buffer_resources,
-				opt.pad_argument_buffer_resources,
-				opt.argument_buffers_tier,
-				opt.force_native_arrays,
-				opt.enable_clip_distance_user_varying,
-				opt.multi_patch_workgroup,
-				opt.raw_buffer_tese_input,
-				opt.vertex_for_tessellation,
-				opt.arrayed_subpass_input,
-				opt.ios_use_simdgroup_functions,
-				opt.emulate_subgroups,
-				opt.vertex_index_type,
-				opt.force_sample_rate_shading,
-				opt.manual_helper_invocation_updates,
-				opt.check_discarded_frag_stores,
-				opt.force_fragment_with_side_effects_execution,
-				opt.input_attachment_is_ds_attachment,
-				opt.sample_dref_lod_array_as_grad,
-				opt.replace_recursive_inputs,
-				opt.agx_manual_cube_grad_fixup);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, MSLShaderInterfaceVariable& si) {
-		archive(si.location,
-				si.component,
-				si.format,
-				si.builtin,
-				si.vecsize,
-				si.rate);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, MSLResourceBinding& rb) {
-		archive(rb.stage,
-				rb.basetype,
-				rb.desc_set,
-				rb.binding,
-				rb.count,
-				rb.msl_buffer,
-				rb.msl_texture,
-				rb.msl_sampler);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, MSLConstexprSampler& cs) {
-		archive(cs.coord,
-				cs.min_filter,
-				cs.mag_filter,
-				cs.mip_filter,
-				cs.s_address,
-				cs.t_address,
-				cs.r_address,
-				cs.compare_func,
-				cs.border_color,
-				cs.lod_clamp_min,
-				cs.lod_clamp_max,
-				cs.max_anisotropy,
-				cs.planes,
-				cs.resolution,
-				cs.chroma_filter,
-				cs.x_chroma_offset,
-				cs.y_chroma_offset,
-				cs.swizzle,
-				cs.ycbcr_model,
-				cs.ycbcr_range,
-				cs.bpc,
-				cs.compare_enable,
-				cs.lod_clamp_enable,
-				cs.anisotropy_enable,
-				cs.ycbcr_conversion_enable);
-	}
-
+template <class Archive>
+void serialize(Archive& archive, CompilerMSL::Options& opt) {
+    archive(opt.platform, opt.msl_version, opt.texel_buffer_texture_width,
+            opt.r32ui_linear_texture_alignment, opt.swizzle_buffer_index,
+            opt.indirect_params_buffer_index, opt.shader_output_buffer_index,
+            opt.shader_patch_output_buffer_index,
+            opt.shader_tess_factor_buffer_index, opt.buffer_size_buffer_index,
+            opt.view_mask_buffer_index, opt.dynamic_offsets_buffer_index,
+            opt.shader_input_buffer_index, opt.shader_index_buffer_index,
+            opt.shader_patch_input_buffer_index, opt.shader_input_wg_index,
+            opt.device_index, opt.enable_frag_output_mask,
+            opt.additional_fixed_sample_mask, opt.fixed_subgroup_size,
+            opt.enable_point_size_builtin, opt.enable_frag_depth_builtin,
+            opt.enable_frag_stencil_ref_builtin, opt.disable_rasterization,
+            opt.capture_output_to_buffer, opt.swizzle_texture_samples,
+            opt.tess_domain_origin_lower_left, opt.multiview,
+            opt.multiview_layered_rendering, opt.view_index_from_device_index,
+            opt.dispatch_base, opt.texture_1D_as_2D, opt.argument_buffers,
+            opt.enable_base_index_zero, opt.pad_fragment_output_components,
+            opt.ios_support_base_vertex_instance,
+            opt.use_framebuffer_fetch_subpasses, opt.invariant_float_math,
+            opt.emulate_cube_array, opt.enable_decoration_binding,
+            opt.texture_buffer_native,
+            opt.force_active_argument_buffer_resources,
+            opt.pad_argument_buffer_resources, opt.argument_buffers_tier,
+            opt.force_native_arrays, opt.enable_clip_distance_user_varying,
+            opt.multi_patch_workgroup, opt.raw_buffer_tese_input,
+            opt.vertex_for_tessellation, opt.arrayed_subpass_input,
+            opt.ios_use_simdgroup_functions, opt.emulate_subgroups,
+            opt.vertex_index_type, opt.force_sample_rate_shading,
+            opt.manual_helper_invocation_updates,
+            opt.check_discarded_frag_stores,
+            opt.force_fragment_with_side_effects_execution,
+            opt.input_attachment_is_ds_attachment,
+            opt.sample_dref_lod_array_as_grad, opt.replace_recursive_inputs,
+            opt.agx_manual_cube_grad_fixup);
 }
+
+template <class Archive>
+void serialize(Archive& archive, MSLShaderInterfaceVariable& si) {
+    archive(si.location, si.component, si.format, si.builtin, si.vecsize,
+            si.rate);
+}
+
+template <class Archive>
+void serialize(Archive& archive, MSLResourceBinding& rb) {
+    archive(rb.stage, rb.basetype, rb.desc_set, rb.binding, rb.count,
+            rb.msl_buffer, rb.msl_texture, rb.msl_sampler);
+}
+
+template <class Archive>
+void serialize(Archive& archive, MSLConstexprSampler& cs) {
+    archive(cs.coord, cs.min_filter, cs.mag_filter, cs.mip_filter, cs.s_address,
+            cs.t_address, cs.r_address, cs.compare_func, cs.border_color,
+            cs.lod_clamp_min, cs.lod_clamp_max, cs.max_anisotropy, cs.planes,
+            cs.resolution, cs.chroma_filter, cs.x_chroma_offset,
+            cs.y_chroma_offset, cs.swizzle, cs.ycbcr_model, cs.ycbcr_range,
+            cs.bpc, cs.compare_enable, cs.lod_clamp_enable,
+            cs.anisotropy_enable, cs.ycbcr_conversion_enable);
+}
+
+} // namespace SPIRV_CROSS_NAMESPACE
 
 namespace mvk {
 
-	template<class Archive>
-	void serialize(Archive & archive, SPIRVWorkgroupSizeDimension& wsd) {
-		archive(wsd.size,
-				wsd.specializationID,
-				wsd.isSpecialized);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, SPIRVEntryPoint& ep) {
-		archive(ep.mtlFunctionName,
-				ep.workgroupSize.width,
-				ep.workgroupSize.height,
-				ep.workgroupSize.depth,
-				ep.supportsFastMath);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, SPIRVToMSLConversionOptions& opt) {
-		archive(opt.mslOptions,
-				opt.entryPointName,
-				opt.entryPointStage,
-				opt.tessPatchKind,
-				opt.numTessControlPoints,
-				opt.shouldFlipVertexY);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, MSLShaderInterfaceVariable& si) {
-		archive(si.shaderVar,
-				si.binding,
-				si.outIsUsedByShader);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, MSLResourceBinding& rb) {
-		archive(rb.resourceBinding,
-				rb.constExprSampler,
-				rb.requiresConstExprSampler,
-				rb.outIsUsedByShader);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, DescriptorBinding& db) {
-		archive(db.stage,
-				db.descriptorSet,
-				db.binding,
-				db.index);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, SPIRVToMSLConversionConfiguration& ctx) {
-		archive(ctx.options,
-				ctx.shaderInputs,
-				ctx.shaderOutputs,
-				ctx.resourceBindings,
-				ctx.discreteDescriptorSets);
-	}
-
-	template<class Archive>
-	void serialize(Archive & archive, SPIRVToMSLConversionResultInfo& scr) {
-		archive(scr.entryPoint,
-				scr.isRasterizationDisabled,
-				scr.isPositionInvariant,
-				scr.needsSwizzleBuffer,
-				scr.needsOutputBuffer,
-				scr.needsPatchOutputBuffer,
-				scr.needsBufferSizeBuffer,
-				scr.needsDynamicOffsetBuffer,
-				scr.needsInputThreadgroupMem,
-				scr.needsDispatchBaseBuffer,
-				scr.needsViewRangeBuffer,
-				scr.usesPhysicalStorageBufferAddressesCapability);
-	}
-
+template <class Archive>
+void serialize(Archive& archive, SPIRVWorkgroupSizeDimension& wsd) {
+    archive(wsd.size, wsd.specializationID, wsd.isSpecialized);
 }
 
-template<class Archive>
-void serialize(Archive & archive, MVKShaderModuleKey& k) {
-	archive(k.codeSize,
-			k.codeHash);
+template <class Archive> void serialize(Archive& archive, SPIRVEntryPoint& ep) {
+    archive(ep.mtlFunctionName, ep.workgroupSize.width, ep.workgroupSize.height,
+            ep.workgroupSize.depth, ep.supportsFastMath);
 }
 
-template<class Archive, class C>
-void serialize(Archive & archive, MVKCompressor<C>& comp) {
-	archive(comp._compressed,
-			comp._uncompressedSize,
-			comp._algorithm);
+template <class Archive>
+void serialize(Archive& archive, SPIRVToMSLConversionOptions& opt) {
+    archive(opt.mslOptions, opt.entryPointName, opt.entryPointStage,
+            opt.tessPatchKind, opt.numTessControlPoints, opt.shouldFlipVertexY);
 }
 
+template <class Archive>
+void serialize(Archive& archive, MSLShaderInterfaceVariable& si) {
+    archive(si.shaderVar, si.binding, si.outIsUsedByShader);
+}
+
+template <class Archive>
+void serialize(Archive& archive, MSLResourceBinding& rb) {
+    archive(rb.resourceBinding, rb.constExprSampler,
+            rb.requiresConstExprSampler, rb.outIsUsedByShader);
+}
+
+template <class Archive>
+void serialize(Archive& archive, DescriptorBinding& db) {
+    archive(db.stage, db.descriptorSet, db.binding, db.index);
+}
+
+template <class Archive>
+void serialize(Archive& archive, SPIRVToMSLConversionConfiguration& ctx) {
+    archive(ctx.options, ctx.shaderInputs, ctx.shaderOutputs,
+            ctx.resourceBindings, ctx.discreteDescriptorSets);
+}
+
+template <class Archive>
+void serialize(Archive& archive, SPIRVToMSLConversionResultInfo& scr) {
+    archive(scr.entryPoint, scr.isRasterizationDisabled,
+            scr.isPositionInvariant, scr.needsSwizzleBuffer,
+            scr.needsOutputBuffer, scr.needsPatchOutputBuffer,
+            scr.needsBufferSizeBuffer, scr.needsDynamicOffsetBuffer,
+            scr.needsInputThreadgroupMem, scr.needsDispatchBaseBuffer,
+            scr.needsViewRangeBuffer,
+            scr.usesPhysicalStorageBufferAddressesCapability);
+}
+
+} // namespace mvk
+
+template <class Archive>
+void serialize(Archive& archive, MVKShaderModuleKey& k) {
+    archive(k.codeSize, k.codeHash);
+}
+
+template <class Archive, class C>
+void serialize(Archive& archive, MVKCompressor<C>& comp) {
+    archive(comp._compressed, comp._uncompressedSize, comp._algorithm);
+}
 
 #pragma mark Construction
 
-MVKPipelineCache::MVKPipelineCache(MVKDevice* device, const VkPipelineCacheCreateInfo* pCreateInfo) :
-	MVKVulkanAPIDeviceObject(device),
-	_isExternallySynchronized(getEnabledPipelineCreationCacheControlFeatures().pipelineCreationCacheControl &&
-							  mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT)) {
+MVKPipelineCache::MVKPipelineCache(MVKDevice* device,
+                                   const VkPipelineCacheCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device),
+      _isExternallySynchronized(
+          getEnabledPipelineCreationCacheControlFeatures()
+              .pipelineCreationCacheControl &&
+          mvkIsAnyFlagEnabled(
+              pCreateInfo->flags,
+              VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT)) {
 
-	readData(pCreateInfo);
+    readData(pCreateInfo);
 }
 
 MVKPipelineCache::~MVKPipelineCache() {
-	for (auto& pair : _shaderCache) { pair.second->destroy(); }
-	_shaderCache.clear();
+    for (auto& pair : _shaderCache) {
+        pair.second->destroy();
+    }
+    _shaderCache.clear();
 }
-
 
 #pragma mark -
 #pragma mark MVKRenderPipelineCompiler
 
-id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(MTLRenderPipelineDescriptor* mtlRPLDesc) {
-	unique_lock<mutex> lock(_completionLock);
+id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(
+    MTLRenderPipelineDescriptor* mtlRPLDesc) {
+    unique_lock<mutex> lock(_completionLock);
 
-	compile(lock, ^{
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			[mtlDev newRenderPipelineStateWithDescriptor: mtlRPLDesc
-									   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
-										   bool isLate = compileComplete(ps, error);
-										   if (isLate) { destroy(); }
-									   }];
-		}
-	});
+    compile(lock, ^{
+      auto mtlDev = getMTLDevice();
+      @synchronized(mtlDev) {
+          [mtlDev
+              newRenderPipelineStateWithDescriptor:mtlRPLDesc
+                                 completionHandler:^(id<MTLRenderPipelineState>
+                                                         ps,
+                                                     NSError* error) {
+                                   bool isLate = compileComplete(ps, error);
+                                   if (isLate) {
+                                       destroy();
+                                   }
+                                 }];
+      }
+    });
 
-	return [_mtlRenderPipelineState retain];
+    return [_mtlRenderPipelineState retain];
 }
 
-bool MVKRenderPipelineCompiler::compileComplete(id<MTLRenderPipelineState> mtlRenderPipelineState, NSError* compileError) {
-	lock_guard<mutex> lock(_completionLock);
+bool MVKRenderPipelineCompiler::compileComplete(
+    id<MTLRenderPipelineState> mtlRenderPipelineState, NSError* compileError) {
+    lock_guard<mutex> lock(_completionLock);
 
-	_mtlRenderPipelineState = [mtlRenderPipelineState retain];		// retained
-	return endCompile(compileError);
+    _mtlRenderPipelineState = [mtlRenderPipelineState retain]; // retained
+    return endCompile(compileError);
 }
 
 #pragma mark Construction
 
 MVKRenderPipelineCompiler::~MVKRenderPipelineCompiler() {
-	[_mtlRenderPipelineState release];
+    [_mtlRenderPipelineState release];
 }
-
 
 #pragma mark -
 #pragma mark MVKComputePipelineCompiler
 
-id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineState(id<MTLFunction> mtlFunction) {
-	unique_lock<mutex> lock(_completionLock);
+id<MTLComputePipelineState>
+MVKComputePipelineCompiler::newMTLComputePipelineState(
+    id<MTLFunction> mtlFunction) {
+    unique_lock<mutex> lock(_completionLock);
 
-	compile(lock, ^{
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			[mtlDev newComputePipelineStateWithFunction: mtlFunction
-									  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
-										  bool isLate = compileComplete(ps, error);
-										  if (isLate) { destroy(); }
-									  }];
-		}
-	});
+    compile(lock, ^{
+      auto mtlDev = getMTLDevice();
+      @synchronized(mtlDev) {
+          [mtlDev
+              newComputePipelineStateWithFunction:mtlFunction
+                                completionHandler:^(id<MTLComputePipelineState>
+                                                        ps,
+                                                    NSError* error) {
+                                  bool isLate = compileComplete(ps, error);
+                                  if (isLate) {
+                                      destroy();
+                                  }
+                                }];
+      }
+    });
 
-	return [_mtlComputePipelineState retain];
+    return [_mtlComputePipelineState retain];
 }
 
-id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineState(MTLComputePipelineDescriptor* plDesc) {
-	unique_lock<mutex> lock(_completionLock);
+id<MTLComputePipelineState>
+MVKComputePipelineCompiler::newMTLComputePipelineState(
+    MTLComputePipelineDescriptor* plDesc) {
+    unique_lock<mutex> lock(_completionLock);
 
-	compile(lock, ^{
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			[mtlDev newComputePipelineStateWithDescriptor: plDesc
-												  options: MTLPipelineOptionNone
-										completionHandler: ^(id<MTLComputePipelineState> ps, MTLComputePipelineReflection*, NSError* error) {
-											bool isLate = compileComplete(ps, error);
-											if (isLate) { destroy(); }
-										}];
-		}
-	});
+    compile(lock, ^{
+      auto mtlDev = getMTLDevice();
+      @synchronized(mtlDev) {
+          [mtlDev newComputePipelineStateWithDescriptor:plDesc
+                                                options:MTLPipelineOptionNone
+                                      completionHandler:
+                                          ^(id<MTLComputePipelineState> ps,
+                                            MTLComputePipelineReflection*,
+                                            NSError* error) {
+                                            bool isLate =
+                                                compileComplete(ps, error);
+                                            if (isLate) {
+                                                destroy();
+                                            }
+                                          }];
+      }
+    });
 
-	return [_mtlComputePipelineState retain];
+    return [_mtlComputePipelineState retain];
 }
 
-bool MVKComputePipelineCompiler::compileComplete(id<MTLComputePipelineState> mtlComputePipelineState, NSError* compileError) {
-	lock_guard<mutex> lock(_completionLock);
+bool MVKComputePipelineCompiler::compileComplete(
+    id<MTLComputePipelineState> mtlComputePipelineState,
+    NSError* compileError) {
+    lock_guard<mutex> lock(_completionLock);
 
-	_mtlComputePipelineState = [mtlComputePipelineState retain];		// retained
-	return endCompile(compileError);
+    _mtlComputePipelineState = [mtlComputePipelineState retain]; // retained
+    return endCompile(compileError);
 }
 
 #pragma mark Construction
 
 MVKComputePipelineCompiler::~MVKComputePipelineCompiler() {
-	[_mtlComputePipelineState release];
+    [_mtlComputePipelineState release];
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.h
@@ -30,153 +30,172 @@
 class MVKPhysicalDevice;
 struct MVKMTLDeviceCapabilities;
 
-
 #pragma mark -
 #pragma mark Metal format capabilities
 
 typedef enum : uint16_t {
 
-	kMVKMTLFmtCapsNone     = 0,
-	kMVKMTLFmtCapsRead     = (1<<0),
-	kMVKMTLFmtCapsFilter   = (1<<1),
-	kMVKMTLFmtCapsWrite    = (1<<2),
-	kMVKMTLFmtCapsAtomic   = (1<<3),
-	kMVKMTLFmtCapsColorAtt = (1<<4),
-	kMVKMTLFmtCapsDSAtt    = (1<<5),
-	kMVKMTLFmtCapsBlend    = (1<<6),
-	kMVKMTLFmtCapsMSAA     = (1<<7),
-	kMVKMTLFmtCapsResolve  = (1<<8),
-	kMVKMTLFmtCapsVertex   = (1<<9),
+    kMVKMTLFmtCapsNone = 0,
+    kMVKMTLFmtCapsRead = (1 << 0),
+    kMVKMTLFmtCapsFilter = (1 << 1),
+    kMVKMTLFmtCapsWrite = (1 << 2),
+    kMVKMTLFmtCapsAtomic = (1 << 3),
+    kMVKMTLFmtCapsColorAtt = (1 << 4),
+    kMVKMTLFmtCapsDSAtt = (1 << 5),
+    kMVKMTLFmtCapsBlend = (1 << 6),
+    kMVKMTLFmtCapsMSAA = (1 << 7),
+    kMVKMTLFmtCapsResolve = (1 << 8),
+    kMVKMTLFmtCapsVertex = (1 << 9),
 
-	kMVKMTLFmtCapsRF       = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsFilter),
-	kMVKMTLFmtCapsRC       = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsColorAtt),
-	kMVKMTLFmtCapsRCB      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsBlend),
-	kMVKMTLFmtCapsRCM      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsMSAA),
-	kMVKMTLFmtCapsRCMB     = (kMVKMTLFmtCapsRCM | kMVKMTLFmtCapsBlend),
-	kMVKMTLFmtCapsRWC      = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsWrite),
-	kMVKMTLFmtCapsRWCB     = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsBlend),
-	kMVKMTLFmtCapsRWCM     = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsMSAA),
-	kMVKMTLFmtCapsRWCMB    = (kMVKMTLFmtCapsRWCM | kMVKMTLFmtCapsBlend),
-	kMVKMTLFmtCapsRFCMRB   = (kMVKMTLFmtCapsRCMB | kMVKMTLFmtCapsFilter | kMVKMTLFmtCapsResolve),
-	kMVKMTLFmtCapsRFWCMB   = (kMVKMTLFmtCapsRWCMB | kMVKMTLFmtCapsFilter),
-	kMVKMTLFmtCapsAll      = (kMVKMTLFmtCapsRFWCMB | kMVKMTLFmtCapsResolve),
+    kMVKMTLFmtCapsRF = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsFilter),
+    kMVKMTLFmtCapsRC = (kMVKMTLFmtCapsRead | kMVKMTLFmtCapsColorAtt),
+    kMVKMTLFmtCapsRCB = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsBlend),
+    kMVKMTLFmtCapsRCM = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsMSAA),
+    kMVKMTLFmtCapsRCMB = (kMVKMTLFmtCapsRCM | kMVKMTLFmtCapsBlend),
+    kMVKMTLFmtCapsRWC = (kMVKMTLFmtCapsRC | kMVKMTLFmtCapsWrite),
+    kMVKMTLFmtCapsRWCB = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsBlend),
+    kMVKMTLFmtCapsRWCM = (kMVKMTLFmtCapsRWC | kMVKMTLFmtCapsMSAA),
+    kMVKMTLFmtCapsRWCMB = (kMVKMTLFmtCapsRWCM | kMVKMTLFmtCapsBlend),
+    kMVKMTLFmtCapsRFCMRB =
+        (kMVKMTLFmtCapsRCMB | kMVKMTLFmtCapsFilter | kMVKMTLFmtCapsResolve),
+    kMVKMTLFmtCapsRFWCMB = (kMVKMTLFmtCapsRWCMB | kMVKMTLFmtCapsFilter),
+    kMVKMTLFmtCapsAll = (kMVKMTLFmtCapsRFWCMB | kMVKMTLFmtCapsResolve),
 
-	kMVKMTLFmtCapsDRM      = (kMVKMTLFmtCapsDSAtt | kMVKMTLFmtCapsRead | kMVKMTLFmtCapsMSAA),
-	kMVKMTLFmtCapsDRFM     = (kMVKMTLFmtCapsDRM | kMVKMTLFmtCapsFilter),
-	kMVKMTLFmtCapsDRMR     = (kMVKMTLFmtCapsDRM | kMVKMTLFmtCapsResolve),
-	kMVKMTLFmtCapsDRFMR    = (kMVKMTLFmtCapsDRFM | kMVKMTLFmtCapsResolve),
+    kMVKMTLFmtCapsDRM =
+        (kMVKMTLFmtCapsDSAtt | kMVKMTLFmtCapsRead | kMVKMTLFmtCapsMSAA),
+    kMVKMTLFmtCapsDRFM = (kMVKMTLFmtCapsDRM | kMVKMTLFmtCapsFilter),
+    kMVKMTLFmtCapsDRMR = (kMVKMTLFmtCapsDRM | kMVKMTLFmtCapsResolve),
+    kMVKMTLFmtCapsDRFMR = (kMVKMTLFmtCapsDRFM | kMVKMTLFmtCapsResolve),
 
-	kMVKMTLFmtCapsChromaSubsampling = kMVKMTLFmtCapsRF,
-	kMVKMTLFmtCapsMultiPlanar = kMVKMTLFmtCapsChromaSubsampling,
+    kMVKMTLFmtCapsChromaSubsampling = kMVKMTLFmtCapsRF,
+    kMVKMTLFmtCapsMultiPlanar = kMVKMTLFmtCapsChromaSubsampling,
 } MVKMTLFmtCaps;
 
-inline MVKMTLFmtCaps operator|(MVKMTLFmtCaps leftCaps, MVKMTLFmtCaps rightCaps) {
-	return static_cast<MVKMTLFmtCaps>(static_cast<uint32_t>(leftCaps) | rightCaps);
+inline MVKMTLFmtCaps operator|(MVKMTLFmtCaps leftCaps,
+                               MVKMTLFmtCaps rightCaps) {
+    return static_cast<MVKMTLFmtCaps>(static_cast<uint32_t>(leftCaps) |
+                                      rightCaps);
 }
 
-inline MVKMTLFmtCaps& operator|=(MVKMTLFmtCaps& leftCaps, MVKMTLFmtCaps rightCaps) {
-	return (leftCaps = leftCaps | rightCaps);
+inline MVKMTLFmtCaps& operator|=(MVKMTLFmtCaps& leftCaps,
+                                 MVKMTLFmtCaps rightCaps) {
+    return (leftCaps = leftCaps | rightCaps);
 }
-
 
 #pragma mark -
 #pragma mark Metal view classes
 
 enum class MVKMTLViewClass : uint8_t {
-	None,
-	Color8,
-	Color16,
-	Color32,
-	Color64,
-	Color128,
-	PVRTC_RGB_2BPP,
-	PVRTC_RGB_4BPP,
-	PVRTC_RGBA_2BPP,
-	PVRTC_RGBA_4BPP,
-	EAC_R11,
-	EAC_RG11,
-	EAC_RGBA8,
-	ETC2_RGB8,
-	ETC2_RGB8A1,
-	ASTC_4x4,
-	ASTC_5x4,
-	ASTC_5x5,
-	ASTC_6x5,
-	ASTC_6x6,
-	ASTC_8x5,
-	ASTC_8x6,
-	ASTC_8x8,
-	ASTC_10x5,
-	ASTC_10x6,
-	ASTC_10x8,
-	ASTC_10x10,
-	ASTC_12x10,
-	ASTC_12x12,
-	BC1_RGBA,
-	BC2_RGBA,
-	BC3_RGBA,
-	BC4_R,
-	BC5_RG,
-	BC6H_RGB,
-	BC7_RGBA,
-	Depth24_Stencil8,
-	Depth32_Stencil8,
-	BGRA10_XR,
-	BGR10_XR
+    None,
+    Color8,
+    Color16,
+    Color32,
+    Color64,
+    Color128,
+    PVRTC_RGB_2BPP,
+    PVRTC_RGB_4BPP,
+    PVRTC_RGBA_2BPP,
+    PVRTC_RGBA_4BPP,
+    EAC_R11,
+    EAC_RG11,
+    EAC_RGBA8,
+    ETC2_RGB8,
+    ETC2_RGB8A1,
+    ASTC_4x4,
+    ASTC_5x4,
+    ASTC_5x5,
+    ASTC_6x5,
+    ASTC_6x6,
+    ASTC_8x5,
+    ASTC_8x6,
+    ASTC_8x8,
+    ASTC_10x5,
+    ASTC_10x6,
+    ASTC_10x8,
+    ASTC_10x10,
+    ASTC_12x10,
+    ASTC_12x12,
+    BC1_RGBA,
+    BC2_RGBA,
+    BC3_RGBA,
+    BC4_R,
+    BC5_RG,
+    BC6H_RGB,
+    BC7_RGBA,
+    Depth24_Stencil8,
+    Depth32_Stencil8,
+    BGRA10_XR,
+    BGR10_XR
 };
-
 
 #pragma mark -
 #pragma mark Format descriptors
 
-/** Describes the properties of a VkFormat, including the corresponding Metal pixel and vertex format. */
+/** Describes the properties of a VkFormat, including the corresponding Metal
+ * pixel and vertex format. */
 typedef struct MVKVkFormatDesc {
-	VkFormat vkFormat;
-	MTLPixelFormat mtlPixelFormat;
-	MTLPixelFormat mtlPixelFormatSubstitute;
-	MTLVertexFormat mtlVertexFormat;
-	MTLVertexFormat mtlVertexFormatSubstitute;
+    VkFormat vkFormat;
+    MTLPixelFormat mtlPixelFormat;
+    MTLPixelFormat mtlPixelFormatSubstitute;
+    MTLVertexFormat mtlVertexFormat;
+    MTLVertexFormat mtlVertexFormatSubstitute;
     uint8_t chromaSubsamplingPlaneCount;
     uint8_t chromaSubsamplingComponentBits;
-	VkExtent2D blockTexelSize;
-	uint32_t bytesPerBlock;
-	MVKFormatType formatType;
+    VkExtent2D blockTexelSize;
+    uint32_t bytesPerBlock;
+    MVKFormatType formatType;
     VkFormatProperties3 properties;
-	VkComponentMapping componentMapping;
-	const char* name;
-	bool hasReportedSubstitution;
-    
-    inline double bytesPerTexel() const { return (double)bytesPerBlock / (double)(blockTexelSize.width * blockTexelSize.height); };
+    VkComponentMapping componentMapping;
+    const char* name;
+    bool hasReportedSubstitution;
 
-	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid || chromaSubsamplingPlaneCount > 1); };
-	inline bool isSupportedOrSubstitutable() const { return isSupported() || (mtlPixelFormatSubstitute != MTLPixelFormatInvalid); };
+    inline double bytesPerTexel() const {
+        return (double)bytesPerBlock /
+               (double)(blockTexelSize.width * blockTexelSize.height);
+    };
 
-	inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid); };
-	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); };
+    inline bool isSupported() const {
+        return (mtlPixelFormat != MTLPixelFormatInvalid ||
+                chromaSubsamplingPlaneCount > 1);
+    };
+    inline bool isSupportedOrSubstitutable() const {
+        return isSupported() ||
+               (mtlPixelFormatSubstitute != MTLPixelFormatInvalid);
+    };
 
-	bool needsSwizzle() const {
-		return (componentMapping.r != VK_COMPONENT_SWIZZLE_IDENTITY ||
-				componentMapping.g != VK_COMPONENT_SWIZZLE_IDENTITY ||
-				componentMapping.b != VK_COMPONENT_SWIZZLE_IDENTITY ||
-				componentMapping.a != VK_COMPONENT_SWIZZLE_IDENTITY);
-	}
+    inline bool vertexIsSupported() const {
+        return (mtlVertexFormat != MTLVertexFormatInvalid);
+    };
+    inline bool vertexIsSupportedOrSubstitutable() const {
+        return vertexIsSupported() ||
+               (mtlVertexFormatSubstitute != MTLVertexFormatInvalid);
+    };
+
+    bool needsSwizzle() const {
+        return (componentMapping.r != VK_COMPONENT_SWIZZLE_IDENTITY ||
+                componentMapping.g != VK_COMPONENT_SWIZZLE_IDENTITY ||
+                componentMapping.b != VK_COMPONENT_SWIZZLE_IDENTITY ||
+                componentMapping.a != VK_COMPONENT_SWIZZLE_IDENTITY);
+    }
 } MVKVkFormatDesc;
 
 /** Describes the properties of a MTLPixelFormat or MTLVertexFormat. */
 typedef struct MVKMTLFormatDesc {
-	union {
-		MTLPixelFormat mtlPixelFormat;
-		MTLVertexFormat mtlVertexFormat;
-	};
-	VkFormat vkFormat;
-	MVKMTLFmtCaps mtlFmtCaps;
-	MVKMTLViewClass mtlViewClass;
-	MTLPixelFormat mtlPixelFormatLinear;
-	const char* name;
+    union {
+        MTLPixelFormat mtlPixelFormat;
+        MTLVertexFormat mtlVertexFormat;
+    };
+    VkFormat vkFormat;
+    MVKMTLFmtCaps mtlFmtCaps;
+    MVKMTLViewClass mtlViewClass;
+    MTLPixelFormat mtlPixelFormatLinear;
+    const char* name;
 
-	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mtlFmtCaps != kMVKMTLFmtCapsNone); };
+    inline bool isSupported() const {
+        return (mtlPixelFormat != MTLPixelFormatInvalid) &&
+               (mtlFmtCaps != kMVKMTLFmtCapsNone);
+    };
 } MVKMTLFormatDesc;
-
 
 #pragma mark -
 #pragma mark MVKPixelFormats
@@ -184,250 +203,311 @@ typedef struct MVKMTLFormatDesc {
 /** Helper class to manage pixel format capabilities and conversions.  */
 class MVKPixelFormats : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
+    /** Returns whether the VkFormat is supported by this implementation. */
+    bool isSupported(VkFormat vkFormat);
 
-	/** Returns whether the VkFormat is supported by this implementation. */
-	bool isSupported(VkFormat vkFormat);
+    /** Returns whether the VkFormat is supported by this implementation, or can
+     * be substituted by one that is. */
+    bool isSupportedOrSubstitutable(VkFormat vkFormat);
 
-	/** Returns whether the VkFormat is supported by this implementation, or can be substituted by one that is. */
-	bool isSupportedOrSubstitutable(VkFormat vkFormat);
+    /** Returns whether the MTLPixelFormat is supported by this implementation.
+     */
+    bool isSupported(MTLPixelFormat mtlFormat);
 
-	/** Returns whether the MTLPixelFormat is supported by this implementation. */
-	bool isSupported(MTLPixelFormat mtlFormat);
+    /** Returns whether the specified Metal MTLPixelFormat can be used as a
+     * depth format. */
+    bool isDepthFormat(MTLPixelFormat mtlFormat);
 
-	/** Returns whether the specified Metal MTLPixelFormat can be used as a depth format. */
-	bool isDepthFormat(MTLPixelFormat mtlFormat);
+    /** Returns whether the specified Metal MTLPixelFormat can be used as a
+     * stencil format. */
+    bool isStencilFormat(MTLPixelFormat mtlFormat);
 
-	/** Returns whether the specified Metal MTLPixelFormat can be used as a stencil format. */
-	bool isStencilFormat(MTLPixelFormat mtlFormat);
+    /** Returns whether the specified Metal MTLPixelFormat is a PVRTC format. */
+    bool isPVRTCFormat(MTLPixelFormat mtlFormat);
 
-	/** Returns whether the specified Metal MTLPixelFormat is a PVRTC format. */
-	bool isPVRTCFormat(MTLPixelFormat mtlFormat);
+    /**
+     * Returns whether the VkFormat only differs from the MTLPixelFormat in that
+     * one may be the sRGB version of the other. Either or both the VkFormat and
+     * MTLPixelFormat may be a linear or sRGB format. Returns true if any of the
+     * following are true:
+     *   - The MTLPixelFormat is the Metal version of the VkFormat.
+     *   - The MTLPixelFormat is the Metal sRGB version of the linear VkFormat.
+     *   - The MTLPixelFormat is the Metal linear version of the sRGB VkFormat.
+     * Returns false if none of those conditions apply.
+     */
+    bool compatibleAsLinearOrSRGB(MTLPixelFormat mtlFormat, VkFormat vkFormat);
 
-	/**
-	 * Returns whether the VkFormat only differs from the MTLPixelFormat in that one may be the sRGB
-	 * version of the other. Either or both the VkFormat and MTLPixelFormat may be a linear or sRGB format.
-	 * Returns true if any of the following are true:
-	 *   - The MTLPixelFormat is the Metal version of the VkFormat.
-	 *   - The MTLPixelFormat is the Metal sRGB version of the linear VkFormat.
-	 *   - The MTLPixelFormat is the Metal linear version of the sRGB VkFormat.
-	 * Returns false if none of those conditions apply.
-	 */
-	bool compatibleAsLinearOrSRGB(MTLPixelFormat mtlFormat, VkFormat vkFormat);
+    /** Returns the format type corresponding to the specified Vulkan VkFormat,
+     */
+    MVKFormatType getFormatType(VkFormat vkFormat);
 
-	/** Returns the format type corresponding to the specified Vulkan VkFormat, */
-	MVKFormatType getFormatType(VkFormat vkFormat);
+    /** Returns the format type corresponding to the specified Metal
+     * MTLPixelFormat, */
+    MVKFormatType getFormatType(MTLPixelFormat mtlFormat);
 
-	/** Returns the format type corresponding to the specified Metal MTLPixelFormat, */
-	MVKFormatType getFormatType(MTLPixelFormat mtlFormat);
+    /**
+     * Returns the Metal MTLPixelFormat corresponding to the specified Vulkan
+     * VkFormat, or returns MTLPixelFormatInvalid if no corresponding
+     * MTLPixelFormat exists.
+     */
+    MTLPixelFormat getMTLPixelFormat(VkFormat vkFormat);
 
-	/**
-	 * Returns the Metal MTLPixelFormat corresponding to the specified Vulkan VkFormat,
-	 * or returns MTLPixelFormatInvalid if no corresponding MTLPixelFormat exists.
-	 */
-	MTLPixelFormat getMTLPixelFormat(VkFormat vkFormat);
+    /**
+     * Returns the Vulkan VkFormat corresponding to the specified Metal
+     * MTLPixelFormat, or returns VK_FORMAT_UNDEFINED if no corresponding
+     * VkFormat exists.
+     */
+    VkFormat getVkFormat(MTLPixelFormat mtlFormat);
 
-	/**
-	 * Returns the Vulkan VkFormat corresponding to the specified Metal MTLPixelFormat,
-	 * or returns VK_FORMAT_UNDEFINED if no corresponding VkFormat exists.
-	 */
-	VkFormat getVkFormat(MTLPixelFormat mtlFormat);
+    /**
+     * Returns the size, in bytes, of a texel block of the specified Vulkan
+     * format. For uncompressed formats, the returned value corresponds to the
+     * size in bytes of a single texel.
+     */
+    uint32_t getBytesPerBlock(VkFormat vkFormat);
 
-	/**
-	 * Returns the size, in bytes, of a texel block of the specified Vulkan format.
-	 * For uncompressed formats, the returned value corresponds to the size in bytes of a single texel.
-	 */
-	uint32_t getBytesPerBlock(VkFormat vkFormat);
+    /**
+     * Returns the size, in bytes, of a texel block of the specified Metal
+     * format. For uncompressed formats, the returned value corresponds to the
+     * size in bytes of a single texel.
+     */
+    uint32_t getBytesPerBlock(MTLPixelFormat mtlFormat);
 
-	/**
-	 * Returns the size, in bytes, of a texel block of the specified Metal format.
-	 * For uncompressed formats, the returned value corresponds to the size in bytes of a single texel.
-	 */
-	uint32_t getBytesPerBlock(MTLPixelFormat mtlFormat);
+    /**
+     * Returns the size of the compression block, measured in texels for a
+     * Vulkan format. The returned value will be {1, 1} for non-compressed
+     * formats without chroma-subsampling.
+     */
+    VkExtent2D getBlockTexelSize(VkFormat vkFormat);
 
-	/**
-	 * Returns the size of the compression block, measured in texels for a Vulkan format.
-	 * The returned value will be {1, 1} for non-compressed formats without chroma-subsampling.
-	 */
-	VkExtent2D getBlockTexelSize(VkFormat vkFormat);
+    /**
+     * Returns the size of the compression block, measured in texels for a Metal
+     * format. The returned value will be {1, 1} for non-compressed formats
+     * without chroma-subsampling.
+     */
+    VkExtent2D getBlockTexelSize(MTLPixelFormat mtlFormat);
 
-	/**
-	 * Returns the size of the compression block, measured in texels for a Metal format.
-	 * The returned value will be {1, 1} for non-compressed formats without chroma-subsampling.
-	 */
-	VkExtent2D getBlockTexelSize(MTLPixelFormat mtlFormat);
+    /** Returns the number of planes of the specified chroma-subsampling (YCbCr)
+     * VkFormat */
+    uint8_t getChromaSubsamplingPlaneCount(VkFormat vkFormat);
 
-	/** Returns the number of planes of the specified chroma-subsampling (YCbCr) VkFormat */
-	uint8_t getChromaSubsamplingPlaneCount(VkFormat vkFormat);
+    /** Returns the number of bits per channel of the specified
+     * chroma-subsampling (YCbCr) VkFormat */
+    uint8_t getChromaSubsamplingComponentBits(VkFormat vkFormat);
 
-	/** Returns the number of bits per channel of the specified chroma-subsampling (YCbCr) VkFormat */
-	uint8_t getChromaSubsamplingComponentBits(VkFormat vkFormat);
+    /** Returns the MSLFormatResolution of the specified chroma-subsampling
+     * (YCbCr) VkFormat */
+    SPIRV_CROSS_NAMESPACE::MSLFormatResolution
+    getChromaSubsamplingResolution(VkFormat vkFormat);
 
-	/** Returns the MSLFormatResolution of the specified chroma-subsampling (YCbCr) VkFormat */
-	SPIRV_CROSS_NAMESPACE::MSLFormatResolution getChromaSubsamplingResolution(VkFormat vkFormat);
+    /** Returns the MTLPixelFormat of the specified chroma-subsampling (YCbCr)
+     * VkFormat for the specified plane. */
+    MTLPixelFormat getChromaSubsamplingPlaneMTLPixelFormat(VkFormat vkFormat,
+                                                           uint8_t planeIndex);
 
-	/** Returns the MTLPixelFormat of the specified chroma-subsampling (YCbCr) VkFormat for the specified plane. */
-	MTLPixelFormat getChromaSubsamplingPlaneMTLPixelFormat(VkFormat vkFormat, uint8_t planeIndex);
+    /** Returns the number of planes, blockTexelSize,  bytesPerBlock and
+     * mtlPixFmt of each plane of the specified chroma-subsampling (YCbCr)
+     * VkFormat into the given arrays */
+    uint8_t getChromaSubsamplingPlanes(VkFormat vkFormat,
+                                       VkExtent2D blockTexelSize[3],
+                                       uint32_t bytesPerBlock[3],
+                                       MTLPixelFormat mtlPixFmt[3]);
 
-    /** Returns the number of planes, blockTexelSize,  bytesPerBlock and mtlPixFmt of each plane of the specified chroma-subsampling (YCbCr) VkFormat into the given arrays */
-    uint8_t getChromaSubsamplingPlanes(VkFormat vkFormat, VkExtent2D blockTexelSize[3], uint32_t bytesPerBlock[3], MTLPixelFormat mtlPixFmt[3]);
+    /**
+     * Returns the size, in bytes, of a texel of the specified Vulkan format.
+     * The returned value may be fractional for certain compressed formats.
+     */
+    float getBytesPerTexel(VkFormat vkFormat);
 
-	/**
-	 * Returns the size, in bytes, of a texel of the specified Vulkan format.
-	 * The returned value may be fractional for certain compressed formats.
-	 */
-	float getBytesPerTexel(VkFormat vkFormat);
+    /**
+     * Returns the size, in bytes, of a texel of the specified Metal format.
+     * The returned value may be fractional for certain compressed formats.
+     */
+    float getBytesPerTexel(MTLPixelFormat mtlFormat);
 
-	/**
-	 * Returns the size, in bytes, of a texel of the specified Metal format.
-	 * The returned value may be fractional for certain compressed formats.
-	 */
-	float getBytesPerTexel(MTLPixelFormat mtlFormat);
+    /**
+     * Returns the size, in bytes, of a row of texels of the specified Vulkan
+     * format.
+     *
+     * For compressed formats, this takes into consideration the compression
+     * block size, and texelsPerRow should specify the width in texels, not
+     * blocks. The result is rounded up if texelsPerRow is not an integer
+     * multiple of the compression block width.
+     */
+    size_t getBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow);
 
-	/**
-	 * Returns the size, in bytes, of a row of texels of the specified Vulkan format.
-	 *
-	 * For compressed formats, this takes into consideration the compression block size,
-	 * and texelsPerRow should specify the width in texels, not blocks. The result is rounded
-	 * up if texelsPerRow is not an integer multiple of the compression block width.
-	 */
-	size_t getBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow);
+    /**
+     * Returns the size, in bytes, of a row of texels of the specified Metal
+     * format.
+     *
+     * For compressed formats, this takes into consideration the compression
+     * block size, and texelsPerRow should specify the width in texels, not
+     * blocks. The result is rounded up if texelsPerRow is not an integer
+     * multiple of the compression block width.
+     */
+    size_t getBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow);
 
-	/**
-	 * Returns the size, in bytes, of a row of texels of the specified Metal format.
-	 *
-	 * For compressed formats, this takes into consideration the compression block size,
-	 * and texelsPerRow should specify the width in texels, not blocks. The result is rounded
-	 * up if texelsPerRow is not an integer multiple of the compression block width.
-	 */
-	size_t getBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow);
+    /**
+     * Returns the size, in bytes, of a texture layer of the specified Vulkan
+     * format.
+     *
+     * For compressed formats, this takes into consideration the compression
+     * block size, and texelRowsPerLayer should specify the height in texels,
+     * not blocks. The result is rounded up if texelRowsPerLayer is not an
+     * integer multiple of the compression block height.
+     */
+    size_t getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow,
+                            uint32_t texelRowsPerLayer);
 
-	/**
-	 * Returns the size, in bytes, of a texture layer of the specified Vulkan format.
-	 *
-	 * For compressed formats, this takes into consideration the compression block size,
-	 * and texelRowsPerLayer should specify the height in texels, not blocks. The result is
-	 * rounded up if texelRowsPerLayer is not an integer multiple of the compression block height.
-	 */
-	size_t getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
+    /**
+     * Returns the size, in bytes, of a texture layer of the specified Metal
+     * format. For compressed formats, this takes into consideration the
+     * compression block size, and texelRowsPerLayer should specify the height
+     * in texels, not blocks. The result is rounded up if texelRowsPerLayer is
+     * not an integer multiple of the compression block height.
+     */
+    size_t getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow,
+                            uint32_t texelRowsPerLayer);
 
-	/**
-	 * Returns the size, in bytes, of a texture layer of the specified Metal format.
-	 * For compressed formats, this takes into consideration the compression block size,
-	 * and texelRowsPerLayer should specify the height in texels, not blocks. The result is
-	 * rounded up if texelRowsPerLayer is not an integer multiple of the compression block height.
-	 */
-	size_t getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer);
+    /** Returns whether or not the specified Vulkan format requires swizzling to
+     * use with Metal. */
+    bool needsSwizzle(VkFormat vkFormat);
 
-	/** Returns whether or not the specified Vulkan format requires swizzling to use with Metal. */
-	bool needsSwizzle(VkFormat vkFormat);
+    /** Returns any VkComponentMapping needed to use the specified Vulkan
+     * format. */
+    VkComponentMapping getVkComponentMapping(VkFormat vkFormat);
 
-	/** Returns any VkComponentMapping needed to use the specified Vulkan format. */
-	VkComponentMapping getVkComponentMapping(VkFormat vkFormat);
+    /**
+     * Returns the inverse of the VkComponentMapping needed to use the specified
+     * Vulkan format. If the original mapping is not a one-to-one function, the
+     * behaviour is undefined.
+     */
+    VkComponentMapping getInverseComponentMapping(VkFormat vkFormat);
 
-	/**
-	 * Returns the inverse of the VkComponentMapping needed to use the specified Vulkan format.
-	 * If the original mapping is not a one-to-one function, the behaviour is undefined.
-	 */
-	VkComponentMapping getInverseComponentMapping(VkFormat vkFormat);
+    /** Returns any MTLTextureSwizzleChannels needed to use the specified Vulkan
+     * format. */
+    MTLTextureSwizzleChannels getMTLTextureSwizzleChannels(VkFormat vkFormat);
 
-	/** Returns any MTLTextureSwizzleChannels needed to use the specified Vulkan format. */
-	MTLTextureSwizzleChannels getMTLTextureSwizzleChannels(VkFormat vkFormat);
-
-	/** Returns the default properties for the specified Vulkan format. */
+    /** Returns the default properties for the specified Vulkan format. */
     VkFormatProperties getVkFormatProperties(VkFormat format);
-	VkFormatProperties3& getVkFormatProperties3(VkFormat vkFormat);
+    VkFormatProperties3& getVkFormatProperties3(VkFormat vkFormat);
 
-	/** Returns the Metal format capabilities supported by the specified Vulkan format, without substitution. */
-	MVKMTLFmtCaps getCapabilities(VkFormat vkFormat, bool isExtended = false);
+    /** Returns the Metal format capabilities supported by the specified Vulkan
+     * format, without substitution. */
+    MVKMTLFmtCaps getCapabilities(VkFormat vkFormat, bool isExtended = false);
 
-	/** Returns the Metal format capabilities supported by the specified Metal format. */
-	MVKMTLFmtCaps getCapabilities(MTLPixelFormat mtlFormat, bool isExtended = false);
+    /** Returns the Metal format capabilities supported by the specified Metal
+     * format. */
+    MVKMTLFmtCaps getCapabilities(MTLPixelFormat mtlFormat,
+                                  bool isExtended = false);
 
-	/** Returns the Metal view class of the specified Vulkan format. */
-	MVKMTLViewClass getViewClass(VkFormat vkFormat);
+    /** Returns the Metal view class of the specified Vulkan format. */
+    MVKMTLViewClass getViewClass(VkFormat vkFormat);
 
-	/** Returns the Metal view class of the specified Metal format. */
-	MVKMTLViewClass getViewClass(MTLPixelFormat mtlFormat);
+    /** Returns the Metal view class of the specified Metal format. */
+    MVKMTLViewClass getViewClass(MTLPixelFormat mtlFormat);
 
-	/** Returns the name of the specified Vulkan format. */
-	const char* getName(VkFormat vkFormat);
+    /** Returns the name of the specified Vulkan format. */
+    const char* getName(VkFormat vkFormat);
 
-	/** Returns the name of the specified Metal pixel format. */
-	const char* getName(MTLPixelFormat mtlFormat);
+    /** Returns the name of the specified Metal pixel format. */
+    const char* getName(MTLPixelFormat mtlFormat);
 
-	/** Returns the name of the specified Metal vertex format. */
-	const char* getName(MTLVertexFormat mtlFormat);
+    /** Returns the name of the specified Metal vertex format. */
+    const char* getName(MTLVertexFormat mtlFormat);
 
-	/**
-	 * Returns the MTLClearColor value corresponding to the color value in the VkClearValue,
-	 * extracting the color value that is VkFormat for the VkFormat.
-	 */
-	MTLClearColor getMTLClearColor(VkClearValue vkClearValue, VkFormat vkFormat);
+    /**
+     * Returns the MTLClearColor value corresponding to the color value in the
+     * VkClearValue, extracting the color value that is VkFormat for the
+     * VkFormat.
+     */
+    MTLClearColor getMTLClearColor(VkClearValue vkClearValue,
+                                   VkFormat vkFormat);
 
-	/** Returns the Metal depth value corresponding to the depth value in the specified VkClearValue. */
-	double getMTLClearDepthValue(VkClearValue vkClearValue);
+    /** Returns the Metal depth value corresponding to the depth value in the
+     * specified VkClearValue. */
+    double getMTLClearDepthValue(VkClearValue vkClearValue);
 
-	/** Returns the Metal stencil value corresponding to the stencil value in the specified VkClearValue. */
-	uint32_t getMTLClearStencilValue(VkClearValue vkClearValue);
+    /** Returns the Metal stencil value corresponding to the stencil value in
+     * the specified VkClearValue. */
+    uint32_t getMTLClearStencilValue(VkClearValue vkClearValue);
 
-	/** Returns the Vulkan image usage from the Metal texture usage and format. */
-	VkImageUsageFlags getVkImageUsageFlags(MTLTextureUsage mtlUsage, MTLPixelFormat mtlFormat);
+    /** Returns the Vulkan image usage from the Metal texture usage and format.
+     */
+    VkImageUsageFlags getVkImageUsageFlags(MTLTextureUsage mtlUsage,
+                                           MTLPixelFormat mtlFormat);
 
-	/**
-	 * Returns the Metal texture usage from the Vulkan image usage and Metal format.
-     * isLinear further restricts the allowed usage to those that are valid for linear textures.
-	 * needsReinterpretation indicates an image view with a format that needs reinterpretation will be applied.
-     * isExtended expands the allowed usage to those that are valid for all formats which
+    /**
+     * Returns the Metal texture usage from the Vulkan image usage and Metal
+     * format. isLinear further restricts the allowed usage to those that are
+     * valid for linear textures. needsReinterpretation indicates an image view
+     * with a format that needs reinterpretation will be applied. isExtended
+     * expands the allowed usage to those that are valid for all formats which
      * can be used in a view created from the specified format.
-	 */
-	MTLTextureUsage getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
-									   MTLPixelFormat mtlFormat,
-									   VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT,
-                                       bool isLinear = false,
-                                       bool needsReinterpretation = true,
-                                       bool isExtended = false,
-									   bool supportAtomics = false);
+     */
+    MTLTextureUsage
+    getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
+                       MTLPixelFormat mtlFormat,
+                       VkSampleCountFlagBits samples = VK_SAMPLE_COUNT_1_BIT,
+                       bool isLinear = false, bool needsReinterpretation = true,
+                       bool isExtended = false, bool supportAtomics = false);
 
-	/** Enumerates all formats that support the given features, calling a specified function for each one. */
-	void enumerateSupportedFormats(const VkFormatProperties3& properties, bool any, std::function<bool(VkFormat)> func);
+    /** Enumerates all formats that support the given features, calling a
+     * specified function for each one. */
+    void enumerateSupportedFormats(const VkFormatProperties3& properties,
+                                   bool any,
+                                   std::function<bool(VkFormat)> func);
 
-	/**
-	 * Returns the Metal MTLVertexFormat corresponding to the specified
-	 * Vulkan VkFormat as used as a vertex attribute format.
-	 */
-	MTLVertexFormat getMTLVertexFormat(VkFormat vkFormat);
-    
-    static VkFormatFeatureFlags convertFormatPropertiesFlagBits(VkFormatFeatureFlags2 flags);
+    /**
+     * Returns the Metal MTLVertexFormat corresponding to the specified
+     * Vulkan VkFormat as used as a vertex attribute format.
+     */
+    MTLVertexFormat getMTLVertexFormat(VkFormat vkFormat);
+
+    static VkFormatFeatureFlags
+    convertFormatPropertiesFlagBits(VkFormatFeatureFlags2 flags);
 #pragma mark Construction
 
-	MVKPixelFormats(MVKPhysicalDevice* physicalDevice = nullptr);
+    MVKPixelFormats(MVKPhysicalDevice* physicalDevice = nullptr);
 
-protected:
-	MVKVkFormatDesc& getVkFormatDesc(VkFormat vkFormat);
-	MVKVkFormatDesc& getVkFormatDesc(MTLPixelFormat mtlFormat);
-	MVKMTLFormatDesc& getMTLPixelFormatDesc(MTLPixelFormat mtlFormat);
-	MVKMTLFmtCaps& getMTLPixelFormatCapsIf(MTLPixelFormat mtlPixFmt, bool cond);
-	MVKMTLFormatDesc& getMTLVertexFormatDesc(MTLVertexFormat mtlFormat);
-	id<MTLDevice> getMTLDevice();
-	void initVkFormatCapabilities();
-	void initMTLPixelFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
-	void initMTLVertexFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
-	void modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
-	void buildVkFormatMaps(const MVKMTLDeviceCapabilities& gpuCaps);
-	void setFormatProperties(MVKVkFormatDesc& vkDesc, const MVKMTLDeviceCapabilities& gpuCaps);
-	void addMTLPixelFormatDescImpl(MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
-								   MVKMTLViewClass viewClass, MVKMTLFmtCaps fmtCaps, const char* name);
-	void addValidatedMTLPixelFormatDesc(MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
-										MVKMTLViewClass viewClass, MVKMTLFmtCaps appleGPUCaps, MVKMTLFmtCaps macGPUCaps,
-										const MVKMTLDeviceCapabilities& mtlDevCaps, const char* name);
-	void addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt, MVKMTLFmtCaps vtxCap, const char* name);
+  protected:
+    MVKVkFormatDesc& getVkFormatDesc(VkFormat vkFormat);
+    MVKVkFormatDesc& getVkFormatDesc(MTLPixelFormat mtlFormat);
+    MVKMTLFormatDesc& getMTLPixelFormatDesc(MTLPixelFormat mtlFormat);
+    MVKMTLFmtCaps& getMTLPixelFormatCapsIf(MTLPixelFormat mtlPixFmt, bool cond);
+    MVKMTLFormatDesc& getMTLVertexFormatDesc(MTLVertexFormat mtlFormat);
+    id<MTLDevice> getMTLDevice();
+    void initVkFormatCapabilities();
+    void
+    initMTLPixelFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
+    void
+    initMTLVertexFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
+    void modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps);
+    void buildVkFormatMaps(const MVKMTLDeviceCapabilities& gpuCaps);
+    void setFormatProperties(MVKVkFormatDesc& vkDesc,
+                             const MVKMTLDeviceCapabilities& gpuCaps);
+    void addMTLPixelFormatDescImpl(MTLPixelFormat mtlPixFmt,
+                                   MTLPixelFormat mtlPixFmtLinear,
+                                   MVKMTLViewClass viewClass,
+                                   MVKMTLFmtCaps fmtCaps, const char* name);
+    void addValidatedMTLPixelFormatDesc(
+        MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
+        MVKMTLViewClass viewClass, MVKMTLFmtCaps appleGPUCaps,
+        MVKMTLFmtCaps macGPUCaps, const MVKMTLDeviceCapabilities& mtlDevCaps,
+        const char* name);
+    void addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt,
+                                    MVKMTLFmtCaps vtxCap, const char* name);
 
-	MVKPhysicalDevice* _physicalDevice;
-	MVKInflectionMap<VkFormat, MVKVkFormatDesc, VK_FORMAT_ASTC_12x12_SRGB_BLOCK + 1> _vkFormatDescriptions;
-	MVKInflectionMap<uint16_t, MVKMTLFormatDesc, MTLPixelFormatX32_Stencil8 + 2> _mtlPixelFormatDescriptions;  // The actual last enum value is not available on iOS
-	MVKSmallVector<MVKMTLFormatDesc> _mtlVertexFormatDescriptions;
+    MVKPhysicalDevice* _physicalDevice;
+    MVKInflectionMap<VkFormat, MVKVkFormatDesc,
+                     VK_FORMAT_ASTC_12x12_SRGB_BLOCK + 1>
+        _vkFormatDescriptions;
+    MVKInflectionMap<uint16_t, MVKMTLFormatDesc, MTLPixelFormatX32_Stencil8 + 2>
+        _mtlPixelFormatDescriptions; // The actual last enum value is not
+                                     // available on iOS
+    MVKSmallVector<MVKMTLFormatDesc> _mtlVertexFormatDescriptions;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -23,266 +23,273 @@
 
 using namespace std;
 
-// Some Metal formats are not supported by the headers on certain platforms. However, formats have
-// been 'unlocked' on some platforms with newer versions of Xcode.
+// Some Metal formats are not supported by the headers on certain platforms.
+// However, formats have been 'unlocked' on some platforms with newer versions
+// of Xcode.
 
 // Add stub defs for unsupported MTLPixelFormats per platform
 #if MVK_MACOS
-#	if !MVK_XCODE_12 // macOS 11.0 / iOS 14.2
-#       define MTLPixelFormatR8Unorm_sRGB           MTLPixelFormatInvalid
-#       define MTLPixelFormatRG8Unorm_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatABGR4Unorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatB5G6R5Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatA1BGR5Unorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR5A1Unorm            MTLPixelFormatInvalid
+#if !MVK_XCODE_12 // macOS 11.0 / iOS 14.2
+#define MTLPixelFormatR8Unorm_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatRG8Unorm_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatABGR4Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatB5G6R5Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatA1BGR5Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatBGR5A1Unorm MTLPixelFormatInvalid
 
-#       define MTLPixelFormatBGR10_XR				MTLPixelFormatInvalid
-#       define MTLPixelFormatBGR10_XR_sRGB			MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRA10_XR				MTLPixelFormatInvalid
-#       define MTLPixelFormatBGRA10_XR_sRGB			MTLPixelFormatInvalid
+#define MTLPixelFormatBGR10_XR MTLPixelFormatInvalid
+#define MTLPixelFormatBGR10_XR_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatBGRA10_XR MTLPixelFormatInvalid
+#define MTLPixelFormatBGRA10_XR_sRGB MTLPixelFormatInvalid
 
-#       define MTLPixelFormatPVRTC_RGB_2BPP         MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_2BPP_sRGB    MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_4BPP         MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGB_4BPP_sRGB    MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_2BPP        MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_2BPP_sRGB   MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_4BPP        MTLPixelFormatInvalid
-#       define MTLPixelFormatPVRTC_RGBA_4BPP_sRGB   MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGB_2BPP MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGB_2BPP_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGB_4BPP MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGB_4BPP_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGBA_2BPP MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGBA_2BPP_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGBA_4BPP MTLPixelFormatInvalid
+#define MTLPixelFormatPVRTC_RGBA_4BPP_sRGB MTLPixelFormatInvalid
 
-#       define MTLPixelFormatEAC_RGBA8              MTLPixelFormatInvalid
-#       define MTLPixelFormatEAC_RGBA8_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatEAC_R11Unorm           MTLPixelFormatInvalid
-#       define MTLPixelFormatEAC_R11Snorm           MTLPixelFormatInvalid
-#       define MTLPixelFormatEAC_RG11Unorm          MTLPixelFormatInvalid
-#       define MTLPixelFormatEAC_RG11Snorm          MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8              MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8A1            MTLPixelFormatInvalid
-#       define MTLPixelFormatETC2_RGB8A1_sRGB       MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_RGBA8 MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_RGBA8_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_R11Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_R11Snorm MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_RG11Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatEAC_RG11Snorm MTLPixelFormatInvalid
+#define MTLPixelFormatETC2_RGB8 MTLPixelFormatInvalid
+#define MTLPixelFormatETC2_RGB8_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatETC2_RGB8A1 MTLPixelFormatInvalid
+#define MTLPixelFormatETC2_RGB8A1_sRGB MTLPixelFormatInvalid
 
-#       define MTLPixelFormatASTC_4x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_4x4_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_4x4_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x4_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x4_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x5_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x5_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x5_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x5_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x6_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x6_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x5_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x5_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x6_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x6_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x8_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x8_LDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x8_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x5_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x5_LDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x5_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x6_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x6_LDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x6_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x8_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x8_LDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x8_sRGB         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x10_LDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x10_sRGB        MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x10_LDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x10_sRGB        MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x12_LDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x12_sRGB        MTLPixelFormatInvalid
-#   endif
+#define MTLPixelFormatASTC_4x4_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_4x4_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_4x4_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x4_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x4_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x4_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x5_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x5_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x5_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x5_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x6_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x6_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x5_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x5_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x6_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x6_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x8_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x8_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x8_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x5_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x5_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x6_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x6_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x8_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x8_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x8_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x10_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x10_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x10_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x10_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x10_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x10_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x12_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x12_LDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x12_sRGB MTLPixelFormatInvalid
+#endif
 
-#   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth24Unorm_Stencil8
+#define MTLPixelFormatDepth16Unorm_Stencil8 MTLPixelFormatDepth24Unorm_Stencil8
 #endif
 
 #if MVK_IOS_OR_TVOS
-#	if !MVK_XCODE_14_3   // iOS/tvOS 16.4
-#       define MTLPixelFormatBC1_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC1_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC2_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC2_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC3_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC3_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC4_RUnorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatBC4_RSnorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatBC5_RGUnorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatBC5_RGSnorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatBC6H_RGBUfloat         MTLPixelFormatInvalid
-#       define MTLPixelFormatBC6H_RGBFloat          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC7_RGBAUnorm          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC7_RGBAUnorm_sRGB     MTLPixelFormatInvalid
-#   endif
+#if !MVK_XCODE_14_3 // iOS/tvOS 16.4
+#define MTLPixelFormatBC1_RGBA MTLPixelFormatInvalid
+#define MTLPixelFormatBC1_RGBA_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatBC2_RGBA MTLPixelFormatInvalid
+#define MTLPixelFormatBC2_RGBA_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatBC3_RGBA MTLPixelFormatInvalid
+#define MTLPixelFormatBC3_RGBA_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatBC4_RUnorm MTLPixelFormatInvalid
+#define MTLPixelFormatBC4_RSnorm MTLPixelFormatInvalid
+#define MTLPixelFormatBC5_RGUnorm MTLPixelFormatInvalid
+#define MTLPixelFormatBC5_RGSnorm MTLPixelFormatInvalid
+#define MTLPixelFormatBC6H_RGBUfloat MTLPixelFormatInvalid
+#define MTLPixelFormatBC6H_RGBFloat MTLPixelFormatInvalid
+#define MTLPixelFormatBC7_RGBAUnorm MTLPixelFormatInvalid
+#define MTLPixelFormatBC7_RGBAUnorm_sRGB MTLPixelFormatInvalid
+#endif
 
-#   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth32Float_Stencil8
-#   define MTLPixelFormatDepth24Unorm_Stencil8      MTLPixelFormatInvalid
-#   define MTLPixelFormatX24_Stencil8               MTLPixelFormatInvalid
+#define MTLPixelFormatDepth16Unorm_Stencil8 MTLPixelFormatDepth32Float_Stencil8
+#define MTLPixelFormatDepth24Unorm_Stencil8 MTLPixelFormatInvalid
+#define MTLPixelFormatX24_Stencil8 MTLPixelFormatInvalid
 #endif
 
 #if MVK_VISIONOS
-#   define MTLPixelFormatDepth24Unorm_Stencil8      MTLPixelFormatInvalid
-#   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatInvalid
-#   define MTLPixelFormatX24_Stencil8               MTLPixelFormatInvalid
+#define MTLPixelFormatDepth24Unorm_Stencil8 MTLPixelFormatInvalid
+#define MTLPixelFormatDepth16Unorm_Stencil8 MTLPixelFormatInvalid
+#define MTLPixelFormatX24_Stencil8 MTLPixelFormatInvalid
 #endif
 
 #if MVK_TVOS
-#       define MTLPixelFormatASTC_4x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x8_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x5_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x6_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x8_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_4x4_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x4_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_5x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_6x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_8x8_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x5_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x6_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x8_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_10x10_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x10_HDR MTLPixelFormatInvalid
+#define MTLPixelFormatASTC_12x12_HDR MTLPixelFormatInvalid
 #endif
 
 #if MVK_OS_SIMULATOR
-#   define MTLPixelFormatR8Unorm_sRGB               MTLPixelFormatInvalid
-#   define MTLPixelFormatRG8Unorm_sRGB              MTLPixelFormatInvalid
-#   define MTLPixelFormatB5G6R5Unorm                MTLPixelFormatInvalid
-#   define MTLPixelFormatA1BGR5Unorm                MTLPixelFormatInvalid
-#   define MTLPixelFormatABGR4Unorm                 MTLPixelFormatInvalid
-#   define MTLPixelFormatBGR5A1Unorm                MTLPixelFormatInvalid
-#   define MTLPixelFormatBGR10_XR                   MTLPixelFormatInvalid
-#   define MTLPixelFormatBGR10_XR_sRGB              MTLPixelFormatInvalid
-#   define MTLPixelFormatBGRA10_XR                  MTLPixelFormatInvalid
-#   define MTLPixelFormatBGRA10_XR_sRGB             MTLPixelFormatInvalid
-#   define MTLPixelFormatGBGR422                    MTLPixelFormatInvalid
-#   define MTLPixelFormatBGRG422                    MTLPixelFormatInvalid
+#define MTLPixelFormatR8Unorm_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatRG8Unorm_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatB5G6R5Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatA1BGR5Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatABGR4Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatBGR5A1Unorm MTLPixelFormatInvalid
+#define MTLPixelFormatBGR10_XR MTLPixelFormatInvalid
+#define MTLPixelFormatBGR10_XR_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatBGRA10_XR MTLPixelFormatInvalid
+#define MTLPixelFormatBGRA10_XR_sRGB MTLPixelFormatInvalid
+#define MTLPixelFormatGBGR422 MTLPixelFormatInvalid
+#define MTLPixelFormatBGRG422 MTLPixelFormatInvalid
 #endif
 
 #if !MVK_XCODE_15
-#   define MTLVertexFormatFloatRG11B10              MTLVertexFormatInvalid
-#   define MTLVertexFormatFloatRGB9E5               MTLVertexFormatInvalid
+#define MTLVertexFormatFloatRG11B10 MTLVertexFormatInvalid
+#define MTLVertexFormatFloatRGB9E5 MTLVertexFormatInvalid
 #endif
-
 
 #pragma mark -
 #pragma mark MVKPixelFormats
 
-MVKVulkanAPIObject* MVKPixelFormats::getVulkanAPIObject() { return _physicalDevice; };
+MVKVulkanAPIObject* MVKPixelFormats::getVulkanAPIObject() {
+    return _physicalDevice;
+};
 
 bool MVKPixelFormats::isSupported(VkFormat vkFormat) {
-	return getVkFormatDesc(vkFormat).isSupported();
+    return getVkFormatDesc(vkFormat).isSupported();
 }
 
 bool MVKPixelFormats::isSupportedOrSubstitutable(VkFormat vkFormat) {
-	return getVkFormatDesc(vkFormat).isSupportedOrSubstitutable();
+    return getVkFormatDesc(vkFormat).isSupportedOrSubstitutable();
 }
 
 bool MVKPixelFormats::isSupported(MTLPixelFormat mtlFormat) {
-	return getMTLPixelFormatDesc(mtlFormat).isSupported();
+    return getMTLPixelFormatDesc(mtlFormat).isSupported();
 }
 
 bool MVKPixelFormats::isDepthFormat(MTLPixelFormat mtlFormat) {
-	switch (mtlFormat) {
-		case MTLPixelFormatDepth32Float:
-		case MTLPixelFormatDepth16Unorm:
-		case MTLPixelFormatDepth32Float_Stencil8:
+    switch (mtlFormat) {
+    case MTLPixelFormatDepth32Float:
+    case MTLPixelFormatDepth16Unorm:
+    case MTLPixelFormatDepth32Float_Stencil8:
 #if MVK_MACOS
-		case MTLPixelFormatDepth24Unorm_Stencil8:
+    case MTLPixelFormatDepth24Unorm_Stencil8:
 #endif
-			return true;
-		default:
-			return false;
-	}
+        return true;
+    default:
+        return false;
+    }
 }
 
 bool MVKPixelFormats::isStencilFormat(MTLPixelFormat mtlFormat) {
-	switch (mtlFormat) {
-		case MTLPixelFormatStencil8:
+    switch (mtlFormat) {
+    case MTLPixelFormatStencil8:
 #if MVK_MACOS
-		case MTLPixelFormatDepth24Unorm_Stencil8:
-		case MTLPixelFormatX24_Stencil8:
+    case MTLPixelFormatDepth24Unorm_Stencil8:
+    case MTLPixelFormatX24_Stencil8:
 #endif
-		case MTLPixelFormatDepth32Float_Stencil8:
-		case MTLPixelFormatX32_Stencil8:
-			return true;
-		default:
-			return false;
-	}
+    case MTLPixelFormatDepth32Float_Stencil8:
+    case MTLPixelFormatX32_Stencil8:
+        return true;
+    default:
+        return false;
+    }
 }
 
 bool MVKPixelFormats::isPVRTCFormat(MTLPixelFormat mtlFormat) {
-	switch (mtlFormat) {
+    switch (mtlFormat) {
 #if MVK_APPLE_SILICON
-		case MTLPixelFormatPVRTC_RGBA_2BPP:
-		case MTLPixelFormatPVRTC_RGBA_2BPP_sRGB:
-		case MTLPixelFormatPVRTC_RGBA_4BPP:
-		case MTLPixelFormatPVRTC_RGBA_4BPP_sRGB:
-		case MTLPixelFormatPVRTC_RGB_2BPP:
-		case MTLPixelFormatPVRTC_RGB_2BPP_sRGB:
-		case MTLPixelFormatPVRTC_RGB_4BPP:
-		case MTLPixelFormatPVRTC_RGB_4BPP_sRGB:
-			return true;
+    case MTLPixelFormatPVRTC_RGBA_2BPP:
+    case MTLPixelFormatPVRTC_RGBA_2BPP_sRGB:
+    case MTLPixelFormatPVRTC_RGBA_4BPP:
+    case MTLPixelFormatPVRTC_RGBA_4BPP_sRGB:
+    case MTLPixelFormatPVRTC_RGB_2BPP:
+    case MTLPixelFormatPVRTC_RGB_2BPP_sRGB:
+    case MTLPixelFormatPVRTC_RGB_4BPP:
+    case MTLPixelFormatPVRTC_RGB_4BPP_sRGB:
+        return true;
 #endif
-		default:
-			return false;
-	}
+    default:
+        return false;
+    }
 }
 
-bool MVKPixelFormats::compatibleAsLinearOrSRGB(MTLPixelFormat mtlFormat, VkFormat vkFormat) {
-	MTLPixelFormat mtlVkFmt = getMTLPixelFormat(vkFormat);
-	return ((mtlVkFmt == mtlFormat) ||
-			(mtlVkFmt == getMTLPixelFormatDesc(mtlFormat).mtlPixelFormatLinear) ||
-			(mtlFormat == getMTLPixelFormatDesc(mtlVkFmt).mtlPixelFormatLinear));
+bool MVKPixelFormats::compatibleAsLinearOrSRGB(MTLPixelFormat mtlFormat,
+                                               VkFormat vkFormat) {
+    MTLPixelFormat mtlVkFmt = getMTLPixelFormat(vkFormat);
+    return (
+        (mtlVkFmt == mtlFormat) ||
+        (mtlVkFmt == getMTLPixelFormatDesc(mtlFormat).mtlPixelFormatLinear) ||
+        (mtlFormat == getMTLPixelFormatDesc(mtlVkFmt).mtlPixelFormatLinear));
 }
 
 MVKFormatType MVKPixelFormats::getFormatType(VkFormat vkFormat) {
-	return getVkFormatDesc(vkFormat).formatType;
+    return getVkFormatDesc(vkFormat).formatType;
 }
 
 MVKFormatType MVKPixelFormats::getFormatType(MTLPixelFormat mtlFormat) {
-	return getVkFormatDesc(mtlFormat).formatType;
+    return getVkFormatDesc(mtlFormat).formatType;
 }
 
 MTLPixelFormat MVKPixelFormats::getMTLPixelFormat(VkFormat vkFormat) {
-	auto& vkDesc = getVkFormatDesc(vkFormat);
-	MTLPixelFormat mtlPixFmt = vkDesc.mtlPixelFormat;
+    auto& vkDesc = getVkFormatDesc(vkFormat);
+    MTLPixelFormat mtlPixFmt = vkDesc.mtlPixelFormat;
 
-	// If the MTLPixelFormat is not supported but VkFormat is valid,
-	// attempt to substitute a different format and potentially report an error.
-	if ( !mtlPixFmt && vkFormat && vkDesc.chromaSubsamplingPlaneCount <= 1 ) {
-		mtlPixFmt = vkDesc.mtlPixelFormatSubstitute;
+    // If the MTLPixelFormat is not supported but VkFormat is valid,
+    // attempt to substitute a different format and potentially report an error.
+    if (!mtlPixFmt && vkFormat && vkDesc.chromaSubsamplingPlaneCount <= 1) {
+        mtlPixFmt = vkDesc.mtlPixelFormatSubstitute;
 
-		// Report an error if there is no substitute, or the first time a substitution is made.
-		if ( !mtlPixFmt || !vkDesc.hasReportedSubstitution ) {
-			string errMsg;
-			errMsg += "VkFormat ";
-			errMsg += vkDesc.name;
-			errMsg += " is not supported on this device.";
+        // Report an error if there is no substitute, or the first time a
+        // substitution is made.
+        if (!mtlPixFmt || !vkDesc.hasReportedSubstitution) {
+            string errMsg;
+            errMsg += "VkFormat ";
+            errMsg += vkDesc.name;
+            errMsg += " is not supported on this device.";
 
-			if (mtlPixFmt) {
-				vkDesc.hasReportedSubstitution = true;
+            if (mtlPixFmt) {
+                vkDesc.hasReportedSubstitution = true;
 
-				auto& vkDescSubs = getVkFormatDesc(mtlPixFmt);
-				errMsg += " Using VkFormat ";
-				errMsg += vkDescSubs.name;
-				errMsg += " instead.";
-			}
-			MVKBaseObject::reportError(_physicalDevice, VK_ERROR_FORMAT_NOT_SUPPORTED, "%s", errMsg.c_str());
-		}
-	}
+                auto& vkDescSubs = getVkFormatDesc(mtlPixFmt);
+                errMsg += " Using VkFormat ";
+                errMsg += vkDescSubs.name;
+                errMsg += " instead.";
+            }
+            MVKBaseObject::reportError(_physicalDevice,
+                                       VK_ERROR_FORMAT_NOT_SUPPORTED, "%s",
+                                       errMsg.c_str());
+        }
+    }
 
-	return mtlPixFmt;
+    return mtlPixFmt;
 }
 
 VkFormat MVKPixelFormats::getVkFormat(MTLPixelFormat mtlFormat) {
@@ -313,66 +320,81 @@ uint8_t MVKPixelFormats::getChromaSubsamplingComponentBits(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).chromaSubsamplingComponentBits;
 }
 
-SPIRV_CROSS_NAMESPACE::MSLFormatResolution MVKPixelFormats::getChromaSubsamplingResolution(VkFormat vkFormat) {
+SPIRV_CROSS_NAMESPACE::MSLFormatResolution
+MVKPixelFormats::getChromaSubsamplingResolution(VkFormat vkFormat) {
     VkExtent2D blockTexelSize = getVkFormatDesc(vkFormat).blockTexelSize;
-    return (blockTexelSize.width != 2) ? SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_444
-        : (blockTexelSize.height != 2) ? SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_422
-                                       : SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_420;
+    return (blockTexelSize.width != 2)
+               ? SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_444
+           : (blockTexelSize.height != 2)
+               ? SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_422
+               : SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_420;
 }
 
-MTLPixelFormat MVKPixelFormats::getChromaSubsamplingPlaneMTLPixelFormat(VkFormat vkFormat, uint8_t planeIndex) {
+MTLPixelFormat
+MVKPixelFormats::getChromaSubsamplingPlaneMTLPixelFormat(VkFormat vkFormat,
+                                                         uint8_t planeIndex) {
     uint8_t planes = getChromaSubsamplingPlaneCount(vkFormat);
     uint8_t bits = getChromaSubsamplingComponentBits(vkFormat);
-    switch(planes) {
-        default:
-        case 1:
-            return getMTLPixelFormat(vkFormat);
-        case 2:
-            if (planeIndex == 1) {
-                return (bits == 8) ? MTLPixelFormatRG8Unorm : MTLPixelFormatRG16Unorm;
-            }
-            /* fallthrough */
-        case 3:
-            return (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
+    switch (planes) {
+    default:
+    case 1:
+        return getMTLPixelFormat(vkFormat);
+    case 2:
+        if (planeIndex == 1) {
+            return (bits == 8) ? MTLPixelFormatRG8Unorm
+                               : MTLPixelFormatRG16Unorm;
+        }
+        /* fallthrough */
+    case 3:
+        return (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
     }
 }
 
-uint8_t MVKPixelFormats::getChromaSubsamplingPlanes(VkFormat vkFormat, VkExtent2D blockTexelSize[3], uint32_t bytesPerBlock[3], MTLPixelFormat mtlPixFmt[3]) {
+uint8_t MVKPixelFormats::getChromaSubsamplingPlanes(
+    VkFormat vkFormat, VkExtent2D blockTexelSize[3], uint32_t bytesPerBlock[3],
+    MTLPixelFormat mtlPixFmt[3]) {
     uint8_t planes = getChromaSubsamplingPlaneCount(vkFormat);
     uint8_t bits = getChromaSubsamplingComponentBits(vkFormat);
-    SPIRV_CROSS_NAMESPACE::MSLFormatResolution resolution = getChromaSubsamplingResolution(vkFormat);
-    bytesPerBlock[0] = mvkCeilingDivide((uint32_t)bits/8U, 1U);
-    switch(resolution) {
-        default:
-            return 0;
-        case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_444:
-            blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] = VkExtent2D{1, 1};
-            break;
-        case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_422:
-            blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] = VkExtent2D{2, 1};
-            break;
-        case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_420:
-            blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] = VkExtent2D{2, 2};
-            break;
+    SPIRV_CROSS_NAMESPACE::MSLFormatResolution resolution =
+        getChromaSubsamplingResolution(vkFormat);
+    bytesPerBlock[0] = mvkCeilingDivide((uint32_t)bits / 8U, 1U);
+    switch (resolution) {
+    default:
+        return 0;
+    case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_444:
+        blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] =
+            VkExtent2D{1, 1};
+        break;
+    case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_422:
+        blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] =
+            VkExtent2D{2, 1};
+        break;
+    case SPIRV_CROSS_NAMESPACE::MSL_FORMAT_RESOLUTION_420:
+        blockTexelSize[0] = blockTexelSize[1] = blockTexelSize[2] =
+            VkExtent2D{2, 2};
+        break;
     }
-    switch(planes) {
-        default:
-            return 0;
-        case 1:
-            bytesPerBlock[0] *= 4;
-            mtlPixFmt[0] = getMTLPixelFormat(vkFormat);
-            break;
-        case 2:
-            blockTexelSize[0] = VkExtent2D{1, 1};
-            bytesPerBlock[1] = bytesPerBlock[0]*2;
-            mtlPixFmt[0] = (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
-            mtlPixFmt[1] = (bits == 8) ? MTLPixelFormatRG8Unorm : MTLPixelFormatRG16Unorm;
-            break;
-        case 3:
-            blockTexelSize[0] = VkExtent2D{1, 1};
-            bytesPerBlock[1] = bytesPerBlock[2] = bytesPerBlock[0];
-            mtlPixFmt[0] = mtlPixFmt[1] = mtlPixFmt[2] = (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
-            break;
+    switch (planes) {
+    default:
+        return 0;
+    case 1:
+        bytesPerBlock[0] *= 4;
+        mtlPixFmt[0] = getMTLPixelFormat(vkFormat);
+        break;
+    case 2:
+        blockTexelSize[0] = VkExtent2D{1, 1};
+        bytesPerBlock[1] = bytesPerBlock[0] * 2;
+        mtlPixFmt[0] =
+            (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
+        mtlPixFmt[1] =
+            (bits == 8) ? MTLPixelFormatRG8Unorm : MTLPixelFormatRG16Unorm;
+        break;
+    case 3:
+        blockTexelSize[0] = VkExtent2D{1, 1};
+        bytesPerBlock[1] = bytesPerBlock[2] = bytesPerBlock[0];
+        mtlPixFmt[0] = mtlPixFmt[1] = mtlPixFmt[2] =
+            (bits == 8) ? MTLPixelFormatR8Unorm : MTLPixelFormatR16Unorm;
+        break;
     }
     return planes;
 }
@@ -385,22 +407,33 @@ float MVKPixelFormats::getBytesPerTexel(MTLPixelFormat mtlFormat) {
     return getVkFormatDesc(mtlFormat).bytesPerTexel();
 }
 
-size_t MVKPixelFormats::getBytesPerRow(VkFormat vkFormat, uint32_t texelsPerRow) {
+size_t MVKPixelFormats::getBytesPerRow(VkFormat vkFormat,
+                                       uint32_t texelsPerRow) {
     auto& vkDesc = getVkFormatDesc(vkFormat);
-    return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) * vkDesc.bytesPerBlock;
+    return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) *
+           vkDesc.bytesPerBlock;
 }
 
-size_t MVKPixelFormats::getBytesPerRow(MTLPixelFormat mtlFormat, uint32_t texelsPerRow) {
-	auto& vkDesc = getVkFormatDesc(mtlFormat);
-    return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) * vkDesc.bytesPerBlock;
+size_t MVKPixelFormats::getBytesPerRow(MTLPixelFormat mtlFormat,
+                                       uint32_t texelsPerRow) {
+    auto& vkDesc = getVkFormatDesc(mtlFormat);
+    return mvkCeilingDivide(texelsPerRow, vkDesc.blockTexelSize.width) *
+           vkDesc.bytesPerBlock;
 }
 
-size_t MVKPixelFormats::getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-    return mvkCeilingDivide(texelRowsPerLayer, getVkFormatDesc(vkFormat).blockTexelSize.height) * bytesPerRow;
+size_t MVKPixelFormats::getBytesPerLayer(VkFormat vkFormat, size_t bytesPerRow,
+                                         uint32_t texelRowsPerLayer) {
+    return mvkCeilingDivide(texelRowsPerLayer,
+                            getVkFormatDesc(vkFormat).blockTexelSize.height) *
+           bytesPerRow;
 }
 
-size_t MVKPixelFormats::getBytesPerLayer(MTLPixelFormat mtlFormat, size_t bytesPerRow, uint32_t texelRowsPerLayer) {
-    return mvkCeilingDivide(texelRowsPerLayer, getVkFormatDesc(mtlFormat).blockTexelSize.height) * bytesPerRow;
+size_t MVKPixelFormats::getBytesPerLayer(MTLPixelFormat mtlFormat,
+                                         size_t bytesPerRow,
+                                         uint32_t texelRowsPerLayer) {
+    return mvkCeilingDivide(texelRowsPerLayer,
+                            getVkFormatDesc(mtlFormat).blockTexelSize.height) *
+           bytesPerRow;
 }
 
 bool MVKPixelFormats::needsSwizzle(VkFormat vkFormat) {
@@ -411,66 +444,83 @@ VkComponentMapping MVKPixelFormats::getVkComponentMapping(VkFormat vkFormat) {
     return getVkFormatDesc(vkFormat).componentMapping;
 }
 
-VkComponentMapping MVKPixelFormats::getInverseComponentMapping(VkFormat vkFormat) {
-#define INVERT_SWIZZLE(x, X, Y) \
-			case VK_COMPONENT_SWIZZLE_##X: \
-				inverse.x = VK_COMPONENT_SWIZZLE_##Y; \
-				break
-#define INVERT_MAPPING(y, Y) \
-		switch (mapping.y) { \
-			case VK_COMPONENT_SWIZZLE_IDENTITY: \
-				inverse.y = VK_COMPONENT_SWIZZLE_IDENTITY; \
-				break; \
-			INVERT_SWIZZLE(r, R, Y); \
-			INVERT_SWIZZLE(g, G, Y); \
-			INVERT_SWIZZLE(b, B, Y); \
-			INVERT_SWIZZLE(a, A, Y); \
-			default: break; \
-		}
-	VkComponentMapping mapping = getVkComponentMapping(vkFormat), inverse;
-	INVERT_MAPPING(r, R)
-	INVERT_MAPPING(g, G)
-	INVERT_MAPPING(b, B)
-	INVERT_MAPPING(a, A)
-	return inverse;
+VkComponentMapping
+MVKPixelFormats::getInverseComponentMapping(VkFormat vkFormat) {
+#define INVERT_SWIZZLE(x, X, Y)                                                \
+    case VK_COMPONENT_SWIZZLE_##X:                                             \
+        inverse.x = VK_COMPONENT_SWIZZLE_##Y;                                  \
+        break
+#define INVERT_MAPPING(y, Y)                                                   \
+    switch (mapping.y) {                                                       \
+    case VK_COMPONENT_SWIZZLE_IDENTITY:                                        \
+        inverse.y = VK_COMPONENT_SWIZZLE_IDENTITY;                             \
+        break;                                                                 \
+        INVERT_SWIZZLE(r, R, Y);                                               \
+        INVERT_SWIZZLE(g, G, Y);                                               \
+        INVERT_SWIZZLE(b, B, Y);                                               \
+        INVERT_SWIZZLE(a, A, Y);                                               \
+    default:                                                                   \
+        break;                                                                 \
+    }
+    VkComponentMapping mapping = getVkComponentMapping(vkFormat), inverse;
+    INVERT_MAPPING(r, R)
+    INVERT_MAPPING(g, G)
+    INVERT_MAPPING(b, B)
+    INVERT_MAPPING(a, A)
+    return inverse;
 #undef INVERT_MAPPING
 #undef INVERT_SWIZZLE
 }
 
-MTLTextureSwizzleChannels MVKPixelFormats::getMTLTextureSwizzleChannels(VkFormat vkFormat) {
-	return mvkMTLTextureSwizzleChannelsFromVkComponentMapping(getVkComponentMapping(vkFormat));
+MTLTextureSwizzleChannels
+MVKPixelFormats::getMTLTextureSwizzleChannels(VkFormat vkFormat) {
+    return mvkMTLTextureSwizzleChannelsFromVkComponentMapping(
+        getVkComponentMapping(vkFormat));
 }
 
-VkFormatProperties3& MVKPixelFormats::getVkFormatProperties3(VkFormat vkFormat) {
-	return getVkFormatDesc(vkFormat).properties;
+VkFormatProperties3&
+MVKPixelFormats::getVkFormatProperties3(VkFormat vkFormat) {
+    return getVkFormatDesc(vkFormat).properties;
 }
 
 VkFormatProperties MVKPixelFormats::getVkFormatProperties(VkFormat vkFormat) {
     auto& properties = getVkFormatProperties3(vkFormat);
     VkFormatProperties ret;
-    ret.linearTilingFeatures = MVKPixelFormats::convertFormatPropertiesFlagBits(properties.linearTilingFeatures);
-    ret.optimalTilingFeatures = MVKPixelFormats::convertFormatPropertiesFlagBits(properties.optimalTilingFeatures);
-    ret.bufferFeatures = MVKPixelFormats::convertFormatPropertiesFlagBits(properties.bufferFeatures);
+    ret.linearTilingFeatures = MVKPixelFormats::convertFormatPropertiesFlagBits(
+        properties.linearTilingFeatures);
+    ret.optimalTilingFeatures =
+        MVKPixelFormats::convertFormatPropertiesFlagBits(
+            properties.optimalTilingFeatures);
+    ret.bufferFeatures = MVKPixelFormats::convertFormatPropertiesFlagBits(
+        properties.bufferFeatures);
     return ret;
 }
 
-MVKMTLFmtCaps MVKPixelFormats::getCapabilities(VkFormat vkFormat, bool isExtended) {
-	return getCapabilities(getVkFormatDesc(vkFormat).mtlPixelFormat, isExtended);
+MVKMTLFmtCaps MVKPixelFormats::getCapabilities(VkFormat vkFormat,
+                                               bool isExtended) {
+    return getCapabilities(getVkFormatDesc(vkFormat).mtlPixelFormat,
+                           isExtended);
 }
 
-MVKMTLFmtCaps MVKPixelFormats::getCapabilities(MTLPixelFormat mtlFormat, bool isExtended) {
+MVKMTLFmtCaps MVKPixelFormats::getCapabilities(MTLPixelFormat mtlFormat,
+                                               bool isExtended) {
     MVKMTLFormatDesc& mtlDesc = getMTLPixelFormatDesc(mtlFormat);
     MVKMTLFmtCaps caps = mtlDesc.mtlFmtCaps;
-    if (!isExtended || mtlDesc.mtlViewClass == MVKMTLViewClass::None) { return caps; }
+    if (!isExtended || mtlDesc.mtlViewClass == MVKMTLViewClass::None) {
+        return caps;
+    }
     // Now get caps of all formats in the view class.
     for (auto& otherDesc : _mtlPixelFormatDescriptions) {
-        if (otherDesc.mtlViewClass == mtlDesc.mtlViewClass) { caps |= otherDesc.mtlFmtCaps; }
+        if (otherDesc.mtlViewClass == mtlDesc.mtlViewClass) {
+            caps |= otherDesc.mtlFmtCaps;
+        }
     }
     return caps;
 }
 
 MVKMTLViewClass MVKPixelFormats::getViewClass(VkFormat vkFormat) {
-    return getMTLPixelFormatDesc(getVkFormatDesc(vkFormat).mtlPixelFormat).mtlViewClass;
+    return getMTLPixelFormatDesc(getVkFormatDesc(vkFormat).mtlPixelFormat)
+        .mtlViewClass;
 }
 
 MVKMTLViewClass MVKPixelFormats::getViewClass(MTLPixelFormat mtlFormat) {
@@ -489,1271 +539,1769 @@ const char* MVKPixelFormats::getName(MTLVertexFormat mtlFormat) {
     return getMTLVertexFormatDesc(mtlFormat).name;
 }
 
-void MVKPixelFormats::enumerateSupportedFormats(const VkFormatProperties3& properties, bool any, std::function<bool(VkFormat)> func) {
-	static const auto areFeaturesSupported = [any](VkFlags64 a, VkFlags64 b) {
-		if (b == 0) return true;
-		if (any)
-			return mvkIsAnyFlagEnabled(a, b);
-		else
-			return mvkAreAllFlagsEnabled(a, b);
-	};
-	for (auto& vkDesc : _vkFormatDescriptions) {
-		if (vkDesc.isSupported() &&
-			areFeaturesSupported(vkDesc.properties.linearTilingFeatures, properties.linearTilingFeatures) &&
-			areFeaturesSupported(vkDesc.properties.optimalTilingFeatures, properties.optimalTilingFeatures) &&
-			areFeaturesSupported(vkDesc.properties.bufferFeatures, properties.bufferFeatures)) {
-			if ( !func(vkDesc.vkFormat) ) {
-				break;
-			}
-		}
-	}
+void MVKPixelFormats::enumerateSupportedFormats(
+    const VkFormatProperties3& properties, bool any,
+    std::function<bool(VkFormat)> func) {
+    static const auto areFeaturesSupported = [any](VkFlags64 a, VkFlags64 b) {
+        if (b == 0) return true;
+        if (any)
+            return mvkIsAnyFlagEnabled(a, b);
+        else
+            return mvkAreAllFlagsEnabled(a, b);
+    };
+    for (auto& vkDesc : _vkFormatDescriptions) {
+        if (vkDesc.isSupported() &&
+            areFeaturesSupported(vkDesc.properties.linearTilingFeatures,
+                                 properties.linearTilingFeatures) &&
+            areFeaturesSupported(vkDesc.properties.optimalTilingFeatures,
+                                 properties.optimalTilingFeatures) &&
+            areFeaturesSupported(vkDesc.properties.bufferFeatures,
+                                 properties.bufferFeatures)) {
+            if (!func(vkDesc.vkFormat)) {
+                break;
+            }
+        }
+    }
 }
 
 MTLVertexFormat MVKPixelFormats::getMTLVertexFormat(VkFormat vkFormat) {
-	auto& vkDesc = getVkFormatDesc(vkFormat);
-	MTLVertexFormat mtlVtxFmt = vkDesc.mtlVertexFormat;
+    auto& vkDesc = getVkFormatDesc(vkFormat);
+    MTLVertexFormat mtlVtxFmt = vkDesc.mtlVertexFormat;
 
-	// If the MTLVertexFormat is not supported but VkFormat is valid,
-	// report an error, and possibly substitute a different MTLVertexFormat.
-	if ( !mtlVtxFmt && vkFormat ) {
-		string errMsg;
-		errMsg += "VkFormat ";
-		errMsg += vkDesc.name;
-		errMsg += " is not supported for vertex buffers on this device.";
+    // If the MTLVertexFormat is not supported but VkFormat is valid,
+    // report an error, and possibly substitute a different MTLVertexFormat.
+    if (!mtlVtxFmt && vkFormat) {
+        string errMsg;
+        errMsg += "VkFormat ";
+        errMsg += vkDesc.name;
+        errMsg += " is not supported for vertex buffers on this device.";
 
-		if (vkDesc.vertexIsSupportedOrSubstitutable()) {
-			mtlVtxFmt = vkDesc.mtlVertexFormatSubstitute;
+        if (vkDesc.vertexIsSupportedOrSubstitutable()) {
+            mtlVtxFmt = vkDesc.mtlVertexFormatSubstitute;
 
-			auto& vkDescSubs = getVkFormatDesc(getMTLVertexFormatDesc(mtlVtxFmt).vkFormat);
-			errMsg += " Using VkFormat ";
-			errMsg += vkDescSubs.name;
-			errMsg += " instead.";
-		}
-		MVKBaseObject::reportError(_physicalDevice, VK_ERROR_FORMAT_NOT_SUPPORTED, "%s", errMsg.c_str());
-	}
+            auto& vkDescSubs =
+                getVkFormatDesc(getMTLVertexFormatDesc(mtlVtxFmt).vkFormat);
+            errMsg += " Using VkFormat ";
+            errMsg += vkDescSubs.name;
+            errMsg += " instead.";
+        }
+        MVKBaseObject::reportError(_physicalDevice,
+                                   VK_ERROR_FORMAT_NOT_SUPPORTED, "%s",
+                                   errMsg.c_str());
+    }
 
-	return mtlVtxFmt;
+    return mtlVtxFmt;
 }
 
-MTLClearColor MVKPixelFormats::getMTLClearColor(VkClearValue vkClearValue, VkFormat vkFormat) {
-	MTLClearColor mtlClr;
-	// The VkComponentMapping (and its MTLTextureSwizzleChannels equivalent) define the *sources*
-	// for the texture color components for reading. Since we're *writing* to the texture,
-	// we need to *invert* the mapping.
-	// n.b. Bad things might happen if the original swizzle isn't one-to-one!
-	VkComponentMapping inverseMap = getInverseComponentMapping(vkFormat);
-	switch (getFormatType(vkFormat)) {
-		case kMVKFormatColorHalf:
-		case kMVKFormatColorFloat: {
-			mtlClr.red		= mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color.float32, 0, inverseMap.r);
-			mtlClr.green	= mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color.float32, 1, inverseMap.g);
-			mtlClr.blue		= mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color.float32, 2, inverseMap.b);
-			mtlClr.alpha	= mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color.float32, 3, inverseMap.a);
+MTLClearColor MVKPixelFormats::getMTLClearColor(VkClearValue vkClearValue,
+                                                VkFormat vkFormat) {
+    MTLClearColor mtlClr;
+    // The VkComponentMapping (and its MTLTextureSwizzleChannels equivalent)
+    // define the *sources* for the texture color components for reading. Since
+    // we're *writing* to the texture, we need to *invert* the mapping. n.b. Bad
+    // things might happen if the original swizzle isn't one-to-one!
+    VkComponentMapping inverseMap = getInverseComponentMapping(vkFormat);
+    switch (getFormatType(vkFormat)) {
+    case kMVKFormatColorHalf:
+    case kMVKFormatColorFloat: {
+        mtlClr.red =
+            mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color
+                                                                .float32,
+                                                            0, inverseMap.r);
+        mtlClr.green =
+            mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color
+                                                                .float32,
+                                                            1, inverseMap.g);
+        mtlClr.blue =
+            mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color
+                                                                .float32,
+                                                            2, inverseMap.b);
+        mtlClr.alpha =
+            mvkVkClearColorFloatValueFromVkComponentSwizzle(vkClearValue.color
+                                                                .float32,
+                                                            3, inverseMap.a);
 
-			if (_physicalDevice && _physicalDevice->getMetalFeatures()->clearColorFloatRounding == MVK_FLOAT_ROUNDING_DOWN) {
-				// For normalized formats, increment the clear value by half the ULP
-				// (i.e. 1/(2*(2**component_size - 1))), to force Metal to round up.
-				// This should fix some problems with clear values being off by one ULP on some platforms.
-				// This adjustment is not performed on SRGB formats, which Vulkan
-				// requires to be treated as linear, with the value managed by the app.
-#define OFFSET_NORM(MIN_VAL, COLOR, BIT_WIDTH)  \
-	if (mtlClr.COLOR > (MIN_VAL) && mtlClr.COLOR < 1.0) {  \
-		mtlClr.COLOR += 1.0 / (2.0 * ((1U << (BIT_WIDTH)) - 1));  \
-	}
-#define OFFSET_UNORM(COLOR, BIT_WIDTH)    OFFSET_NORM(0.0, COLOR, BIT_WIDTH)
-#define OFFSET_SNORM(COLOR, BIT_WIDTH)    OFFSET_NORM(-1.0, COLOR, BIT_WIDTH - 1)
-				switch (vkFormat) {
-					case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
-					case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
-					case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
-					case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
-						OFFSET_UNORM(red, 4)
-						OFFSET_UNORM(green, 4)
-						OFFSET_UNORM(blue, 4)
-						OFFSET_UNORM(alpha, 4)
-						break;
-					case VK_FORMAT_R5G6B5_UNORM_PACK16:
-					case VK_FORMAT_B5G6R5_UNORM_PACK16:
-						OFFSET_UNORM(red, 5)
-						OFFSET_UNORM(green, 6)
-						OFFSET_UNORM(blue, 5)
-						break;
-					case VK_FORMAT_R5G5B5A1_UNORM_PACK16:
-					case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
-					case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
-						OFFSET_UNORM(red, 5)
-						OFFSET_UNORM(green, 5)
-						OFFSET_UNORM(blue, 5)
-						break;
-					case VK_FORMAT_R8_UNORM:
-						OFFSET_UNORM(red, 8)
-						break;
-					case VK_FORMAT_R8_SNORM:
-						OFFSET_SNORM(red, 8)
-						break;
-					case VK_FORMAT_R8G8_UNORM:
-						OFFSET_UNORM(red, 8)
-						OFFSET_UNORM(green, 8)
-						break;
-					case VK_FORMAT_R8G8_SNORM:
-						OFFSET_SNORM(red, 8)
-						OFFSET_SNORM(green, 8)
-						break;
-					case VK_FORMAT_R8G8B8A8_UNORM:
-					case VK_FORMAT_B8G8R8A8_UNORM:
-					case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
-						OFFSET_UNORM(red, 8)
-						OFFSET_UNORM(green, 8)
-						OFFSET_UNORM(blue, 8)
-						OFFSET_UNORM(alpha, 8)
-						break;
-					case VK_FORMAT_R8G8B8A8_SNORM:
-						OFFSET_SNORM(red, 8)
-						OFFSET_SNORM(green, 8)
-						OFFSET_SNORM(blue, 8)
-						OFFSET_SNORM(alpha, 8)
-						break;
-					case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
-					case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
-						OFFSET_UNORM(red, 10)
-						OFFSET_UNORM(green, 10)
-						OFFSET_UNORM(blue, 10)
-						OFFSET_UNORM(alpha, 2)
-						break;
-					case VK_FORMAT_R16_UNORM:
-						OFFSET_UNORM(red, 16)
-						break;
-					case VK_FORMAT_R16_SNORM:
-						OFFSET_SNORM(red, 16)
-						break;
-					case VK_FORMAT_R16G16_UNORM:
-						OFFSET_UNORM(red, 16)
-						OFFSET_UNORM(green, 16)
-						break;
-					case VK_FORMAT_R16G16_SNORM:
-						OFFSET_SNORM(red, 16)
-						OFFSET_SNORM(green, 16)
-						break;
-					case VK_FORMAT_R16G16B16A16_UNORM:
-						OFFSET_UNORM(red, 16)
-						OFFSET_UNORM(green, 16)
-						OFFSET_UNORM(blue, 16)
-						OFFSET_UNORM(alpha, 16)
-						break;
-					case VK_FORMAT_R16G16B16A16_SNORM:
-						OFFSET_SNORM(red, 16)
-						OFFSET_SNORM(green, 16)
-						OFFSET_SNORM(blue, 16)
-						OFFSET_SNORM(alpha, 16)
-						break;
-					default:
-						break;
-				}
+        if (_physicalDevice &&
+            _physicalDevice->getMetalFeatures()->clearColorFloatRounding ==
+                MVK_FLOAT_ROUNDING_DOWN) {
+            // For normalized formats, increment the clear value by half the ULP
+            // (i.e. 1/(2*(2**component_size - 1))), to force Metal to round up.
+            // This should fix some problems with clear values being off by one
+            // ULP on some platforms. This adjustment is not performed on SRGB
+            // formats, which Vulkan requires to be treated as linear, with the
+            // value managed by the app.
+#define OFFSET_NORM(MIN_VAL, COLOR, BIT_WIDTH)                                 \
+    if (mtlClr.COLOR > (MIN_VAL) && mtlClr.COLOR < 1.0) {                      \
+        mtlClr.COLOR += 1.0 / (2.0 * ((1U << (BIT_WIDTH)) - 1));               \
+    }
+#define OFFSET_UNORM(COLOR, BIT_WIDTH) OFFSET_NORM(0.0, COLOR, BIT_WIDTH)
+#define OFFSET_SNORM(COLOR, BIT_WIDTH) OFFSET_NORM(-1.0, COLOR, BIT_WIDTH - 1)
+            switch (vkFormat) {
+            case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+            case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
+            case VK_FORMAT_A4R4G4B4_UNORM_PACK16:
+            case VK_FORMAT_A4B4G4R4_UNORM_PACK16:
+                OFFSET_UNORM(red, 4)
+                OFFSET_UNORM(green, 4)
+                OFFSET_UNORM(blue, 4)
+                OFFSET_UNORM(alpha, 4)
+                break;
+            case VK_FORMAT_R5G6B5_UNORM_PACK16:
+            case VK_FORMAT_B5G6R5_UNORM_PACK16:
+                OFFSET_UNORM(red, 5)
+                OFFSET_UNORM(green, 6)
+                OFFSET_UNORM(blue, 5)
+                break;
+            case VK_FORMAT_R5G5B5A1_UNORM_PACK16:
+            case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
+            case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
+                OFFSET_UNORM(red, 5)
+                OFFSET_UNORM(green, 5)
+                OFFSET_UNORM(blue, 5)
+                break;
+            case VK_FORMAT_R8_UNORM:
+                OFFSET_UNORM(red, 8)
+                break;
+            case VK_FORMAT_R8_SNORM:
+                OFFSET_SNORM(red, 8)
+                break;
+            case VK_FORMAT_R8G8_UNORM:
+                OFFSET_UNORM(red, 8)
+                OFFSET_UNORM(green, 8)
+                break;
+            case VK_FORMAT_R8G8_SNORM:
+                OFFSET_SNORM(red, 8)
+                OFFSET_SNORM(green, 8)
+                break;
+            case VK_FORMAT_R8G8B8A8_UNORM:
+            case VK_FORMAT_B8G8R8A8_UNORM:
+            case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+                OFFSET_UNORM(red, 8)
+                OFFSET_UNORM(green, 8)
+                OFFSET_UNORM(blue, 8)
+                OFFSET_UNORM(alpha, 8)
+                break;
+            case VK_FORMAT_R8G8B8A8_SNORM:
+                OFFSET_SNORM(red, 8)
+                OFFSET_SNORM(green, 8)
+                OFFSET_SNORM(blue, 8)
+                OFFSET_SNORM(alpha, 8)
+                break;
+            case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+            case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
+                OFFSET_UNORM(red, 10)
+                OFFSET_UNORM(green, 10)
+                OFFSET_UNORM(blue, 10)
+                OFFSET_UNORM(alpha, 2)
+                break;
+            case VK_FORMAT_R16_UNORM:
+                OFFSET_UNORM(red, 16)
+                break;
+            case VK_FORMAT_R16_SNORM:
+                OFFSET_SNORM(red, 16)
+                break;
+            case VK_FORMAT_R16G16_UNORM:
+                OFFSET_UNORM(red, 16)
+                OFFSET_UNORM(green, 16)
+                break;
+            case VK_FORMAT_R16G16_SNORM:
+                OFFSET_SNORM(red, 16)
+                OFFSET_SNORM(green, 16)
+                break;
+            case VK_FORMAT_R16G16B16A16_UNORM:
+                OFFSET_UNORM(red, 16)
+                OFFSET_UNORM(green, 16)
+                OFFSET_UNORM(blue, 16)
+                OFFSET_UNORM(alpha, 16)
+                break;
+            case VK_FORMAT_R16G16B16A16_SNORM:
+                OFFSET_SNORM(red, 16)
+                OFFSET_SNORM(green, 16)
+                OFFSET_SNORM(blue, 16)
+                OFFSET_SNORM(alpha, 16)
+                break;
+            default:
+                break;
+            }
 #undef OFFSET_UNORM
 #undef OFFSET_SNORM
 #undef OFFSET_NORM
-			}
-			break;
-		}
-		case kMVKFormatColorUInt8:
-		case kMVKFormatColorUInt16:
-		case kMVKFormatColorUInt32:
-			mtlClr.red   = mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color.uint32, 0, inverseMap.r);
-			mtlClr.green = mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color.uint32, 1, inverseMap.g);
-			mtlClr.blue  = mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color.uint32, 2, inverseMap.b);
-			mtlClr.alpha = mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color.uint32, 3, inverseMap.a);
-			break;
-		case kMVKFormatColorInt8:
-		case kMVKFormatColorInt16:
-		case kMVKFormatColorInt32:
-			mtlClr.red   = mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color.int32, 0, inverseMap.r);
-			mtlClr.green = mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color.int32, 1, inverseMap.g);
-			mtlClr.blue  = mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color.int32, 2, inverseMap.b);
-			mtlClr.alpha = mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color.int32, 3, inverseMap.a);
-			break;
-		default:
-			mtlClr.red   = 0.0;
-			mtlClr.green = 0.0;
-			mtlClr.blue  = 0.0;
-			mtlClr.alpha = 1.0;
-			break;
-	}
-	return mtlClr;
+        }
+        break;
+    }
+    case kMVKFormatColorUInt8:
+    case kMVKFormatColorUInt16:
+    case kMVKFormatColorUInt32:
+        mtlClr.red =
+            mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                               .uint32,
+                                                           0, inverseMap.r);
+        mtlClr.green =
+            mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                               .uint32,
+                                                           1, inverseMap.g);
+        mtlClr.blue =
+            mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                               .uint32,
+                                                           2, inverseMap.b);
+        mtlClr.alpha =
+            mvkVkClearColorUIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                               .uint32,
+                                                           3, inverseMap.a);
+        break;
+    case kMVKFormatColorInt8:
+    case kMVKFormatColorInt16:
+    case kMVKFormatColorInt32:
+        mtlClr.red =
+            mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                              .int32,
+                                                          0, inverseMap.r);
+        mtlClr.green =
+            mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                              .int32,
+                                                          1, inverseMap.g);
+        mtlClr.blue =
+            mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                              .int32,
+                                                          2, inverseMap.b);
+        mtlClr.alpha =
+            mvkVkClearColorIntValueFromVkComponentSwizzle(vkClearValue.color
+                                                              .int32,
+                                                          3, inverseMap.a);
+        break;
+    default:
+        mtlClr.red = 0.0;
+        mtlClr.green = 0.0;
+        mtlClr.blue = 0.0;
+        mtlClr.alpha = 1.0;
+        break;
+    }
+    return mtlClr;
 }
 
 double MVKPixelFormats::getMTLClearDepthValue(VkClearValue vkClearValue) {
-	return vkClearValue.depthStencil.depth;
+    return vkClearValue.depthStencil.depth;
 }
 
 uint32_t MVKPixelFormats::getMTLClearStencilValue(VkClearValue vkClearValue) {
-	return vkClearValue.depthStencil.stencil;
+    return vkClearValue.depthStencil.stencil;
 }
 
-VkImageUsageFlags MVKPixelFormats::getVkImageUsageFlags(MTLTextureUsage mtlUsage,
-														MTLPixelFormat mtlFormat) {
+VkImageUsageFlags
+MVKPixelFormats::getVkImageUsageFlags(MTLTextureUsage mtlUsage,
+                                      MTLPixelFormat mtlFormat) {
     VkImageUsageFlags vkImageUsageFlags = 0;
 
-    if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderRead) ) {
+    if (mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderRead)) {
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_SAMPLED_BIT);
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     }
-    if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageRenderTarget) ) {
+    if (mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageRenderTarget)) {
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
         if (isDepthFormat(mtlFormat) || isStencilFormat(mtlFormat)) {
-            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags,
+                           VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         } else {
-            mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+            mvkEnableFlags(vkImageUsageFlags,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
         }
     }
-    if ( mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderWrite) ) {
+    if (mvkAreAllFlagsEnabled(mtlUsage, MTLTextureUsageShaderWrite)) {
         mvkEnableFlags(vkImageUsageFlags, VK_IMAGE_USAGE_STORAGE_BIT);
     }
 
     return vkImageUsageFlags;
 }
 
-MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsageFlags,
-													MTLPixelFormat mtlFormat,
-													VkSampleCountFlagBits samples,
-                                                    bool isLinear,
-                                                    bool needsReinterpretation,
-                                                    bool isExtended,
-													bool supportAtomics) {
-	bool isDepthFmt = isDepthFormat(mtlFormat);
-	bool isStencilFmt = isStencilFormat(mtlFormat);
-	bool isCombinedDepthStencilFmt = isDepthFmt && isStencilFmt;
-	bool isColorFormat = !(isDepthFmt || isStencilFmt);
-	bool supportsStencilViews = _physicalDevice ? _physicalDevice->getMetalFeatures()->stencilViews : false;
-	MVKMTLFmtCaps mtlFmtCaps = getCapabilities(mtlFormat, isExtended);
+MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(
+    VkImageUsageFlags vkImageUsageFlags, MTLPixelFormat mtlFormat,
+    VkSampleCountFlagBits samples, bool isLinear, bool needsReinterpretation,
+    bool isExtended, bool supportAtomics) {
+    bool isDepthFmt = isDepthFormat(mtlFormat);
+    bool isStencilFmt = isStencilFormat(mtlFormat);
+    bool isCombinedDepthStencilFmt = isDepthFmt && isStencilFmt;
+    bool isColorFormat = !(isDepthFmt || isStencilFmt);
+    bool supportsStencilViews =
+        _physicalDevice ? _physicalDevice->getMetalFeatures()->stencilViews
+                        : false;
+    MVKMTLFmtCaps mtlFmtCaps = getCapabilities(mtlFormat, isExtended);
 
-	MTLTextureUsage mtlUsage = MTLTextureUsageUnknown;
+    MTLTextureUsage mtlUsage = MTLTextureUsageUnknown;
 
-	// Read from...
-	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-												VK_IMAGE_USAGE_SAMPLED_BIT |
-												VK_IMAGE_USAGE_STORAGE_BIT |
-												VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT))) {
-		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderRead);
-	}
+    // Read from...
+    if (mvkIsAnyFlagEnabled(vkImageUsageFlags,
+                            (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                             VK_IMAGE_USAGE_SAMPLED_BIT |
+                             VK_IMAGE_USAGE_STORAGE_BIT |
+                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT))) {
+        mvkEnableFlags(mtlUsage, MTLTextureUsageShaderRead);
+    }
 
-	// Write to, but only if format supports writing...
-	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_STORAGE_BIT)) &&
-		mvkIsAnyFlagEnabled(mtlFmtCaps, kMVKMTLFmtCapsWrite)) {
+    // Write to, but only if format supports writing...
+    if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_STORAGE_BIT)) &&
+        mvkIsAnyFlagEnabled(mtlFmtCaps, kMVKMTLFmtCapsWrite)) {
 
-		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
-	}
+        mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
+    }
 
 #if MVK_XCODE_15
-	if (supportAtomics && (mtlFormat == MTLPixelFormatR32Uint || mtlFormat == MTLPixelFormatR32Sint || mtlFormat == MTLPixelFormatRG32Uint)) {
-		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderAtomic);
-	}
+    if (supportAtomics && (mtlFormat == MTLPixelFormatR32Uint ||
+                           mtlFormat == MTLPixelFormatR32Sint ||
+                           mtlFormat == MTLPixelFormatRG32Uint)) {
+        mvkEnableFlags(mtlUsage, MTLTextureUsageShaderAtomic);
+    }
 #endif
 
 #if MVK_MACOS
     // Clearing a linear image may use shader writes.
-    if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_DST_BIT)) &&
+    if (mvkIsAnyFlagEnabled(vkImageUsageFlags,
+                            (VK_IMAGE_USAGE_TRANSFER_DST_BIT)) &&
         mvkIsAnyFlagEnabled(mtlFmtCaps, kMVKMTLFmtCapsWrite) && isLinear) {
 
-		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
+        mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
     }
 #endif
 
-	// Render to but only if format supports rendering...
-	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-												VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-												VK_IMAGE_USAGE_TRANSFER_DST_BIT)) &&	// Scaling a BLIT may use rendering.
-		mvkIsAnyFlagEnabled(mtlFmtCaps, (kMVKMTLFmtCapsColorAtt | kMVKMTLFmtCapsDSAtt))) {
+    // Render to but only if format supports rendering...
+    if (mvkIsAnyFlagEnabled(
+            vkImageUsageFlags,
+            (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+             VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+             VK_IMAGE_USAGE_TRANSFER_DST_BIT)) && // Scaling a BLIT may use
+                                                  // rendering.
+        mvkIsAnyFlagEnabled(mtlFmtCaps,
+                            (kMVKMTLFmtCapsColorAtt | kMVKMTLFmtCapsDSAtt))) {
 
 #if MVK_MACOS
-        if(!isLinear || (_physicalDevice && _physicalDevice->getMetalFeatures()->renderLinearTextures)) {
+        if (!isLinear ||
+            (_physicalDevice &&
+             _physicalDevice->getMetalFeatures()->renderLinearTextures)) {
             mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
         }
 #else
         mvkEnableFlags(mtlUsage, MTLTextureUsageRenderTarget);
 #endif
-	}
+    }
 
-	// Resolving an MSAA color attachment whose format Metal cannot resolve natively, may use a compute shader
-	// to perform theh resolve, by reading from the multisample texture and writing to the single-sample texture.
-	if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) &&
-		!mvkIsAnyFlagEnabled(mtlFmtCaps, kMVKMTLFmtCapsResolve)) {
+    // Resolving an MSAA color attachment whose format Metal cannot resolve
+    // natively, may use a compute shader to perform theh resolve, by reading
+    // from the multisample texture and writing to the single-sample texture.
+    if (mvkIsAnyFlagEnabled(vkImageUsageFlags,
+                            (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) &&
+        !mvkIsAnyFlagEnabled(mtlFmtCaps, kMVKMTLFmtCapsResolve)) {
 
-		mvkEnableFlags(mtlUsage, samples == VK_SAMPLE_COUNT_1_BIT ? MTLTextureUsageShaderWrite : MTLTextureUsageShaderRead);
-	}
+        mvkEnableFlags(mtlUsage, samples == VK_SAMPLE_COUNT_1_BIT
+                                     ? MTLTextureUsageShaderWrite
+                                     : MTLTextureUsageShaderRead);
+    }
 
-	bool pfv = false;
+    bool pfv = false;
 
-	// Swizzle emulation may need to reinterpret
-	needsReinterpretation |= !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle;
+    // Swizzle emulation may need to reinterpret
+    needsReinterpretation |=
+        !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle;
 
-	pfv |= isColorFormat && needsReinterpretation &&
-	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_SAMPLED_BIT |
-	                                               VK_IMAGE_USAGE_STORAGE_BIT |
-	                                               VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
-	                                               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
-	pfv |= isCombinedDepthStencilFmt && supportsStencilViews &&
-	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | // May use temp view if transfer involves format change
-	                                               VK_IMAGE_USAGE_SAMPLED_BIT |
-	                                               VK_IMAGE_USAGE_STORAGE_BIT |
-	                                               VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
+    pfv |= isColorFormat && needsReinterpretation &&
+           mvkIsAnyFlagEnabled(vkImageUsageFlags,
+                               (VK_IMAGE_USAGE_SAMPLED_BIT |
+                                VK_IMAGE_USAGE_STORAGE_BIT |
+                                VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
+    pfv |=
+        isCombinedDepthStencilFmt && supportsStencilViews &&
+        mvkIsAnyFlagEnabled(
+            vkImageUsageFlags,
+            (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | // May use temp view if transfer
+                                               // involves format change
+             VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT |
+             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT));
 
-	if (pfv) {
-		mvkEnableFlags(mtlUsage, MTLTextureUsagePixelFormatView);
-	}
+    if (pfv) {
+        mvkEnableFlags(mtlUsage, MTLTextureUsagePixelFormatView);
+    }
 
-	return mtlUsage;
+    return mtlUsage;
 }
 
-// Return a reference to the Vulkan format descriptor corresponding to the VkFormat.
+// Return a reference to the Vulkan format descriptor corresponding to the
+// VkFormat.
 MVKVkFormatDesc& MVKPixelFormats::getVkFormatDesc(VkFormat vkFormat) {
-	return _vkFormatDescriptions[vkFormat];
+    return _vkFormatDescriptions[vkFormat];
 }
 
-// Return a reference to the Vulkan format descriptor corresponding to the MTLPixelFormat.
+// Return a reference to the Vulkan format descriptor corresponding to the
+// MTLPixelFormat.
 MVKVkFormatDesc& MVKPixelFormats::getVkFormatDesc(MTLPixelFormat mtlFormat) {
-	return getVkFormatDesc(getMTLPixelFormatDesc(mtlFormat).vkFormat);
+    return getVkFormatDesc(getMTLPixelFormatDesc(mtlFormat).vkFormat);
 }
 
-// Return a reference to the Metal format descriptor corresponding to the MTLPixelFormat.
-MVKMTLFormatDesc& MVKPixelFormats::getMTLPixelFormatDesc(MTLPixelFormat mtlFormat) {
-	return _mtlPixelFormatDescriptions[mtlFormat];
+// Return a reference to the Metal format descriptor corresponding to the
+// MTLPixelFormat.
+MVKMTLFormatDesc&
+MVKPixelFormats::getMTLPixelFormatDesc(MTLPixelFormat mtlFormat) {
+    return _mtlPixelFormatDescriptions[mtlFormat];
 }
 
-// Return a reference to the Metal format descriptor corresponding to the MTLVertexFormat.
-MVKMTLFormatDesc& MVKPixelFormats::getMTLVertexFormatDesc(MTLVertexFormat mtlFormat) {
-	return _mtlVertexFormatDescriptions[mtlFormat];
+// Return a reference to the Metal format descriptor corresponding to the
+// MTLVertexFormat.
+MVKMTLFormatDesc&
+MVKPixelFormats::getMTLVertexFormatDesc(MTLVertexFormat mtlFormat) {
+    return _mtlVertexFormatDescriptions[mtlFormat];
 }
 
-VkFormatFeatureFlags MVKPixelFormats::convertFormatPropertiesFlagBits(VkFormatFeatureFlags2 flags) {
+VkFormatFeatureFlags
+MVKPixelFormats::convertFormatPropertiesFlagBits(VkFormatFeatureFlags2 flags) {
     // Truncate to 32-bits and just return. All current values are identical.
     return static_cast<VkFormatFeatureFlags>(flags);
 }
 
-
 #pragma mark Construction
 
-MVKPixelFormats::MVKPixelFormats(MVKPhysicalDevice* physicalDevice) : _physicalDevice(physicalDevice) {
+MVKPixelFormats::MVKPixelFormats(MVKPhysicalDevice* physicalDevice)
+    : _physicalDevice(physicalDevice) {
 
-	const auto& gpuCaps = _physicalDevice ? _physicalDevice->getMTLDeviceCapabilities() : MVKMTLDeviceCapabilities(getMTLDevice());
+    const auto& gpuCaps = _physicalDevice
+                              ? _physicalDevice->getMTLDeviceCapabilities()
+                              : MVKMTLDeviceCapabilities(getMTLDevice());
 
-	// Build and update the Metal formats
-	initMTLPixelFormatCapabilities(gpuCaps);
-	initMTLVertexFormatCapabilities(gpuCaps);
-	modifyMTLFormatCapabilities(gpuCaps);
+    // Build and update the Metal formats
+    initMTLPixelFormatCapabilities(gpuCaps);
+    initMTLVertexFormatCapabilities(gpuCaps);
+    modifyMTLFormatCapabilities(gpuCaps);
 
-	// Build the Vulkan formats and link them to the Metal formats
-	initVkFormatCapabilities();
-	buildVkFormatMaps(gpuCaps);
+    // Build the Vulkan formats and link them to the Metal formats
+    initVkFormatCapabilities();
+    buildVkFormatMaps(gpuCaps);
 }
 
-// Call this sparsely. If there is no physical device, this operation may be costly.
-// If supporting a physical device, retrieve the MTLDevice from it, otherwise
-// retrieve the array of physical GPU devices, and use the first one.
+// Call this sparsely. If there is no physical device, this operation may be
+// costly. If supporting a physical device, retrieve the MTLDevice from it,
+// otherwise retrieve the array of physical GPU devices, and use the first one.
 // Retrieving the GPUs creates a number of autoreleased instances of Metal
 // and other Obj-C classes, so wrap it all in an autorelease pool.
 id<MTLDevice> MVKPixelFormats::getMTLDevice() {
-	if (_physicalDevice) { return _physicalDevice->getMTLDevice(); }
-	@autoreleasepool {
-		auto* mtlDevs = mvkGetAvailableMTLDevicesArray(nullptr);
-		return mtlDevs.count ? mtlDevs[0] : nil;
-	}
+    if (_physicalDevice) {
+        return _physicalDevice->getMTLDevice();
+    }
+    @autoreleasepool {
+        auto* mtlDevs = mvkGetAvailableMTLDevicesArray(nullptr);
+        return mtlDevs.count ? mtlDevs[0] : nil;
+    }
 }
 
-#define addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A)  \
-	vkFmt = VK_FORMAT_ ##VK_FMT;  \
-	_vkFormatDescriptions[vkFmt] = { vkFmt, MTLPixelFormat ##MTL_FMT, MTLPixelFormat ##MTL_FMT_ALT, MTLVertexFormat ##MTL_VTX_FMT, MTLVertexFormat ##MTL_VTX_FMT_ALT,  \
-									 CSPC, CSCB, { BLK_W, BLK_H }, BLK_BYTE_CNT, kMVKFormat ##MVK_FMT_TYPE, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3, nullptr, 0, 0, 0 }, \
-									 { VK_COMPONENT_SWIZZLE_ ##SWIZ_R, VK_COMPONENT_SWIZZLE_ ##SWIZ_G, VK_COMPONENT_SWIZZLE_ ##SWIZ_B, VK_COMPONENT_SWIZZLE_ ##SWIZ_A }, \
-									 "VK_FORMAT_" #VK_FMT, false }
+#define addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT,         \
+                            MTL_VTX_FMT_ALT, CSPC, CSCB, BLK_W, BLK_H,         \
+                            BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G,        \
+                            SWIZ_B, SWIZ_A)                                    \
+    vkFmt = VK_FORMAT_##VK_FMT;                                                \
+    _vkFormatDescriptions[vkFmt] =                                             \
+        {vkFmt,                                                                \
+         MTLPixelFormat##MTL_FMT,                                              \
+         MTLPixelFormat##MTL_FMT_ALT,                                          \
+         MTLVertexFormat##MTL_VTX_FMT,                                         \
+         MTLVertexFormat##MTL_VTX_FMT_ALT,                                     \
+         CSPC,                                                                 \
+         CSCB,                                                                 \
+         {BLK_W, BLK_H},                                                       \
+         BLK_BYTE_CNT,                                                         \
+         kMVKFormat##MVK_FMT_TYPE,                                             \
+         {VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3, nullptr, 0, 0, 0},            \
+         {VK_COMPONENT_SWIZZLE_##SWIZ_R, VK_COMPONENT_SWIZZLE_##SWIZ_G,        \
+          VK_COMPONENT_SWIZZLE_##SWIZ_B, VK_COMPONENT_SWIZZLE_##SWIZ_A},       \
+         "VK_FORMAT_" #VK_FMT,                                                 \
+         false}
 
-#define addVkFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE)  \
-    addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, 0, 0, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, IDENTITY, IDENTITY, IDENTITY, IDENTITY)
+#define addVkFormatDesc(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT,             \
+                        MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT,           \
+                        MVK_FMT_TYPE)                                          \
+    addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT,             \
+                        MTL_VTX_FMT_ALT, 0, 0, BLK_W, BLK_H, BLK_BYTE_CNT,     \
+                        MVK_FMT_TYPE, IDENTITY, IDENTITY, IDENTITY, IDENTITY)
 
-#define addVkFormatDescSwizzled(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A)  \
-    addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT, MTL_VTX_FMT_ALT, 0, 0, BLK_W, BLK_H, BLK_BYTE_CNT, MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A)
+#define addVkFormatDescSwizzled(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT,     \
+                                MTL_VTX_FMT_ALT, BLK_W, BLK_H, BLK_BYTE_CNT,   \
+                                MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A)  \
+    addVkFormatDescFull(VK_FMT, MTL_FMT, MTL_FMT_ALT, MTL_VTX_FMT,             \
+                        MTL_VTX_FMT_ALT, 0, 0, BLK_W, BLK_H, BLK_BYTE_CNT,     \
+                        MVK_FMT_TYPE, SWIZ_R, SWIZ_G, SWIZ_B, SWIZ_A)
 
-#define addVkFormatDescChromaSubsampling(VK_FMT, MTL_FMT, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT)  \
-	addVkFormatDescFull(VK_FMT, MTL_FMT, Invalid, Invalid, Invalid, CSPC, CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, ColorFloat, IDENTITY, IDENTITY, IDENTITY, IDENTITY)
+#define addVkFormatDescChromaSubsampling(VK_FMT, MTL_FMT, CSPC, CSCB, BLK_W,   \
+                                         BLK_H, BLK_BYTE_CNT)                  \
+    addVkFormatDescFull(VK_FMT, MTL_FMT, Invalid, Invalid, Invalid, CSPC,      \
+                        CSCB, BLK_W, BLK_H, BLK_BYTE_CNT, ColorFloat,          \
+                        IDENTITY, IDENTITY, IDENTITY, IDENTITY)
 
 void MVKPixelFormats::initVkFormatCapabilities() {
-	VkFormat vkFmt;
-	_vkFormatDescriptions.reserve(KIBI);	// High estimate to future-proof against allocations as elements are added. shrink_to_fit() below will collapse.
+    VkFormat vkFmt;
+    _vkFormatDescriptions.reserve(
+        KIBI); // High estimate to future-proof against allocations as elements
+               // are added. shrink_to_fit() below will collapse.
 
-	// UNDEFINED must come first.
-	addVkFormatDesc( UNDEFINED, Invalid, Invalid, Invalid, Invalid, 1, 1, 0, None );
+    // UNDEFINED must come first.
+    addVkFormatDesc(UNDEFINED, Invalid, Invalid, Invalid, Invalid, 1, 1, 0,
+                    None);
 
-	addVkFormatDesc( R4G4_UNORM_PACK8, Invalid, Invalid, Invalid, Invalid, 1, 1, 1, ColorFloat );
-	addVkFormatDesc( R4G4B4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDescSwizzled( B4G4R4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, B, G, R, A );
-	addVkFormatDescSwizzled( A4R4G4B4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, G, B, A, R );
-	addVkFormatDescSwizzled( A4B4G4R4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, A, B, G, R );
+    addVkFormatDesc(R4G4_UNORM_PACK8, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    1, ColorFloat);
+    addVkFormatDesc(R4G4B4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid,
+                    Invalid, 1, 1, 2, ColorFloat);
+    addVkFormatDescSwizzled(B4G4R4A4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid,
+                            Invalid, 1, 1, 2, ColorFloat, B, G, R, A);
+    addVkFormatDescSwizzled(A4R4G4B4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid,
+                            Invalid, 1, 1, 2, ColorFloat, G, B, A, R);
+    addVkFormatDescSwizzled(A4B4G4R4_UNORM_PACK16, ABGR4Unorm, Invalid, Invalid,
+                            Invalid, 1, 1, 2, ColorFloat, A, B, G, R);
 
-	addVkFormatDesc( R5G6B5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDescSwizzled( B5G6R5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, B, G, R, A );
-	addVkFormatDesc( R5G5B5A1_UNORM_PACK16, A1BGR5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDescSwizzled( B5G5R5A1_UNORM_PACK16, A1BGR5Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat, B, G, R, A );
-	addVkFormatDesc( A1R5G5B5_UNORM_PACK16, BGR5A1Unorm, Invalid, Invalid, Invalid, 1, 1, 2, ColorFloat );
+    addVkFormatDesc(R5G6B5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid, Invalid,
+                    1, 1, 2, ColorFloat);
+    addVkFormatDescSwizzled(B5G6R5_UNORM_PACK16, B5G6R5Unorm, Invalid, Invalid,
+                            Invalid, 1, 1, 2, ColorFloat, B, G, R, A);
+    addVkFormatDesc(R5G5B5A1_UNORM_PACK16, A1BGR5Unorm, Invalid, Invalid,
+                    Invalid, 1, 1, 2, ColorFloat);
+    addVkFormatDescSwizzled(B5G5R5A1_UNORM_PACK16, A1BGR5Unorm, Invalid,
+                            Invalid, Invalid, 1, 1, 2, ColorFloat, B, G, R, A);
+    addVkFormatDesc(A1R5G5B5_UNORM_PACK16, BGR5A1Unorm, Invalid, Invalid,
+                    Invalid, 1, 1, 2, ColorFloat);
 
-	addVkFormatDesc( R8_UNORM, R8Unorm, Invalid, UCharNormalized, UChar2Normalized, 1, 1, 1, ColorFloat );
-	addVkFormatDesc( R8_SNORM, R8Snorm, Invalid, CharNormalized, Char2Normalized, 1, 1, 1, ColorFloat );
-	addVkFormatDesc( R8_USCALED, Invalid, Invalid, UChar, UChar2, 1, 1, 1, ColorFloat );
-	addVkFormatDesc( R8_SSCALED, Invalid, Invalid, Char, Char2, 1, 1, 1, ColorFloat );
-	addVkFormatDesc( R8_UINT, R8Uint, Invalid, UChar, UChar2, 1, 1, 1, ColorUInt8 );
-	addVkFormatDesc( R8_SINT, R8Sint, Invalid, Char, Char2, 1, 1, 1, ColorInt8 );
-	addVkFormatDesc( R8_SRGB, R8Unorm_sRGB, Invalid, UCharNormalized, UChar2Normalized, 1, 1, 1, ColorFloat );
+    addVkFormatDesc(R8_UNORM, R8Unorm, Invalid, UCharNormalized,
+                    UChar2Normalized, 1, 1, 1, ColorFloat);
+    addVkFormatDesc(R8_SNORM, R8Snorm, Invalid, CharNormalized, Char2Normalized,
+                    1, 1, 1, ColorFloat);
+    addVkFormatDesc(R8_USCALED, Invalid, Invalid, UChar, UChar2, 1, 1, 1,
+                    ColorFloat);
+    addVkFormatDesc(R8_SSCALED, Invalid, Invalid, Char, Char2, 1, 1, 1,
+                    ColorFloat);
+    addVkFormatDesc(R8_UINT, R8Uint, Invalid, UChar, UChar2, 1, 1, 1,
+                    ColorUInt8);
+    addVkFormatDesc(R8_SINT, R8Sint, Invalid, Char, Char2, 1, 1, 1, ColorInt8);
+    addVkFormatDesc(R8_SRGB, R8Unorm_sRGB, Invalid, UCharNormalized,
+                    UChar2Normalized, 1, 1, 1, ColorFloat);
 
-	addVkFormatDesc( R8G8_UNORM, RG8Unorm, Invalid, UChar2Normalized, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R8G8_SNORM, RG8Snorm, Invalid, Char2Normalized, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R8G8_USCALED, Invalid, Invalid, UChar2, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R8G8_SSCALED, Invalid, Invalid, Char2, Invalid, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R8G8_UINT, RG8Uint, Invalid, UChar2, Invalid, 1, 1, 2, ColorUInt8 );
-	addVkFormatDesc( R8G8_SINT, RG8Sint, Invalid, Char2, Invalid, 1, 1, 2, ColorInt8 );
-	addVkFormatDesc( R8G8_SRGB, RG8Unorm_sRGB, Invalid, UChar2Normalized, Invalid, 1, 1, 2, ColorFloat );
+    addVkFormatDesc(R8G8_UNORM, RG8Unorm, Invalid, UChar2Normalized, Invalid, 1,
+                    1, 2, ColorFloat);
+    addVkFormatDesc(R8G8_SNORM, RG8Snorm, Invalid, Char2Normalized, Invalid, 1,
+                    1, 2, ColorFloat);
+    addVkFormatDesc(R8G8_USCALED, Invalid, Invalid, UChar2, Invalid, 1, 1, 2,
+                    ColorFloat);
+    addVkFormatDesc(R8G8_SSCALED, Invalid, Invalid, Char2, Invalid, 1, 1, 2,
+                    ColorFloat);
+    addVkFormatDesc(R8G8_UINT, RG8Uint, Invalid, UChar2, Invalid, 1, 1, 2,
+                    ColorUInt8);
+    addVkFormatDesc(R8G8_SINT, RG8Sint, Invalid, Char2, Invalid, 1, 1, 2,
+                    ColorInt8);
+    addVkFormatDesc(R8G8_SRGB, RG8Unorm_sRGB, Invalid, UChar2Normalized,
+                    Invalid, 1, 1, 2, ColorFloat);
 
-	addVkFormatDesc( R8G8B8_UNORM, Invalid, Invalid, UChar3Normalized, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( R8G8B8_SNORM, Invalid, Invalid, Char3Normalized, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( R8G8B8_USCALED, Invalid, Invalid, UChar3, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( R8G8B8_SSCALED, Invalid, Invalid, Char3, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( R8G8B8_UINT, Invalid, Invalid, UChar3, Invalid, 1, 1, 3, ColorUInt8 );
-	addVkFormatDesc( R8G8B8_SINT, Invalid, Invalid, Char3, Invalid, 1, 1, 3, ColorInt8 );
-	addVkFormatDesc( R8G8B8_SRGB, Invalid, Invalid, UChar3Normalized, Invalid, 1, 1, 3, ColorFloat );
+    addVkFormatDesc(R8G8B8_UNORM, Invalid, Invalid, UChar3Normalized, Invalid,
+                    1, 1, 3, ColorFloat);
+    addVkFormatDesc(R8G8B8_SNORM, Invalid, Invalid, Char3Normalized, Invalid, 1,
+                    1, 3, ColorFloat);
+    addVkFormatDesc(R8G8B8_USCALED, Invalid, Invalid, UChar3, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(R8G8B8_SSCALED, Invalid, Invalid, Char3, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(R8G8B8_UINT, Invalid, Invalid, UChar3, Invalid, 1, 1, 3,
+                    ColorUInt8);
+    addVkFormatDesc(R8G8B8_SINT, Invalid, Invalid, Char3, Invalid, 1, 1, 3,
+                    ColorInt8);
+    addVkFormatDesc(R8G8B8_SRGB, Invalid, Invalid, UChar3Normalized, Invalid, 1,
+                    1, 3, ColorFloat);
 
-	addVkFormatDesc( B8G8R8_UNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( B8G8R8_SNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( B8G8R8_USCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( B8G8R8_SSCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorFloat );
-	addVkFormatDesc( B8G8R8_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorUInt8 );
-	addVkFormatDesc( B8G8R8_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorInt8 );
-	addVkFormatDesc( B8G8R8_SRGB, Invalid, Invalid, Invalid, Invalid, 1, 1, 3, ColorFloat );
+    addVkFormatDesc(B8G8R8_UNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(B8G8R8_SNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(B8G8R8_USCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(B8G8R8_SSCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorFloat);
+    addVkFormatDesc(B8G8R8_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorUInt8);
+    addVkFormatDesc(B8G8R8_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorInt8);
+    addVkFormatDesc(B8G8R8_SRGB, Invalid, Invalid, Invalid, Invalid, 1, 1, 3,
+                    ColorFloat);
 
-	addVkFormatDesc( R8G8B8A8_UNORM, RGBA8Unorm, Invalid, UChar4Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R8G8B8A8_SNORM, RGBA8Snorm, Invalid, Char4Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R8G8B8A8_USCALED, Invalid, Invalid, UChar4, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R8G8B8A8_SSCALED, Invalid, Invalid, Char4, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R8G8B8A8_UINT, RGBA8Uint, Invalid, UChar4, Invalid, 1, 1, 4, ColorUInt8 );
-	addVkFormatDesc( R8G8B8A8_SINT, RGBA8Sint, Invalid, Char4, Invalid, 1, 1, 4, ColorInt8 );
-	addVkFormatDesc( R8G8B8A8_SRGB, RGBA8Unorm_sRGB, Invalid, UChar4Normalized, Invalid, 1, 1, 4, ColorFloat );
+    addVkFormatDesc(R8G8B8A8_UNORM, RGBA8Unorm, Invalid, UChar4Normalized,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(R8G8B8A8_SNORM, RGBA8Snorm, Invalid, Char4Normalized,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(R8G8B8A8_USCALED, Invalid, Invalid, UChar4, Invalid, 1, 1,
+                    4, ColorFloat);
+    addVkFormatDesc(R8G8B8A8_SSCALED, Invalid, Invalid, Char4, Invalid, 1, 1, 4,
+                    ColorFloat);
+    addVkFormatDesc(R8G8B8A8_UINT, RGBA8Uint, Invalid, UChar4, Invalid, 1, 1, 4,
+                    ColorUInt8);
+    addVkFormatDesc(R8G8B8A8_SINT, RGBA8Sint, Invalid, Char4, Invalid, 1, 1, 4,
+                    ColorInt8);
+    addVkFormatDesc(R8G8B8A8_SRGB, RGBA8Unorm_sRGB, Invalid, UChar4Normalized,
+                    Invalid, 1, 1, 4, ColorFloat);
 
-	addVkFormatDesc( B8G8R8A8_UNORM, BGRA8Unorm, Invalid, UChar4Normalized_BGRA, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( B8G8R8A8_SNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( B8G8R8A8_USCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( B8G8R8A8_SSCALED, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( B8G8R8A8_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt8 );
-	addVkFormatDesc( B8G8R8A8_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorInt8 );
-	addVkFormatDesc( B8G8R8A8_SRGB, BGRA8Unorm_sRGB, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
+    addVkFormatDesc(B8G8R8A8_UNORM, BGRA8Unorm, Invalid, UChar4Normalized_BGRA,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(B8G8R8A8_SNORM, Invalid, Invalid, Invalid, Invalid, 1, 1, 4,
+                    ColorFloat);
+    addVkFormatDesc(B8G8R8A8_USCALED, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    4, ColorFloat);
+    addVkFormatDesc(B8G8R8A8_SSCALED, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    4, ColorFloat);
+    addVkFormatDesc(B8G8R8A8_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 4,
+                    ColorUInt8);
+    addVkFormatDesc(B8G8R8A8_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 4,
+                    ColorInt8);
+    addVkFormatDesc(B8G8R8A8_SRGB, BGRA8Unorm_sRGB, Invalid, Invalid, Invalid,
+                    1, 1, 4, ColorFloat);
 
-	addVkFormatDesc( A8B8G8R8_UNORM_PACK32, RGBA8Unorm, Invalid, UChar4Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A8B8G8R8_SNORM_PACK32, RGBA8Snorm, Invalid, Char4Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A8B8G8R8_USCALED_PACK32, Invalid, Invalid, UChar4, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A8B8G8R8_SSCALED_PACK32, Invalid, Invalid, Char4, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A8B8G8R8_UINT_PACK32, RGBA8Uint, Invalid, UChar4, Invalid, 1, 1, 4, ColorUInt8 );
-	addVkFormatDesc( A8B8G8R8_SINT_PACK32, RGBA8Sint, Invalid, Char4, Invalid, 1, 1, 4, ColorInt8 );
-	addVkFormatDesc( A8B8G8R8_SRGB_PACK32, RGBA8Unorm_sRGB, Invalid, UChar4Normalized, Invalid, 1, 1, 4, ColorFloat );
+    addVkFormatDesc(A8B8G8R8_UNORM_PACK32, RGBA8Unorm, Invalid,
+                    UChar4Normalized, Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A8B8G8R8_SNORM_PACK32, RGBA8Snorm, Invalid, Char4Normalized,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A8B8G8R8_USCALED_PACK32, Invalid, Invalid, UChar4, Invalid,
+                    1, 1, 4, ColorFloat);
+    addVkFormatDesc(A8B8G8R8_SSCALED_PACK32, Invalid, Invalid, Char4, Invalid,
+                    1, 1, 4, ColorFloat);
+    addVkFormatDesc(A8B8G8R8_UINT_PACK32, RGBA8Uint, Invalid, UChar4, Invalid,
+                    1, 1, 4, ColorUInt8);
+    addVkFormatDesc(A8B8G8R8_SINT_PACK32, RGBA8Sint, Invalid, Char4, Invalid, 1,
+                    1, 4, ColorInt8);
+    addVkFormatDesc(A8B8G8R8_SRGB_PACK32, RGBA8Unorm_sRGB, Invalid,
+                    UChar4Normalized, Invalid, 1, 1, 4, ColorFloat);
 
-	addVkFormatDesc( A2R10G10B10_UNORM_PACK32, BGR10A2Unorm, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2R10G10B10_SNORM_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2R10G10B10_USCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2R10G10B10_SSCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2R10G10B10_UINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt16 );
-	addVkFormatDesc( A2R10G10B10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorInt16 );
+    addVkFormatDesc(A2R10G10B10_UNORM_PACK32, BGR10A2Unorm, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2R10G10B10_SNORM_PACK32, Invalid, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2R10G10B10_USCALED_PACK32, Invalid, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2R10G10B10_SSCALED_PACK32, Invalid, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2R10G10B10_UINT_PACK32, Invalid, Invalid, Invalid, Invalid,
+                    1, 1, 4, ColorUInt16);
+    addVkFormatDesc(A2R10G10B10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid,
+                    1, 1, 4, ColorInt16);
 
-	addVkFormatDesc( A2B10G10R10_UNORM_PACK32, RGB10A2Unorm, Invalid, UInt1010102Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2B10G10R10_SNORM_PACK32, Invalid, Invalid, Int1010102Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2B10G10R10_USCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2B10G10R10_SSCALED_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( A2B10G10R10_UINT_PACK32, RGB10A2Uint, Invalid, Invalid, Invalid, 1, 1, 4, ColorUInt16 );
-	addVkFormatDesc( A2B10G10R10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid, 1, 1, 4, ColorInt16 );
+    addVkFormatDesc(A2B10G10R10_UNORM_PACK32, RGB10A2Unorm, Invalid,
+                    UInt1010102Normalized, Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2B10G10R10_SNORM_PACK32, Invalid, Invalid,
+                    Int1010102Normalized, Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2B10G10R10_USCALED_PACK32, Invalid, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2B10G10R10_SSCALED_PACK32, Invalid, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(A2B10G10R10_UINT_PACK32, RGB10A2Uint, Invalid, Invalid,
+                    Invalid, 1, 1, 4, ColorUInt16);
+    addVkFormatDesc(A2B10G10R10_SINT_PACK32, Invalid, Invalid, Invalid, Invalid,
+                    1, 1, 4, ColorInt16);
 
-	addVkFormatDesc( R16_UNORM, R16Unorm, Invalid, UShortNormalized, UShort2Normalized, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R16_SNORM, R16Snorm, Invalid, ShortNormalized, Short2Normalized, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R16_USCALED, Invalid, Invalid, UShort, UShort2, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R16_SSCALED, Invalid, Invalid, Short, Short2, 1, 1, 2, ColorFloat );
-	addVkFormatDesc( R16_UINT, R16Uint, Invalid, UShort, UShort2, 1, 1, 2, ColorUInt16 );
-	addVkFormatDesc( R16_SINT, R16Sint, Invalid, Short, Short2, 1, 1, 2, ColorInt16 );
-	addVkFormatDesc( R16_SFLOAT, R16Float, Invalid, Half, Half2, 1, 1, 2, ColorFloat );
+    addVkFormatDesc(R16_UNORM, R16Unorm, Invalid, UShortNormalized,
+                    UShort2Normalized, 1, 1, 2, ColorFloat);
+    addVkFormatDesc(R16_SNORM, R16Snorm, Invalid, ShortNormalized,
+                    Short2Normalized, 1, 1, 2, ColorFloat);
+    addVkFormatDesc(R16_USCALED, Invalid, Invalid, UShort, UShort2, 1, 1, 2,
+                    ColorFloat);
+    addVkFormatDesc(R16_SSCALED, Invalid, Invalid, Short, Short2, 1, 1, 2,
+                    ColorFloat);
+    addVkFormatDesc(R16_UINT, R16Uint, Invalid, UShort, UShort2, 1, 1, 2,
+                    ColorUInt16);
+    addVkFormatDesc(R16_SINT, R16Sint, Invalid, Short, Short2, 1, 1, 2,
+                    ColorInt16);
+    addVkFormatDesc(R16_SFLOAT, R16Float, Invalid, Half, Half2, 1, 1, 2,
+                    ColorFloat);
 
-	addVkFormatDesc( R16G16_UNORM, RG16Unorm, Invalid, UShort2Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R16G16_SNORM, RG16Snorm, Invalid, Short2Normalized, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R16G16_USCALED, Invalid, Invalid, UShort2, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R16G16_SSCALED, Invalid, Invalid, Short2, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( R16G16_UINT, RG16Uint, Invalid, UShort2, Invalid, 1, 1, 4, ColorUInt16 );
-	addVkFormatDesc( R16G16_SINT, RG16Sint, Invalid, Short2, Invalid, 1, 1, 4, ColorInt16 );
-	addVkFormatDesc( R16G16_SFLOAT, RG16Float, Invalid, Half2, Invalid, 1, 1, 4, ColorFloat );
+    addVkFormatDesc(R16G16_UNORM, RG16Unorm, Invalid, UShort2Normalized,
+                    Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(R16G16_SNORM, RG16Snorm, Invalid, Short2Normalized, Invalid,
+                    1, 1, 4, ColorFloat);
+    addVkFormatDesc(R16G16_USCALED, Invalid, Invalid, UShort2, Invalid, 1, 1, 4,
+                    ColorFloat);
+    addVkFormatDesc(R16G16_SSCALED, Invalid, Invalid, Short2, Invalid, 1, 1, 4,
+                    ColorFloat);
+    addVkFormatDesc(R16G16_UINT, RG16Uint, Invalid, UShort2, Invalid, 1, 1, 4,
+                    ColorUInt16);
+    addVkFormatDesc(R16G16_SINT, RG16Sint, Invalid, Short2, Invalid, 1, 1, 4,
+                    ColorInt16);
+    addVkFormatDesc(R16G16_SFLOAT, RG16Float, Invalid, Half2, Invalid, 1, 1, 4,
+                    ColorFloat);
 
-	addVkFormatDesc( R16G16B16_UNORM, Invalid, Invalid, UShort3Normalized, Invalid, 1, 1, 6, ColorFloat );
-	addVkFormatDesc( R16G16B16_SNORM, Invalid, Invalid, Short3Normalized, Invalid, 1, 1, 6, ColorFloat );
-	addVkFormatDesc( R16G16B16_USCALED, Invalid, Invalid, UShort3, Invalid, 1, 1, 6, ColorFloat );
-	addVkFormatDesc( R16G16B16_SSCALED, Invalid, Invalid, Short3, Invalid, 1, 1, 6, ColorFloat );
-	addVkFormatDesc( R16G16B16_UINT, Invalid, Invalid, UShort3, Invalid, 1, 1, 6, ColorUInt16 );
-	addVkFormatDesc( R16G16B16_SINT, Invalid, Invalid, Short3, Invalid, 1, 1, 6, ColorInt16 );
-	addVkFormatDesc( R16G16B16_SFLOAT, Invalid, Invalid, Half3, Invalid, 1, 1, 6, ColorFloat );
+    addVkFormatDesc(R16G16B16_UNORM, Invalid, Invalid, UShort3Normalized,
+                    Invalid, 1, 1, 6, ColorFloat);
+    addVkFormatDesc(R16G16B16_SNORM, Invalid, Invalid, Short3Normalized,
+                    Invalid, 1, 1, 6, ColorFloat);
+    addVkFormatDesc(R16G16B16_USCALED, Invalid, Invalid, UShort3, Invalid, 1, 1,
+                    6, ColorFloat);
+    addVkFormatDesc(R16G16B16_SSCALED, Invalid, Invalid, Short3, Invalid, 1, 1,
+                    6, ColorFloat);
+    addVkFormatDesc(R16G16B16_UINT, Invalid, Invalid, UShort3, Invalid, 1, 1, 6,
+                    ColorUInt16);
+    addVkFormatDesc(R16G16B16_SINT, Invalid, Invalid, Short3, Invalid, 1, 1, 6,
+                    ColorInt16);
+    addVkFormatDesc(R16G16B16_SFLOAT, Invalid, Invalid, Half3, Invalid, 1, 1, 6,
+                    ColorFloat);
 
-	addVkFormatDesc( R16G16B16A16_UNORM, RGBA16Unorm, Invalid, UShort4Normalized, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R16G16B16A16_SNORM, RGBA16Snorm, Invalid, Short4Normalized, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R16G16B16A16_USCALED, Invalid, Invalid, UShort4, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R16G16B16A16_SSCALED, Invalid, Invalid, Short4, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R16G16B16A16_UINT, RGBA16Uint, Invalid, UShort4, Invalid, 1, 1, 8, ColorUInt16 );
-	addVkFormatDesc( R16G16B16A16_SINT, RGBA16Sint, Invalid, Short4, Invalid, 1, 1, 8, ColorInt16 );
-	addVkFormatDesc( R16G16B16A16_SFLOAT, RGBA16Float, Invalid, Half4, Invalid, 1, 1, 8, ColorFloat );
+    addVkFormatDesc(R16G16B16A16_UNORM, RGBA16Unorm, Invalid, UShort4Normalized,
+                    Invalid, 1, 1, 8, ColorFloat);
+    addVkFormatDesc(R16G16B16A16_SNORM, RGBA16Snorm, Invalid, Short4Normalized,
+                    Invalid, 1, 1, 8, ColorFloat);
+    addVkFormatDesc(R16G16B16A16_USCALED, Invalid, Invalid, UShort4, Invalid, 1,
+                    1, 8, ColorFloat);
+    addVkFormatDesc(R16G16B16A16_SSCALED, Invalid, Invalid, Short4, Invalid, 1,
+                    1, 8, ColorFloat);
+    addVkFormatDesc(R16G16B16A16_UINT, RGBA16Uint, Invalid, UShort4, Invalid, 1,
+                    1, 8, ColorUInt16);
+    addVkFormatDesc(R16G16B16A16_SINT, RGBA16Sint, Invalid, Short4, Invalid, 1,
+                    1, 8, ColorInt16);
+    addVkFormatDesc(R16G16B16A16_SFLOAT, RGBA16Float, Invalid, Half4, Invalid,
+                    1, 1, 8, ColorFloat);
 
-	addVkFormatDesc( R32_UINT, R32Uint, Invalid, UInt, Invalid, 1, 1, 4, ColorUInt32 );
-	addVkFormatDesc( R32_SINT, R32Sint, Invalid, Int, Invalid, 1, 1, 4, ColorInt32 );
-	addVkFormatDesc( R32_SFLOAT, R32Float, Invalid, Float, Invalid, 1, 1, 4, ColorFloat );
+    addVkFormatDesc(R32_UINT, R32Uint, Invalid, UInt, Invalid, 1, 1, 4,
+                    ColorUInt32);
+    addVkFormatDesc(R32_SINT, R32Sint, Invalid, Int, Invalid, 1, 1, 4,
+                    ColorInt32);
+    addVkFormatDesc(R32_SFLOAT, R32Float, Invalid, Float, Invalid, 1, 1, 4,
+                    ColorFloat);
 
-	addVkFormatDesc( R32G32_UINT, RG32Uint, Invalid, UInt2, Invalid, 1, 1, 8, ColorUInt32 );
-	addVkFormatDesc( R32G32_SINT, RG32Sint, Invalid, Int2, Invalid, 1, 1, 8, ColorInt32 );
-	addVkFormatDesc( R32G32_SFLOAT, RG32Float, Invalid, Float2, Invalid, 1, 1, 8, ColorFloat );
+    addVkFormatDesc(R32G32_UINT, RG32Uint, Invalid, UInt2, Invalid, 1, 1, 8,
+                    ColorUInt32);
+    addVkFormatDesc(R32G32_SINT, RG32Sint, Invalid, Int2, Invalid, 1, 1, 8,
+                    ColorInt32);
+    addVkFormatDesc(R32G32_SFLOAT, RG32Float, Invalid, Float2, Invalid, 1, 1, 8,
+                    ColorFloat);
 
-	addVkFormatDesc( R32G32B32_UINT, Invalid, Invalid, UInt3, Invalid, 1, 1, 12, ColorUInt32 );
-	addVkFormatDesc( R32G32B32_SINT, Invalid, Invalid, Int3, Invalid, 1, 1, 12, ColorInt32 );
-	addVkFormatDesc( R32G32B32_SFLOAT, Invalid, Invalid, Float3, Invalid, 1, 1, 12, ColorFloat );
+    addVkFormatDesc(R32G32B32_UINT, Invalid, Invalid, UInt3, Invalid, 1, 1, 12,
+                    ColorUInt32);
+    addVkFormatDesc(R32G32B32_SINT, Invalid, Invalid, Int3, Invalid, 1, 1, 12,
+                    ColorInt32);
+    addVkFormatDesc(R32G32B32_SFLOAT, Invalid, Invalid, Float3, Invalid, 1, 1,
+                    12, ColorFloat);
 
-	addVkFormatDesc( R32G32B32A32_UINT, RGBA32Uint, Invalid, UInt4, Invalid, 1, 1, 16, ColorUInt32 );
-	addVkFormatDesc( R32G32B32A32_SINT, RGBA32Sint, Invalid, Int4, Invalid, 1, 1, 16, ColorInt32 );
-	addVkFormatDesc( R32G32B32A32_SFLOAT, RGBA32Float, Invalid, Float4, Invalid, 1, 1, 16, ColorFloat );
+    addVkFormatDesc(R32G32B32A32_UINT, RGBA32Uint, Invalid, UInt4, Invalid, 1,
+                    1, 16, ColorUInt32);
+    addVkFormatDesc(R32G32B32A32_SINT, RGBA32Sint, Invalid, Int4, Invalid, 1, 1,
+                    16, ColorInt32);
+    addVkFormatDesc(R32G32B32A32_SFLOAT, RGBA32Float, Invalid, Float4, Invalid,
+                    1, 1, 16, ColorFloat);
 
-	addVkFormatDesc( R64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8, ColorFloat );
-	addVkFormatDesc( R64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8, ColorFloat );
+    addVkFormatDesc(R64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8,
+                    ColorFloat);
+    addVkFormatDesc(R64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8,
+                    ColorFloat);
+    addVkFormatDesc(R64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 8,
+                    ColorFloat);
 
-	addVkFormatDesc( R64G64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16, ColorFloat );
-	addVkFormatDesc( R64G64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16, ColorFloat );
-	addVkFormatDesc( R64G64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16, ColorFloat );
+    addVkFormatDesc(R64G64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16,
+                    ColorFloat);
+    addVkFormatDesc(R64G64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16,
+                    ColorFloat);
+    addVkFormatDesc(R64G64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 16,
+                    ColorFloat);
 
-	addVkFormatDesc( R64G64B64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 24, ColorFloat );
-	addVkFormatDesc( R64G64B64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 24, ColorFloat );
-	addVkFormatDesc( R64G64B64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 24, ColorFloat );
+    addVkFormatDesc(R64G64B64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    24, ColorFloat);
+    addVkFormatDesc(R64G64B64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    24, ColorFloat);
+    addVkFormatDesc(R64G64B64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    24, ColorFloat);
 
-	addVkFormatDesc( R64G64B64A64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat );
-	addVkFormatDesc( R64G64B64A64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat );
-	addVkFormatDesc( R64G64B64A64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1, 1, 32, ColorFloat );
+    addVkFormatDesc(R64G64B64A64_UINT, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    32, ColorFloat);
+    addVkFormatDesc(R64G64B64A64_SINT, Invalid, Invalid, Invalid, Invalid, 1, 1,
+                    32, ColorFloat);
+    addVkFormatDesc(R64G64B64A64_SFLOAT, Invalid, Invalid, Invalid, Invalid, 1,
+                    1, 32, ColorFloat);
 
-	addVkFormatDesc( B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid, FloatRG11B10, Invalid, 1, 1, 4, ColorFloat );
-	addVkFormatDesc( E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, FloatRGB9E5, Invalid, 1, 1, 4, ColorFloat );
-	
-	addVkFormatDesc( D32_SFLOAT, Depth32Float, Invalid, Invalid, Invalid, 1, 1, 4, DepthStencil );
-	addVkFormatDesc( D32_SFLOAT_S8_UINT, Depth32Float_Stencil8, Invalid, Invalid, Invalid, 1, 1, 5, DepthStencil );
+    addVkFormatDesc(B10G11R11_UFLOAT_PACK32, RG11B10Float, Invalid,
+                    FloatRG11B10, Invalid, 1, 1, 4, ColorFloat);
+    addVkFormatDesc(E5B9G9R9_UFLOAT_PACK32, RGB9E5Float, Invalid, FloatRGB9E5,
+                    Invalid, 1, 1, 4, ColorFloat);
 
-	addVkFormatDesc( S8_UINT, Stencil8, Invalid, Invalid, Invalid, 1, 1, 1, DepthStencil );
+    addVkFormatDesc(D32_SFLOAT, Depth32Float, Invalid, Invalid, Invalid, 1, 1,
+                    4, DepthStencil);
+    addVkFormatDesc(D32_SFLOAT_S8_UINT, Depth32Float_Stencil8, Invalid, Invalid,
+                    Invalid, 1, 1, 5, DepthStencil);
 
-	addVkFormatDesc( D16_UNORM, Depth16Unorm, Depth32Float, Invalid, Invalid, 1, 1, 2, DepthStencil );
-	addVkFormatDesc( D16_UNORM_S8_UINT, Invalid, Depth16Unorm_Stencil8, Invalid, Invalid, 1, 1, 3, DepthStencil );
-	addVkFormatDesc( D24_UNORM_S8_UINT, Depth24Unorm_Stencil8, Depth32Float_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil );
+    addVkFormatDesc(S8_UINT, Stencil8, Invalid, Invalid, Invalid, 1, 1, 1,
+                    DepthStencil);
 
-	addVkFormatDesc( X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8, Invalid, Invalid, 1, 1, 4, DepthStencil );
+    addVkFormatDesc(D16_UNORM, Depth16Unorm, Depth32Float, Invalid, Invalid, 1,
+                    1, 2, DepthStencil);
+    addVkFormatDesc(D16_UNORM_S8_UINT, Invalid, Depth16Unorm_Stencil8, Invalid,
+                    Invalid, 1, 1, 3, DepthStencil);
+    addVkFormatDesc(D24_UNORM_S8_UINT, Depth24Unorm_Stencil8,
+                    Depth32Float_Stencil8, Invalid, Invalid, 1, 1, 4,
+                    DepthStencil);
 
-	addVkFormatDesc( BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC1_RGBA_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC1_RGBA_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+    addVkFormatDesc(X8_D24_UNORM_PACK32, Invalid, Depth24Unorm_Stencil8,
+                    Invalid, Invalid, 1, 1, 4, DepthStencil);
 
-	addVkFormatDesc( BC2_UNORM_BLOCK, BC2_RGBA, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( BC2_SRGB_BLOCK, BC2_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(BC1_RGB_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid, 4,
+                    4, 8, Compressed);
+    addVkFormatDesc(BC1_RGB_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(BC1_RGBA_UNORM_BLOCK, BC1_RGBA, Invalid, Invalid, Invalid,
+                    4, 4, 8, Compressed);
+    addVkFormatDesc(BC1_RGBA_SRGB_BLOCK, BC1_RGBA_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
 
-	addVkFormatDesc( BC3_UNORM_BLOCK, BC3_RGBA, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( BC3_SRGB_BLOCK, BC3_RGBA_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(BC2_UNORM_BLOCK, BC2_RGBA, Invalid, Invalid, Invalid, 4, 4,
+                    16, Compressed);
+    addVkFormatDesc(BC2_SRGB_BLOCK, BC2_RGBA_sRGB, Invalid, Invalid, Invalid, 4,
+                    4, 16, Compressed);
 
-	addVkFormatDesc( BC4_UNORM_BLOCK, BC4_RUnorm, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( BC4_SNORM_BLOCK, BC4_RSnorm, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+    addVkFormatDesc(BC3_UNORM_BLOCK, BC3_RGBA, Invalid, Invalid, Invalid, 4, 4,
+                    16, Compressed);
+    addVkFormatDesc(BC3_SRGB_BLOCK, BC3_RGBA_sRGB, Invalid, Invalid, Invalid, 4,
+                    4, 16, Compressed);
 
-	addVkFormatDesc( BC5_UNORM_BLOCK, BC5_RGUnorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( BC5_SNORM_BLOCK, BC5_RGSnorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(BC4_UNORM_BLOCK, BC4_RUnorm, Invalid, Invalid, Invalid, 4,
+                    4, 8, Compressed);
+    addVkFormatDesc(BC4_SNORM_BLOCK, BC4_RSnorm, Invalid, Invalid, Invalid, 4,
+                    4, 8, Compressed);
 
-	addVkFormatDesc( BC6H_UFLOAT_BLOCK, BC6H_RGBUfloat, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( BC6H_SFLOAT_BLOCK, BC6H_RGBFloat, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(BC5_UNORM_BLOCK, BC5_RGUnorm, Invalid, Invalid, Invalid, 4,
+                    4, 16, Compressed);
+    addVkFormatDesc(BC5_SNORM_BLOCK, BC5_RGSnorm, Invalid, Invalid, Invalid, 4,
+                    4, 16, Compressed);
 
-	addVkFormatDesc( BC7_UNORM_BLOCK, BC7_RGBAUnorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( BC7_SRGB_BLOCK, BC7_RGBAUnorm_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(BC6H_UFLOAT_BLOCK, BC6H_RGBUfloat, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(BC6H_SFLOAT_BLOCK, BC6H_RGBFloat, Invalid, Invalid, Invalid,
+                    4, 4, 16, Compressed);
 
-	addVkFormatDesc( ETC2_R8G8B8_UNORM_BLOCK, ETC2_RGB8, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( ETC2_R8G8B8_SRGB_BLOCK, ETC2_RGB8_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( ETC2_R8G8B8A1_UNORM_BLOCK, ETC2_RGB8A1, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( ETC2_R8G8B8A1_SRGB_BLOCK, ETC2_RGB8A1_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+    addVkFormatDesc(BC7_UNORM_BLOCK, BC7_RGBAUnorm, Invalid, Invalid, Invalid,
+                    4, 4, 16, Compressed);
+    addVkFormatDesc(BC7_SRGB_BLOCK, BC7_RGBAUnorm_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
 
-	addVkFormatDesc( ETC2_R8G8B8A8_UNORM_BLOCK, EAC_RGBA8, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( ETC2_R8G8B8A8_SRGB_BLOCK, EAC_RGBA8_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(ETC2_R8G8B8_UNORM_BLOCK, ETC2_RGB8, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(ETC2_R8G8B8_SRGB_BLOCK, ETC2_RGB8_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(ETC2_R8G8B8A1_UNORM_BLOCK, ETC2_RGB8A1, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(ETC2_R8G8B8A1_SRGB_BLOCK, ETC2_RGB8A1_sRGB, Invalid,
+                    Invalid, Invalid, 4, 4, 8, Compressed);
 
-	addVkFormatDesc( EAC_R11_UNORM_BLOCK, EAC_R11Unorm, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( EAC_R11_SNORM_BLOCK, EAC_R11Snorm, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+    addVkFormatDesc(ETC2_R8G8B8A8_UNORM_BLOCK, EAC_RGBA8, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(ETC2_R8G8B8A8_SRGB_BLOCK, EAC_RGBA8_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
 
-	addVkFormatDesc( EAC_R11G11_UNORM_BLOCK, EAC_RG11Unorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( EAC_R11G11_SNORM_BLOCK, EAC_RG11Snorm, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
+    addVkFormatDesc(EAC_R11_UNORM_BLOCK, EAC_R11Unorm, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(EAC_R11_SNORM_BLOCK, EAC_R11Snorm, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
 
-	addVkFormatDesc( ASTC_4x4_UNORM_BLOCK, ASTC_4x4_LDR, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_4x4_SFLOAT_BLOCK_EXT, ASTC_4x4_HDR, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_4x4_SRGB_BLOCK, ASTC_4x4_sRGB, Invalid, Invalid, Invalid, 4, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_5x4_UNORM_BLOCK, ASTC_5x4_LDR, Invalid, Invalid, Invalid, 5, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_5x4_SFLOAT_BLOCK_EXT, ASTC_5x4_HDR, Invalid, Invalid, Invalid, 5, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_5x4_SRGB_BLOCK, ASTC_5x4_sRGB, Invalid, Invalid, Invalid, 5, 4, 16, Compressed );
-	addVkFormatDesc( ASTC_5x5_UNORM_BLOCK, ASTC_5x5_LDR, Invalid, Invalid, Invalid, 5, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_5x5_SFLOAT_BLOCK_EXT, ASTC_5x5_HDR, Invalid, Invalid, Invalid, 5, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_5x5_SRGB_BLOCK, ASTC_5x5_sRGB, Invalid, Invalid, Invalid, 5, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_6x5_UNORM_BLOCK, ASTC_6x5_LDR, Invalid, Invalid, Invalid, 6, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_6x5_SFLOAT_BLOCK_EXT, ASTC_6x5_HDR, Invalid, Invalid, Invalid, 6, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_6x5_SRGB_BLOCK, ASTC_6x5_sRGB, Invalid, Invalid, Invalid, 6, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_6x6_UNORM_BLOCK, ASTC_6x6_LDR, Invalid, Invalid, Invalid, 6, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_6x6_SFLOAT_BLOCK_EXT, ASTC_6x6_HDR, Invalid, Invalid, Invalid, 6, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_6x6_SRGB_BLOCK, ASTC_6x6_sRGB, Invalid, Invalid, Invalid, 6, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_8x5_UNORM_BLOCK, ASTC_8x5_LDR, Invalid, Invalid, Invalid, 8, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_8x5_SFLOAT_BLOCK_EXT, ASTC_8x5_HDR, Invalid, Invalid, Invalid, 8, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_8x5_SRGB_BLOCK, ASTC_8x5_sRGB, Invalid, Invalid, Invalid, 8, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_8x6_UNORM_BLOCK, ASTC_8x6_LDR, Invalid, Invalid, Invalid, 8, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_8x6_SFLOAT_BLOCK_EXT, ASTC_8x6_HDR, Invalid, Invalid, Invalid, 8, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_8x6_SRGB_BLOCK, ASTC_8x6_sRGB, Invalid, Invalid, Invalid, 8, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_8x8_UNORM_BLOCK, ASTC_8x8_LDR, Invalid, Invalid, Invalid, 8, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_8x8_SFLOAT_BLOCK_EXT, ASTC_8x8_HDR, Invalid, Invalid, Invalid, 8, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_8x8_SRGB_BLOCK, ASTC_8x8_sRGB, Invalid, Invalid, Invalid, 8, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_10x5_UNORM_BLOCK, ASTC_10x5_LDR, Invalid, Invalid, Invalid, 10, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_10x5_SFLOAT_BLOCK_EXT, ASTC_10x5_HDR, Invalid, Invalid, Invalid, 10, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_10x5_SRGB_BLOCK, ASTC_10x5_sRGB, Invalid, Invalid, Invalid, 10, 5, 16, Compressed );
-	addVkFormatDesc( ASTC_10x6_UNORM_BLOCK, ASTC_10x6_LDR, Invalid, Invalid, Invalid, 10, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_10x6_SFLOAT_BLOCK_EXT, ASTC_10x6_HDR, Invalid, Invalid, Invalid, 10, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_10x6_SRGB_BLOCK, ASTC_10x6_sRGB, Invalid, Invalid, Invalid, 10, 6, 16, Compressed );
-	addVkFormatDesc( ASTC_10x8_UNORM_BLOCK, ASTC_10x8_LDR, Invalid, Invalid, Invalid, 10, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_10x8_SFLOAT_BLOCK_EXT, ASTC_10x8_HDR, Invalid, Invalid, Invalid, 10, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_10x8_SRGB_BLOCK, ASTC_10x8_sRGB, Invalid, Invalid, Invalid, 10, 8, 16, Compressed );
-	addVkFormatDesc( ASTC_10x10_UNORM_BLOCK, ASTC_10x10_LDR, Invalid, Invalid, Invalid, 10, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_10x10_SFLOAT_BLOCK_EXT, ASTC_10x10_HDR, Invalid, Invalid, Invalid, 10, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_10x10_SRGB_BLOCK, ASTC_10x10_sRGB, Invalid, Invalid, Invalid, 10, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_12x10_UNORM_BLOCK, ASTC_12x10_LDR, Invalid, Invalid, Invalid, 12, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_12x10_SFLOAT_BLOCK_EXT, ASTC_12x10_HDR, Invalid, Invalid, Invalid, 12, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_12x10_SRGB_BLOCK, ASTC_12x10_sRGB, Invalid, Invalid, Invalid, 12, 10, 16, Compressed );
-	addVkFormatDesc( ASTC_12x12_UNORM_BLOCK, ASTC_12x12_LDR, Invalid, Invalid, Invalid, 12, 12, 16, Compressed );
-	addVkFormatDesc( ASTC_12x12_SFLOAT_BLOCK_EXT, ASTC_12x12_HDR, Invalid, Invalid, Invalid, 12, 12, 16, Compressed );
-	addVkFormatDesc( ASTC_12x12_SRGB_BLOCK, ASTC_12x12_sRGB, Invalid, Invalid, Invalid, 12, 12, 16, Compressed );
+    addVkFormatDesc(EAC_R11G11_UNORM_BLOCK, EAC_RG11Unorm, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(EAC_R11G11_SNORM_BLOCK, EAC_RG11Snorm, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
 
-	// Extension VK_IMG_format_pvrtc
-	addVkFormatDesc( PVRTC1_2BPP_UNORM_BLOCK_IMG, PVRTC_RGBA_2BPP, Invalid, Invalid, Invalid, 8, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC1_4BPP_UNORM_BLOCK_IMG, PVRTC_RGBA_4BPP, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC2_2BPP_UNORM_BLOCK_IMG, Invalid, Invalid, Invalid, Invalid, 8, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC2_4BPP_UNORM_BLOCK_IMG, Invalid, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC1_2BPP_SRGB_BLOCK_IMG, PVRTC_RGBA_2BPP_sRGB, Invalid, Invalid, Invalid, 8, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC1_4BPP_SRGB_BLOCK_IMG, PVRTC_RGBA_4BPP_sRGB, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC2_2BPP_SRGB_BLOCK_IMG, Invalid, Invalid, Invalid, Invalid, 8, 4, 8, Compressed );
-	addVkFormatDesc( PVRTC2_4BPP_SRGB_BLOCK_IMG, Invalid, Invalid, Invalid, Invalid, 4, 4, 8, Compressed );
+    addVkFormatDesc(ASTC_4x4_UNORM_BLOCK, ASTC_4x4_LDR, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_4x4_SFLOAT_BLOCK_EXT, ASTC_4x4_HDR, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_4x4_SRGB_BLOCK, ASTC_4x4_sRGB, Invalid, Invalid,
+                    Invalid, 4, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_5x4_UNORM_BLOCK, ASTC_5x4_LDR, Invalid, Invalid,
+                    Invalid, 5, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_5x4_SFLOAT_BLOCK_EXT, ASTC_5x4_HDR, Invalid, Invalid,
+                    Invalid, 5, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_5x4_SRGB_BLOCK, ASTC_5x4_sRGB, Invalid, Invalid,
+                    Invalid, 5, 4, 16, Compressed);
+    addVkFormatDesc(ASTC_5x5_UNORM_BLOCK, ASTC_5x5_LDR, Invalid, Invalid,
+                    Invalid, 5, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_5x5_SFLOAT_BLOCK_EXT, ASTC_5x5_HDR, Invalid, Invalid,
+                    Invalid, 5, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_5x5_SRGB_BLOCK, ASTC_5x5_sRGB, Invalid, Invalid,
+                    Invalid, 5, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_6x5_UNORM_BLOCK, ASTC_6x5_LDR, Invalid, Invalid,
+                    Invalid, 6, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_6x5_SFLOAT_BLOCK_EXT, ASTC_6x5_HDR, Invalid, Invalid,
+                    Invalid, 6, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_6x5_SRGB_BLOCK, ASTC_6x5_sRGB, Invalid, Invalid,
+                    Invalid, 6, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_6x6_UNORM_BLOCK, ASTC_6x6_LDR, Invalid, Invalid,
+                    Invalid, 6, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_6x6_SFLOAT_BLOCK_EXT, ASTC_6x6_HDR, Invalid, Invalid,
+                    Invalid, 6, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_6x6_SRGB_BLOCK, ASTC_6x6_sRGB, Invalid, Invalid,
+                    Invalid, 6, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_8x5_UNORM_BLOCK, ASTC_8x5_LDR, Invalid, Invalid,
+                    Invalid, 8, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_8x5_SFLOAT_BLOCK_EXT, ASTC_8x5_HDR, Invalid, Invalid,
+                    Invalid, 8, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_8x5_SRGB_BLOCK, ASTC_8x5_sRGB, Invalid, Invalid,
+                    Invalid, 8, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_8x6_UNORM_BLOCK, ASTC_8x6_LDR, Invalid, Invalid,
+                    Invalid, 8, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_8x6_SFLOAT_BLOCK_EXT, ASTC_8x6_HDR, Invalid, Invalid,
+                    Invalid, 8, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_8x6_SRGB_BLOCK, ASTC_8x6_sRGB, Invalid, Invalid,
+                    Invalid, 8, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_8x8_UNORM_BLOCK, ASTC_8x8_LDR, Invalid, Invalid,
+                    Invalid, 8, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_8x8_SFLOAT_BLOCK_EXT, ASTC_8x8_HDR, Invalid, Invalid,
+                    Invalid, 8, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_8x8_SRGB_BLOCK, ASTC_8x8_sRGB, Invalid, Invalid,
+                    Invalid, 8, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_10x5_UNORM_BLOCK, ASTC_10x5_LDR, Invalid, Invalid,
+                    Invalid, 10, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_10x5_SFLOAT_BLOCK_EXT, ASTC_10x5_HDR, Invalid, Invalid,
+                    Invalid, 10, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_10x5_SRGB_BLOCK, ASTC_10x5_sRGB, Invalid, Invalid,
+                    Invalid, 10, 5, 16, Compressed);
+    addVkFormatDesc(ASTC_10x6_UNORM_BLOCK, ASTC_10x6_LDR, Invalid, Invalid,
+                    Invalid, 10, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_10x6_SFLOAT_BLOCK_EXT, ASTC_10x6_HDR, Invalid, Invalid,
+                    Invalid, 10, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_10x6_SRGB_BLOCK, ASTC_10x6_sRGB, Invalid, Invalid,
+                    Invalid, 10, 6, 16, Compressed);
+    addVkFormatDesc(ASTC_10x8_UNORM_BLOCK, ASTC_10x8_LDR, Invalid, Invalid,
+                    Invalid, 10, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_10x8_SFLOAT_BLOCK_EXT, ASTC_10x8_HDR, Invalid, Invalid,
+                    Invalid, 10, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_10x8_SRGB_BLOCK, ASTC_10x8_sRGB, Invalid, Invalid,
+                    Invalid, 10, 8, 16, Compressed);
+    addVkFormatDesc(ASTC_10x10_UNORM_BLOCK, ASTC_10x10_LDR, Invalid, Invalid,
+                    Invalid, 10, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_10x10_SFLOAT_BLOCK_EXT, ASTC_10x10_HDR, Invalid,
+                    Invalid, Invalid, 10, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_10x10_SRGB_BLOCK, ASTC_10x10_sRGB, Invalid, Invalid,
+                    Invalid, 10, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_12x10_UNORM_BLOCK, ASTC_12x10_LDR, Invalid, Invalid,
+                    Invalid, 12, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_12x10_SFLOAT_BLOCK_EXT, ASTC_12x10_HDR, Invalid,
+                    Invalid, Invalid, 12, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_12x10_SRGB_BLOCK, ASTC_12x10_sRGB, Invalid, Invalid,
+                    Invalid, 12, 10, 16, Compressed);
+    addVkFormatDesc(ASTC_12x12_UNORM_BLOCK, ASTC_12x12_LDR, Invalid, Invalid,
+                    Invalid, 12, 12, 16, Compressed);
+    addVkFormatDesc(ASTC_12x12_SFLOAT_BLOCK_EXT, ASTC_12x12_HDR, Invalid,
+                    Invalid, Invalid, 12, 12, 16, Compressed);
+    addVkFormatDesc(ASTC_12x12_SRGB_BLOCK, ASTC_12x12_sRGB, Invalid, Invalid,
+                    Invalid, 12, 12, 16, Compressed);
 
-	// Extension VK_KHR_sampler_ycbcr_conversion
-    addVkFormatDescChromaSubsampling( G8B8G8R8_422_UNORM, GBGR422, 1, 8, 2, 1, 4 );
-    addVkFormatDescChromaSubsampling( B8G8R8G8_422_UNORM, BGRG422, 1, 8, 2, 1, 4 );
-    addVkFormatDescChromaSubsampling( G8_B8_R8_3PLANE_420_UNORM, Invalid, 3, 8, 2, 2, 6 );
-    addVkFormatDescChromaSubsampling( G8_B8R8_2PLANE_420_UNORM, Invalid, 2, 8, 2, 2, 6 );
-    addVkFormatDescChromaSubsampling( G8_B8_R8_3PLANE_422_UNORM, Invalid, 3, 8, 2, 1, 4 );
-    addVkFormatDescChromaSubsampling( G8_B8R8_2PLANE_422_UNORM, Invalid, 2, 8, 2, 1, 4 );
-    addVkFormatDescChromaSubsampling( G8_B8_R8_3PLANE_444_UNORM, Invalid, 3, 8, 1, 1, 3 );
-    addVkFormatDescChromaSubsampling( R10X6_UNORM_PACK16, R16Unorm, 0, 10, 1, 1, 2 );
-    addVkFormatDescChromaSubsampling( R10X6G10X6_UNORM_2PACK16, RG16Unorm, 0, 10, 1, 1, 4 );
-    addVkFormatDescChromaSubsampling( R10X6G10X6B10X6A10X6_UNORM_4PACK16, RGBA16Unorm, 0, 10, 1, 1, 8 );
-    addVkFormatDescChromaSubsampling( G10X6B10X6G10X6R10X6_422_UNORM_4PACK16, Invalid, 1, 10, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( B10X6G10X6R10X6G10X6_422_UNORM_4PACK16, Invalid, 1, 10, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, Invalid, 3, 10, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16, Invalid, 2, 10, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16, Invalid, 3, 10, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16, Invalid, 2, 10, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16, Invalid, 3, 10, 1, 1, 6 );
-    addVkFormatDescChromaSubsampling( R12X4_UNORM_PACK16, R16Unorm, 0, 12, 1, 1, 2 );
-    addVkFormatDescChromaSubsampling( R12X4G12X4_UNORM_2PACK16, RG16Unorm, 0, 12, 1, 1, 4 );
-    addVkFormatDescChromaSubsampling( R12X4G12X4B12X4A12X4_UNORM_4PACK16, RGBA16Unorm, 0, 12, 1, 1, 8 );
-    addVkFormatDescChromaSubsampling( G12X4B12X4G12X4R12X4_422_UNORM_4PACK16, Invalid, 1, 12, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( B12X4G12X4R12X4G12X4_422_UNORM_4PACK16, Invalid, 1, 12, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16, Invalid, 3, 12, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16, Invalid, 2, 12, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16, Invalid, 3, 12, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16, Invalid, 2, 12, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16, Invalid, 3, 12, 1, 1, 6 );
-    addVkFormatDescChromaSubsampling( G16B16G16R16_422_UNORM, Invalid, 1, 16, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( B16G16R16G16_422_UNORM, Invalid, 1, 16, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G16_B16_R16_3PLANE_420_UNORM, Invalid, 3, 16, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G16_B16R16_2PLANE_420_UNORM, Invalid, 2, 16, 2, 2, 12 );
-    addVkFormatDescChromaSubsampling( G16_B16_R16_3PLANE_422_UNORM, Invalid, 3, 16, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G16_B16R16_2PLANE_422_UNORM, Invalid, 2, 16, 2, 1, 8 );
-    addVkFormatDescChromaSubsampling( G16_B16_R16_3PLANE_444_UNORM, Invalid, 3, 16, 1, 1, 6 );
+    // Extension VK_IMG_format_pvrtc
+    addVkFormatDesc(PVRTC1_2BPP_UNORM_BLOCK_IMG, PVRTC_RGBA_2BPP, Invalid,
+                    Invalid, Invalid, 8, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC1_4BPP_UNORM_BLOCK_IMG, PVRTC_RGBA_4BPP, Invalid,
+                    Invalid, Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC2_2BPP_UNORM_BLOCK_IMG, Invalid, Invalid, Invalid,
+                    Invalid, 8, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC2_4BPP_UNORM_BLOCK_IMG, Invalid, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC1_2BPP_SRGB_BLOCK_IMG, PVRTC_RGBA_2BPP_sRGB, Invalid,
+                    Invalid, Invalid, 8, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC1_4BPP_SRGB_BLOCK_IMG, PVRTC_RGBA_4BPP_sRGB, Invalid,
+                    Invalid, Invalid, 4, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC2_2BPP_SRGB_BLOCK_IMG, Invalid, Invalid, Invalid,
+                    Invalid, 8, 4, 8, Compressed);
+    addVkFormatDesc(PVRTC2_4BPP_SRGB_BLOCK_IMG, Invalid, Invalid, Invalid,
+                    Invalid, 4, 4, 8, Compressed);
 
-	_vkFormatDescriptions.shrink_to_fit();
+    // Extension VK_KHR_sampler_ycbcr_conversion
+    addVkFormatDescChromaSubsampling(G8B8G8R8_422_UNORM, GBGR422, 1, 8, 2, 1,
+                                     4);
+    addVkFormatDescChromaSubsampling(B8G8R8G8_422_UNORM, BGRG422, 1, 8, 2, 1,
+                                     4);
+    addVkFormatDescChromaSubsampling(G8_B8_R8_3PLANE_420_UNORM, Invalid, 3, 8,
+                                     2, 2, 6);
+    addVkFormatDescChromaSubsampling(G8_B8R8_2PLANE_420_UNORM, Invalid, 2, 8, 2,
+                                     2, 6);
+    addVkFormatDescChromaSubsampling(G8_B8_R8_3PLANE_422_UNORM, Invalid, 3, 8,
+                                     2, 1, 4);
+    addVkFormatDescChromaSubsampling(G8_B8R8_2PLANE_422_UNORM, Invalid, 2, 8, 2,
+                                     1, 4);
+    addVkFormatDescChromaSubsampling(G8_B8_R8_3PLANE_444_UNORM, Invalid, 3, 8,
+                                     1, 1, 3);
+    addVkFormatDescChromaSubsampling(R10X6_UNORM_PACK16, R16Unorm, 0, 10, 1, 1,
+                                     2);
+    addVkFormatDescChromaSubsampling(R10X6G10X6_UNORM_2PACK16, RG16Unorm, 0, 10,
+                                     1, 1, 4);
+    addVkFormatDescChromaSubsampling(R10X6G10X6B10X6A10X6_UNORM_4PACK16,
+                                     RGBA16Unorm, 0, 10, 1, 1, 8);
+    addVkFormatDescChromaSubsampling(G10X6B10X6G10X6R10X6_422_UNORM_4PACK16,
+                                     Invalid, 1, 10, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(B10X6G10X6R10X6G10X6_422_UNORM_4PACK16,
+                                     Invalid, 1, 10, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16,
+                                     Invalid, 3, 10, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16,
+                                     Invalid, 2, 10, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16,
+                                     Invalid, 3, 10, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16,
+                                     Invalid, 2, 10, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16,
+                                     Invalid, 3, 10, 1, 1, 6);
+    addVkFormatDescChromaSubsampling(R12X4_UNORM_PACK16, R16Unorm, 0, 12, 1, 1,
+                                     2);
+    addVkFormatDescChromaSubsampling(R12X4G12X4_UNORM_2PACK16, RG16Unorm, 0, 12,
+                                     1, 1, 4);
+    addVkFormatDescChromaSubsampling(R12X4G12X4B12X4A12X4_UNORM_4PACK16,
+                                     RGBA16Unorm, 0, 12, 1, 1, 8);
+    addVkFormatDescChromaSubsampling(G12X4B12X4G12X4R12X4_422_UNORM_4PACK16,
+                                     Invalid, 1, 12, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(B12X4G12X4R12X4G12X4_422_UNORM_4PACK16,
+                                     Invalid, 1, 12, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16,
+                                     Invalid, 3, 12, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16,
+                                     Invalid, 2, 12, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16,
+                                     Invalid, 3, 12, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16,
+                                     Invalid, 2, 12, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16,
+                                     Invalid, 3, 12, 1, 1, 6);
+    addVkFormatDescChromaSubsampling(G16B16G16R16_422_UNORM, Invalid, 1, 16, 2,
+                                     1, 8);
+    addVkFormatDescChromaSubsampling(B16G16R16G16_422_UNORM, Invalid, 1, 16, 2,
+                                     1, 8);
+    addVkFormatDescChromaSubsampling(G16_B16_R16_3PLANE_420_UNORM, Invalid, 3,
+                                     16, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G16_B16R16_2PLANE_420_UNORM, Invalid, 2,
+                                     16, 2, 2, 12);
+    addVkFormatDescChromaSubsampling(G16_B16_R16_3PLANE_422_UNORM, Invalid, 3,
+                                     16, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G16_B16R16_2PLANE_422_UNORM, Invalid, 2,
+                                     16, 2, 1, 8);
+    addVkFormatDescChromaSubsampling(G16_B16_R16_3PLANE_444_UNORM, Invalid, 3,
+                                     16, 1, 1, 6);
+
+    _vkFormatDescriptions.shrink_to_fit();
 }
 
-void MVKPixelFormats::addMTLPixelFormatDescImpl(MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
-												MVKMTLViewClass viewClass, MVKMTLFmtCaps fmtCaps, const char* name) {
-	_mtlPixelFormatDescriptions[mtlPixFmt] = { .mtlPixelFormat = mtlPixFmt, VK_FORMAT_UNDEFINED, fmtCaps, viewClass, mtlPixFmtLinear, name };
+void MVKPixelFormats::addMTLPixelFormatDescImpl(MTLPixelFormat mtlPixFmt,
+                                                MTLPixelFormat mtlPixFmtLinear,
+                                                MVKMTLViewClass viewClass,
+                                                MVKMTLFmtCaps fmtCaps,
+                                                const char* name) {
+    _mtlPixelFormatDescriptions[mtlPixFmt] = {.mtlPixelFormat = mtlPixFmt,
+                                              VK_FORMAT_UNDEFINED,
+                                              fmtCaps,
+                                              viewClass,
+                                              mtlPixFmtLinear,
+                                              name};
 }
 
-// Verify mtlFmt exists on platform, to avoid overwriting the MTLPixelFormatInvalid entry.
-// Select the appropriate capabilities for the GPU. Apple Silicon on Mac is a blend of both Apple and Mac caps.
-void MVKPixelFormats::addValidatedMTLPixelFormatDesc(MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
-													 MVKMTLViewClass viewClass, MVKMTLFmtCaps appleGPUCaps, MVKMTLFmtCaps macGPUCaps,
-													 const MVKMTLDeviceCapabilities& mtlDevCaps, const char* name) {
-	if ( !mtlPixFmt) { return; }
+// Verify mtlFmt exists on platform, to avoid overwriting the
+// MTLPixelFormatInvalid entry. Select the appropriate capabilities for the GPU.
+// Apple Silicon on Mac is a blend of both Apple and Mac caps.
+void MVKPixelFormats::addValidatedMTLPixelFormatDesc(
+    MTLPixelFormat mtlPixFmt, MTLPixelFormat mtlPixFmtLinear,
+    MVKMTLViewClass viewClass, MVKMTLFmtCaps appleGPUCaps,
+    MVKMTLFmtCaps macGPUCaps, const MVKMTLDeviceCapabilities& mtlDevCaps,
+    const char* name) {
+    if (!mtlPixFmt) {
+        return;
+    }
 
-	MVKMTLFmtCaps fmtCaps = kMVKMTLFmtCapsNone;
-	if (mtlDevCaps.isAppleGPU && mtlDevCaps.supportsMac1) {
-		mvkEnableFlags(fmtCaps, appleGPUCaps);
-		mvkEnableFlags(fmtCaps, macGPUCaps);
-	} else {
-		fmtCaps = mtlDevCaps.isAppleGPU ? appleGPUCaps : macGPUCaps;
-	}
-	addMTLPixelFormatDescImpl(mtlPixFmt, mtlPixFmtLinear, viewClass, fmtCaps, name);
+    MVKMTLFmtCaps fmtCaps = kMVKMTLFmtCapsNone;
+    if (mtlDevCaps.isAppleGPU && mtlDevCaps.supportsMac1) {
+        mvkEnableFlags(fmtCaps, appleGPUCaps);
+        mvkEnableFlags(fmtCaps, macGPUCaps);
+    } else {
+        fmtCaps = mtlDevCaps.isAppleGPU ? appleGPUCaps : macGPUCaps;
+    }
+    addMTLPixelFormatDescImpl(mtlPixFmt, mtlPixFmtLinear, viewClass, fmtCaps,
+                              name);
 }
 
-#define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleGPUCaps, macGPUCaps)  \
-	addValidatedMTLPixelFormatDesc(MTLPixelFormat ##mtlFmt, MTLPixelFormat ##mtlFmtLinear, MVKMTLViewClass:: viewClass,  \
-	                               appleGPUCaps, macGPUCaps, gpuCaps, "MTLPixelFormat" #mtlFmt)
+#define addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass,             \
+                                  appleGPUCaps, macGPUCaps)                    \
+    addValidatedMTLPixelFormatDesc(MTLPixelFormat##mtlFmt,                     \
+                                   MTLPixelFormat##mtlFmtLinear,               \
+                                   MVKMTLViewClass::viewClass, appleGPUCaps,   \
+                                   macGPUCaps, gpuCaps,                        \
+                                   "MTLPixelFormat" #mtlFmt)
 
-#define addMTLPixelFormatDesc(mtlFmt, viewClass, appleGPUCaps, macGPUCaps)  \
-	addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps)
+#define addMTLPixelFormatDesc(mtlFmt, viewClass, appleGPUCaps, macGPUCaps)     \
+    addMTLPixelFormatDescFull(mtlFmt, mtlFmt, viewClass,                       \
+                              kMVKMTLFmtCaps##appleGPUCaps,                    \
+                              kMVKMTLFmtCaps##macGPUCaps)
 
-#define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, macGPUCaps, mtlFmtLinear)  \
-	/* Cannot write to sRGB textures in the simulator */  \
-	if(MVK_OS_SIMULATOR) { MVKMTLFmtCaps appleFmtCaps = kMVKMTLFmtCaps ##appleGPUCaps;  \
-	                       mvkDisableFlags(appleFmtCaps, kMVKMTLFmtCapsWrite);  \
-	                       addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, appleFmtCaps, kMVKMTLFmtCaps ##macGPUCaps); }  \
-	else                 { addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass, kMVKMTLFmtCaps ##appleGPUCaps, kMVKMTLFmtCaps ##macGPUCaps); }
+#define addMTLPixelFormatDescSRGB(mtlFmt, viewClass, appleGPUCaps, macGPUCaps, \
+                                  mtlFmtLinear)                                \
+    /* Cannot write to sRGB textures in the simulator */                       \
+    if (MVK_OS_SIMULATOR) {                                                    \
+        MVKMTLFmtCaps appleFmtCaps = kMVKMTLFmtCaps##appleGPUCaps;             \
+        mvkDisableFlags(appleFmtCaps, kMVKMTLFmtCapsWrite);                    \
+        addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass,             \
+                                  appleFmtCaps, kMVKMTLFmtCaps##macGPUCaps);   \
+    } else {                                                                   \
+        addMTLPixelFormatDescFull(mtlFmt, mtlFmtLinear, viewClass,             \
+                                  kMVKMTLFmtCaps##appleGPUCaps,                \
+                                  kMVKMTLFmtCaps##macGPUCaps);                 \
+    }
 
-void MVKPixelFormats::initMTLPixelFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps) {
-	_mtlPixelFormatDescriptions.reserve(KIBI);	// High estimate to future-proof against allocations as elements are added. shrink_to_fit() below will collapse.
+void MVKPixelFormats::initMTLPixelFormatCapabilities(
+    const MVKMTLDeviceCapabilities& gpuCaps) {
+    _mtlPixelFormatDescriptions.reserve(
+        KIBI); // High estimate to future-proof against allocations as elements
+               // are added. shrink_to_fit() below will collapse.
 
-	// MTLPixelFormatInvalid must come first. Use addMTLPixelFormatDescImpl to avoid guard code.
-	addMTLPixelFormatDescImpl( MTLPixelFormatInvalid, MTLPixelFormatInvalid, MVKMTLViewClass::None, kMVKMTLFmtCapsNone, "MTLPixelFormatInvalid" );
+    // MTLPixelFormatInvalid must come first. Use addMTLPixelFormatDescImpl to
+    // avoid guard code.
+    addMTLPixelFormatDescImpl(MTLPixelFormatInvalid, MTLPixelFormatInvalid,
+                              MVKMTLViewClass::None, kMVKMTLFmtCapsNone,
+                              "MTLPixelFormatInvalid");
 
-	// Ordinary 8-bit pixel formats
-	addMTLPixelFormatDesc    ( A8Unorm, Color8, All, All );
-	addMTLPixelFormatDesc    ( R8Unorm, Color8, All, All );
-	addMTLPixelFormatDescSRGB( R8Unorm_sRGB, Color8, All, None, R8Unorm );
-	addMTLPixelFormatDesc    ( R8Snorm, Color8, All, All );
-	addMTLPixelFormatDesc    ( R8Uint, Color8, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( R8Sint, Color8, RWCM, RWCM );
+    // Ordinary 8-bit pixel formats
+    addMTLPixelFormatDesc(A8Unorm, Color8, All, All);
+    addMTLPixelFormatDesc(R8Unorm, Color8, All, All);
+    addMTLPixelFormatDescSRGB(R8Unorm_sRGB, Color8, All, None, R8Unorm);
+    addMTLPixelFormatDesc(R8Snorm, Color8, All, All);
+    addMTLPixelFormatDesc(R8Uint, Color8, RWCM, RWCM);
+    addMTLPixelFormatDesc(R8Sint, Color8, RWCM, RWCM);
 
-	// Ordinary 16-bit pixel formats
-	addMTLPixelFormatDesc    ( R16Unorm, Color16, RFWCMB, All );
-	addMTLPixelFormatDesc    ( R16Snorm, Color16, RFWCMB, All );
-	addMTLPixelFormatDesc    ( R16Uint, Color16, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( R16Sint, Color16, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( R16Float, Color16, All, All );
+    // Ordinary 16-bit pixel formats
+    addMTLPixelFormatDesc(R16Unorm, Color16, RFWCMB, All);
+    addMTLPixelFormatDesc(R16Snorm, Color16, RFWCMB, All);
+    addMTLPixelFormatDesc(R16Uint, Color16, RWCM, RWCM);
+    addMTLPixelFormatDesc(R16Sint, Color16, RWCM, RWCM);
+    addMTLPixelFormatDesc(R16Float, Color16, All, All);
 
-	addMTLPixelFormatDesc    ( RG8Unorm, Color16, All, All );
-	addMTLPixelFormatDescSRGB( RG8Unorm_sRGB, Color16, All, None, RG8Unorm );
-	addMTLPixelFormatDesc    ( RG8Snorm, Color16, All, All );
-	addMTLPixelFormatDesc    ( RG8Uint, Color16, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG8Sint, Color16, RWCM, RWCM );
+    addMTLPixelFormatDesc(RG8Unorm, Color16, All, All);
+    addMTLPixelFormatDescSRGB(RG8Unorm_sRGB, Color16, All, None, RG8Unorm);
+    addMTLPixelFormatDesc(RG8Snorm, Color16, All, All);
+    addMTLPixelFormatDesc(RG8Uint, Color16, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG8Sint, Color16, RWCM, RWCM);
 
-	// Packed 16-bit pixel formats
-	addMTLPixelFormatDesc    ( B5G6R5Unorm, Color16, RFCMRB, None );
-	addMTLPixelFormatDesc    ( A1BGR5Unorm, Color16, RFCMRB, None );
-	addMTLPixelFormatDesc    ( ABGR4Unorm, Color16, RFCMRB, None );
-	addMTLPixelFormatDesc    ( BGR5A1Unorm, Color16, RFCMRB, None );
+    // Packed 16-bit pixel formats
+    addMTLPixelFormatDesc(B5G6R5Unorm, Color16, RFCMRB, None);
+    addMTLPixelFormatDesc(A1BGR5Unorm, Color16, RFCMRB, None);
+    addMTLPixelFormatDesc(ABGR4Unorm, Color16, RFCMRB, None);
+    addMTLPixelFormatDesc(BGR5A1Unorm, Color16, RFCMRB, None);
 
-	// Ordinary 32-bit pixel formats
-	addMTLPixelFormatDesc    ( R32Uint, Color32, RWC, RWCM );
-	addMTLPixelFormatDesc    ( R32Sint, Color32, RWC, RWCM );
-	addMTLPixelFormatDesc    ( R32Float, Color32, All, All );
+    // Ordinary 32-bit pixel formats
+    addMTLPixelFormatDesc(R32Uint, Color32, RWC, RWCM);
+    addMTLPixelFormatDesc(R32Sint, Color32, RWC, RWCM);
+    addMTLPixelFormatDesc(R32Float, Color32, All, All);
 
-	addMTLPixelFormatDesc    ( RG16Unorm, Color32, RFWCMB, All );
-	addMTLPixelFormatDesc    ( RG16Snorm, Color32, RFWCMB, All );
-	addMTLPixelFormatDesc    ( RG16Uint, Color32, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG16Sint, Color32, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG16Float, Color32, All, All );
+    addMTLPixelFormatDesc(RG16Unorm, Color32, RFWCMB, All);
+    addMTLPixelFormatDesc(RG16Snorm, Color32, RFWCMB, All);
+    addMTLPixelFormatDesc(RG16Uint, Color32, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG16Sint, Color32, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG16Float, Color32, All, All);
 
-	addMTLPixelFormatDesc    ( RGBA8Unorm, Color32, All, All );
-	addMTLPixelFormatDescSRGB( RGBA8Unorm_sRGB, Color32, All, RFCMRB, RGBA8Unorm );
-	addMTLPixelFormatDesc    ( RGBA8Snorm, Color32, All, All );
-	addMTLPixelFormatDesc    ( RGBA8Uint, Color32, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RGBA8Sint, Color32, RWCM, RWCM );
+    addMTLPixelFormatDesc(RGBA8Unorm, Color32, All, All);
+    addMTLPixelFormatDescSRGB(RGBA8Unorm_sRGB, Color32, All, RFCMRB,
+                              RGBA8Unorm);
+    addMTLPixelFormatDesc(RGBA8Snorm, Color32, All, All);
+    addMTLPixelFormatDesc(RGBA8Uint, Color32, RWCM, RWCM);
+    addMTLPixelFormatDesc(RGBA8Sint, Color32, RWCM, RWCM);
 
-	addMTLPixelFormatDesc    ( BGRA8Unorm, Color32, All, All );
-	addMTLPixelFormatDescSRGB( BGRA8Unorm_sRGB, Color32, All, RFCMRB, BGRA8Unorm );
+    addMTLPixelFormatDesc(BGRA8Unorm, Color32, All, All);
+    addMTLPixelFormatDescSRGB(BGRA8Unorm_sRGB, Color32, All, RFCMRB,
+                              BGRA8Unorm);
 
-	// Packed 32-bit pixel formats
-	addMTLPixelFormatDesc    ( RGB10A2Unorm, Color32, All, All );
-	addMTLPixelFormatDesc    ( BGR10A2Unorm, Color32, All, All );
-	addMTLPixelFormatDesc    ( RGB10A2Uint, Color32, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG11B10Float, Color32, All, All );
-	addMTLPixelFormatDesc    ( RGB9E5Float, Color32, All, RF );
+    // Packed 32-bit pixel formats
+    addMTLPixelFormatDesc(RGB10A2Unorm, Color32, All, All);
+    addMTLPixelFormatDesc(BGR10A2Unorm, Color32, All, All);
+    addMTLPixelFormatDesc(RGB10A2Uint, Color32, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG11B10Float, Color32, All, All);
+    addMTLPixelFormatDesc(RGB9E5Float, Color32, All, RF);
 
-	// Ordinary 64-bit pixel formats
-	addMTLPixelFormatDesc    ( RG32Uint, Color64, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG32Sint, Color64, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RG32Float, Color64, All, All );
+    // Ordinary 64-bit pixel formats
+    addMTLPixelFormatDesc(RG32Uint, Color64, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG32Sint, Color64, RWCM, RWCM);
+    addMTLPixelFormatDesc(RG32Float, Color64, All, All);
 
-	addMTLPixelFormatDesc    ( RGBA16Unorm, Color64, RFWCMB, All );
-	addMTLPixelFormatDesc    ( RGBA16Snorm, Color64, RFWCMB, All );
-	addMTLPixelFormatDesc    ( RGBA16Uint, Color64, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RGBA16Sint, Color64, RWCM, RWCM );
-	addMTLPixelFormatDesc    ( RGBA16Float, Color64, All, All );
+    addMTLPixelFormatDesc(RGBA16Unorm, Color64, RFWCMB, All);
+    addMTLPixelFormatDesc(RGBA16Snorm, Color64, RFWCMB, All);
+    addMTLPixelFormatDesc(RGBA16Uint, Color64, RWCM, RWCM);
+    addMTLPixelFormatDesc(RGBA16Sint, Color64, RWCM, RWCM);
+    addMTLPixelFormatDesc(RGBA16Float, Color64, All, All);
 
-	// Ordinary 128-bit pixel formats
-	addMTLPixelFormatDesc    ( RGBA32Uint, Color128, RWC, RWCM );
-	addMTLPixelFormatDesc    ( RGBA32Sint, Color128, RWC, RWCM );
-	addMTLPixelFormatDesc    ( RGBA32Float, Color128, All, All );
+    // Ordinary 128-bit pixel formats
+    addMTLPixelFormatDesc(RGBA32Uint, Color128, RWC, RWCM);
+    addMTLPixelFormatDesc(RGBA32Sint, Color128, RWC, RWCM);
+    addMTLPixelFormatDesc(RGBA32Float, Color128, All, All);
 
-	// Compressed pixel formats
-	addMTLPixelFormatDesc    ( PVRTC_RGBA_2BPP, PVRTC_RGBA_2BPP, RF, None );
-	addMTLPixelFormatDescSRGB( PVRTC_RGBA_2BPP_sRGB, PVRTC_RGBA_2BPP, RF, None, PVRTC_RGBA_2BPP );
-	addMTLPixelFormatDesc    ( PVRTC_RGBA_4BPP, PVRTC_RGBA_4BPP, RF, None );
-	addMTLPixelFormatDescSRGB( PVRTC_RGBA_4BPP_sRGB, PVRTC_RGBA_4BPP, RF, None, PVRTC_RGBA_4BPP );
+    // Compressed pixel formats
+    addMTLPixelFormatDesc(PVRTC_RGBA_2BPP, PVRTC_RGBA_2BPP, RF, None);
+    addMTLPixelFormatDescSRGB(PVRTC_RGBA_2BPP_sRGB, PVRTC_RGBA_2BPP, RF, None,
+                              PVRTC_RGBA_2BPP);
+    addMTLPixelFormatDesc(PVRTC_RGBA_4BPP, PVRTC_RGBA_4BPP, RF, None);
+    addMTLPixelFormatDescSRGB(PVRTC_RGBA_4BPP_sRGB, PVRTC_RGBA_4BPP, RF, None,
+                              PVRTC_RGBA_4BPP);
 
-	addMTLPixelFormatDesc    ( ETC2_RGB8, ETC2_RGB8, RF, None );
-	addMTLPixelFormatDescSRGB( ETC2_RGB8_sRGB, ETC2_RGB8, RF, None, ETC2_RGB8 );
-	addMTLPixelFormatDesc    ( ETC2_RGB8A1, ETC2_RGB8A1, RF, None );
-	addMTLPixelFormatDescSRGB( ETC2_RGB8A1_sRGB, ETC2_RGB8A1, RF, None, ETC2_RGB8A1 );
-	addMTLPixelFormatDesc    ( EAC_RGBA8, EAC_RGBA8, RF, None );
-	addMTLPixelFormatDescSRGB( EAC_RGBA8_sRGB, EAC_RGBA8, RF, None, EAC_RGBA8 );
-	addMTLPixelFormatDesc    ( EAC_R11Unorm, EAC_R11, RF, None );
-	addMTLPixelFormatDesc    ( EAC_R11Snorm, EAC_R11, RF, None );
-	addMTLPixelFormatDesc    ( EAC_RG11Unorm, EAC_RG11, RF, None );
-	addMTLPixelFormatDesc    ( EAC_RG11Snorm, EAC_RG11, RF, None );
+    addMTLPixelFormatDesc(ETC2_RGB8, ETC2_RGB8, RF, None);
+    addMTLPixelFormatDescSRGB(ETC2_RGB8_sRGB, ETC2_RGB8, RF, None, ETC2_RGB8);
+    addMTLPixelFormatDesc(ETC2_RGB8A1, ETC2_RGB8A1, RF, None);
+    addMTLPixelFormatDescSRGB(ETC2_RGB8A1_sRGB, ETC2_RGB8A1, RF, None,
+                              ETC2_RGB8A1);
+    addMTLPixelFormatDesc(EAC_RGBA8, EAC_RGBA8, RF, None);
+    addMTLPixelFormatDescSRGB(EAC_RGBA8_sRGB, EAC_RGBA8, RF, None, EAC_RGBA8);
+    addMTLPixelFormatDesc(EAC_R11Unorm, EAC_R11, RF, None);
+    addMTLPixelFormatDesc(EAC_R11Snorm, EAC_R11, RF, None);
+    addMTLPixelFormatDesc(EAC_RG11Unorm, EAC_RG11, RF, None);
+    addMTLPixelFormatDesc(EAC_RG11Snorm, EAC_RG11, RF, None);
 
-	addMTLPixelFormatDesc    ( ASTC_4x4_LDR, ASTC_4x4, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_4x4_sRGB, ASTC_4x4, RF, None, ASTC_4x4_LDR );
-	addMTLPixelFormatDesc    ( ASTC_4x4_HDR, ASTC_4x4, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_5x4_LDR, ASTC_5x4, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_5x4_sRGB, ASTC_5x4, RF, None, ASTC_5x4_LDR );
-	addMTLPixelFormatDesc    ( ASTC_5x4_HDR, ASTC_5x4, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_5x5_LDR, ASTC_5x5, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_5x5_sRGB, ASTC_5x5, RF, None, ASTC_5x5_LDR );
-	addMTLPixelFormatDesc    ( ASTC_5x5_HDR, ASTC_5x5, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_6x5_LDR, ASTC_6x5, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_6x5_sRGB, ASTC_6x5, RF, None, ASTC_6x5_LDR );
-	addMTLPixelFormatDesc    ( ASTC_6x5_HDR, ASTC_6x5, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_6x6_LDR, ASTC_6x6, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_6x6_sRGB, ASTC_6x6, RF, None, ASTC_6x6_LDR );
-	addMTLPixelFormatDesc    ( ASTC_6x6_HDR, ASTC_6x6, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_8x5_LDR, ASTC_8x5, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_8x5_sRGB, ASTC_8x5, RF, None, ASTC_8x5_LDR );
-	addMTLPixelFormatDesc    ( ASTC_8x5_HDR, ASTC_8x5, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_8x6_LDR, ASTC_8x6, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_8x6_sRGB, ASTC_8x6, RF, None, ASTC_8x6_LDR );
-	addMTLPixelFormatDesc    ( ASTC_8x6_HDR, ASTC_8x6, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_8x8_LDR, ASTC_8x8, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_8x8_sRGB, ASTC_8x8, RF, None, ASTC_8x8_LDR );
-	addMTLPixelFormatDesc    ( ASTC_8x8_HDR, ASTC_8x8, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_10x5_LDR, ASTC_10x5, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_10x5_sRGB, ASTC_10x5, RF, None, ASTC_10x5_LDR );
-	addMTLPixelFormatDesc    ( ASTC_10x5_HDR, ASTC_10x5, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_10x6_LDR, ASTC_10x6, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_10x6_sRGB, ASTC_10x6, RF, None, ASTC_10x6_LDR );
-	addMTLPixelFormatDesc    ( ASTC_10x6_HDR, ASTC_10x6, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_10x8_LDR, ASTC_10x8, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_10x8_sRGB, ASTC_10x8, RF, None, ASTC_10x8_LDR );
-	addMTLPixelFormatDesc    ( ASTC_10x8_HDR, ASTC_10x8, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_10x10_LDR, ASTC_10x10, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_10x10_sRGB, ASTC_10x10, RF, None, ASTC_10x10_LDR );
-	addMTLPixelFormatDesc    ( ASTC_10x10_HDR, ASTC_10x10, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_12x10_LDR, ASTC_12x10, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_12x10_sRGB, ASTC_12x10, RF, None, ASTC_12x10_LDR );
-	addMTLPixelFormatDesc    ( ASTC_12x10_HDR, ASTC_12x10, RF, None );
-	addMTLPixelFormatDesc    ( ASTC_12x12_LDR, ASTC_12x12, RF, None );
-	addMTLPixelFormatDescSRGB( ASTC_12x12_sRGB, ASTC_12x12, RF, None, ASTC_12x12_LDR );
-	addMTLPixelFormatDesc    ( ASTC_12x12_HDR, ASTC_12x12, RF, None );
+    addMTLPixelFormatDesc(ASTC_4x4_LDR, ASTC_4x4, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_4x4_sRGB, ASTC_4x4, RF, None, ASTC_4x4_LDR);
+    addMTLPixelFormatDesc(ASTC_4x4_HDR, ASTC_4x4, RF, None);
+    addMTLPixelFormatDesc(ASTC_5x4_LDR, ASTC_5x4, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_5x4_sRGB, ASTC_5x4, RF, None, ASTC_5x4_LDR);
+    addMTLPixelFormatDesc(ASTC_5x4_HDR, ASTC_5x4, RF, None);
+    addMTLPixelFormatDesc(ASTC_5x5_LDR, ASTC_5x5, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_5x5_sRGB, ASTC_5x5, RF, None, ASTC_5x5_LDR);
+    addMTLPixelFormatDesc(ASTC_5x5_HDR, ASTC_5x5, RF, None);
+    addMTLPixelFormatDesc(ASTC_6x5_LDR, ASTC_6x5, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_6x5_sRGB, ASTC_6x5, RF, None, ASTC_6x5_LDR);
+    addMTLPixelFormatDesc(ASTC_6x5_HDR, ASTC_6x5, RF, None);
+    addMTLPixelFormatDesc(ASTC_6x6_LDR, ASTC_6x6, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_6x6_sRGB, ASTC_6x6, RF, None, ASTC_6x6_LDR);
+    addMTLPixelFormatDesc(ASTC_6x6_HDR, ASTC_6x6, RF, None);
+    addMTLPixelFormatDesc(ASTC_8x5_LDR, ASTC_8x5, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_8x5_sRGB, ASTC_8x5, RF, None, ASTC_8x5_LDR);
+    addMTLPixelFormatDesc(ASTC_8x5_HDR, ASTC_8x5, RF, None);
+    addMTLPixelFormatDesc(ASTC_8x6_LDR, ASTC_8x6, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_8x6_sRGB, ASTC_8x6, RF, None, ASTC_8x6_LDR);
+    addMTLPixelFormatDesc(ASTC_8x6_HDR, ASTC_8x6, RF, None);
+    addMTLPixelFormatDesc(ASTC_8x8_LDR, ASTC_8x8, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_8x8_sRGB, ASTC_8x8, RF, None, ASTC_8x8_LDR);
+    addMTLPixelFormatDesc(ASTC_8x8_HDR, ASTC_8x8, RF, None);
+    addMTLPixelFormatDesc(ASTC_10x5_LDR, ASTC_10x5, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_10x5_sRGB, ASTC_10x5, RF, None,
+                              ASTC_10x5_LDR);
+    addMTLPixelFormatDesc(ASTC_10x5_HDR, ASTC_10x5, RF, None);
+    addMTLPixelFormatDesc(ASTC_10x6_LDR, ASTC_10x6, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_10x6_sRGB, ASTC_10x6, RF, None,
+                              ASTC_10x6_LDR);
+    addMTLPixelFormatDesc(ASTC_10x6_HDR, ASTC_10x6, RF, None);
+    addMTLPixelFormatDesc(ASTC_10x8_LDR, ASTC_10x8, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_10x8_sRGB, ASTC_10x8, RF, None,
+                              ASTC_10x8_LDR);
+    addMTLPixelFormatDesc(ASTC_10x8_HDR, ASTC_10x8, RF, None);
+    addMTLPixelFormatDesc(ASTC_10x10_LDR, ASTC_10x10, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_10x10_sRGB, ASTC_10x10, RF, None,
+                              ASTC_10x10_LDR);
+    addMTLPixelFormatDesc(ASTC_10x10_HDR, ASTC_10x10, RF, None);
+    addMTLPixelFormatDesc(ASTC_12x10_LDR, ASTC_12x10, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_12x10_sRGB, ASTC_12x10, RF, None,
+                              ASTC_12x10_LDR);
+    addMTLPixelFormatDesc(ASTC_12x10_HDR, ASTC_12x10, RF, None);
+    addMTLPixelFormatDesc(ASTC_12x12_LDR, ASTC_12x12, RF, None);
+    addMTLPixelFormatDescSRGB(ASTC_12x12_sRGB, ASTC_12x12, RF, None,
+                              ASTC_12x12_LDR);
+    addMTLPixelFormatDesc(ASTC_12x12_HDR, ASTC_12x12, RF, None);
 
-	addMTLPixelFormatDesc    ( BC1_RGBA, BC1_RGBA, RF, RF );
-	addMTLPixelFormatDescSRGB( BC1_RGBA_sRGB, BC1_RGBA, RF, RF, BC1_RGBA );
-	addMTLPixelFormatDesc    ( BC2_RGBA, BC2_RGBA, RF, RF );
-	addMTLPixelFormatDescSRGB( BC2_RGBA_sRGB, BC2_RGBA, RF, RF, BC2_RGBA );
-	addMTLPixelFormatDesc    ( BC3_RGBA, BC3_RGBA, RF, RF );
-	addMTLPixelFormatDescSRGB( BC3_RGBA_sRGB, BC3_RGBA, RF, RF, BC3_RGBA );
-	addMTLPixelFormatDesc    ( BC4_RUnorm, BC4_R, RF, RF );
-	addMTLPixelFormatDesc    ( BC4_RSnorm, BC4_R, RF, RF );
-	addMTLPixelFormatDesc    ( BC5_RGUnorm, BC5_RG, RF, RF );
-	addMTLPixelFormatDesc    ( BC5_RGSnorm, BC5_RG, RF, RF );
-	addMTLPixelFormatDesc    ( BC6H_RGBUfloat, BC6H_RGB, RF, RF );
-	addMTLPixelFormatDesc    ( BC6H_RGBFloat, BC6H_RGB, RF, RF );
-	addMTLPixelFormatDesc    ( BC7_RGBAUnorm, BC7_RGBA, RF, RF );
-	addMTLPixelFormatDescSRGB( BC7_RGBAUnorm_sRGB, BC7_RGBA, RF, RF, BC7_RGBAUnorm );
+    addMTLPixelFormatDesc(BC1_RGBA, BC1_RGBA, RF, RF);
+    addMTLPixelFormatDescSRGB(BC1_RGBA_sRGB, BC1_RGBA, RF, RF, BC1_RGBA);
+    addMTLPixelFormatDesc(BC2_RGBA, BC2_RGBA, RF, RF);
+    addMTLPixelFormatDescSRGB(BC2_RGBA_sRGB, BC2_RGBA, RF, RF, BC2_RGBA);
+    addMTLPixelFormatDesc(BC3_RGBA, BC3_RGBA, RF, RF);
+    addMTLPixelFormatDescSRGB(BC3_RGBA_sRGB, BC3_RGBA, RF, RF, BC3_RGBA);
+    addMTLPixelFormatDesc(BC4_RUnorm, BC4_R, RF, RF);
+    addMTLPixelFormatDesc(BC4_RSnorm, BC4_R, RF, RF);
+    addMTLPixelFormatDesc(BC5_RGUnorm, BC5_RG, RF, RF);
+    addMTLPixelFormatDesc(BC5_RGSnorm, BC5_RG, RF, RF);
+    addMTLPixelFormatDesc(BC6H_RGBUfloat, BC6H_RGB, RF, RF);
+    addMTLPixelFormatDesc(BC6H_RGBFloat, BC6H_RGB, RF, RF);
+    addMTLPixelFormatDesc(BC7_RGBAUnorm, BC7_RGBA, RF, RF);
+    addMTLPixelFormatDescSRGB(BC7_RGBAUnorm_sRGB, BC7_RGBA, RF, RF,
+                              BC7_RGBAUnorm);
 
-	// YUV pixel formats
-	addMTLPixelFormatDesc    ( GBGR422, None, RF, RF );
-	addMTLPixelFormatDesc    ( BGRG422, None, RF, RF );
+    // YUV pixel formats
+    addMTLPixelFormatDesc(GBGR422, None, RF, RF);
+    addMTLPixelFormatDesc(BGRG422, None, RF, RF);
 
-	// Extended range and wide color pixel formats
-	addMTLPixelFormatDesc    ( BGRA10_XR, BGRA10_XR, All, None );
-	addMTLPixelFormatDescSRGB( BGRA10_XR_sRGB, BGRA10_XR, All, None, BGRA10_XR );
-	addMTLPixelFormatDesc    ( BGR10_XR, BGR10_XR, All, None );
-	addMTLPixelFormatDescSRGB( BGR10_XR_sRGB, BGR10_XR, All, None, BGR10_XR );
+    // Extended range and wide color pixel formats
+    addMTLPixelFormatDesc(BGRA10_XR, BGRA10_XR, All, None);
+    addMTLPixelFormatDescSRGB(BGRA10_XR_sRGB, BGRA10_XR, All, None, BGRA10_XR);
+    addMTLPixelFormatDesc(BGR10_XR, BGR10_XR, All, None);
+    addMTLPixelFormatDescSRGB(BGR10_XR_sRGB, BGR10_XR, All, None, BGR10_XR);
 
-	// Depth and stencil pixel formats
-	addMTLPixelFormatDesc    ( Depth16Unorm, None, DRFMR, DRFMR );
-	addMTLPixelFormatDesc    ( Depth32Float, None, DRMR, DRFMR );
-	addMTLPixelFormatDesc    ( Stencil8, None, DRM, DRM );
-	addMTLPixelFormatDesc    ( Depth24Unorm_Stencil8, Depth24_Stencil8, None, DRFMR );
-	addMTLPixelFormatDesc    ( Depth32Float_Stencil8, Depth32_Stencil8, DRMR, DRFMR );
-	addMTLPixelFormatDesc    ( X24_Stencil8, Depth24_Stencil8, None, DRM );
-	addMTLPixelFormatDesc    ( X32_Stencil8, Depth32_Stencil8, DRM, DRM );
+    // Depth and stencil pixel formats
+    addMTLPixelFormatDesc(Depth16Unorm, None, DRFMR, DRFMR);
+    addMTLPixelFormatDesc(Depth32Float, None, DRMR, DRFMR);
+    addMTLPixelFormatDesc(Stencil8, None, DRM, DRM);
+    addMTLPixelFormatDesc(Depth24Unorm_Stencil8, Depth24_Stencil8, None, DRFMR);
+    addMTLPixelFormatDesc(Depth32Float_Stencil8, Depth32_Stencil8, DRMR, DRFMR);
+    addMTLPixelFormatDesc(X24_Stencil8, Depth24_Stencil8, None, DRM);
+    addMTLPixelFormatDesc(X32_Stencil8, Depth32_Stencil8, DRM, DRM);
 
-	_mtlPixelFormatDescriptions.shrink_to_fit();
+    _mtlPixelFormatDescriptions.shrink_to_fit();
 }
 
 // If necessary, resize vector with empty elements
-void MVKPixelFormats::addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt, MVKMTLFmtCaps vtxCap, const char* name) {
-	if (mtlVtxFmt >= _mtlVertexFormatDescriptions.size()) { _mtlVertexFormatDescriptions.resize(mtlVtxFmt + 1, {}); }
-	_mtlVertexFormatDescriptions[mtlVtxFmt] = { .mtlVertexFormat = mtlVtxFmt, VK_FORMAT_UNDEFINED, vtxCap, MVKMTLViewClass::None, MTLPixelFormatInvalid, name };
+void MVKPixelFormats::addMTLVertexFormatDescImpl(MTLVertexFormat mtlVtxFmt,
+                                                 MVKMTLFmtCaps vtxCap,
+                                                 const char* name) {
+    if (mtlVtxFmt >= _mtlVertexFormatDescriptions.size()) {
+        _mtlVertexFormatDescriptions.resize(mtlVtxFmt + 1, {});
+    }
+    _mtlVertexFormatDescriptions[mtlVtxFmt] = {.mtlVertexFormat = mtlVtxFmt,
+                                               VK_FORMAT_UNDEFINED,
+                                               vtxCap,
+                                               MVKMTLViewClass::None,
+                                               MTLPixelFormatInvalid,
+                                               name};
 }
 
-// Check mtlVtx exists on platform, to avoid overwriting the MTLVertexFormatInvalid entry.
-#define addMTLVertexFormatDesc(mtlVtx)  if (MTLVertexFormat ##mtlVtx) { addMTLVertexFormatDescImpl(MTLVertexFormat ##mtlVtx, kMVKMTLFmtCapsVertex, "MTLVertexFormat" #mtlVtx); }
+// Check mtlVtx exists on platform, to avoid overwriting the
+// MTLVertexFormatInvalid entry.
+#define addMTLVertexFormatDesc(mtlVtx)                                         \
+    if (MTLVertexFormat##mtlVtx) {                                             \
+        addMTLVertexFormatDescImpl(MTLVertexFormat##mtlVtx,                    \
+                                   kMVKMTLFmtCapsVertex,                       \
+                                   "MTLVertexFormat" #mtlVtx);                 \
+    }
 
-void MVKPixelFormats::initMTLVertexFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps) {
-	_mtlVertexFormatDescriptions.resize(MTLVertexFormatHalf + 3, {});
+void MVKPixelFormats::initMTLVertexFormatCapabilities(
+    const MVKMTLDeviceCapabilities& gpuCaps) {
+    _mtlVertexFormatDescriptions.resize(MTLVertexFormatHalf + 3, {});
 
-	// MTLVertexFormatInvalid must come first. Use addMTLVertexFormatDescImpl to avoid guard code.
-	addMTLVertexFormatDescImpl(MTLVertexFormatInvalid, kMVKMTLFmtCapsNone, "MTLVertexFormatInvalid");
+    // MTLVertexFormatInvalid must come first. Use addMTLVertexFormatDescImpl to
+    // avoid guard code.
+    addMTLVertexFormatDescImpl(MTLVertexFormatInvalid, kMVKMTLFmtCapsNone,
+                               "MTLVertexFormatInvalid");
 
-	addMTLVertexFormatDesc( UChar2Normalized );
-	addMTLVertexFormatDesc( Char2Normalized );
-	addMTLVertexFormatDesc( UChar2 );
-	addMTLVertexFormatDesc( Char2 );
+    addMTLVertexFormatDesc(UChar2Normalized);
+    addMTLVertexFormatDesc(Char2Normalized);
+    addMTLVertexFormatDesc(UChar2);
+    addMTLVertexFormatDesc(Char2);
 
-	addMTLVertexFormatDesc( UChar3Normalized );
-	addMTLVertexFormatDesc( Char3Normalized );
-	addMTLVertexFormatDesc( UChar3 );
-	addMTLVertexFormatDesc( Char3 );
+    addMTLVertexFormatDesc(UChar3Normalized);
+    addMTLVertexFormatDesc(Char3Normalized);
+    addMTLVertexFormatDesc(UChar3);
+    addMTLVertexFormatDesc(Char3);
 
-	addMTLVertexFormatDesc( UChar4Normalized );
-	addMTLVertexFormatDesc( Char4Normalized );
-	addMTLVertexFormatDesc( UChar4 );
-	addMTLVertexFormatDesc( Char4 );
+    addMTLVertexFormatDesc(UChar4Normalized);
+    addMTLVertexFormatDesc(Char4Normalized);
+    addMTLVertexFormatDesc(UChar4);
+    addMTLVertexFormatDesc(Char4);
 
-	addMTLVertexFormatDesc( UInt1010102Normalized );
-	addMTLVertexFormatDesc( Int1010102Normalized );
+    addMTLVertexFormatDesc(UInt1010102Normalized);
+    addMTLVertexFormatDesc(Int1010102Normalized);
 
-	addMTLVertexFormatDesc( UShort2Normalized );
-	addMTLVertexFormatDesc( Short2Normalized );
-	addMTLVertexFormatDesc( UShort2 );
-	addMTLVertexFormatDesc( Short2 );
-	addMTLVertexFormatDesc( Half2 );
+    addMTLVertexFormatDesc(UShort2Normalized);
+    addMTLVertexFormatDesc(Short2Normalized);
+    addMTLVertexFormatDesc(UShort2);
+    addMTLVertexFormatDesc(Short2);
+    addMTLVertexFormatDesc(Half2);
 
-	addMTLVertexFormatDesc( UShort3Normalized );
-	addMTLVertexFormatDesc( Short3Normalized );
-	addMTLVertexFormatDesc( UShort3 );
-	addMTLVertexFormatDesc( Short3 );
-	addMTLVertexFormatDesc( Half3 );
+    addMTLVertexFormatDesc(UShort3Normalized);
+    addMTLVertexFormatDesc(Short3Normalized);
+    addMTLVertexFormatDesc(UShort3);
+    addMTLVertexFormatDesc(Short3);
+    addMTLVertexFormatDesc(Half3);
 
-	addMTLVertexFormatDesc( UShort4Normalized );
-	addMTLVertexFormatDesc( Short4Normalized );
-	addMTLVertexFormatDesc( UShort4 );
-	addMTLVertexFormatDesc( Short4 );
-	addMTLVertexFormatDesc( Half4 );
+    addMTLVertexFormatDesc(UShort4Normalized);
+    addMTLVertexFormatDesc(Short4Normalized);
+    addMTLVertexFormatDesc(UShort4);
+    addMTLVertexFormatDesc(Short4);
+    addMTLVertexFormatDesc(Half4);
 
-	addMTLVertexFormatDesc( UInt );
-	addMTLVertexFormatDesc( Int );
-	addMTLVertexFormatDesc( Float );
+    addMTLVertexFormatDesc(UInt);
+    addMTLVertexFormatDesc(Int);
+    addMTLVertexFormatDesc(Float);
 
-	addMTLVertexFormatDesc( UInt2 );
-	addMTLVertexFormatDesc( Int2 );
-	addMTLVertexFormatDesc( Float2 );
+    addMTLVertexFormatDesc(UInt2);
+    addMTLVertexFormatDesc(Int2);
+    addMTLVertexFormatDesc(Float2);
 
-	addMTLVertexFormatDesc( UInt3 );
-	addMTLVertexFormatDesc( Int3 );
-	addMTLVertexFormatDesc( Float3 );
+    addMTLVertexFormatDesc(UInt3);
+    addMTLVertexFormatDesc(Int3);
+    addMTLVertexFormatDesc(Float3);
 
-	addMTLVertexFormatDesc( UInt4 );
-	addMTLVertexFormatDesc( Int4 );
-	addMTLVertexFormatDesc( Float4 );
+    addMTLVertexFormatDesc(UInt4);
+    addMTLVertexFormatDesc(Int4);
+    addMTLVertexFormatDesc(Float4);
 
-	addMTLVertexFormatDesc( UCharNormalized );
-	addMTLVertexFormatDesc( CharNormalized );
-	addMTLVertexFormatDesc( UChar );
-	addMTLVertexFormatDesc( Char );
+    addMTLVertexFormatDesc(UCharNormalized);
+    addMTLVertexFormatDesc(CharNormalized);
+    addMTLVertexFormatDesc(UChar);
+    addMTLVertexFormatDesc(Char);
 
-	addMTLVertexFormatDesc( UShortNormalized );
-	addMTLVertexFormatDesc( ShortNormalized );
-	addMTLVertexFormatDesc( UShort );
-	addMTLVertexFormatDesc( Short );
-	addMTLVertexFormatDesc( Half );
+    addMTLVertexFormatDesc(UShortNormalized);
+    addMTLVertexFormatDesc(ShortNormalized);
+    addMTLVertexFormatDesc(UShort);
+    addMTLVertexFormatDesc(Short);
+    addMTLVertexFormatDesc(Half);
 
-	addMTLVertexFormatDesc( UChar4Normalized_BGRA );
-	
-	if (gpuCaps.supportsApple5 || gpuCaps.supportsMac2) {
-		addMTLVertexFormatDesc( FloatRG11B10 );
-		addMTLVertexFormatDesc( FloatRGB9E5 );
-	}
+    addMTLVertexFormatDesc(UChar4Normalized_BGRA);
 
-	_mtlVertexFormatDescriptions.shrink_to_fit();
+    if (gpuCaps.supportsApple5 || gpuCaps.supportsMac2) {
+        addMTLVertexFormatDesc(FloatRG11B10);
+        addMTLVertexFormatDesc(FloatRGB9E5);
+    }
+
+    _mtlVertexFormatDescriptions.shrink_to_fit();
 }
 
-// Return a reference to the format capabilities, so the caller can manipulate them.
-// Check mtlPixFmt exists on platform, to avoid overwriting the MTLPixelFormatInvalid entry.
-// When returning the dummy, reset it on each access because it can be written to by caller.
-MVKMTLFmtCaps& MVKPixelFormats::getMTLPixelFormatCapsIf(MTLPixelFormat mtlPixFmt, bool cond) {
-	static MVKMTLFmtCaps dummyFmtCaps;
-	if (mtlPixFmt && cond) {
-		return getMTLPixelFormatDesc(mtlPixFmt).mtlFmtCaps;
-	} else {
-		dummyFmtCaps = kMVKMTLFmtCapsNone;
-		return dummyFmtCaps;
-	}
+// Return a reference to the format capabilities, so the caller can manipulate
+// them. Check mtlPixFmt exists on platform, to avoid overwriting the
+// MTLPixelFormatInvalid entry. When returning the dummy, reset it on each
+// access because it can be written to by caller.
+MVKMTLFmtCaps&
+MVKPixelFormats::getMTLPixelFormatCapsIf(MTLPixelFormat mtlPixFmt, bool cond) {
+    static MVKMTLFmtCaps dummyFmtCaps;
+    if (mtlPixFmt && cond) {
+        return getMTLPixelFormatDesc(mtlPixFmt).mtlFmtCaps;
+    } else {
+        dummyFmtCaps = kMVKMTLFmtCapsNone;
+        return dummyFmtCaps;
+    }
 }
 
-#define setMTLPixFmtCapsIf(cond, mtlFmt, caps)           getMTLPixelFormatCapsIf(MTLPixelFormat ##mtlFmt, cond) = kMVKMTLFmtCaps ##caps;
-#define setMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)      setMTLPixFmtCapsIf(gpuCaps.supports ##gpuFam, mtlFmt, caps)
+#define setMTLPixFmtCapsIf(cond, mtlFmt, caps)                                 \
+    getMTLPixelFormatCapsIf(MTLPixelFormat##mtlFmt, cond) =                    \
+        kMVKMTLFmtCaps##caps;
+#define setMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)                            \
+    setMTLPixFmtCapsIf(gpuCaps.supports##gpuFam, mtlFmt, caps)
 
-#define enableMTLPixFmtCapsIf(cond, mtlFmt, caps)        mvkEnableFlags(getMTLPixelFormatCapsIf(MTLPixelFormat ##mtlFmt, cond), kMVKMTLFmtCaps ##caps);
-#define enableMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)   enableMTLPixFmtCapsIf(gpuCaps.supports ##gpuFam, mtlFmt, caps)
+#define enableMTLPixFmtCapsIf(cond, mtlFmt, caps)                              \
+    mvkEnableFlags(getMTLPixelFormatCapsIf(MTLPixelFormat##mtlFmt, cond),      \
+                   kMVKMTLFmtCaps##caps);
+#define enableMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)                         \
+    enableMTLPixFmtCapsIf(gpuCaps.supports##gpuFam, mtlFmt, caps)
 
-#define disableMTLPixFmtCapsIf(cond, mtlFmt, caps)       mvkDisableFlags(getMTLPixelFormatCapsIf(MTLPixelFormat ##mtlFmt, cond), kMVKMTLFmtCaps ##caps);
-#define disableMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)  disableMTLPixFmtCapsIf(gpuCaps.supports ##gpuFam, mtlFmt, caps)
+#define disableMTLPixFmtCapsIf(cond, mtlFmt, caps)                             \
+    mvkDisableFlags(getMTLPixelFormatCapsIf(MTLPixelFormat##mtlFmt, cond),     \
+                    kMVKMTLFmtCaps##caps);
+#define disableMTLPixFmtCapsIfGPU(gpuFam, mtlFmt, caps)                        \
+    disableMTLPixFmtCapsIf(gpuCaps.supports##gpuFam, mtlFmt, caps)
 
-// Modifies the format capability tables based on the capabilities of the specific MTLDevice
-void MVKPixelFormats::modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities& gpuCaps) {
+// Modifies the format capability tables based on the capabilities of the
+// specific MTLDevice
+void MVKPixelFormats::modifyMTLFormatCapabilities(
+    const MVKMTLDeviceCapabilities& gpuCaps) {
 
-	bool noVulkanSupport =  false;		// Indicated supported in Metal but not Vulkan or SPIR-V.
-	bool notMac =  gpuCaps.isAppleGPU && !gpuCaps.supportsMac1;
-	bool iosOnly1 = notMac && !gpuCaps.supportsApple2;
-	bool iosOnly2 = notMac && !gpuCaps.supportsApple3;
-	bool iosOnly6 = notMac && !gpuCaps.supportsApple7;
-	bool iosOnly8 = notMac && !gpuCaps.supportsApple9;
+    bool noVulkanSupport =
+        false; // Indicated supported in Metal but not Vulkan or SPIR-V.
+    bool notMac = gpuCaps.isAppleGPU && !gpuCaps.supportsMac1;
+    bool iosOnly1 = notMac && !gpuCaps.supportsApple2;
+    bool iosOnly2 = notMac && !gpuCaps.supportsApple3;
+    bool iosOnly6 = notMac && !gpuCaps.supportsApple7;
+    bool iosOnly8 = notMac && !gpuCaps.supportsApple9;
 
-	setMTLPixFmtCapsIf( iosOnly2, A8Unorm, RF );
-	setMTLPixFmtCapsIf( iosOnly1, R8Unorm_sRGB, RFCMRB );
-	setMTLPixFmtCapsIf( iosOnly1, R8Snorm, RFWCMB );
+    setMTLPixFmtCapsIf(iosOnly2, A8Unorm, RF);
+    setMTLPixFmtCapsIf(iosOnly1, R8Unorm_sRGB, RFCMRB);
+    setMTLPixFmtCapsIf(iosOnly1, R8Snorm, RFWCMB);
 
-	setMTLPixFmtCapsIf( iosOnly1, RG8Unorm_sRGB, RFCMRB );
-	setMTLPixFmtCapsIf( iosOnly1, RG8Snorm, RFWCMB );
+    setMTLPixFmtCapsIf(iosOnly1, RG8Unorm_sRGB, RFCMRB);
+    setMTLPixFmtCapsIf(iosOnly1, RG8Snorm, RFWCMB);
 
-	enableMTLPixFmtCapsIfGPU( Apple6, R32Uint, Atomic );
-	enableMTLPixFmtCapsIfGPU( Mac2,   R32Uint, Atomic );
-	enableMTLPixFmtCapsIfGPU( Apple6, R32Sint, Atomic );
-	enableMTLPixFmtCapsIfGPU( Mac2,   R32Sint, Atomic );
+    enableMTLPixFmtCapsIfGPU(Apple6, R32Uint, Atomic);
+    enableMTLPixFmtCapsIfGPU(Mac2, R32Uint, Atomic);
+    enableMTLPixFmtCapsIfGPU(Apple6, R32Sint, Atomic);
+    enableMTLPixFmtCapsIfGPU(Mac2, R32Sint, Atomic);
 
-	setMTLPixFmtCapsIf( iosOnly8, R32Float, RWCMB );
+    setMTLPixFmtCapsIf(iosOnly8, R32Float, RWCMB);
 
-	setMTLPixFmtCapsIf( iosOnly1, RGBA8Unorm_sRGB, RFCMRB );
-	setMTLPixFmtCapsIf( iosOnly1, RGBA8Snorm, RFWCMB );
-	setMTLPixFmtCapsIf( iosOnly1, BGRA8Unorm_sRGB, RFCMRB );
+    setMTLPixFmtCapsIf(iosOnly1, RGBA8Unorm_sRGB, RFCMRB);
+    setMTLPixFmtCapsIf(iosOnly1, RGBA8Snorm, RFWCMB);
+    setMTLPixFmtCapsIf(iosOnly1, BGRA8Unorm_sRGB, RFCMRB);
 
-	setMTLPixFmtCapsIf( iosOnly2, RGB10A2Unorm, RFCMRB );
-	setMTLPixFmtCapsIf( iosOnly2, RGB10A2Uint, RCM );
-	setMTLPixFmtCapsIf( iosOnly2, RG11B10Float, RFCMRB );
-	setMTLPixFmtCapsIf( iosOnly2, RGB9E5Float, RFCMRB );
+    setMTLPixFmtCapsIf(iosOnly2, RGB10A2Unorm, RFCMRB);
+    setMTLPixFmtCapsIf(iosOnly2, RGB10A2Uint, RCM);
+    setMTLPixFmtCapsIf(iosOnly2, RG11B10Float, RFCMRB);
+    setMTLPixFmtCapsIf(iosOnly2, RGB9E5Float, RFCMRB);
 
-	// Blending is actually supported for RGB9E5Float, but format channels cannot
-	// be individually write-enabled during blending on macOS. Disabling blending
-	// on macOS is the least-intrusive way to handle this in a Vulkan-friendly way.
-	disableMTLPixFmtCapsIfGPU( Mac1, RGB9E5Float, Blend);
+    // Blending is actually supported for RGB9E5Float, but format channels
+    // cannot be individually write-enabled during blending on macOS. Disabling
+    // blending on macOS is the least-intrusive way to handle this in a
+    // Vulkan-friendly way.
+    disableMTLPixFmtCapsIfGPU(Mac1, RGB9E5Float, Blend);
 
-	// RGB9E5Float cannot be used as a render target on the simulator
-	disableMTLPixFmtCapsIf( MVK_OS_SIMULATOR, RGB9E5Float, ColorAtt );
+    // RGB9E5Float cannot be used as a render target on the simulator
+    disableMTLPixFmtCapsIf(MVK_OS_SIMULATOR, RGB9E5Float, ColorAtt);
 
-	setMTLPixFmtCapsIf( iosOnly6, RG32Uint, RWC );
-	setMTLPixFmtCapsIf( iosOnly6, RG32Sint, RWC );
+    setMTLPixFmtCapsIf(iosOnly6, RG32Uint, RWC);
+    setMTLPixFmtCapsIf(iosOnly6, RG32Sint, RWC);
 
-	// Metal supports reading both R&G into as one 64-bit atomic operation, but Vulkan and SPIR-V do not.
-	// Including this here so we remember to update this if support is added to Vulkan in the future.
-	bool atomic64 = noVulkanSupport && (gpuCaps.supportsApple9 || (gpuCaps.supportsApple8 && gpuCaps.supportsMac2));
-	enableMTLPixFmtCapsIf( atomic64, RG32Uint, Atomic );
-	enableMTLPixFmtCapsIf( atomic64, RG32Sint, Atomic );
+    // Metal supports reading both R&G into as one 64-bit atomic operation, but
+    // Vulkan and SPIR-V do not. Including this here so we remember to update
+    // this if support is added to Vulkan in the future.
+    bool atomic64 =
+        noVulkanSupport && (gpuCaps.supportsApple9 ||
+                            (gpuCaps.supportsApple8 && gpuCaps.supportsMac2));
+    enableMTLPixFmtCapsIf(atomic64, RG32Uint, Atomic);
+    enableMTLPixFmtCapsIf(atomic64, RG32Sint, Atomic);
 
-	setMTLPixFmtCapsIf( iosOnly8, RG32Float, RWCMB );
-	setMTLPixFmtCapsIf( iosOnly6, RG32Float, RWCB );
+    setMTLPixFmtCapsIf(iosOnly8, RG32Float, RWCMB);
+    setMTLPixFmtCapsIf(iosOnly6, RG32Float, RWCB);
 
-	setMTLPixFmtCapsIf( iosOnly8, RGBA32Float, RWCM );
-	setMTLPixFmtCapsIf( iosOnly6, RGBA32Float, RWC );
+    setMTLPixFmtCapsIf(iosOnly8, RGBA32Float, RWCM);
+    setMTLPixFmtCapsIf(iosOnly6, RGBA32Float, RWC);
 
-	bool msaa32 = gpuCaps.supports32BitMSAA;
-	enableMTLPixFmtCapsIf(msaa32, R32Uint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, R32Sint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, R32Float, Resolve );
-	enableMTLPixFmtCapsIf(msaa32, RG32Uint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, RG32Sint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, RG32Float, Resolve );
-	enableMTLPixFmtCapsIf(msaa32, RGBA32Uint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, RGBA32Sint, MSAA );
-	enableMTLPixFmtCapsIf(msaa32, RGBA32Float, Resolve );
+    bool msaa32 = gpuCaps.supports32BitMSAA;
+    enableMTLPixFmtCapsIf(msaa32, R32Uint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, R32Sint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, R32Float, Resolve);
+    enableMTLPixFmtCapsIf(msaa32, RG32Uint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, RG32Sint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, RG32Float, Resolve);
+    enableMTLPixFmtCapsIf(msaa32, RGBA32Uint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, RGBA32Sint, MSAA);
+    enableMTLPixFmtCapsIf(msaa32, RGBA32Float, Resolve);
 
-	bool floatFB = gpuCaps.supports32BitFloatFiltering;
-	enableMTLPixFmtCapsIf( floatFB, R32Float, Filter );
-	enableMTLPixFmtCapsIf( floatFB, RG32Float, Filter );
-	enableMTLPixFmtCapsIf( floatFB, RGBA32Float, Filter );
-	enableMTLPixFmtCapsIf( floatFB, RGBA32Float, Blend );	// Undocumented by confirmed through testing
+    bool floatFB = gpuCaps.supports32BitFloatFiltering;
+    enableMTLPixFmtCapsIf(floatFB, R32Float, Filter);
+    enableMTLPixFmtCapsIf(floatFB, RG32Float, Filter);
+    enableMTLPixFmtCapsIf(floatFB, RGBA32Float, Filter);
+    enableMTLPixFmtCapsIf(floatFB, RGBA32Float,
+                          Blend); // Undocumented by confirmed through testing
 
-	bool noHDR_ASTC = !gpuCaps.supportsApple6;
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_4x4_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_5x4_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_5x5_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_6x5_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_6x6_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_8x5_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_8x6_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_8x8_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_10x5_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_10x6_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_10x8_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_10x10_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_12x10_HDR, None );
-	setMTLPixFmtCapsIf( noHDR_ASTC, ASTC_12x12_HDR, None );
+    bool noHDR_ASTC = !gpuCaps.supportsApple6;
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_4x4_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_5x4_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_5x5_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_6x5_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_6x6_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_8x5_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_8x6_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_8x8_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_10x5_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_10x6_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_10x8_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_10x10_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_12x10_HDR, None);
+    setMTLPixFmtCapsIf(noHDR_ASTC, ASTC_12x12_HDR, None);
 
-	bool noBC = !gpuCaps.supportsBCTextureCompression;
-	setMTLPixFmtCapsIf( noBC, BC1_RGBA, None );
-	setMTLPixFmtCapsIf( noBC, BC1_RGBA_sRGB, None );
-	setMTLPixFmtCapsIf( noBC, BC2_RGBA, None );
-	setMTLPixFmtCapsIf( noBC, BC2_RGBA_sRGB, None );
-	setMTLPixFmtCapsIf( noBC, BC3_RGBA, None );
-	setMTLPixFmtCapsIf( noBC, BC3_RGBA_sRGB, None );
-	setMTLPixFmtCapsIf( noBC, BC4_RUnorm, None );
-	setMTLPixFmtCapsIf( noBC, BC4_RSnorm, None );
-	setMTLPixFmtCapsIf( noBC, BC5_RGUnorm, None );
-	setMTLPixFmtCapsIf( noBC, BC5_RGSnorm, None );
-	setMTLPixFmtCapsIf( noBC, BC6H_RGBUfloat, None );
-	setMTLPixFmtCapsIf( noBC, BC6H_RGBFloat, None );
-	setMTLPixFmtCapsIf( noBC, BC7_RGBAUnorm, None );
-	setMTLPixFmtCapsIf( noBC, BC7_RGBAUnorm_sRGB, None );
+    bool noBC = !gpuCaps.supportsBCTextureCompression;
+    setMTLPixFmtCapsIf(noBC, BC1_RGBA, None);
+    setMTLPixFmtCapsIf(noBC, BC1_RGBA_sRGB, None);
+    setMTLPixFmtCapsIf(noBC, BC2_RGBA, None);
+    setMTLPixFmtCapsIf(noBC, BC2_RGBA_sRGB, None);
+    setMTLPixFmtCapsIf(noBC, BC3_RGBA, None);
+    setMTLPixFmtCapsIf(noBC, BC3_RGBA_sRGB, None);
+    setMTLPixFmtCapsIf(noBC, BC4_RUnorm, None);
+    setMTLPixFmtCapsIf(noBC, BC4_RSnorm, None);
+    setMTLPixFmtCapsIf(noBC, BC5_RGUnorm, None);
+    setMTLPixFmtCapsIf(noBC, BC5_RGSnorm, None);
+    setMTLPixFmtCapsIf(noBC, BC6H_RGBUfloat, None);
+    setMTLPixFmtCapsIf(noBC, BC6H_RGBFloat, None);
+    setMTLPixFmtCapsIf(noBC, BC7_RGBAUnorm, None);
+    setMTLPixFmtCapsIf(noBC, BC7_RGBAUnorm_sRGB, None);
 
-	setMTLPixFmtCapsIf( iosOnly2, BGRA10_XR, None );
-	setMTLPixFmtCapsIf( iosOnly2, BGRA10_XR_sRGB, None );
-	setMTLPixFmtCapsIf( iosOnly2, BGR10_XR, None );
-	setMTLPixFmtCapsIf( iosOnly2, BGR10_XR_sRGB, None );
+    setMTLPixFmtCapsIf(iosOnly2, BGRA10_XR, None);
+    setMTLPixFmtCapsIf(iosOnly2, BGRA10_XR_sRGB, None);
+    setMTLPixFmtCapsIf(iosOnly2, BGR10_XR, None);
+    setMTLPixFmtCapsIf(iosOnly2, BGR10_XR_sRGB, None);
 
-	setMTLPixFmtCapsIf( iosOnly2, Depth16Unorm, DRFM );
-	setMTLPixFmtCapsIf( iosOnly2, Depth32Float, DRM );
+    setMTLPixFmtCapsIf(iosOnly2, Depth16Unorm, DRFM);
+    setMTLPixFmtCapsIf(iosOnly2, Depth32Float, DRM);
 
-	setMTLPixFmtCapsIf( !gpuCaps.supportsDepth24Stencil8, Depth24Unorm_Stencil8, None );
-	setMTLPixFmtCapsIf( iosOnly2, Depth32Float_Stencil8, DRM );
+    setMTLPixFmtCapsIf(!gpuCaps.supportsDepth24Stencil8, Depth24Unorm_Stencil8,
+                       None);
+    setMTLPixFmtCapsIf(iosOnly2, Depth32Float_Stencil8, DRM);
 }
 
 // Connects Vulkan and Metal pixel formats to one-another.
-void MVKPixelFormats::buildVkFormatMaps(const MVKMTLDeviceCapabilities& gpuCaps) {
-	for (auto& vkDesc : _vkFormatDescriptions) {
-		if (vkDesc.needsSwizzle()) {
-			bool supportsNativeTextureSwizzle = ((gpuCaps.isAppleGPU || gpuCaps.supportsMac2)
-												 && mvkOSVersionIsAtLeast(10.15, 13.0, 1.0));
-			if (!supportsNativeTextureSwizzle && !getMVKConfig().fullImageViewSwizzle) {
-				vkDesc.mtlPixelFormat = vkDesc.mtlPixelFormatSubstitute = MTLPixelFormatInvalid;
-			}
-		}
+void MVKPixelFormats::buildVkFormatMaps(
+    const MVKMTLDeviceCapabilities& gpuCaps) {
+    for (auto& vkDesc : _vkFormatDescriptions) {
+        if (vkDesc.needsSwizzle()) {
+            bool supportsNativeTextureSwizzle =
+                ((gpuCaps.isAppleGPU || gpuCaps.supportsMac2) &&
+                 mvkOSVersionIsAtLeast(10.15, 13.0, 1.0));
+            if (!supportsNativeTextureSwizzle &&
+                !getMVKConfig().fullImageViewSwizzle) {
+                vkDesc.mtlPixelFormat = vkDesc.mtlPixelFormatSubstitute =
+                    MTLPixelFormatInvalid;
+            }
+        }
 
-		// Populate the back reference from the Metal formats to the Vulkan format.
-		// Validate the corresponding Metal formats for the platform, and clear them
-		// if the Vulkan format if not supported.
-		if (vkDesc.mtlPixelFormat) {
-			auto& mtlDesc = getMTLPixelFormatDesc(vkDesc.mtlPixelFormat);
-			if ( !mtlDesc.vkFormat ) { mtlDesc.vkFormat = vkDesc.vkFormat; }
-			if ( !mtlDesc.isSupported() ) { vkDesc.mtlPixelFormat = MTLPixelFormatInvalid; }
-		}
-		if (vkDesc.mtlPixelFormatSubstitute) {
-			auto& mtlDesc = getMTLPixelFormatDesc(vkDesc.mtlPixelFormatSubstitute);
-			if ( !mtlDesc.isSupported() ) { vkDesc.mtlPixelFormatSubstitute = MTLPixelFormatInvalid; }
-		}
-		if (vkDesc.mtlVertexFormat) {
-			auto& mtlDesc = getMTLVertexFormatDesc(vkDesc.mtlVertexFormat);
-			if ( !mtlDesc.vkFormat ) { mtlDesc.vkFormat = vkDesc.vkFormat; }
-			if ( !mtlDesc.isSupported() ) { vkDesc.mtlVertexFormat = MTLVertexFormatInvalid; }
-		}
-		if (vkDesc.mtlVertexFormatSubstitute) {
-			auto& mtlDesc = getMTLVertexFormatDesc(vkDesc.mtlVertexFormatSubstitute);
-			if ( !mtlDesc.isSupported() ) { vkDesc.mtlVertexFormatSubstitute = MTLVertexFormatInvalid; }
-		}
+        // Populate the back reference from the Metal formats to the Vulkan
+        // format. Validate the corresponding Metal formats for the platform,
+        // and clear them if the Vulkan format if not supported.
+        if (vkDesc.mtlPixelFormat) {
+            auto& mtlDesc = getMTLPixelFormatDesc(vkDesc.mtlPixelFormat);
+            if (!mtlDesc.vkFormat) {
+                mtlDesc.vkFormat = vkDesc.vkFormat;
+            }
+            if (!mtlDesc.isSupported()) {
+                vkDesc.mtlPixelFormat = MTLPixelFormatInvalid;
+            }
+        }
+        if (vkDesc.mtlPixelFormatSubstitute) {
+            auto& mtlDesc =
+                getMTLPixelFormatDesc(vkDesc.mtlPixelFormatSubstitute);
+            if (!mtlDesc.isSupported()) {
+                vkDesc.mtlPixelFormatSubstitute = MTLPixelFormatInvalid;
+            }
+        }
+        if (vkDesc.mtlVertexFormat) {
+            auto& mtlDesc = getMTLVertexFormatDesc(vkDesc.mtlVertexFormat);
+            if (!mtlDesc.vkFormat) {
+                mtlDesc.vkFormat = vkDesc.vkFormat;
+            }
+            if (!mtlDesc.isSupported()) {
+                vkDesc.mtlVertexFormat = MTLVertexFormatInvalid;
+            }
+        }
+        if (vkDesc.mtlVertexFormatSubstitute) {
+            auto& mtlDesc =
+                getMTLVertexFormatDesc(vkDesc.mtlVertexFormatSubstitute);
+            if (!mtlDesc.isSupported()) {
+                vkDesc.mtlVertexFormatSubstitute = MTLVertexFormatInvalid;
+            }
+        }
 
-		// Set Vulkan format properties
-		setFormatProperties(vkDesc, gpuCaps);
-	}
+        // Set Vulkan format properties
+        setFormatProperties(vkDesc, gpuCaps);
+    }
 }
 
-// Enumeration of Vulkan format features aligned to the MVKMTLFmtCaps enumeration.
+// Enumeration of Vulkan format features aligned to the MVKMTLFmtCaps
+// enumeration.
 typedef enum : VkFormatFeatureFlags2 {
-	kMVKVkFormatFeatureFlagsTexNone     = 0,
-	kMVKVkFormatFeatureFlagsTexRead     = (VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT |
-										   VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
-										   VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
-										   VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT |
-										   VK_FORMAT_FEATURE_2_BLIT_SRC_BIT),
-	kMVKVkFormatFeatureFlagsTexFilter   = (VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT),
-	kMVKVkFormatFeatureFlagsTexWrite    = (VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT |
-										   VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT |
-										   VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT),
-	kMVKVkFormatFeatureFlagsTexAtomic   = (VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT),
-	kMVKVkFormatFeatureFlagsTexColorAtt = (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
-										   VK_FORMAT_FEATURE_2_BLIT_DST_BIT),
-	kMVKVkFormatFeatureFlagsTexDSAtt    = (VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
-										   VK_FORMAT_FEATURE_2_BLIT_DST_BIT),
-	kMVKVkFormatFeatureFlagsTexBlend    = (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT),
-    kMVKVkFormatFeatureFlagsTexChromaSubsampling = (VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR),
-    kMVKVkFormatFeatureFlagsTexMultiPlanar       = (VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR |
-                                                    VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR),
-	kMVKVkFormatFeatureFlagsBufRead     = (VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT),
-	kMVKVkFormatFeatureFlagsBufWrite    = (VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT |
-                                                                                   VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT |
-                                                                                   VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT),
-	kMVKVkFormatFeatureFlagsBufAtomic   = (VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT),
-	kMVKVkFormatFeatureFlagsBufVertex   = (VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT),
+    kMVKVkFormatFeatureFlagsTexNone = 0,
+    kMVKVkFormatFeatureFlagsTexRead =
+        (VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT |
+         VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
+         VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
+         VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT |
+         VK_FORMAT_FEATURE_2_BLIT_SRC_BIT),
+    kMVKVkFormatFeatureFlagsTexFilter =
+        (VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT),
+    kMVKVkFormatFeatureFlagsTexWrite =
+        (VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT |
+         VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT |
+         VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT),
+    kMVKVkFormatFeatureFlagsTexAtomic =
+        (VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT),
+    kMVKVkFormatFeatureFlagsTexColorAtt =
+        (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT |
+         VK_FORMAT_FEATURE_2_BLIT_DST_BIT),
+    kMVKVkFormatFeatureFlagsTexDSAtt =
+        (VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT |
+         VK_FORMAT_FEATURE_2_BLIT_DST_BIT),
+    kMVKVkFormatFeatureFlagsTexBlend =
+        (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT),
+    kMVKVkFormatFeatureFlagsTexChromaSubsampling =
+        (VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR |
+         VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR),
+    kMVKVkFormatFeatureFlagsTexMultiPlanar =
+        (VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR |
+         VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR |
+         VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT_KHR |
+         VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR |
+         VK_FORMAT_FEATURE_2_DISJOINT_BIT_KHR),
+    kMVKVkFormatFeatureFlagsBufRead =
+        (VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT),
+    kMVKVkFormatFeatureFlagsBufWrite =
+        (VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT |
+         VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT |
+         VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT),
+    kMVKVkFormatFeatureFlagsBufAtomic =
+        (VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT),
+    kMVKVkFormatFeatureFlagsBufVertex = (VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT),
 } MVKVkFormatFeatureFlags;
 
 // Sets the VkFormatProperties (optimal/linear/buffer) for the Vulkan format.
-void MVKPixelFormats::setFormatProperties(MVKVkFormatDesc& vkDesc, const MVKMTLDeviceCapabilities& gpuCaps) {
+void MVKPixelFormats::setFormatProperties(
+    MVKVkFormatDesc& vkDesc, const MVKMTLDeviceCapabilities& gpuCaps) {
 
-#	define enableFormatFeatures(CAP, TYPE, MTL_FMT_CAPS, VK_FEATS)        \
-	if (mvkAreAllFlagsEnabled(MTL_FMT_CAPS, kMVKMTLFmtCaps ##CAP)) {      \
-		mvkEnableFlags(VK_FEATS, kMVKVkFormatFeatureFlags ##TYPE ##CAP);  \
-	}
+#define enableFormatFeatures(CAP, TYPE, MTL_FMT_CAPS, VK_FEATS)                \
+    if (mvkAreAllFlagsEnabled(MTL_FMT_CAPS, kMVKMTLFmtCaps##CAP)) {            \
+        mvkEnableFlags(VK_FEATS, kMVKVkFormatFeatureFlags##TYPE##CAP);         \
+    }
 
-	VkFormatProperties3& vkProps = vkDesc.properties;
-	MVKMTLFmtCaps mtlPixFmtCaps = getMTLPixelFormatDesc(vkDesc.mtlPixelFormat).mtlFmtCaps;
+    VkFormatProperties3& vkProps = vkDesc.properties;
+    MVKMTLFmtCaps mtlPixFmtCaps =
+        getMTLPixelFormatDesc(vkDesc.mtlPixelFormat).mtlFmtCaps;
     vkProps.optimalTilingFeatures = kMVKVkFormatFeatureFlagsTexNone;
     vkProps.linearTilingFeatures = kMVKVkFormatFeatureFlagsTexNone;
 
     // Chroma subsampling and multi planar features
-    uint8_t chromaSubsamplingPlaneCount = getChromaSubsamplingPlaneCount(vkDesc.vkFormat);
-    uint8_t chromaSubsamplingComponentBits = getChromaSubsamplingComponentBits(vkDesc.vkFormat);
+    uint8_t chromaSubsamplingPlaneCount =
+        getChromaSubsamplingPlaneCount(vkDesc.vkFormat);
+    uint8_t chromaSubsamplingComponentBits =
+        getChromaSubsamplingComponentBits(vkDesc.vkFormat);
     if (chromaSubsamplingComponentBits > 0) {
         if (mtlPixFmtCaps != 0 || chromaSubsamplingPlaneCount > 1) {
             mtlPixFmtCaps = kMVKMTLFmtCapsRF;
         }
-        enableFormatFeatures(ChromaSubsampling, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
+        enableFormatFeatures(ChromaSubsampling, Tex, mtlPixFmtCaps,
+                             vkProps.optimalTilingFeatures);
     }
     if (chromaSubsamplingPlaneCount > 1) {
-        enableFormatFeatures(MultiPlanar, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
+        enableFormatFeatures(MultiPlanar, Tex, mtlPixFmtCaps,
+                             vkProps.optimalTilingFeatures);
     }
 
-	// Optimal tiling features
-	enableFormatFeatures(Read, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(Filter, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(Write, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(Atomic, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(ColorAtt, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(DSAtt, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
-	enableFormatFeatures(Blend, Tex, mtlPixFmtCaps, vkProps.optimalTilingFeatures);
+    // Optimal tiling features
+    enableFormatFeatures(Read, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(Filter, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(Write, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(Atomic, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(ColorAtt, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(DSAtt, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
+    enableFormatFeatures(Blend, Tex, mtlPixFmtCaps,
+                         vkProps.optimalTilingFeatures);
 
-	if (isDepthFormat(vkDesc.mtlPixelFormat) && mvkIsAnyFlagEnabled(vkProps.optimalTilingFeatures, VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
-		vkProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT;
-	}
+    if (isDepthFormat(vkDesc.mtlPixelFormat) &&
+        mvkIsAnyFlagEnabled(vkProps.optimalTilingFeatures,
+                            VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT)) {
+        vkProps.optimalTilingFeatures |=
+            VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT;
+    }
 
-	// Vulkan forbids blits between chroma-subsampled formats.
-	// If we can't write the stencil reference from the shader, we can't blit stencil.
-	bool supportsStencilFeedback = gpuCaps.supportsApple5 || gpuCaps.supportsMac2;
-	if (chromaSubsamplingComponentBits > 0 || (isStencilFormat(vkDesc.mtlPixelFormat) && !supportsStencilFeedback)) {
-		mvkDisableFlags(vkProps.optimalTilingFeatures, (VK_FORMAT_FEATURE_2_BLIT_SRC_BIT | VK_FORMAT_FEATURE_2_BLIT_DST_BIT));
-	}
+    // Vulkan forbids blits between chroma-subsampled formats.
+    // If we can't write the stencil reference from the shader, we can't blit
+    // stencil.
+    bool supportsStencilFeedback =
+        gpuCaps.supportsApple5 || gpuCaps.supportsMac2;
+    if (chromaSubsamplingComponentBits > 0 ||
+        (isStencilFormat(vkDesc.mtlPixelFormat) && !supportsStencilFeedback)) {
+        mvkDisableFlags(vkProps.optimalTilingFeatures,
+                        (VK_FORMAT_FEATURE_2_BLIT_SRC_BIT |
+                         VK_FORMAT_FEATURE_2_BLIT_DST_BIT));
+    }
 
-	// These formats require swizzling. In order to support rendering, we'll have to swizzle
-	// in the fragment shader, but that hasn't been implemented yet.
-	if (vkDesc.needsSwizzle()) {
-		mvkDisableFlags(vkProps.optimalTilingFeatures, (kMVKVkFormatFeatureFlagsTexColorAtt |
-														kMVKVkFormatFeatureFlagsTexBlend));
-	}
+    // These formats require swizzling. In order to support rendering, we'll
+    // have to swizzle in the fragment shader, but that hasn't been implemented
+    // yet.
+    if (vkDesc.needsSwizzle()) {
+        mvkDisableFlags(vkProps.optimalTilingFeatures,
+                        (kMVKVkFormatFeatureFlagsTexColorAtt |
+                         kMVKVkFormatFeatureFlagsTexBlend));
+    }
 
-	// Linear tiling is not available to depth/stencil or compressed formats.
-	// GBGR and BGRG formats also do not support linear tiling in Metal.
-	if ( !(vkDesc.formatType == kMVKFormatDepthStencil || vkDesc.formatType == kMVKFormatCompressed ||
-		   (chromaSubsamplingPlaneCount == 1 && vkDesc.blockTexelSize.width > 1)) ) {
-		// Start with optimal tiling features, and modify.
-		vkProps.linearTilingFeatures = vkProps.optimalTilingFeatures;
+    // Linear tiling is not available to depth/stencil or compressed formats.
+    // GBGR and BGRG formats also do not support linear tiling in Metal.
+    if (!(vkDesc.formatType == kMVKFormatDepthStencil ||
+          vkDesc.formatType == kMVKFormatCompressed ||
+          (chromaSubsamplingPlaneCount == 1 &&
+           vkDesc.blockTexelSize.width > 1))) {
+        // Start with optimal tiling features, and modify.
+        vkProps.linearTilingFeatures = vkProps.optimalTilingFeatures;
 
 #if !MVK_APPLE_SILICON
-		// On macOS IMR GPUs, linear textures cannot be used as attachments, so disable those features.
-		mvkDisableFlags(vkProps.linearTilingFeatures, (kMVKVkFormatFeatureFlagsTexColorAtt |
-													   kMVKVkFormatFeatureFlagsTexDSAtt |
-													   kMVKVkFormatFeatureFlagsTexBlend));
+        // On macOS IMR GPUs, linear textures cannot be used as attachments, so
+        // disable those features.
+        mvkDisableFlags(vkProps.linearTilingFeatures,
+                        (kMVKVkFormatFeatureFlagsTexColorAtt |
+                         kMVKVkFormatFeatureFlagsTexDSAtt |
+                         kMVKVkFormatFeatureFlagsTexBlend));
 #endif
-	}
+    }
 
-	// Texel buffers are not available to depth/stencil, compressed, or chroma subsampled formats.
-	vkProps.bufferFeatures = kMVKVkFormatFeatureFlagsTexNone;
-	if ( !(vkDesc.formatType == kMVKFormatDepthStencil || vkDesc.formatType == kMVKFormatCompressed ||
-		   chromaSubsamplingComponentBits > 0) ) {
-		enableFormatFeatures(Read, Buf, mtlPixFmtCaps, vkProps.bufferFeatures);
-		enableFormatFeatures(Write, Buf, mtlPixFmtCaps, vkProps.bufferFeatures);
-		enableFormatFeatures(Atomic, Buf, mtlPixFmtCaps, vkProps.bufferFeatures);
-		enableFormatFeatures(Vertex, Buf, getMTLVertexFormatDesc(vkDesc.mtlVertexFormat).mtlFmtCaps, vkProps.bufferFeatures);
-	}
+    // Texel buffers are not available to depth/stencil, compressed, or chroma
+    // subsampled formats.
+    vkProps.bufferFeatures = kMVKVkFormatFeatureFlagsTexNone;
+    if (!(vkDesc.formatType == kMVKFormatDepthStencil ||
+          vkDesc.formatType == kMVKFormatCompressed ||
+          chromaSubsamplingComponentBits > 0)) {
+        enableFormatFeatures(Read, Buf, mtlPixFmtCaps, vkProps.bufferFeatures);
+        enableFormatFeatures(Write, Buf, mtlPixFmtCaps, vkProps.bufferFeatures);
+        enableFormatFeatures(Atomic, Buf, mtlPixFmtCaps,
+                             vkProps.bufferFeatures);
+        enableFormatFeatures(Vertex, Buf,
+                             getMTLVertexFormatDesc(vkDesc.mtlVertexFormat)
+                                 .mtlFmtCaps,
+                             vkProps.bufferFeatures);
+    }
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,29 +28,32 @@ class MVKCommandBuffer;
 class MVKCommandEncoder;
 
 // The size of one query slot in bytes
-#define kMVKQuerySlotSizeInBytes		sizeof(uint64_t)
-#define kMVKDefaultQueryCount			64
-
+#define kMVKQuerySlotSizeInBytes sizeof(uint64_t)
+#define kMVKDefaultQueryCount 64
 
 #pragma mark -
 #pragma mark MVKQueryPool
 
-/** 
+/**
  * Abstract class representing a Vulkan query pool.
  * Subclasses are specialized for specific query types.
  */
 class MVKQueryPool : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_QUERY_POOL;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_QUERY_POOL; }
-
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT;
+    }
 
     /** Begins the specified query. */
-    virtual void beginQuery(uint32_t query, VkQueryControlFlags flags, MVKCommandEncoder* cmdEncoder) {}
+    virtual void beginQuery(uint32_t query, VkQueryControlFlags flags,
+                            MVKCommandEncoder* cmdEncoder) {}
 
     /** Ends the specified query. */
     virtual void endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder);
@@ -58,84 +61,95 @@ public:
     /** Finishes the specified queries and marks them as available. */
     virtual void finishQueries(MVKArrayRef<const uint32_t> queries);
 
-	/** Resets the results and availability status of the specified queries. */
-	virtual void resetResults(uint32_t firstQuery, uint32_t queryCount, MVKCommandEncoder* cmdEncoder);
+    /** Resets the results and availability status of the specified queries. */
+    virtual void resetResults(uint32_t firstQuery, uint32_t queryCount,
+                              MVKCommandEncoder* cmdEncoder);
 
-	/** Copies the results of the specified queries into host memory. */
-	VkResult getResults(uint32_t firstQuery,
-						uint32_t queryCount,
-						size_t dataSize,
-						void* pData,
-						VkDeviceSize stride,
-						VkQueryResultFlags flags);
+    /** Copies the results of the specified queries into host memory. */
+    VkResult getResults(uint32_t firstQuery, uint32_t queryCount,
+                        size_t dataSize, void* pData, VkDeviceSize stride,
+                        VkQueryResultFlags flags);
 
-	/** Encodes commands to copy the results of the specified queries into device memory. */
-	void encodeCopyResults(MVKCommandEncoder* cmdEncoder,
-						   uint32_t firstQuery,
-						   uint32_t queryCount,
-						   MVKBuffer* destBuffer,
-						   VkDeviceSize destOffset,
-						   VkDeviceSize stride,
-						   VkQueryResultFlags flags);
+    /** Encodes commands to copy the results of the specified queries into
+     * device memory. */
+    void encodeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery,
+                           uint32_t queryCount, MVKBuffer* destBuffer,
+                           VkDeviceSize destOffset, VkDeviceSize stride,
+                           VkQueryResultFlags flags);
 
-	/**
-	 * Defers a request to copy the results of the specified queries into device memory, to be
-	 * encoded when all specified queries are ready.
-	 */
-	void deferCopyResults(uint32_t firstQuery,
-						  uint32_t queryCount,
-						  MVKBuffer* destBuffer,
-						  VkDeviceSize destOffset,
-						  VkDeviceSize stride,
-						  VkQueryResultFlags flags);
+    /**
+     * Defers a request to copy the results of the specified queries into device
+     * memory, to be encoded when all specified queries are ready.
+     */
+    void deferCopyResults(uint32_t firstQuery, uint32_t queryCount,
+                          MVKBuffer* destBuffer, VkDeviceSize destOffset,
+                          VkDeviceSize stride, VkQueryResultFlags flags);
 
-    /** Called from the MVKCmdBeginQuery command when it is added to the command buffer */
-    virtual void beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) {};
+    /** Called from the MVKCmdBeginQuery command when it is added to the command
+     * buffer */
+    virtual void beginQueryAddedTo(uint32_t query,
+                                   MVKCommandBuffer* cmdBuffer) {};
 
-    /** Returns whether all the queries in [firstQuery, endQuery) are available on the device. */
+    /** Returns whether all the queries in [firstQuery, endQuery) are available
+     * on the device. */
     bool areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQuery);
 
 #pragma mark Construction
 
-	MVKQueryPool(MVKDevice* device,
-				 const VkQueryPoolCreateInfo* pCreateInfo,
-				 const uint32_t queryElementCount) : MVKVulkanAPIDeviceObject(device),
-                    _availability(pCreateInfo->queryCount, Initial),
-                    _queryElementCount(queryElementCount) {}
+    MVKQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo,
+                 const uint32_t queryElementCount)
+        : MVKVulkanAPIDeviceObject(device),
+          _availability(pCreateInfo->queryCount, Initial),
+          _queryElementCount(queryElementCount) {}
 
-protected:
-	bool areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuery);
-	virtual NSData* getQuerySourceData(uint32_t firstQuery, uint32_t queryCount) { return nil; }
-    VkResult getResult(uint32_t query, NSData* srcData, uint32_t srcDataQueryOffset, void* pDstData, VkQueryResultFlags flags);
-	virtual id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, NSUInteger& offset) { return nil; }
-	virtual id<MTLComputeCommandEncoder> encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, uint32_t index) { return nil; }
-	virtual void encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount,
-										 MVKBuffer* destBuffer, VkDeviceSize destOffset, VkDeviceSize stride);
+  protected:
+    bool areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuery);
+    virtual NSData* getQuerySourceData(uint32_t firstQuery,
+                                       uint32_t queryCount) {
+        return nil;
+    }
+    VkResult getResult(uint32_t query, NSData* srcData,
+                       uint32_t srcDataQueryOffset, void* pDstData,
+                       VkQueryResultFlags flags);
+    virtual id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder,
+                                          uint32_t firstQuery,
+                                          uint32_t queryCount,
+                                          NSUInteger& offset) {
+        return nil;
+    }
+    virtual id<MTLComputeCommandEncoder>
+    encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery,
+                             uint32_t queryCount, uint32_t index) {
+        return nil;
+    }
+    virtual void
+    encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery,
+                            uint32_t queryCount, MVKBuffer* destBuffer,
+                            VkDeviceSize destOffset, VkDeviceSize stride);
 
-	struct DeferredCopy {
-		uint32_t firstQuery;
-		uint32_t queryCount;
-		MVKBuffer* destBuffer;
-		VkDeviceSize destOffset;
-		VkDeviceSize stride;
-		VkQueryResultFlags flags;
-	};
+    struct DeferredCopy {
+        uint32_t firstQuery;
+        uint32_t queryCount;
+        MVKBuffer* destBuffer;
+        VkDeviceSize destOffset;
+        VkDeviceSize stride;
+        VkQueryResultFlags flags;
+    };
 
-	/** The possible states of a query. */
-	enum Status {
-		Initial,            /**< Initial state when created or reset. */
-		DeviceAvailable,    /**< Query was ended and is available on the device. */
-		Available           /**< Query is available to the host. */
-	};
+    /** The possible states of a query. */
+    enum Status {
+        Initial,         /**< Initial state when created or reset. */
+        DeviceAvailable, /**< Query was ended and is available on the device. */
+        Available        /**< Query is available to the host. */
+    };
 
-	MVKSmallVector<Status, kMVKDefaultQueryCount> _availability;
-	MVKSmallVector<DeferredCopy, 4> _deferredCopies;
-	uint32_t _queryElementCount;
-	std::mutex _availabilityLock;
-	std::condition_variable _availabilityBlocker;
-	std::mutex _deferredCopiesLock;
+    MVKSmallVector<Status, kMVKDefaultQueryCount> _availability;
+    MVKSmallVector<DeferredCopy, 4> _deferredCopies;
+    uint32_t _queryElementCount;
+    std::mutex _availabilityLock;
+    std::condition_variable _availabilityBlocker;
+    std::mutex _deferredCopiesLock;
 };
-
 
 #pragma mark -
 #pragma mark MVKOcclusionQueryPool
@@ -143,66 +157,75 @@ protected:
 /** A Vulkan query pool for occlusion queries. */
 class MVKOcclusionQueryPool : public MVKQueryPool {
 
-public:
-
+  public:
     /** Returns the MTLBuffer used to hold occlusion query results. */
     id<MTLBuffer> getVisibilityResultMTLBuffer();
 
-    /** Returns the offset of the specified query in the visibility MTLBuffer. */
+    /** Returns the offset of the specified query in the visibility MTLBuffer.
+     */
     NSUInteger getVisibilityResultOffset(uint32_t query);
 
-    void beginQuery(uint32_t query, VkQueryControlFlags flags, MVKCommandEncoder* cmdEncoder) override;
+    void beginQuery(uint32_t query, VkQueryControlFlags flags,
+                    MVKCommandEncoder* cmdEncoder) override;
     void endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) override;
-    void resetResults(uint32_t firstQuery, uint32_t queryCount, MVKCommandEncoder* cmdEncoder) override;
-    void beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) override;
-
+    void resetResults(uint32_t firstQuery, uint32_t queryCount,
+                      MVKCommandEncoder* cmdEncoder) override;
+    void beginQueryAddedTo(uint32_t query,
+                           MVKCommandBuffer* cmdBuffer) override;
 
 #pragma mark Construction
 
-    MVKOcclusionQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo);
+    MVKOcclusionQueryPool(MVKDevice* device,
+                          const VkQueryPoolCreateInfo* pCreateInfo);
 
     ~MVKOcclusionQueryPool() override;
 
-protected:
-	void propagateDebugName() override;
-	NSData* getQuerySourceData(uint32_t firstQuery, uint32_t queryCount) override;
-	id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, NSUInteger& offset) override;
-	id<MTLComputeCommandEncoder> encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, uint32_t index) override;
+  protected:
+    void propagateDebugName() override;
+    NSData* getQuerySourceData(uint32_t firstQuery,
+                               uint32_t queryCount) override;
+    id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder,
+                                  uint32_t firstQuery, uint32_t queryCount,
+                                  NSUInteger& offset) override;
+    id<MTLComputeCommandEncoder>
+    encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery,
+                             uint32_t queryCount, uint32_t index) override;
 
     id<MTLBuffer> _visibilityResultMTLBuffer;
     uint32_t _queryIndexOffset;
 };
 
-
 #pragma mark -
 #pragma mark MVKGPUCounterQueryPool
 
-/** An abstract parent class for query pools that use Metal GPU counters if they are supported on the platform. */
+/** An abstract parent class for query pools that use Metal GPU counters if they
+ * are supported on the platform. */
 class MVKGPUCounterQueryPool : public MVKQueryPool {
 
-public:
+  public:
+    /** Returns whether a MTLCounterBuffer is being used by this query pool. */
+    bool hasMTLCounterBuffer() { return _mtlCounterBuffer != nil; }
 
-	/** Returns whether a MTLCounterBuffer is being used by this query pool. */
-	bool hasMTLCounterBuffer() { return _mtlCounterBuffer != nil; }
+    /**
+     * Returns the MTLCounterBuffer being used by this query pool,
+     * or returns nil if GPU counters are not supported.
+     * */
+    id<MTLCounterSampleBuffer> getMTLCounterBuffer() {
+        return _mtlCounterBuffer;
+    }
 
-	/**
-	 * Returns the MTLCounterBuffer being used by this query pool,
-	 * or returns nil if GPU counters are not supported.
-	 * */
-	id<MTLCounterSampleBuffer> getMTLCounterBuffer() { return _mtlCounterBuffer; }
+    MVKGPUCounterQueryPool(MVKDevice* device,
+                           const VkQueryPoolCreateInfo* pCreateInfo);
 
-	MVKGPUCounterQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo);
+    ~MVKGPUCounterQueryPool() override;
 
-	~MVKGPUCounterQueryPool() override;
+  protected:
+    void initMTLCounterSampleBuffer(const VkQueryPoolCreateInfo* pCreateInfo,
+                                    id<MTLCounterSet> mtlCounterSet,
+                                    const char* queryTypeName);
 
-protected:
-	void initMTLCounterSampleBuffer(const VkQueryPoolCreateInfo* pCreateInfo,
-									id<MTLCounterSet> mtlCounterSet,
-									const char* queryTypeName);
-
-	id<MTLCounterSampleBuffer> _mtlCounterBuffer;
+    id<MTLCounterSampleBuffer> _mtlCounterBuffer;
 };
-
 
 #pragma mark -
 #pragma mark MVKTimestampQueryPool
@@ -210,39 +233,47 @@ protected:
 /** A Vulkan query pool for timestamp queries. */
 class MVKTimestampQueryPool : public MVKGPUCounterQueryPool {
 
-public:
-	void endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) override;
-	void finishQueries(MVKArrayRef<const uint32_t> queries) override;
+  public:
+    void endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) override;
+    void finishQueries(MVKArrayRef<const uint32_t> queries) override;
 
 #pragma mark Construction
 
-	MVKTimestampQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo);
+    MVKTimestampQueryPool(MVKDevice* device,
+                          const VkQueryPoolCreateInfo* pCreateInfo);
 
-protected:
-	void propagateDebugName() override {}
-	NSData* getQuerySourceData(uint32_t firstQuery, uint32_t queryCount) override;
-	id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, NSUInteger& offset) override;
-	id<MTLComputeCommandEncoder> encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, uint32_t index) override;
-	void encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount,
-								 MVKBuffer* destBuffer, VkDeviceSize destOffset, VkDeviceSize stride) override;
+  protected:
+    void propagateDebugName() override {}
+    NSData* getQuerySourceData(uint32_t firstQuery,
+                               uint32_t queryCount) override;
+    id<MTLBuffer> getResultBuffer(MVKCommandEncoder* cmdEncoder,
+                                  uint32_t firstQuery, uint32_t queryCount,
+                                  NSUInteger& offset) override;
+    id<MTLComputeCommandEncoder>
+    encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery,
+                             uint32_t queryCount, uint32_t index) override;
+    void encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder,
+                                 uint32_t firstQuery, uint32_t queryCount,
+                                 MVKBuffer* destBuffer, VkDeviceSize destOffset,
+                                 VkDeviceSize stride) override;
 
-	MVKSmallVector<uint64_t> _timestamps;
+    MVKSmallVector<uint64_t> _timestamps;
 };
-
 
 #pragma mark -
 #pragma mark MVKPipelineStatisticsQueryPool
 
-/** A Vulkan query pool for a query pool type that tracks pipeline statistics. */
+/** A Vulkan query pool for a query pool type that tracks pipeline statistics.
+ */
 class MVKPipelineStatisticsQueryPool : public MVKGPUCounterQueryPool {
 
-public:
-    MVKPipelineStatisticsQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo);
+  public:
+    MVKPipelineStatisticsQueryPool(MVKDevice* device,
+                                   const VkQueryPoolCreateInfo* pCreateInfo);
 
-protected:
-	void propagateDebugName() override {}
+  protected:
+    void propagateDebugName() override {}
 };
-
 
 #pragma mark -
 #pragma mark MVKUnsupportedQueryPool
@@ -250,10 +281,10 @@ protected:
 /** A Vulkan query pool for a query pool type that is unsupported in Metal. */
 class MVKUnsupportedQueryPool : public MVKQueryPool {
 
-public:
-	MVKUnsupportedQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo);
+  public:
+    MVKUnsupportedQueryPool(MVKDevice* device,
+                            const VkQueryPoolCreateInfo* pCreateInfo);
 
-protected:
-	void propagateDebugName() override {}
+  protected:
+    void propagateDebugName() override {}
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,11 +27,14 @@
 
 using namespace std;
 
-
 #pragma mark MVKQueryPool
 
 void MVKQueryPool::endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) {
-    uint32_t queryCount = cmdEncoder->isInRenderPass() ? cmdEncoder->getSubpass()->getViewCountInMetalPass(cmdEncoder->getMultiviewPassIndex()) : 1;
+    uint32_t queryCount =
+        cmdEncoder->isInRenderPass()
+            ? cmdEncoder->getSubpass()->getViewCountInMetalPass(
+                  cmdEncoder->getMultiviewPassIndex())
+            : 1;
     queryCount = max(queryCount, 1u);
     lock_guard<mutex> lock(_availabilityLock);
     for (uint32_t i = query; i < query + queryCount; ++i) {
@@ -40,12 +43,17 @@ void MVKQueryPool::endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) {
     lock_guard<mutex> copyLock(_deferredCopiesLock);
     if (!_deferredCopies.empty()) {
         // Partition by readiness.
-        auto ready = std::partition(_deferredCopies.begin(), _deferredCopies.end(), [this](const DeferredCopy& copy) {
-            return !areQueriesDeviceAvailable(copy.firstQuery, copy.queryCount);
-        });
+        auto ready = std::
+            partition(_deferredCopies.begin(), _deferredCopies.end(),
+                      [this](const DeferredCopy& copy) {
+                          return !areQueriesDeviceAvailable(copy.firstQuery,
+                                                            copy.queryCount);
+                      });
         // Execute the ready copies, then remove them.
         for (auto i = ready; i != _deferredCopies.end(); ++i) {
-            encodeCopyResults(cmdEncoder, i->firstQuery, i->queryCount, i->destBuffer, i->destOffset, i->stride, i->flags);
+            encodeCopyResults(cmdEncoder, i->firstQuery, i->queryCount,
+                              i->destBuffer, i->destOffset, i->stride,
+                              i->flags);
         }
         _deferredCopies.erase(ready, _deferredCopies.end());
     }
@@ -59,10 +67,13 @@ void MVKQueryPool::finishQueries(MVKArrayRef<const uint32_t> queries) {
             _availability[qry] = Available;
         }
     }
-    _availabilityBlocker.notify_all();      // Predicate of each wait() call will check whether all required queries are available
+    _availabilityBlocker
+        .notify_all(); // Predicate of each wait() call will check whether all
+                       // required queries are available
 }
 
-void MVKQueryPool::resetResults(uint32_t firstQuery, uint32_t queryCount, MVKCommandEncoder* cmdEncoder) {
+void MVKQueryPool::resetResults(uint32_t firstQuery, uint32_t queryCount,
+                                MVKCommandEncoder* cmdEncoder) {
     lock_guard<mutex> lock(_availabilityLock);
     uint32_t endQuery = firstQuery + queryCount;
     for (uint32_t query = firstQuery; query < endQuery; query++) {
@@ -70,265 +81,339 @@ void MVKQueryPool::resetResults(uint32_t firstQuery, uint32_t queryCount, MVKCom
     }
 }
 
-VkResult MVKQueryPool::getResults(uint32_t firstQuery,
-								  uint32_t queryCount,
-								  size_t dataSize,
-								  void* pData,
-								  VkDeviceSize stride,
-								  VkQueryResultFlags flags) {
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+VkResult MVKQueryPool::getResults(uint32_t firstQuery, uint32_t queryCount,
+                                  size_t dataSize, void* pData,
+                                  VkDeviceSize stride,
+                                  VkQueryResultFlags flags) {
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
 
-	unique_lock<mutex> lock(_availabilityLock);
+    unique_lock<mutex> lock(_availabilityLock);
 
-	uint32_t endQuery = firstQuery + queryCount;
+    uint32_t endQuery = firstQuery + queryCount;
 
-	if (mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_WAIT_BIT)) {
-		_availabilityBlocker.wait(lock, [this, firstQuery, endQuery]{
-			return areQueriesHostAvailable(firstQuery, endQuery);
-		});
-	}
+    if (mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_WAIT_BIT)) {
+        _availabilityBlocker.wait(lock, [this, firstQuery, endQuery] {
+            return areQueriesHostAvailable(firstQuery, endQuery);
+        });
+    }
 
-	VkResult rqstRslt = VK_SUCCESS;
-	@autoreleasepool {
-		NSData* srcData = getQuerySourceData(firstQuery, queryCount);
-		uintptr_t pDstData = (uintptr_t)pData;
-		for (uint32_t query = firstQuery; query < endQuery; query++, pDstData += stride) {
-			VkResult qryRslt = getResult(query, srcData, firstQuery, (void*)pDstData, flags);
-			if (rqstRslt == VK_SUCCESS) { rqstRslt = qryRslt; }
-		}
-	}
-	return rqstRslt;
+    VkResult rqstRslt = VK_SUCCESS;
+    @autoreleasepool {
+        NSData* srcData = getQuerySourceData(firstQuery, queryCount);
+        uintptr_t pDstData = (uintptr_t)pData;
+        for (uint32_t query = firstQuery; query < endQuery;
+             query++, pDstData += stride) {
+            VkResult qryRslt =
+                getResult(query, srcData, firstQuery, (void*)pDstData, flags);
+            if (rqstRslt == VK_SUCCESS) {
+                rqstRslt = qryRslt;
+            }
+        }
+    }
+    return rqstRslt;
 }
 
-bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQuery) {
+bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery,
+                                             uint32_t endQuery) {
     for (uint32_t query = firstQuery; query < endQuery; query++) {
-        if ( _availability[query] < DeviceAvailable ) { return false; }
+        if (_availability[query] < DeviceAvailable) {
+            return false;
+        }
     }
     return true;
 }
 
-// Returns whether any queries between the start (inclusive) and end (exclusive) queries,
-// that were encoded to be written to by an earlier EndQuery or Timestamp command, are now available.
-// Queries that were not encoded to be written, will be in Initial state.
-// Queries that were encoded to be written, and are available, will be in Available state.
-// Queries that were encoded to be written, but are not available, will be in DeviceAvailable state.
-bool MVKQueryPool::areQueriesHostAvailable(uint32_t firstQuery, uint32_t endQuery) {
+// Returns whether any queries between the start (inclusive) and end (exclusive)
+// queries, that were encoded to be written to by an earlier EndQuery or
+// Timestamp command, are now available. Queries that were not encoded to be
+// written, will be in Initial state. Queries that were encoded to be written,
+// and are available, will be in Available state. Queries that were encoded to
+// be written, but are not available, will be in DeviceAvailable state.
+bool MVKQueryPool::areQueriesHostAvailable(uint32_t firstQuery,
+                                           uint32_t endQuery) {
     // If we lost the device, stop waiting immediately.
-    if (_device->getConfigurationResult() != VK_SUCCESS) { return true; }
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return true;
+    }
     for (uint32_t query = firstQuery; query < endQuery; query++) {
-        if (_availability[query] == DeviceAvailable) { return false; }
+        if (_availability[query] == DeviceAvailable) {
+            return false;
+        }
     }
     return true;
 }
 
-VkResult MVKQueryPool::getResult(uint32_t query, NSData* srcData, uint32_t srcDataQueryOffset, void* pDstData, VkQueryResultFlags flags) {
+VkResult MVKQueryPool::getResult(uint32_t query, NSData* srcData,
+                                 uint32_t srcDataQueryOffset, void* pDstData,
+                                 VkQueryResultFlags flags) {
 
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
 
-	bool isAvailable = _availability[query] == Available;
-	bool shouldOutput = (isAvailable || mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_PARTIAL_BIT));
-	bool shouldOutput64Bit = mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_64_BIT);
+    bool isAvailable = _availability[query] == Available;
+    bool shouldOutput =
+        (isAvailable ||
+         mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_PARTIAL_BIT));
+    bool shouldOutput64Bit =
+        mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_64_BIT);
 
-	// Output the results of this query
-	if (shouldOutput) {
-		uint64_t rsltVal = ((uint64_t*)srcData.bytes)[query - srcDataQueryOffset];
-		if (shouldOutput64Bit) {
-			*(uint64_t*)pDstData = rsltVal;
-		} else {
-			*(uint32_t*)pDstData = (uint32_t)rsltVal;
-		}
-	}
+    // Output the results of this query
+    if (shouldOutput) {
+        uint64_t rsltVal =
+            ((uint64_t*)srcData.bytes)[query - srcDataQueryOffset];
+        if (shouldOutput64Bit) {
+            *(uint64_t*)pDstData = rsltVal;
+        } else {
+            *(uint32_t*)pDstData = (uint32_t)rsltVal;
+        }
+    }
 
-	// If requested, output the availability bit
-	if (mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) {
-		if (shouldOutput64Bit) {
-			uintptr_t pAvailability = (uintptr_t)pDstData + (_queryElementCount * sizeof(uint64_t));
-			*(uint64_t*)pAvailability = isAvailable;
-		} else {
-			uintptr_t pAvailability = (uintptr_t)pDstData + (_queryElementCount * sizeof(uint32_t));
-			*(uint32_t*)pAvailability = isAvailable;
-		}
-	}
+    // If requested, output the availability bit
+    if (mvkAreAllFlagsEnabled(flags, VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) {
+        if (shouldOutput64Bit) {
+            uintptr_t pAvailability =
+                (uintptr_t)pDstData + (_queryElementCount * sizeof(uint64_t));
+            *(uint64_t*)pAvailability = isAvailable;
+        } else {
+            uintptr_t pAvailability =
+                (uintptr_t)pDstData + (_queryElementCount * sizeof(uint32_t));
+            *(uint32_t*)pAvailability = isAvailable;
+        }
+    }
 
-	return shouldOutput ? VK_SUCCESS : VK_NOT_READY;
+    return shouldOutput ? VK_SUCCESS : VK_NOT_READY;
 }
 
 void MVKQueryPool::encodeCopyResults(MVKCommandEncoder* cmdEncoder,
-									 uint32_t firstQuery,
-									 uint32_t queryCount,
-									 MVKBuffer* destBuffer,
-									 VkDeviceSize destOffset,
-									 VkDeviceSize stride,
-									 VkQueryResultFlags flags) {
+                                     uint32_t firstQuery, uint32_t queryCount,
+                                     MVKBuffer* destBuffer,
+                                     VkDeviceSize destOffset,
+                                     VkDeviceSize stride,
+                                     VkQueryResultFlags flags) {
 
-	if (queryCount == 0) { return; }
+    if (queryCount == 0) {
+        return;
+    }
 
-	// If this asked for 64-bit results with no availability and packed stride, then we can do
-	// a straight copy. Otherwise, we need a shader.
-	if (mvkIsAnyFlagEnabled(flags, VK_QUERY_RESULT_64_BIT) &&
-		!mvkIsAnyFlagEnabled(flags, VK_QUERY_RESULT_WITH_AVAILABILITY_BIT) &&
-		stride == _queryElementCount * sizeof(uint64_t) &&
-		areQueriesDeviceAvailable(firstQuery, queryCount)) {
+    // If this asked for 64-bit results with no availability and packed stride,
+    // then we can do a straight copy. Otherwise, we need a shader.
+    if (mvkIsAnyFlagEnabled(flags, VK_QUERY_RESULT_64_BIT) &&
+        !mvkIsAnyFlagEnabled(flags, VK_QUERY_RESULT_WITH_AVAILABILITY_BIT) &&
+        stride == _queryElementCount * sizeof(uint64_t) &&
+        areQueriesDeviceAvailable(firstQuery, queryCount)) {
 
-		encodeDirectCopyResults(cmdEncoder, firstQuery, queryCount, destBuffer, destOffset, stride);
-		// TODO: In the case where none of the queries is ready, we can fill with 0.
-	} else {
-		id<MTLComputePipelineState> mtlCopyResultsState = cmdEncoder->getCommandEncodingPool()->getCmdCopyQueryPoolResultsMTLComputePipelineState();
-		id<MTLComputeCommandEncoder> mtlComputeCmdEnc = encodeComputeCopyResults(cmdEncoder, firstQuery, queryCount, 0);
-		[mtlComputeCmdEnc setComputePipelineState: mtlCopyResultsState];
-		[mtlComputeCmdEnc setBuffer: destBuffer->getMTLBuffer()
-							 offset: destBuffer->getMTLBufferOffset() + destOffset
-							atIndex: 1];
-		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &stride, sizeof(uint32_t), 2);
-		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &queryCount, sizeof(uint32_t), 3);
-		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &flags, sizeof(VkQueryResultFlags), 4);
-		_availabilityLock.lock();
-		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, _availability.data(), _availability.size() * sizeof(Status), 5);
-		_availabilityLock.unlock();
+        encodeDirectCopyResults(cmdEncoder, firstQuery, queryCount, destBuffer,
+                                destOffset, stride);
+        // TODO: In the case where none of the queries is ready, we can fill
+        // with 0.
+    } else {
+        id<MTLComputePipelineState> mtlCopyResultsState =
+            cmdEncoder->getCommandEncodingPool()
+                ->getCmdCopyQueryPoolResultsMTLComputePipelineState();
+        id<MTLComputeCommandEncoder> mtlComputeCmdEnc =
+            encodeComputeCopyResults(cmdEncoder, firstQuery, queryCount, 0);
+        [mtlComputeCmdEnc setComputePipelineState:mtlCopyResultsState];
+        [mtlComputeCmdEnc
+            setBuffer:destBuffer->getMTLBuffer()
+               offset:destBuffer->getMTLBufferOffset() + destOffset
+              atIndex:1];
+        cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &stride, sizeof(uint32_t),
+                                    2);
+        cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &queryCount,
+                                    sizeof(uint32_t), 3);
+        cmdEncoder->setComputeBytes(mtlComputeCmdEnc, &flags,
+                                    sizeof(VkQueryResultFlags), 4);
+        _availabilityLock.lock();
+        cmdEncoder->setComputeBytes(mtlComputeCmdEnc, _availability.data(),
+                                    _availability.size() * sizeof(Status), 5);
+        _availabilityLock.unlock();
 
-		// Run one thread per query. Try to fill up a subgroup.
-		NSUInteger threadCount = NSUInteger(queryCount);
-		NSUInteger threadExecutionWidth = mtlCopyResultsState.threadExecutionWidth;
-		NSUInteger tgWidth = min(threadCount, threadExecutionWidth);
-		NSUInteger tgCount = threadCount / threadExecutionWidth;
-		if(threadCount > (tgCount * threadExecutionWidth)) tgCount++;	// Round up
+        // Run one thread per query. Try to fill up a subgroup.
+        NSUInteger threadCount = NSUInteger(queryCount);
+        NSUInteger threadExecutionWidth =
+            mtlCopyResultsState.threadExecutionWidth;
+        NSUInteger tgWidth = min(threadCount, threadExecutionWidth);
+        NSUInteger tgCount = threadCount / threadExecutionWidth;
+        if (threadCount > (tgCount * threadExecutionWidth))
+            tgCount++; // Round up
 
-		[mtlComputeCmdEnc dispatchThreadgroups: MTLSizeMake(tgCount, 1, 1)
-						 threadsPerThreadgroup: MTLSizeMake(tgWidth, 1, 1)];
-	}
+        [mtlComputeCmdEnc dispatchThreadgroups:MTLSizeMake(tgCount, 1, 1)
+                         threadsPerThreadgroup:MTLSizeMake(tgWidth, 1, 1)];
+    }
 }
 
-// If this asked for 64-bit results with no availability and packed stride, then we can do a straight copy.
-void MVKQueryPool::encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder,
-									 uint32_t firstQuery,
-									 uint32_t queryCount,
-									 MVKBuffer* destBuffer,
-									 VkDeviceSize destOffset,
-									 VkDeviceSize stride) {
+// If this asked for 64-bit results with no availability and packed stride, then
+// we can do a straight copy.
+void MVKQueryPool::encodeDirectCopyResults(
+    MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount,
+    MVKBuffer* destBuffer, VkDeviceSize destOffset, VkDeviceSize stride) {
 
-	id<MTLBlitCommandEncoder> mtlBlitCmdEnc = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
-	NSUInteger srcOffset;
-	id<MTLBuffer> srcBuff = getResultBuffer(cmdEncoder, firstQuery, queryCount, srcOffset);
-	[mtlBlitCmdEnc copyFromBuffer: srcBuff
-					 sourceOffset: srcOffset
-						 toBuffer: destBuffer->getMTLBuffer()
-				destinationOffset: destBuffer->getMTLBufferOffset() + destOffset
-							 size: stride * queryCount];
+    id<MTLBlitCommandEncoder> mtlBlitCmdEnc =
+        cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
+    NSUInteger srcOffset;
+    id<MTLBuffer> srcBuff =
+        getResultBuffer(cmdEncoder, firstQuery, queryCount, srcOffset);
+    [mtlBlitCmdEnc copyFromBuffer:srcBuff
+                     sourceOffset:srcOffset
+                         toBuffer:destBuffer->getMTLBuffer()
+                destinationOffset:destBuffer->getMTLBufferOffset() + destOffset
+                             size:stride * queryCount];
 }
 
-void MVKQueryPool::deferCopyResults(uint32_t firstQuery,
-									uint32_t queryCount,
-									MVKBuffer* destBuffer,
-									VkDeviceSize destOffset,
-									VkDeviceSize stride,
-									VkQueryResultFlags flags) {
+void MVKQueryPool::deferCopyResults(uint32_t firstQuery, uint32_t queryCount,
+                                    MVKBuffer* destBuffer,
+                                    VkDeviceSize destOffset,
+                                    VkDeviceSize stride,
+                                    VkQueryResultFlags flags) {
 
-	lock_guard<mutex> lock(_deferredCopiesLock);
-	_deferredCopies.push_back({firstQuery, queryCount, destBuffer, destOffset, stride, flags});
+    lock_guard<mutex> lock(_deferredCopiesLock);
+    _deferredCopies.push_back(
+        {firstQuery, queryCount, destBuffer, destOffset, stride, flags});
 }
-
 
 #pragma mark -
 #pragma mark MVKOcclusionQueryPool
 
-void MVKOcclusionQueryPool::propagateDebugName() { setMetalObjectLabel(_visibilityResultMTLBuffer, _debugName); }
+void MVKOcclusionQueryPool::propagateDebugName() {
+    setMetalObjectLabel(_visibilityResultMTLBuffer, _debugName);
+}
 
-// If a dedicated visibility buffer has been established, use it, otherwise fetch the
-// current global visibility buffer, but don't cache it because it could be replaced later.
+// If a dedicated visibility buffer has been established, use it, otherwise
+// fetch the current global visibility buffer, but don't cache it because it
+// could be replaced later.
 id<MTLBuffer> MVKOcclusionQueryPool::getVisibilityResultMTLBuffer() {
-    return _visibilityResultMTLBuffer ? _visibilityResultMTLBuffer : _device->getGlobalVisibilityResultMTLBuffer();
+    return _visibilityResultMTLBuffer
+               ? _visibilityResultMTLBuffer
+               : _device->getGlobalVisibilityResultMTLBuffer();
 }
 
 NSUInteger MVKOcclusionQueryPool::getVisibilityResultOffset(uint32_t query) {
     return (NSUInteger)(_queryIndexOffset + query) * kMVKQuerySlotSizeInBytes;
 }
 
-void MVKOcclusionQueryPool::beginQuery(uint32_t query, VkQueryControlFlags flags, MVKCommandEncoder* cmdEncoder) {
+void MVKOcclusionQueryPool::beginQuery(uint32_t query,
+                                       VkQueryControlFlags flags,
+                                       MVKCommandEncoder* cmdEncoder) {
     MVKQueryPool::beginQuery(query, flags, cmdEncoder);
     cmdEncoder->beginOcclusionQuery(this, query, flags);
 }
 
-void MVKOcclusionQueryPool::endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) {
+void MVKOcclusionQueryPool::endQuery(uint32_t query,
+                                     MVKCommandEncoder* cmdEncoder) {
     cmdEncoder->endOcclusionQuery(this, query);
     MVKQueryPool::endQuery(query, cmdEncoder);
 }
 
-void MVKOcclusionQueryPool::resetResults(uint32_t firstQuery, uint32_t queryCount, MVKCommandEncoder* cmdEncoder) {
+void MVKOcclusionQueryPool::resetResults(uint32_t firstQuery,
+                                         uint32_t queryCount,
+                                         MVKCommandEncoder* cmdEncoder) {
     MVKQueryPool::resetResults(firstQuery, queryCount, cmdEncoder);
 
     NSUInteger firstOffset = getVisibilityResultOffset(firstQuery);
     NSUInteger lastOffset = getVisibilityResultOffset(firstQuery + queryCount);
     if (cmdEncoder) {
-        id<MTLBlitCommandEncoder> blitEncoder = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseResetQueryPool);
+        id<MTLBlitCommandEncoder> blitEncoder =
+            cmdEncoder->getMTLBlitEncoder(kMVKCommandUseResetQueryPool);
 
-        [blitEncoder fillBuffer: getVisibilityResultMTLBuffer()
-                          range: NSMakeRange(firstOffset, lastOffset - firstOffset)
-                          value: 0];
-    } else {  // Host-side reset
+        [blitEncoder
+            fillBuffer:getVisibilityResultMTLBuffer()
+                 range:NSMakeRange(firstOffset, lastOffset - firstOffset)
+                 value:0];
+    } else { // Host-side reset
         id<MTLBuffer> vizBuff = getVisibilityResultMTLBuffer();
         size_t byteCount = std::min(lastOffset, vizBuff.length) - firstOffset;
-        mvkClear((char *)[vizBuff contents] + firstOffset, byteCount);
+        mvkClear((char*)[vizBuff contents] + firstOffset, byteCount);
     }
 }
 
-NSData* MVKOcclusionQueryPool::getQuerySourceData(uint32_t firstQuery, uint32_t queryCount) {
-	id<MTLBuffer> vizBuff = getVisibilityResultMTLBuffer();
-	return [NSData dataWithBytesNoCopy: (void*)((uintptr_t)vizBuff.contents + getVisibilityResultOffset(firstQuery))
-								length: queryCount * kMVKQuerySlotSizeInBytes
-						  freeWhenDone: false];
+NSData* MVKOcclusionQueryPool::getQuerySourceData(uint32_t firstQuery,
+                                                  uint32_t queryCount) {
+    id<MTLBuffer> vizBuff = getVisibilityResultMTLBuffer();
+    return [NSData
+        dataWithBytesNoCopy:(void*)((uintptr_t)vizBuff.contents +
+                                    getVisibilityResultOffset(firstQuery))
+                     length:queryCount * kMVKQuerySlotSizeInBytes
+               freeWhenDone:false];
 }
 
-id<MTLBuffer> MVKOcclusionQueryPool::getResultBuffer(MVKCommandEncoder*, uint32_t firstQuery, uint32_t, NSUInteger& offset) {
-	offset = getVisibilityResultOffset(firstQuery);
-	return getVisibilityResultMTLBuffer();
+id<MTLBuffer> MVKOcclusionQueryPool::getResultBuffer(MVKCommandEncoder*,
+                                                     uint32_t firstQuery,
+                                                     uint32_t,
+                                                     NSUInteger& offset) {
+    offset = getVisibilityResultOffset(firstQuery);
+    return getVisibilityResultMTLBuffer();
 }
 
-id<MTLComputeCommandEncoder> MVKOcclusionQueryPool::encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t, uint32_t index) {
-	id<MTLComputeCommandEncoder> mtlCmdEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults, true);
-	[mtlCmdEnc setBuffer: getVisibilityResultMTLBuffer() offset: getVisibilityResultOffset(firstQuery) atIndex: index];
-	return mtlCmdEnc;
+id<MTLComputeCommandEncoder>
+MVKOcclusionQueryPool::encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder,
+                                                uint32_t firstQuery, uint32_t,
+                                                uint32_t index) {
+    id<MTLComputeCommandEncoder> mtlCmdEnc =
+        cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults,
+                                         true);
+    [mtlCmdEnc setBuffer:getVisibilityResultMTLBuffer()
+                  offset:getVisibilityResultOffset(firstQuery)
+                 atIndex:index];
+    return mtlCmdEnc;
 }
 
-void MVKOcclusionQueryPool::beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) {
-	// In multiview passes, one query is used for each view.
-	NSUInteger queryCount = cmdBuffer->getViewCount();
+void MVKOcclusionQueryPool::beginQueryAddedTo(uint32_t query,
+                                              MVKCommandBuffer* cmdBuffer) {
+    // In multiview passes, one query is used for each view.
+    NSUInteger queryCount = cmdBuffer->getViewCount();
     NSUInteger offset = getVisibilityResultOffset(query);
-    NSUInteger maxOffset = getMetalFeatures().maxQueryBufferSize - kMVKQuerySlotSizeInBytes * queryCount;
+    NSUInteger maxOffset = getMetalFeatures().maxQueryBufferSize -
+                           kMVKQuerySlotSizeInBytes * queryCount;
     if (offset > maxOffset) {
-        cmdBuffer->setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkCmdBeginQuery(): The query offset value %lu is larger than the maximum offset value %lu available on this device.", offset, maxOffset));
+        cmdBuffer->setConfigurationResult(reportError(
+            VK_ERROR_OUT_OF_DEVICE_MEMORY,
+            "vkCmdBeginQuery(): The query offset value %lu is larger than "
+            "the maximum offset value %lu available on this device.",
+            offset, maxOffset));
     }
 
     cmdBuffer->_needsVisibilityResultMTLBuffer = true;
 }
 
-
 #pragma mark Construction
 
-MVKOcclusionQueryPool::MVKOcclusionQueryPool(MVKDevice* device,
-                                             const VkQueryPoolCreateInfo* pCreateInfo) : MVKQueryPool(device, pCreateInfo, 1) {
+MVKOcclusionQueryPool::MVKOcclusionQueryPool(
+    MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo)
+    : MVKQueryPool(device, pCreateInfo, 1) {
 
     if (getMVKConfig().supportLargeQueryPools) {
         _queryIndexOffset = 0;
 
         // Ensure we don't overflow the maximum number of queries
-		auto& mtlFeats = getMetalFeatures();
-        VkDeviceSize reqBuffLen = (VkDeviceSize)pCreateInfo->queryCount * kMVKQuerySlotSizeInBytes;
+        auto& mtlFeats = getMetalFeatures();
+        VkDeviceSize reqBuffLen =
+            (VkDeviceSize)pCreateInfo->queryCount * kMVKQuerySlotSizeInBytes;
         VkDeviceSize maxBuffLen = mtlFeats.maxQueryBufferSize;
         VkDeviceSize newBuffLen = min(reqBuffLen, maxBuffLen);
 
         if (reqBuffLen > maxBuffLen) {
-			reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
-						"vkCreateQueryPool(): Each occlusion query pool can support a maximum of %d queries.",
-						uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes));
+            reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                        "vkCreateQueryPool(): Each occlusion query pool can "
+                        "support a maximum of %d queries.",
+                        uint32_t(newBuffLen / kMVKQuerySlotSizeInBytes));
         }
 
-        NSUInteger mtlBuffLen = mvkAlignByteCount(newBuffLen, mtlFeats.mtlBufferAlignment);
-        MTLResourceOptions mtlBuffOpts = MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache;
-        _visibilityResultMTLBuffer = [getMTLDevice() newBufferWithLength: mtlBuffLen options: mtlBuffOpts];     // retained
+        NSUInteger mtlBuffLen =
+            mvkAlignByteCount(newBuffLen, mtlFeats.mtlBufferAlignment);
+        MTLResourceOptions mtlBuffOpts =
+            MTLResourceStorageModeShared | MTLResourceCPUCacheModeDefaultCache;
+        _visibilityResultMTLBuffer =
+            [getMTLDevice() newBufferWithLength:mtlBuffLen
+                                        options:mtlBuffOpts]; // retained
 
     } else {
-        _queryIndexOffset = _device->expandVisibilityResultMTLBuffer(pCreateInfo->queryCount);
-        _visibilityResultMTLBuffer = nil;   // Will delegate to global buffer in device on access
+        _queryIndexOffset =
+            _device->expandVisibilityResultMTLBuffer(pCreateInfo->queryCount);
+        _visibilityResultMTLBuffer =
+            nil; // Will delegate to global buffer in device on access
     }
 }
 
@@ -336,144 +421,191 @@ MVKOcclusionQueryPool::~MVKOcclusionQueryPool() {
     [_visibilityResultMTLBuffer release];
 };
 
-
 #pragma mark -
 #pragma mark MVKGPUCounterQueryPool
 
-MVKGPUCounterQueryPool::MVKGPUCounterQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo) :
-	MVKQueryPool(device, pCreateInfo, 1), _mtlCounterBuffer(nil) {}
+MVKGPUCounterQueryPool::MVKGPUCounterQueryPool(
+    MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo)
+    : MVKQueryPool(device, pCreateInfo, 1), _mtlCounterBuffer(nil) {}
 
-// To establish the Metal counter sample buffer, this must be called from the construtors
-// of subclasses, because the type of MTLCounterSet is determined by the subclass.
-void MVKGPUCounterQueryPool::initMTLCounterSampleBuffer(const VkQueryPoolCreateInfo* pCreateInfo,
-														id<MTLCounterSet> mtlCounterSet,
-														const char* queryTypeName) {
-	if ( !mtlCounterSet ) { return; }
+// To establish the Metal counter sample buffer, this must be called from the
+// construtors of subclasses, because the type of MTLCounterSet is determined by
+// the subclass.
+void MVKGPUCounterQueryPool::initMTLCounterSampleBuffer(
+    const VkQueryPoolCreateInfo* pCreateInfo, id<MTLCounterSet> mtlCounterSet,
+    const char* queryTypeName) {
+    if (!mtlCounterSet) {
+        return;
+    }
 
-	@autoreleasepool {
-		MTLCounterSampleBufferDescriptor* tsDesc = [[[MTLCounterSampleBufferDescriptor alloc] init] autorelease];
-		tsDesc.counterSet = mtlCounterSet;
-		tsDesc.storageMode = MTLStorageModeShared;
-		tsDesc.sampleCount = pCreateInfo->queryCount;
+    @autoreleasepool {
+        MTLCounterSampleBufferDescriptor* tsDesc =
+            [[[MTLCounterSampleBufferDescriptor alloc] init] autorelease];
+        tsDesc.counterSet = mtlCounterSet;
+        tsDesc.storageMode = MTLStorageModeShared;
+        tsDesc.sampleCount = pCreateInfo->queryCount;
 
-		NSError* err = nil;
-		_mtlCounterBuffer = [getMTLDevice() newCounterSampleBufferWithDescriptor: tsDesc error: &err];
-		if (err) {
-			reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
-						"Could not create MTLCounterSampleBuffer of size %llu, for %d queries, in query pool of type %s. Reverting to emulated behavior. (Error code %li): %s",
-						(VkDeviceSize)pCreateInfo->queryCount * kMVKQuerySlotSizeInBytes, pCreateInfo->queryCount, queryTypeName, (long)err.code, err.localizedDescription.UTF8String);
-		}
-	}
+        NSError* err = nil;
+        _mtlCounterBuffer =
+            [getMTLDevice() newCounterSampleBufferWithDescriptor:tsDesc
+                                                           error:&err];
+        if (err) {
+            reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY,
+                        "Could not create MTLCounterSampleBuffer of size %llu, "
+                        "for %d queries, in query pool of type "
+                        "%s. Reverting to emulated behavior. (Error code %li): "
+                        "%s",
+                        (VkDeviceSize)pCreateInfo->queryCount *
+                            kMVKQuerySlotSizeInBytes,
+                        pCreateInfo->queryCount, queryTypeName, (long)err.code,
+                        err.localizedDescription.UTF8String);
+        }
+    }
 };
 
 MVKGPUCounterQueryPool::~MVKGPUCounterQueryPool() {
-	[_mtlCounterBuffer release];
+    [_mtlCounterBuffer release];
 }
-
 
 #pragma mark -
 #pragma mark MVKTimestampQueryPool
 
-void MVKTimestampQueryPool::endQuery(uint32_t query, MVKCommandEncoder* cmdEncoder) {
-	cmdEncoder->markTimestamp(this, query);
-	MVKQueryPool::endQuery(query, cmdEncoder);
+void MVKTimestampQueryPool::endQuery(uint32_t query,
+                                     MVKCommandEncoder* cmdEncoder) {
+    cmdEncoder->markTimestamp(this, query);
+    MVKQueryPool::endQuery(query, cmdEncoder);
 }
 
-// If not using MTLCounterSampleBuffer, update timestamp values, then mark queries as available
+// If not using MTLCounterSampleBuffer, update timestamp values, then mark
+// queries as available
 void MVKTimestampQueryPool::finishQueries(MVKArrayRef<const uint32_t> queries) {
-	if ( !_mtlCounterBuffer ) {
-		uint64_t ts = mvkGetElapsedNanoseconds();
-		for (uint32_t qry : queries) { _timestamps[qry] = ts; }
-	}
-	MVKQueryPool::finishQueries(queries);
+    if (!_mtlCounterBuffer) {
+        uint64_t ts = mvkGetElapsedNanoseconds();
+        for (uint32_t qry : queries) {
+            _timestamps[qry] = ts;
+        }
+    }
+    MVKQueryPool::finishQueries(queries);
 }
 
-NSData* MVKTimestampQueryPool::getQuerySourceData(uint32_t firstQuery, uint32_t queryCount) {
-	if (_mtlCounterBuffer) {
-		return [_mtlCounterBuffer resolveCounterRange: NSMakeRange(firstQuery, queryCount)];
-	} else {
-		return [NSData dataWithBytesNoCopy: (void*)&_timestamps[firstQuery]
-									length: queryCount * kMVKQuerySlotSizeInBytes
-							  freeWhenDone: false];
-	}
+NSData* MVKTimestampQueryPool::getQuerySourceData(uint32_t firstQuery,
+                                                  uint32_t queryCount) {
+    if (_mtlCounterBuffer) {
+        return [_mtlCounterBuffer
+            resolveCounterRange:NSMakeRange(firstQuery, queryCount)];
+    } else {
+        return [NSData dataWithBytesNoCopy:(void*)&_timestamps[firstQuery]
+                                    length:queryCount * kMVKQuerySlotSizeInBytes
+                              freeWhenDone:false];
+    }
 }
 
-void MVKTimestampQueryPool::encodeDirectCopyResults(MVKCommandEncoder* cmdEncoder,
-													uint32_t firstQuery,
-													uint32_t queryCount,
-													MVKBuffer* destBuffer,
-													VkDeviceSize destOffset,
-													VkDeviceSize stride) {
-	if (_mtlCounterBuffer) {
-		id<MTLBlitCommandEncoder> mtlBlitCmdEnc = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
-		[mtlBlitCmdEnc resolveCounters: _mtlCounterBuffer
-							   inRange: NSMakeRange(firstQuery,  queryCount)
-					 destinationBuffer: destBuffer->getMTLBuffer()
-					 destinationOffset: destBuffer->getMTLBufferOffset() + destOffset];
-	} else {
-		MVKQueryPool::encodeDirectCopyResults(cmdEncoder, firstQuery, queryCount, destBuffer, destOffset, stride);
-	}
+void MVKTimestampQueryPool::encodeDirectCopyResults(
+    MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount,
+    MVKBuffer* destBuffer, VkDeviceSize destOffset, VkDeviceSize stride) {
+    if (_mtlCounterBuffer) {
+        id<MTLBlitCommandEncoder> mtlBlitCmdEnc =
+            cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
+        [mtlBlitCmdEnc
+              resolveCounters:_mtlCounterBuffer
+                      inRange:NSMakeRange(firstQuery, queryCount)
+            destinationBuffer:destBuffer->getMTLBuffer()
+            destinationOffset:destBuffer->getMTLBufferOffset() + destOffset];
+    } else {
+        MVKQueryPool::encodeDirectCopyResults(cmdEncoder, firstQuery,
+                                              queryCount, destBuffer,
+                                              destOffset, stride);
+    }
 }
 
-id<MTLBuffer> MVKTimestampQueryPool::getResultBuffer(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, NSUInteger& offset) {
-	const MVKMTLBufferAllocation* tempBuff = cmdEncoder->getTempMTLBuffer(queryCount * _queryElementCount * sizeof(uint64_t));
-	void* pBuffData = tempBuff->getContents();
-	size_t size = queryCount * _queryElementCount * sizeof(uint64_t);
-	memcpy(pBuffData, &_timestamps[firstQuery], size);
-	offset = tempBuff->_offset;
-	return tempBuff->_mtlBuffer;
+id<MTLBuffer>
+MVKTimestampQueryPool::getResultBuffer(MVKCommandEncoder* cmdEncoder,
+                                       uint32_t firstQuery, uint32_t queryCount,
+                                       NSUInteger& offset) {
+    const MVKMTLBufferAllocation* tempBuff = cmdEncoder->getTempMTLBuffer(
+        queryCount * _queryElementCount * sizeof(uint64_t));
+    void* pBuffData = tempBuff->getContents();
+    size_t size = queryCount * _queryElementCount * sizeof(uint64_t);
+    memcpy(pBuffData, &_timestamps[firstQuery], size);
+    offset = tempBuff->_offset;
+    return tempBuff->_mtlBuffer;
 }
 
-id<MTLComputeCommandEncoder> MVKTimestampQueryPool::encodeComputeCopyResults(MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount, uint32_t index) {
-	if (_mtlCounterBuffer) {
-		// We first need to resolve from the MTLCounterSampleBuffer into a temp buffer using a
-		// MTLBlitCommandEncoder, before creating the compute encoder and set that temp buffer into it.
-		const MVKMTLBufferAllocation* tempBuff = cmdEncoder->getTempMTLBuffer(queryCount * _queryElementCount * sizeof(uint64_t));
-		id<MTLBlitCommandEncoder> mtlBlitCmdEnc = cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
-		[mtlBlitCmdEnc resolveCounters: _mtlCounterBuffer
-							   inRange: NSMakeRange(firstQuery,  queryCount)
-					 destinationBuffer: tempBuff->_mtlBuffer
-					 destinationOffset: tempBuff->_offset];
+id<MTLComputeCommandEncoder> MVKTimestampQueryPool::encodeComputeCopyResults(
+    MVKCommandEncoder* cmdEncoder, uint32_t firstQuery, uint32_t queryCount,
+    uint32_t index) {
+    if (_mtlCounterBuffer) {
+        // We first need to resolve from the MTLCounterSampleBuffer into a temp
+        // buffer using a MTLBlitCommandEncoder, before creating the compute
+        // encoder and set that temp buffer into it.
+        const MVKMTLBufferAllocation* tempBuff = cmdEncoder->getTempMTLBuffer(
+            queryCount * _queryElementCount * sizeof(uint64_t));
+        id<MTLBlitCommandEncoder> mtlBlitCmdEnc =
+            cmdEncoder->getMTLBlitEncoder(kMVKCommandUseCopyQueryPoolResults);
+        [mtlBlitCmdEnc resolveCounters:_mtlCounterBuffer
+                               inRange:NSMakeRange(firstQuery, queryCount)
+                     destinationBuffer:tempBuff->_mtlBuffer
+                     destinationOffset:tempBuff->_offset];
 
-		id<MTLComputeCommandEncoder> mtlCmdEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults, true);
-		[mtlCmdEnc setBuffer: tempBuff->_mtlBuffer offset: tempBuff->_offset atIndex: index];
-		return mtlCmdEnc;
-	} else {
-		// We can set the timestamp bytes into the compute encoder.
-		id<MTLComputeCommandEncoder> mtlCmdEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults, true);
-		cmdEncoder->setComputeBytes(mtlCmdEnc, &_timestamps[firstQuery], queryCount * _queryElementCount * sizeof(uint64_t), index);
-		return mtlCmdEnc;
-	}
+        id<MTLComputeCommandEncoder> mtlCmdEnc =
+            cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults,
+                                             true);
+        [mtlCmdEnc setBuffer:tempBuff->_mtlBuffer
+                      offset:tempBuff->_offset
+                     atIndex:index];
+        return mtlCmdEnc;
+    } else {
+        // We can set the timestamp bytes into the compute encoder.
+        id<MTLComputeCommandEncoder> mtlCmdEnc =
+            cmdEncoder->getMTLComputeEncoder(kMVKCommandUseCopyQueryPoolResults,
+                                             true);
+        cmdEncoder->setComputeBytes(mtlCmdEnc, &_timestamps[firstQuery],
+                                    queryCount * _queryElementCount *
+                                        sizeof(uint64_t),
+                                    index);
+        return mtlCmdEnc;
+    }
 }
-
 
 #pragma mark Construction
 
-MVKTimestampQueryPool::MVKTimestampQueryPool(MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo) :
-	MVKGPUCounterQueryPool(device, pCreateInfo) {
+MVKTimestampQueryPool::MVKTimestampQueryPool(
+    MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo)
+    : MVKGPUCounterQueryPool(device, pCreateInfo) {
 
-		initMTLCounterSampleBuffer(pCreateInfo, _device->getTimestampMTLCounterSet(), "VK_QUERY_TYPE_TIMESTAMP");
+    initMTLCounterSampleBuffer(pCreateInfo,
+                               _device->getTimestampMTLCounterSet(),
+                               "VK_QUERY_TYPE_TIMESTAMP");
 
-		// If we don't use a MTLCounterSampleBuffer, allocate memory to hold the timestamps.
-		if ( !_mtlCounterBuffer ) { _timestamps.resize(pCreateInfo->queryCount, 0); }
+    // If we don't use a MTLCounterSampleBuffer, allocate memory to hold the
+    // timestamps.
+    if (!_mtlCounterBuffer) {
+        _timestamps.resize(pCreateInfo->queryCount, 0);
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKPipelineStatisticsQueryPool
 
-MVKPipelineStatisticsQueryPool::MVKPipelineStatisticsQueryPool(MVKDevice* device,
-															   const VkQueryPoolCreateInfo* pCreateInfo) : MVKGPUCounterQueryPool(device, pCreateInfo) {
-	if ( !getEnabledFeatures().pipelineStatisticsQuery ) {
-		setConfigurationResult(reportError(VK_ERROR_FEATURE_NOT_PRESENT, "vkCreateQueryPool: VK_QUERY_TYPE_PIPELINE_STATISTICS is not supported."));
-	}
+MVKPipelineStatisticsQueryPool::MVKPipelineStatisticsQueryPool(
+    MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo)
+    : MVKGPUCounterQueryPool(device, pCreateInfo) {
+    if (!getEnabledFeatures().pipelineStatisticsQuery) {
+        setConfigurationResult(
+            reportError(VK_ERROR_FEATURE_NOT_PRESENT,
+                        "vkCreateQueryPool: VK_QUERY_TYPE_PIPELINE_STATISTICS "
+                        "is not supported."));
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKUnsupportedQueryPool
 
-MVKUnsupportedQueryPool::MVKUnsupportedQueryPool(MVKDevice* device,
-												 const VkQueryPoolCreateInfo* pCreateInfo) : MVKQueryPool(device, pCreateInfo, 1) {
-	setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkCreateQueryPool: Unsupported query pool type: %d.", pCreateInfo->queryType));
+MVKUnsupportedQueryPool::MVKUnsupportedQueryPool(
+    MVKDevice* device, const VkQueryPoolCreateInfo* pCreateInfo)
+    : MVKQueryPool(device, pCreateInfo, 1) {
+    setConfigurationResult(
+        reportError(VK_ERROR_INITIALIZATION_FAILED,
+                    "vkCreateQueryPool: Unsupported query pool type: %d.",
+                    pCreateInfo->queryType));
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,93 +33,101 @@ class MVKQueueSubmission;
 class MVKPhysicalDevice;
 class MVKGPUCaptureScope;
 
-
 #pragma mark -
 #pragma mark MVKQueueFamily
 
 /** Represents a Vulkan queue family. */
 class MVKQueueFamily : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _physicalDevice->getVulkanAPIObject();
+    }
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _physicalDevice->getVulkanAPIObject(); }
+    /** Returns the index of this queue family. */
+    uint32_t getIndex() { return _queueFamilyIndex; }
 
-	/** Returns the index of this queue family. */
-	uint32_t getIndex() { return _queueFamilyIndex; }
+    /** Populates the specified properties structure. */
+    void getProperties(VkQueueFamilyProperties* queueProperties) {
+        if (queueProperties) {
+            *queueProperties = _properties;
+        }
+    }
 
-	/** Populates the specified properties structure. */
-	void getProperties(VkQueueFamilyProperties* queueProperties) {
-		if (queueProperties) { *queueProperties = _properties; }
-	}
+    /** Returns the MTLCommandQueue at the specified index. */
+    id<MTLCommandQueue> getMTLCommandQueue(uint32_t queueIndex);
 
-	/** Returns the MTLCommandQueue at the specified index. */
-	id<MTLCommandQueue> getMTLCommandQueue(uint32_t queueIndex);
+    /** Constructs an instance with the specified index. */
+    MVKQueueFamily(MVKPhysicalDevice* physicalDevice, uint32_t queueFamilyIndex,
+                   const VkQueueFamilyProperties* pProperties);
 
-	/** Constructs an instance with the specified index. */
-	MVKQueueFamily(MVKPhysicalDevice* physicalDevice, uint32_t queueFamilyIndex, const VkQueueFamilyProperties* pProperties);
+    ~MVKQueueFamily() override;
 
-	~MVKQueueFamily() override;
-
-protected:
-	MVKPhysicalDevice* _physicalDevice;
+  protected:
+    MVKPhysicalDevice* _physicalDevice;
     uint32_t _queueFamilyIndex;
-	VkQueueFamilyProperties _properties;
-	MVKSmallVector<id<MTLCommandQueue>, kMVKQueueCountPerQueueFamily> _mtlQueues;
-	std::mutex _qLock;
+    VkQueueFamilyProperties _properties;
+    MVKSmallVector<id<MTLCommandQueue>, kMVKQueueCountPerQueueFamily>
+        _mtlQueues;
+    std::mutex _qLock;
 };
-
 
 #pragma mark -
 #pragma mark MVKQueue
 
 /** Represents a Vulkan queue. */
-class MVKQueue : public MVKDispatchableVulkanAPIObject, public MVKDeviceTrackingMixin {
+class MVKQueue : public MVKDispatchableVulkanAPIObject,
+                 public MVKDeviceTrackingMixin {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_QUEUE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_QUEUE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return _device->getInstance(); }
 
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _device->getInstance(); }
-
-	/** Return the name of this queue. */
-	const std::string& getName() { return _name; }
+    /** Return the name of this queue. */
+    const std::string& getName() { return _name; }
 
 #pragma mark Queue submissions
 
-	/** Submits the specified command buffers to the queue. */
-	template <typename S>
-	VkResult submit(uint32_t submitCount, const S* pSubmits, VkFence fence, MVKCommandUse cmdUse);
+    /** Submits the specified command buffers to the queue. */
+    template <typename S>
+    VkResult submit(uint32_t submitCount, const S* pSubmits, VkFence fence,
+                    MVKCommandUse cmdUse);
 
-	/** Submits the specified presentation command to the queue. */
-	VkResult submit(const VkPresentInfoKHR* pPresentInfo);
+    /** Submits the specified presentation command to the queue. */
+    VkResult submit(const VkPresentInfoKHR* pPresentInfo);
 
-	/** Block the current thread until this queue is idle. */
-	VkResult waitIdle(MVKCommandUse cmdUse);
+    /** Block the current thread until this queue is idle. */
+    VkResult waitIdle(MVKCommandUse cmdUse);
 
 #pragma mark Metal
 
-	/** Returns the Metal queue underlying this queue. */
-	id<MTLCommandQueue> getMTLCommandQueue() { return _mtlQueue; }
+    /** Returns the Metal queue underlying this queue. */
+    id<MTLCommandQueue> getMTLCommandQueue() { return _mtlQueue; }
 
-	/** Returns a Metal command buffer from the Metal queue. */
-	id<MTLCommandBuffer> getMTLCommandBuffer(MVKCommandUse cmdUse, bool retainRefs = false);
+    /** Returns a Metal command buffer from the Metal queue. */
+    id<MTLCommandBuffer> getMTLCommandBuffer(MVKCommandUse cmdUse,
+                                             bool retainRefs = false);
 
 #pragma mark Construction
-	
-	/** Constructs an instance for the device and queue family. */
-	MVKQueue(MVKDevice* device, MVKQueueFamily* queueFamily, uint32_t index, float priority);
 
-	~MVKQueue() override;
+    /** Constructs an instance for the device and queue family. */
+    MVKQueue(MVKDevice* device, MVKQueueFamily* queueFamily, uint32_t index,
+             float priority);
+
+    ~MVKQueue() override;
 
     /**
-     * Returns a reference to this object suitable for use as a Vulkan API handle.
-     * This is the compliment of the getMVKQueue() method.
+     * Returns a reference to this object suitable for use as a Vulkan API
+     * handle. This is the compliment of the getMVKQueue() method.
      */
     VkQueue getVkQueue() { return (VkQueue)getVkHandle(); }
 
@@ -131,109 +139,112 @@ public:
         return (MVKQueue*)getDispatchableObject(vkQueue);
     }
 
-protected:
-	friend class MVKQueueSubmission;
-	friend class MVKQueueCommandBufferSubmission;
-	friend class MVKQueuePresentSurfaceSubmission;
+  protected:
+    friend class MVKQueueSubmission;
+    friend class MVKQueueCommandBufferSubmission;
+    friend class MVKQueuePresentSurfaceSubmission;
 
-	void propagateDebugName() override;
-	void initName();
-	void initExecQueue();
-	void initMTLCommandQueue();
-	void destroyExecQueue();
-	VkResult submit(MVKQueueSubmission* qSubmit);
-	NSString* getMTLCommandBufferLabel(MVKCommandUse cmdUse);
-	void handleMTLCommandBufferError(id<MTLCommandBuffer> mtlCmdBuff);
+    void propagateDebugName() override;
+    void initName();
+    void initExecQueue();
+    void initMTLCommandQueue();
+    void destroyExecQueue();
+    VkResult submit(MVKQueueSubmission* qSubmit);
+    NSString* getMTLCommandBufferLabel(MVKCommandUse cmdUse);
+    void handleMTLCommandBufferError(id<MTLCommandBuffer> mtlCmdBuff);
 
-	MVKQueueFamily* _queueFamily;
-	std::string _name;
-	dispatch_queue_t _execQueue;
-	std::mutex _execQueueMutex;
-	std::condition_variable _execQueueConditionVariable;
-	uint32_t _execQueueJobCount = 0;
-	id<MTLCommandQueue> _mtlQueue = nil;
-	NSString* _mtlCmdBuffLabelBeginCommandBuffer = nil;
-	NSString* _mtlCmdBuffLabelQueueSubmit = nil;
-	NSString* _mtlCmdBuffLabelQueuePresent = nil;
-	NSString* _mtlCmdBuffLabelDeviceWaitIdle = nil;
-	NSString* _mtlCmdBuffLabelQueueWaitIdle = nil;
-	NSString* _mtlCmdBuffLabelAcquireNextImage = nil;
-	NSString* _mtlCmdBuffLabelInvalidateMappedMemoryRanges = nil;
-	NSString* _mtlCmdBuffLabelCopyImageToMemory = nil;
-	MVKGPUCaptureScope* _submissionCaptureScope = nil;
-	float _priority;
-	uint32_t _index;
+    MVKQueueFamily* _queueFamily;
+    std::string _name;
+    dispatch_queue_t _execQueue;
+    std::mutex _execQueueMutex;
+    std::condition_variable _execQueueConditionVariable;
+    uint32_t _execQueueJobCount = 0;
+    id<MTLCommandQueue> _mtlQueue = nil;
+    NSString* _mtlCmdBuffLabelBeginCommandBuffer = nil;
+    NSString* _mtlCmdBuffLabelQueueSubmit = nil;
+    NSString* _mtlCmdBuffLabelQueuePresent = nil;
+    NSString* _mtlCmdBuffLabelDeviceWaitIdle = nil;
+    NSString* _mtlCmdBuffLabelQueueWaitIdle = nil;
+    NSString* _mtlCmdBuffLabelAcquireNextImage = nil;
+    NSString* _mtlCmdBuffLabelInvalidateMappedMemoryRanges = nil;
+    NSString* _mtlCmdBuffLabelCopyImageToMemory = nil;
+    MVKGPUCaptureScope* _submissionCaptureScope = nil;
+    float _priority;
+    uint32_t _index;
 };
-
 
 #pragma mark -
 #pragma mark MVKQueueSubmission
 
 typedef struct MVKSemaphoreSubmitInfo {
-private:
-	MVKSemaphore* _semaphore;
-public:
-	uint64_t value;
-	VkPipelineStageFlags2 stageMask;
-	uint32_t deviceIndex;
+  private:
+    MVKSemaphore* _semaphore;
 
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff);
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff);
-	MVKSemaphoreSubmitInfo(const VkSemaphoreSubmitInfo& semaphoreSubmitInfo);
-	MVKSemaphoreSubmitInfo(const VkSemaphore semaphore, VkPipelineStageFlags stageMask);
-	MVKSemaphoreSubmitInfo(const MVKSemaphoreSubmitInfo& other);
-	MVKSemaphoreSubmitInfo& operator=(const MVKSemaphoreSubmitInfo& other);
-	~MVKSemaphoreSubmitInfo();
+  public:
+    uint64_t value;
+    VkPipelineStageFlags2 stageMask;
+    uint32_t deviceIndex;
+
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff);
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff);
+    MVKSemaphoreSubmitInfo(const VkSemaphoreSubmitInfo& semaphoreSubmitInfo);
+    MVKSemaphoreSubmitInfo(const VkSemaphore semaphore,
+                           VkPipelineStageFlags stageMask);
+    MVKSemaphoreSubmitInfo(const MVKSemaphoreSubmitInfo& other);
+    MVKSemaphoreSubmitInfo& operator=(const MVKSemaphoreSubmitInfo& other);
+    ~MVKSemaphoreSubmitInfo();
 
 } MVKSemaphoreSubmitInfo;
 
-/** This is an abstract class for an operation that can be submitted to an MVKQueue. */
-class MVKQueueSubmission : public MVKBaseDeviceObject, public MVKConfigurableMixin {
+/** This is an abstract class for an operation that can be submitted to an
+ * MVKQueue. */
+class MVKQueueSubmission : public MVKBaseDeviceObject,
+                           public MVKConfigurableMixin {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _queue->getVulkanAPIObject();
+    }
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _queue->getVulkanAPIObject(); }
+    /**
+     * Executes this action on the queue and then disposes of this instance.
+     *
+     * Upon completion of this function, no further calls should be made to this
+     * instance.
+     */
+    virtual VkResult execute() = 0;
 
-	/**
-	 * Executes this action on the queue and then disposes of this instance.
-	 *
-	 * Upon completion of this function, no further calls should be made to this instance.
-	 */
-	virtual VkResult execute() = 0;
+    MVKQueueSubmission(MVKQueue* queue, uint32_t waitSemaphoreInfoCount,
+                       const VkSemaphoreSubmitInfo* pWaitSemaphoreSubmitInfos);
 
-	MVKQueueSubmission(MVKQueue* queue,
-					   uint32_t waitSemaphoreInfoCount,
-					   const VkSemaphoreSubmitInfo* pWaitSemaphoreSubmitInfos);
+    MVKQueueSubmission(MVKQueue* queue, uint32_t waitSemaphoreCount,
+                       const VkSemaphore* pWaitSemaphores,
+                       const VkPipelineStageFlags* pWaitDstStageMask);
 
-	MVKQueueSubmission(MVKQueue* queue,
-					   uint32_t waitSemaphoreCount,
-					   const VkSemaphore* pWaitSemaphores,
-					   const VkPipelineStageFlags* pWaitDstStageMask);
+    ~MVKQueueSubmission() override;
 
-	~MVKQueueSubmission() override;
+  protected:
+    friend class MVKQueue;
 
-protected:
-	friend class MVKQueue;
+    virtual void finish() = 0;
+    MVKDevice* getDevice() { return _queue->getDevice(); }
 
-	virtual void finish() = 0;
-	MVKDevice* getDevice() { return _queue->getDevice(); }
-
-	MVKQueue* _queue;
-	MVKSmallVector<MVKSemaphoreSubmitInfo> _waitSemaphores;
-	uint64_t _creationTime;
+    MVKQueue* _queue;
+    MVKSmallVector<MVKSemaphoreSubmitInfo> _waitSemaphores;
+    uint64_t _creationTime;
 };
-
 
 #pragma mark -
 #pragma mark MVKQueueCommandBufferSubmission
 
 typedef struct MVKCommandBufferSubmitInfo {
-	MVKCommandBuffer* commandBuffer;
-	uint32_t deviceMask;
+    MVKCommandBuffer* commandBuffer;
+    uint32_t deviceMask;
 
-	MVKCommandBufferSubmitInfo(const VkCommandBufferSubmitInfo& commandBufferInfo);
-	MVKCommandBufferSubmitInfo(VkCommandBuffer commandBuffer);
+    MVKCommandBufferSubmitInfo(
+        const VkCommandBufferSubmitInfo& commandBufferInfo);
+    MVKCommandBufferSubmitInfo(VkCommandBuffer commandBuffer);
 
 } MVKCommandBufferSubmitInfo;
 
@@ -243,63 +254,60 @@ typedef struct MVKCommandBufferSubmitInfo {
  */
 class MVKQueueCommandBufferSubmission : public MVKQueueSubmission {
 
-public:
-	VkResult execute() override;
+  public:
+    VkResult execute() override;
 
-	MVKQueueCommandBufferSubmission(MVKQueue* queue, 
-									const VkSubmitInfo2* pSubmit,
-									VkFence fence, 
-									MVKCommandUse cmdUse);
+    MVKQueueCommandBufferSubmission(MVKQueue* queue,
+                                    const VkSubmitInfo2* pSubmit, VkFence fence,
+                                    MVKCommandUse cmdUse);
 
-	MVKQueueCommandBufferSubmission(MVKQueue* queue, 
-									const VkSubmitInfo* pSubmit,
-									VkFence fence,
-									MVKCommandUse cmdUse);
+    MVKQueueCommandBufferSubmission(MVKQueue* queue,
+                                    const VkSubmitInfo* pSubmit, VkFence fence,
+                                    MVKCommandUse cmdUse);
 
-	~MVKQueueCommandBufferSubmission() override;
+    ~MVKQueueCommandBufferSubmission() override;
 
-protected:
-	friend MVKCommandBuffer;
+  protected:
+    friend MVKCommandBuffer;
 
-	id<MTLCommandBuffer> getActiveMTLCommandBuffer();
-	void setActiveMTLCommandBuffer(id<MTLCommandBuffer> mtlCmdBuff);
-	VkResult commitActiveMTLCommandBuffer(bool signalCompletion = false);
-	void finish() override;
-	virtual void submitCommandBuffers() {}
+    id<MTLCommandBuffer> getActiveMTLCommandBuffer();
+    void setActiveMTLCommandBuffer(id<MTLCommandBuffer> mtlCmdBuff);
+    VkResult commitActiveMTLCommandBuffer(bool signalCompletion = false);
+    void finish() override;
+    virtual void submitCommandBuffers() {}
 
-	MVKCommandEncodingContext _encodingContext;
-	MVKSmallVector<MVKSemaphoreSubmitInfo> _signalSemaphores;
-	MVKFence* _fence = nullptr;
-	id<MTLCommandBuffer> _activeMTLCommandBuffer = nil;
-	MVKCommandUse _commandUse = kMVKCommandUseNone;
-	bool _emulatedWaitDone = false;		//Used to track if we've already waited for emulated semaphores.
+    MVKCommandEncodingContext _encodingContext;
+    MVKSmallVector<MVKSemaphoreSubmitInfo> _signalSemaphores;
+    MVKFence* _fence = nullptr;
+    id<MTLCommandBuffer> _activeMTLCommandBuffer = nil;
+    MVKCommandUse _commandUse = kMVKCommandUseNone;
+    bool _emulatedWaitDone =
+        false; // Used to track if we've already waited for emulated semaphores.
 };
-
 
 /**
  * Submits the commands in a set of command buffers to the queue.
- * Template class to balance vector pre-allocations between very common low counts and fewer larger counts.
+ * Template class to balance vector pre-allocations between very common low
+ * counts and fewer larger counts.
  */
 template <size_t N>
-class MVKQueueFullCommandBufferSubmission : public MVKQueueCommandBufferSubmission {
+class MVKQueueFullCommandBufferSubmission
+    : public MVKQueueCommandBufferSubmission {
 
-public:
-	MVKQueueFullCommandBufferSubmission(MVKQueue* queue, 
-										const VkSubmitInfo2* pSubmit,
-										VkFence fence,
-										MVKCommandUse cmdUse);
+  public:
+    MVKQueueFullCommandBufferSubmission(MVKQueue* queue,
+                                        const VkSubmitInfo2* pSubmit,
+                                        VkFence fence, MVKCommandUse cmdUse);
 
-	MVKQueueFullCommandBufferSubmission(MVKQueue* queue, 
-										const VkSubmitInfo* pSubmit,
-										VkFence fence,
-										MVKCommandUse cmdUse);
+    MVKQueueFullCommandBufferSubmission(MVKQueue* queue,
+                                        const VkSubmitInfo* pSubmit,
+                                        VkFence fence, MVKCommandUse cmdUse);
 
-protected:
-	void submitCommandBuffers() override;
+  protected:
+    void submitCommandBuffers() override;
 
-	MVKSmallVector<MVKCommandBufferSubmitInfo, N> _cmdBuffers;
+    MVKSmallVector<MVKCommandBufferSubmitInfo, N> _cmdBuffers;
 };
-
 
 #pragma mark -
 #pragma mark MVKQueuePresentSurfaceSubmission
@@ -307,15 +315,14 @@ protected:
 /** Presents a swapchain surface image to the OS. */
 class MVKQueuePresentSurfaceSubmission : public MVKQueueSubmission {
 
-public:
-	VkResult execute() override;
+  public:
+    VkResult execute() override;
 
-	MVKQueuePresentSurfaceSubmission(MVKQueue* queue,
-									 const VkPresentInfoKHR* pPresentInfo);
+    MVKQueuePresentSurfaceSubmission(MVKQueue* queue,
+                                     const VkPresentInfoKHR* pPresentInfo);
 
-protected:
-	void finish() override;
+  protected:
+    void finish() override;
 
-	MVKSmallVector<MVKImagePresentInfo, 4> _presentInfo;
+    MVKSmallVector<MVKImagePresentInfo, 4> _presentInfo;
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,807 +27,995 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKQueueFamily
 
-// MTLCommandQueues are cached in MVKQueueFamily/MVKPhysicalDevice because they are very
-// limited in number. An app that creates multiple VkDevices over time (such as a test suite)
-// will soon find 15 second delays when creating subsequent MTLCommandQueues.
+// MTLCommandQueues are cached in MVKQueueFamily/MVKPhysicalDevice because they
+// are very limited in number. An app that creates multiple VkDevices over time
+// (such as a test suite) will soon find 15 second delays when creating
+// subsequent MTLCommandQueues.
 id<MTLCommandQueue> MVKQueueFamily::getMTLCommandQueue(uint32_t queueIndex) {
-	lock_guard<mutex> lock(_qLock);
-	id<MTLCommandQueue> mtlQ = _mtlQueues[queueIndex];
-	if ( !mtlQ ) {
-		@autoreleasepool {		// Catch any autoreleased objects created during MTLCommandQueue creation
-			uint32_t maxCmdBuffs = getMVKConfig().maxActiveMetalCommandBuffersPerQueue;
-			mtlQ = [_physicalDevice->getMTLDevice() newCommandQueueWithMaxCommandBufferCount: maxCmdBuffs];		// retained
-			_mtlQueues[queueIndex] = mtlQ;
-		}
-	}
-	return mtlQ;
+    lock_guard<mutex> lock(_qLock);
+    id<MTLCommandQueue> mtlQ = _mtlQueues[queueIndex];
+    if (!mtlQ) {
+        @autoreleasepool { // Catch any autoreleased objects created during
+                           // MTLCommandQueue creation
+            uint32_t maxCmdBuffs =
+                getMVKConfig().maxActiveMetalCommandBuffersPerQueue;
+            mtlQ = [_physicalDevice->getMTLDevice()
+                newCommandQueueWithMaxCommandBufferCount:
+                    maxCmdBuffs]; // retained
+            _mtlQueues[queueIndex] = mtlQ;
+        }
+    }
+    return mtlQ;
 }
 
-MVKQueueFamily::MVKQueueFamily(MVKPhysicalDevice* physicalDevice, uint32_t queueFamilyIndex, const VkQueueFamilyProperties* pProperties) {
-	_physicalDevice = physicalDevice;
-	_queueFamilyIndex = queueFamilyIndex;
-	_properties = *pProperties;
-	_mtlQueues.assign(_properties.queueCount, nil);
+MVKQueueFamily::MVKQueueFamily(MVKPhysicalDevice* physicalDevice,
+                               uint32_t queueFamilyIndex,
+                               const VkQueueFamilyProperties* pProperties) {
+    _physicalDevice = physicalDevice;
+    _queueFamilyIndex = queueFamilyIndex;
+    _properties = *pProperties;
+    _mtlQueues.assign(_properties.queueCount, nil);
 }
 
-MVKQueueFamily::~MVKQueueFamily() {
-	mvkReleaseContainerContents(_mtlQueues);
-}
-
+MVKQueueFamily::~MVKQueueFamily() { mvkReleaseContainerContents(_mtlQueues); }
 
 #pragma mark -
 #pragma mark MVKQueue
 
-void MVKQueue::propagateDebugName() { setMetalObjectLabel(_mtlQueue, _debugName); }
-
+void MVKQueue::propagateDebugName() {
+    setMetalObjectLabel(_mtlQueue, _debugName);
+}
 
 #pragma mark Queue submissions
 
-// Execute the queue submission under an autoreleasepool to ensure transient Metal objects are autoreleased.
-// This is critical for apps that don't use standard OS autoreleasing runloop threading.
-static inline VkResult execute(MVKQueueSubmission* qSubmit) { @autoreleasepool { return qSubmit->execute(); } }
-
-// Executes the submmission, either immediately, or by dispatching to an execution queue.
-// Submissions to the execution queue are wrapped in a dedicated autoreleasepool.
-// Relying on the dispatch queue to find time to drain the autoreleasepool can
-// result in significant memory creep under heavy workloads.
-VkResult MVKQueue::submit(MVKQueueSubmission* qSubmit) {
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
-
-	if ( !qSubmit ) { return VK_SUCCESS; }     // Ignore nils
-
-	// Extract result before submission to avoid race condition with early destruction
-	// Submit regardless of config result, to ensure submission semaphores and fences are signalled.
-	// The submissions will ensure a misconfiguration will be safe to execute.
-	VkResult rslt = qSubmit->getConfigurationResult();
-	if (_execQueue) {
-		std::unique_lock lock(_execQueueMutex);
-		_execQueueJobCount++;
-
-		dispatch_async(_execQueue, ^{
-			execute(qSubmit);
-
-			std::unique_lock execLock(_execQueueMutex);
-			if (!--_execQueueJobCount)
-				_execQueueConditionVariable.notify_all();
-		} );
-	} else {
-		rslt = execute(qSubmit);
-	}
-	return rslt;
+// Execute the queue submission under an autoreleasepool to ensure transient
+// Metal objects are autoreleased. This is critical for apps that don't use
+// standard OS autoreleasing runloop threading.
+static inline VkResult execute(MVKQueueSubmission* qSubmit) {
+    @autoreleasepool {
+        return qSubmit->execute();
+    }
 }
 
-static inline uint32_t getCommandBufferCount(const VkSubmitInfo2* pSubmitInfo) { return pSubmitInfo->commandBufferInfoCount; }
-static inline uint32_t getCommandBufferCount(const VkSubmitInfo* pSubmitInfo) { return pSubmitInfo->commandBufferCount; }
+// Executes the submmission, either immediately, or by dispatching to an
+// execution queue. Submissions to the execution queue are wrapped in a
+// dedicated autoreleasepool. Relying on the dispatch queue to find time to
+// drain the autoreleasepool can result in significant memory creep under heavy
+// workloads.
+VkResult MVKQueue::submit(MVKQueueSubmission* qSubmit) {
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
+
+    if (!qSubmit) {
+        return VK_SUCCESS;
+    } // Ignore nils
+
+    // Extract result before submission to avoid race condition with early
+    // destruction Submit regardless of config result, to ensure submission
+    // semaphores and fences are signalled. The submissions will ensure a
+    // misconfiguration will be safe to execute.
+    VkResult rslt = qSubmit->getConfigurationResult();
+    if (_execQueue) {
+        std::unique_lock lock(_execQueueMutex);
+        _execQueueJobCount++;
+
+        dispatch_async(_execQueue, ^{
+          execute(qSubmit);
+
+          std::unique_lock execLock(_execQueueMutex);
+          if (!--_execQueueJobCount) _execQueueConditionVariable.notify_all();
+        });
+    } else {
+        rslt = execute(qSubmit);
+    }
+    return rslt;
+}
+
+static inline uint32_t getCommandBufferCount(const VkSubmitInfo2* pSubmitInfo) {
+    return pSubmitInfo->commandBufferInfoCount;
+}
+static inline uint32_t getCommandBufferCount(const VkSubmitInfo* pSubmitInfo) {
+    return pSubmitInfo->commandBufferCount;
+}
 
 template <typename S>
-VkResult MVKQueue::submit(uint32_t submitCount, const S* pSubmits, VkFence fence, MVKCommandUse cmdUse) {
+VkResult MVKQueue::submit(uint32_t submitCount, const S* pSubmits,
+                          VkFence fence, MVKCommandUse cmdUse) {
 
     // Fence-only submission
     if (submitCount == 0 && fence) {
-        return submit(new MVKQueueCommandBufferSubmission(this, (S*)nullptr, fence, cmdUse));
+        return submit(new MVKQueueCommandBufferSubmission(this, (S*)nullptr,
+                                                          fence, cmdUse));
     }
 
     VkResult rslt = VK_SUCCESS;
     for (uint32_t sIdx = 0; sIdx < submitCount; sIdx++) {
-        VkFence fenceOrNil = (sIdx == (submitCount - 1)) ? fence : VK_NULL_HANDLE; // last one gets the fence
+        VkFence fenceOrNil = (sIdx == (submitCount - 1))
+                                 ? fence
+                                 : VK_NULL_HANDLE; // last one gets the fence
 
-		const S* pVkSub = &pSubmits[sIdx];
-		MVKQueueCommandBufferSubmission* mvkSub;
-		uint32_t cbCnt = getCommandBufferCount(pVkSub);
-		if (cbCnt <= 1) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<1>(this, pVkSub, fenceOrNil, cmdUse);
-		} else if (cbCnt <= 16) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<16>(this, pVkSub, fenceOrNil, cmdUse);
-		} else if (cbCnt <= 32) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<32>(this, pVkSub, fenceOrNil, cmdUse);
-		} else if (cbCnt <= 64) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<64>(this, pVkSub, fenceOrNil, cmdUse);
-		} else if (cbCnt <= 128) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<128>(this, pVkSub, fenceOrNil, cmdUse);
-		} else if (cbCnt <= 256) {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<256>(this, pVkSub, fenceOrNil, cmdUse);
-		} else {
-			mvkSub = new MVKQueueFullCommandBufferSubmission<512>(this, pVkSub, fenceOrNil, cmdUse);
-		}
+        const S* pVkSub = &pSubmits[sIdx];
+        MVKQueueCommandBufferSubmission* mvkSub;
+        uint32_t cbCnt = getCommandBufferCount(pVkSub);
+        if (cbCnt <= 1) {
+            mvkSub =
+                new MVKQueueFullCommandBufferSubmission<1>(this, pVkSub,
+                                                           fenceOrNil, cmdUse);
+        } else if (cbCnt <= 16) {
+            mvkSub =
+                new MVKQueueFullCommandBufferSubmission<16>(this, pVkSub,
+                                                            fenceOrNil, cmdUse);
+        } else if (cbCnt <= 32) {
+            mvkSub =
+                new MVKQueueFullCommandBufferSubmission<32>(this, pVkSub,
+                                                            fenceOrNil, cmdUse);
+        } else if (cbCnt <= 64) {
+            mvkSub =
+                new MVKQueueFullCommandBufferSubmission<64>(this, pVkSub,
+                                                            fenceOrNil, cmdUse);
+        } else if (cbCnt <= 128) {
+            mvkSub = new MVKQueueFullCommandBufferSubmission<128>(this, pVkSub,
+                                                                  fenceOrNil,
+                                                                  cmdUse);
+        } else if (cbCnt <= 256) {
+            mvkSub = new MVKQueueFullCommandBufferSubmission<256>(this, pVkSub,
+                                                                  fenceOrNil,
+                                                                  cmdUse);
+        } else {
+            mvkSub = new MVKQueueFullCommandBufferSubmission<512>(this, pVkSub,
+                                                                  fenceOrNil,
+                                                                  cmdUse);
+        }
 
         VkResult subRslt = submit(mvkSub);
-        if (rslt == VK_SUCCESS) { rslt = subRslt; }
+        if (rslt == VK_SUCCESS) {
+            rslt = subRslt;
+        }
     }
     return rslt;
 }
 
 // Concrete implementations of templated MVKQueue::submit().
-template VkResult MVKQueue::submit(uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence, MVKCommandUse cmdUse);
-template VkResult MVKQueue::submit(uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence, MVKCommandUse cmdUse);
+template VkResult MVKQueue::submit(uint32_t submitCount,
+                                   const VkSubmitInfo2* pSubmits, VkFence fence,
+                                   MVKCommandUse cmdUse);
+template VkResult MVKQueue::submit(uint32_t submitCount,
+                                   const VkSubmitInfo* pSubmits, VkFence fence,
+                                   MVKCommandUse cmdUse);
 
 VkResult MVKQueue::submit(const VkPresentInfoKHR* pPresentInfo) {
-	return submit(new MVKQueuePresentSurfaceSubmission(this, pPresentInfo));
+    return submit(new MVKQueuePresentSurfaceSubmission(this, pPresentInfo));
 }
 
 VkResult MVKQueue::waitIdle(MVKCommandUse cmdUse) {
 
-	VkResult rslt = _device->getConfigurationResult();
-	if (rslt != VK_SUCCESS) { return rslt; }
+    VkResult rslt = _device->getConfigurationResult();
+    if (rslt != VK_SUCCESS) {
+        return rslt;
+    }
 
-	if (_execQueue) {
-		std::unique_lock lock(_execQueueMutex);
-		while (_execQueueJobCount)
-			_execQueueConditionVariable.wait(lock);
-	}
+    if (_execQueue) {
+        std::unique_lock lock(_execQueueMutex);
+        while (_execQueueJobCount) _execQueueConditionVariable.wait(lock);
+    }
 
-	@autoreleasepool {
-		auto* mtlCmdBuff = getMTLCommandBuffer(cmdUse);
-		[mtlCmdBuff commit];
-		[mtlCmdBuff waitUntilCompleted];
-	}
+    @autoreleasepool {
+        auto* mtlCmdBuff = getMTLCommandBuffer(cmdUse);
+        [mtlCmdBuff commit];
+        [mtlCmdBuff waitUntilCompleted];
+    }
 
-	return VK_SUCCESS;
+    return VK_SUCCESS;
 }
 
-id<MTLCommandBuffer> MVKQueue::getMTLCommandBuffer(MVKCommandUse cmdUse, bool retainRefs) {
-	id<MTLCommandBuffer> mtlCmdBuff = nil;
-	uint64_t startTime = getPerformanceTimestamp();
+id<MTLCommandBuffer> MVKQueue::getMTLCommandBuffer(MVKCommandUse cmdUse,
+                                                   bool retainRefs) {
+    id<MTLCommandBuffer> mtlCmdBuff = nil;
+    uint64_t startTime = getPerformanceTimestamp();
 #if MVK_XCODE_12
-	if ([_mtlQueue respondsToSelector: @selector(commandBufferWithDescriptor:)]) {
-		MTLCommandBufferDescriptor* mtlCmdBuffDesc = [MTLCommandBufferDescriptor new];	// temp retain
-		mtlCmdBuffDesc.retainedReferences = retainRefs;
-		if (getMVKConfig().debugMode) {
-			mtlCmdBuffDesc.errorOptions |= MTLCommandBufferErrorOptionEncoderExecutionStatus;
-		}
-		mtlCmdBuff = [_mtlQueue commandBufferWithDescriptor: mtlCmdBuffDesc];
-		[mtlCmdBuffDesc release];														// temp release
-	} else
+    if ([_mtlQueue
+            respondsToSelector:@selector(commandBufferWithDescriptor:)]) {
+        MTLCommandBufferDescriptor* mtlCmdBuffDesc =
+            [MTLCommandBufferDescriptor new]; // temp retain
+        mtlCmdBuffDesc.retainedReferences = retainRefs;
+        if (getMVKConfig().debugMode) {
+            mtlCmdBuffDesc.errorOptions |=
+                MTLCommandBufferErrorOptionEncoderExecutionStatus;
+        }
+        mtlCmdBuff = [_mtlQueue commandBufferWithDescriptor:mtlCmdBuffDesc];
+        [mtlCmdBuffDesc release]; // temp release
+    } else
 #endif
-	if (retainRefs) {
-		mtlCmdBuff = [_mtlQueue commandBuffer];
-	} else {
-		mtlCmdBuff = [_mtlQueue commandBufferWithUnretainedReferences];
-	}
-	addPerformanceInterval(getPerformanceStats().queue.retrieveMTLCommandBuffer, startTime);
-	NSString* mtlCmdBuffLabel = getMTLCommandBufferLabel(cmdUse);
-	setMetalObjectLabel(mtlCmdBuff, mtlCmdBuffLabel);
-	[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) { handleMTLCommandBufferError(mtlCB); }];
+        if (retainRefs) {
+        mtlCmdBuff = [_mtlQueue commandBuffer];
+    } else {
+        mtlCmdBuff = [_mtlQueue commandBufferWithUnretainedReferences];
+    }
+    addPerformanceInterval(getPerformanceStats().queue.retrieveMTLCommandBuffer,
+                           startTime);
+    NSString* mtlCmdBuffLabel = getMTLCommandBufferLabel(cmdUse);
+    setMetalObjectLabel(mtlCmdBuff, mtlCmdBuffLabel);
+    [mtlCmdBuff addCompletedHandler:^(id<MTLCommandBuffer> mtlCB) {
+      handleMTLCommandBufferError(mtlCB);
+    }];
 
-	if ( !mtlCmdBuff ) { reportError(VK_ERROR_OUT_OF_POOL_MEMORY, "%s could not be acquired.", mtlCmdBuffLabel.UTF8String); }
-	return mtlCmdBuff;
+    if (!mtlCmdBuff) {
+        reportError(VK_ERROR_OUT_OF_POOL_MEMORY, "%s could not be acquired.",
+                    mtlCmdBuffLabel.UTF8String);
+    }
+    return mtlCmdBuff;
 }
 
 NSString* MVKQueue::getMTLCommandBufferLabel(MVKCommandUse cmdUse) {
-#define CASE_GET_LABEL(cu)  \
-	case kMVKCommandUse ##cu:  \
-		if ( !_mtlCmdBuffLabel ##cu ) { _mtlCmdBuffLabel ##cu = [[NSString stringWithFormat: @"%s MTLCommandBuffer on Queue %d-%d", mvkVkCommandName(kMVKCommandUse ##cu), _queueFamily->getIndex(), _index] retain]; }  \
-		return _mtlCmdBuffLabel ##cu
+#define CASE_GET_LABEL(cu)                                                     \
+    case kMVKCommandUse##cu:                                                   \
+        if (!_mtlCmdBuffLabel##cu) {                                           \
+            _mtlCmdBuffLabel##cu = [[NSString                                  \
+                stringWithFormat:@"%s MTLCommandBuffer on Queue %d-%d",        \
+                                 mvkVkCommandName(kMVKCommandUse##cu),         \
+                                 _queueFamily->getIndex(), _index] retain];    \
+        }                                                                      \
+        return _mtlCmdBuffLabel##cu
 
-	switch (cmdUse) {
-		CASE_GET_LABEL(BeginCommandBuffer);
-		CASE_GET_LABEL(QueueSubmit);
-		CASE_GET_LABEL(QueuePresent);
-		CASE_GET_LABEL(QueueWaitIdle);
-		CASE_GET_LABEL(DeviceWaitIdle);
-		CASE_GET_LABEL(AcquireNextImage);
-		CASE_GET_LABEL(InvalidateMappedMemoryRanges);
-		CASE_GET_LABEL(CopyImageToMemory);
-		default:
-			MVKAssert(false, "Uncached MTLCommandBuffer label for command use %s.", mvkVkCommandName(cmdUse));
-			return [NSString stringWithFormat: @"%s MTLCommandBuffer on Queue %d-%d", mvkVkCommandName(cmdUse), _queueFamily->getIndex(), _index];
-	}
+    switch (cmdUse) {
+        CASE_GET_LABEL(BeginCommandBuffer);
+        CASE_GET_LABEL(QueueSubmit);
+        CASE_GET_LABEL(QueuePresent);
+        CASE_GET_LABEL(QueueWaitIdle);
+        CASE_GET_LABEL(DeviceWaitIdle);
+        CASE_GET_LABEL(AcquireNextImage);
+        CASE_GET_LABEL(InvalidateMappedMemoryRanges);
+        CASE_GET_LABEL(CopyImageToMemory);
+    default:
+        MVKAssert(false, "Uncached MTLCommandBuffer label for command use %s.",
+                  mvkVkCommandName(cmdUse));
+        return [NSString stringWithFormat:@"%s MTLCommandBuffer on Queue %d-%d",
+                                          mvkVkCommandName(cmdUse),
+                                          _queueFamily->getIndex(), _index];
+    }
 #undef CASE_GET_LABEL
 }
 
 #if MVK_XCODE_12
-static const char* mvkStringFromMTLCommandEncoderErrorState(MTLCommandEncoderErrorState errState) {
-	switch (errState) {
-		case MTLCommandEncoderErrorStateUnknown:   return "unknown";
-		case MTLCommandEncoderErrorStateAffected:  return "affected";
-		case MTLCommandEncoderErrorStateCompleted: return "completed";
-		case MTLCommandEncoderErrorStateFaulted:   return "faulted";
-		case MTLCommandEncoderErrorStatePending:   return "pending";
-	}
-	return "unknown";
+static const char*
+mvkStringFromMTLCommandEncoderErrorState(MTLCommandEncoderErrorState errState) {
+    switch (errState) {
+    case MTLCommandEncoderErrorStateUnknown:
+        return "unknown";
+    case MTLCommandEncoderErrorStateAffected:
+        return "affected";
+    case MTLCommandEncoderErrorStateCompleted:
+        return "completed";
+    case MTLCommandEncoderErrorStateFaulted:
+        return "faulted";
+    case MTLCommandEncoderErrorStatePending:
+        return "pending";
+    }
+    return "unknown";
 }
 #endif
 
 void MVKQueue::handleMTLCommandBufferError(id<MTLCommandBuffer> mtlCmdBuff) {
-	if (mtlCmdBuff.status != MTLCommandBufferStatusError) { return; }
+    if (mtlCmdBuff.status != MTLCommandBufferStatusError) {
+        return;
+    }
 
-	// If a command buffer error has occurred, report the error. If the error affects
-	// the physical device, always mark both the device and physical device as lost.
-	// If the error is local to this command buffer, optionally mark the device (but not the
-	// physical device) as lost, depending on the value of MVKConfiguration::resumeLostDevice.
-	VkResult vkErr = VK_ERROR_UNKNOWN;
-	bool markDeviceLoss = !getMVKConfig().resumeLostDevice;
-	bool markPhysicalDeviceLoss = false;
-	switch (mtlCmdBuff.error.code) {
-		case MTLCommandBufferErrorBlacklisted:
-		case MTLCommandBufferErrorNotPermitted:	// May also be used for command buffers executed in the background without the right entitlement.
+    // If a command buffer error has occurred, report the error. If the error
+    // affects the physical device, always mark both the device and physical
+    // device as lost. If the error is local to this command buffer, optionally
+    // mark the device (but not the physical device) as lost, depending on the
+    // value of MVKConfiguration::resumeLostDevice.
+    VkResult vkErr = VK_ERROR_UNKNOWN;
+    bool markDeviceLoss = !getMVKConfig().resumeLostDevice;
+    bool markPhysicalDeviceLoss = false;
+    switch (mtlCmdBuff.error.code) {
+    case MTLCommandBufferErrorBlacklisted:
+    case MTLCommandBufferErrorNotPermitted: // May also be used for command
+                                            // buffers executed in the
+                                            // background without the right
+                                            // entitlement.
 #if MVK_MACOS && !MVK_MACCAT
-		case MTLCommandBufferErrorDeviceRemoved:
+    case MTLCommandBufferErrorDeviceRemoved:
 #endif
-			vkErr = VK_ERROR_DEVICE_LOST;
-			markDeviceLoss = true;
-			markPhysicalDeviceLoss = true;
-			break;
-		case MTLCommandBufferErrorTimeout:
-			vkErr = VK_TIMEOUT;
-			break;
+        vkErr = VK_ERROR_DEVICE_LOST;
+        markDeviceLoss = true;
+        markPhysicalDeviceLoss = true;
+        break;
+    case MTLCommandBufferErrorTimeout:
+        vkErr = VK_TIMEOUT;
+        break;
 #if MVK_XCODE_13
-		case MTLCommandBufferErrorStackOverflow:
+    case MTLCommandBufferErrorStackOverflow:
 #endif
-		case MTLCommandBufferErrorPageFault:
-		case MTLCommandBufferErrorOutOfMemory:
-		default:
-			vkErr = VK_ERROR_OUT_OF_DEVICE_MEMORY;
-			break;
-	}
-	if (markDeviceLoss) {
-		getDevice()->stopAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE);
-		getDevice()->markLost(markPhysicalDeviceLoss);
-	}
-	reportResult(vkErr, (markDeviceLoss ? MVK_CONFIG_LOG_LEVEL_ERROR : MVK_CONFIG_LOG_LEVEL_WARNING),
-				 "%s VkDevice after MTLCommandBuffer \"%s\" execution failed (code %li): %s",
-				 (markDeviceLoss ? "Lost" : "Resumed"),
-				 (mtlCmdBuff.label ? mtlCmdBuff.label.UTF8String : ""),
-				 mtlCmdBuff.error.code, mtlCmdBuff.error.localizedDescription.UTF8String);
+    case MTLCommandBufferErrorPageFault:
+    case MTLCommandBufferErrorOutOfMemory:
+    default:
+        vkErr = VK_ERROR_OUT_OF_DEVICE_MEMORY;
+        break;
+    }
+    if (markDeviceLoss) {
+        getDevice()->stopAutoGPUCapture(
+            MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_DEVICE);
+        getDevice()->markLost(markPhysicalDeviceLoss);
+    }
+    reportResult(vkErr,
+                 (markDeviceLoss ? MVK_CONFIG_LOG_LEVEL_ERROR
+                                 : MVK_CONFIG_LOG_LEVEL_WARNING),
+                 "%s VkDevice after MTLCommandBuffer \"%s\" execution failed "
+                 "(code %li): %s",
+                 (markDeviceLoss ? "Lost" : "Resumed"),
+                 (mtlCmdBuff.label ? mtlCmdBuff.label.UTF8String : ""),
+                 mtlCmdBuff.error.code,
+                 mtlCmdBuff.error.localizedDescription.UTF8String);
 
 #if MVK_XCODE_12
-	if (&MTLCommandBufferEncoderInfoErrorKey != nullptr) {
-		if (NSArray<id<MTLCommandBufferEncoderInfo>>* mtlEncInfo = mtlCmdBuff.error.userInfo[MTLCommandBufferEncoderInfoErrorKey]) {
-			MVKLogInfo("Encoders for %p \"%s\":", mtlCmdBuff, mtlCmdBuff.label ? mtlCmdBuff.label.UTF8String : "");
-			for (id<MTLCommandBufferEncoderInfo> enc in mtlEncInfo) {
-				MVKLogInfo(" - %s: %s", enc.label.UTF8String, mvkStringFromMTLCommandEncoderErrorState(enc.errorState));
-				if (enc.debugSignposts.count > 0) {
-					MVKLogInfo("   Debug signposts:");
-					for (NSString* signpost in enc.debugSignposts) {
-						MVKLogInfo("    - %s", signpost.UTF8String);
-					}
-				}
-			}
-		}
-	}
-	if ([mtlCmdBuff respondsToSelector: @selector(logs)]) {
-		bool isFirstMsg = true;
-		for (id<MTLFunctionLog> log in mtlCmdBuff.logs) {
-			if (isFirstMsg) {
-				MVKLogInfo("Shader log messages:");
-				isFirstMsg = false;
-			}
-			MVKLogInfo("%s", log.description.UTF8String);
-		}
-	}
+    if (&MTLCommandBufferEncoderInfoErrorKey != nullptr) {
+        if (NSArray<id<MTLCommandBufferEncoderInfo>>* mtlEncInfo =
+                mtlCmdBuff.error
+                    .userInfo[MTLCommandBufferEncoderInfoErrorKey]) {
+            MVKLogInfo("Encoders for %p \"%s\":", mtlCmdBuff,
+                       mtlCmdBuff.label ? mtlCmdBuff.label.UTF8String : "");
+            for (id<MTLCommandBufferEncoderInfo> enc in mtlEncInfo) {
+                MVKLogInfo(" - %s: %s", enc.label.UTF8String,
+                           mvkStringFromMTLCommandEncoderErrorState(
+                               enc.errorState));
+                if (enc.debugSignposts.count > 0) {
+                    MVKLogInfo("   Debug signposts:");
+                    for (NSString* signpost in enc.debugSignposts) {
+                        MVKLogInfo("    - %s", signpost.UTF8String);
+                    }
+                }
+            }
+        }
+    }
+    if ([mtlCmdBuff respondsToSelector:@selector(logs)]) {
+        bool isFirstMsg = true;
+        for (id<MTLFunctionLog> log in mtlCmdBuff.logs) {
+            if (isFirstMsg) {
+                MVKLogInfo("Shader log messages:");
+                isFirstMsg = false;
+            }
+            MVKLogInfo("%s", log.description.UTF8String);
+        }
+    }
 #endif
 }
 
 #pragma mark Construction
 
-#define MVK_DISPATCH_QUEUE_QOS_CLASS		QOS_CLASS_USER_INITIATED
+#define MVK_DISPATCH_QUEUE_QOS_CLASS QOS_CLASS_USER_INITIATED
 
-MVKQueue::MVKQueue(MVKDevice* device, MVKQueueFamily* queueFamily, uint32_t index, float priority) : MVKDeviceTrackingMixin(device) {
-	_queueFamily = queueFamily;
-	_index = index;
-	_priority = priority;
+MVKQueue::MVKQueue(MVKDevice* device, MVKQueueFamily* queueFamily,
+                   uint32_t index, float priority)
+    : MVKDeviceTrackingMixin(device) {
+    _queueFamily = queueFamily;
+    _index = index;
+    _priority = priority;
 
-	initName();
-	initExecQueue();
-	initMTLCommandQueue();
+    initName();
+    initExecQueue();
+    initMTLCommandQueue();
 }
 
 void MVKQueue::initName() {
-	const char* fmt = "MoltenVKQueue-%d-%d-%.1f";
-	char name[256];
-	snprintf(name, sizeof(name)/sizeof(char), fmt, _queueFamily->getIndex(), _index, _priority);
-	_name = name;
+    const char* fmt = "MoltenVKQueue-%d-%d-%.1f";
+    char name[256];
+    snprintf(name, sizeof(name) / sizeof(char), fmt, _queueFamily->getIndex(),
+             _index, _priority);
+    _name = name;
 }
 
 void MVKQueue::initExecQueue() {
-	_execQueue = nil;
-	if ( !getMVKConfig().synchronousQueueSubmits ) {
-		// Determine the dispatch queue priority
-		dispatch_qos_class_t dqQOS = MVK_DISPATCH_QUEUE_QOS_CLASS;
-		int dqPriority = (1.0 - _priority) * QOS_MIN_RELATIVE_PRIORITY;
-		dispatch_queue_attr_t dqAttr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, dqQOS, dqPriority);
+    _execQueue = nil;
+    if (!getMVKConfig().synchronousQueueSubmits) {
+        // Determine the dispatch queue priority
+        dispatch_qos_class_t dqQOS = MVK_DISPATCH_QUEUE_QOS_CLASS;
+        int dqPriority = (1.0 - _priority) * QOS_MIN_RELATIVE_PRIORITY;
+        dispatch_queue_attr_t dqAttr =
+            dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL,
+                                                    dqQOS, dqPriority);
 
-		// Create the dispatch queue
-		_execQueue = dispatch_queue_create((getName() + "-Dispatch").c_str(), dqAttr);		// retained
-	}
+        // Create the dispatch queue
+        _execQueue = dispatch_queue_create((getName() + "-Dispatch").c_str(),
+                                           dqAttr); // retained
+    }
 }
 
-// Retrieves and initializes the Metal command queue and Xcode GPU capture scopes
+// Retrieves and initializes the Metal command queue and Xcode GPU capture
+// scopes
 void MVKQueue::initMTLCommandQueue() {
-	_mtlQueue = _queueFamily->getMTLCommandQueue(_index);	// not retained (cached in queue family)
+    _mtlQueue = _queueFamily->getMTLCommandQueue(
+        _index); // not retained (cached in queue family)
 
-	_submissionCaptureScope = new MVKGPUCaptureScope(this);
-	if (_queueFamily->getIndex() == getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
-		_index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
-		getDevice()->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME, _mtlQueue);
-		_submissionCaptureScope->makeDefault();
-	}
-	_submissionCaptureScope->beginScope();	// Allow Xcode to capture the first frame if desired.
+    _submissionCaptureScope = new MVKGPUCaptureScope(this);
+    if (_queueFamily->getIndex() ==
+            getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
+        _index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
+        getDevice()
+            ->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME,
+                                  _mtlQueue);
+        _submissionCaptureScope->makeDefault();
+    }
+    _submissionCaptureScope
+        ->beginScope(); // Allow Xcode to capture the first frame if desired.
 }
 
 MVKQueue::~MVKQueue() {
-	destroyExecQueue();
-	_submissionCaptureScope->destroy();
+    destroyExecQueue();
+    _submissionCaptureScope->destroy();
 
-	[_mtlCmdBuffLabelBeginCommandBuffer release];
-	[_mtlCmdBuffLabelQueueSubmit release];
-	[_mtlCmdBuffLabelQueuePresent release];
-	[_mtlCmdBuffLabelDeviceWaitIdle release];
-	[_mtlCmdBuffLabelQueueWaitIdle release];
-	[_mtlCmdBuffLabelAcquireNextImage release];
-	[_mtlCmdBuffLabelInvalidateMappedMemoryRanges release];
+    [_mtlCmdBuffLabelBeginCommandBuffer release];
+    [_mtlCmdBuffLabelQueueSubmit release];
+    [_mtlCmdBuffLabelQueuePresent release];
+    [_mtlCmdBuffLabelDeviceWaitIdle release];
+    [_mtlCmdBuffLabelQueueWaitIdle release];
+    [_mtlCmdBuffLabelAcquireNextImage release];
+    [_mtlCmdBuffLabelInvalidateMappedMemoryRanges release];
 }
 
 // Destroys the execution dispatch queue.
 void MVKQueue::destroyExecQueue() {
-	if (_execQueue) {
-		dispatch_release(_execQueue);
-		_execQueue = nullptr;
-	}
+    if (_execQueue) {
+        dispatch_release(_execQueue);
+        _execQueue = nullptr;
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKQueueSubmission
 
 void MVKSemaphoreSubmitInfo::encodeWait(id<MTLCommandBuffer> mtlCmdBuff) {
-	if (_semaphore) { _semaphore->encodeWait(mtlCmdBuff, value); }
+    if (_semaphore) {
+        _semaphore->encodeWait(mtlCmdBuff, value);
+    }
 }
 
 void MVKSemaphoreSubmitInfo::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff) {
-	if (_semaphore) { _semaphore->encodeSignal(mtlCmdBuff, value); }
+    if (_semaphore) {
+        _semaphore->encodeSignal(mtlCmdBuff, value);
+    }
 }
 
-MVKSemaphoreSubmitInfo::MVKSemaphoreSubmitInfo(const VkSemaphoreSubmitInfo& semaphoreSubmitInfo) :
-	_semaphore((MVKSemaphore*)semaphoreSubmitInfo.semaphore),
-	value(semaphoreSubmitInfo.value),
-	stageMask(semaphoreSubmitInfo.stageMask),
-	deviceIndex(semaphoreSubmitInfo.deviceIndex) {
-		if (_semaphore) { _semaphore->retain(); }
+MVKSemaphoreSubmitInfo::MVKSemaphoreSubmitInfo(
+    const VkSemaphoreSubmitInfo& semaphoreSubmitInfo)
+    : _semaphore((MVKSemaphore*)semaphoreSubmitInfo.semaphore),
+      value(semaphoreSubmitInfo.value),
+      stageMask(semaphoreSubmitInfo.stageMask),
+      deviceIndex(semaphoreSubmitInfo.deviceIndex) {
+    if (_semaphore) {
+        _semaphore->retain();
+    }
 }
 
 MVKSemaphoreSubmitInfo::MVKSemaphoreSubmitInfo(const VkSemaphore semaphore,
-											   VkPipelineStageFlags stageMask) :
-	_semaphore((MVKSemaphore*)semaphore),
-	value(0),
-	stageMask(stageMask),
-	deviceIndex(0) {
-		if (_semaphore) { _semaphore->retain(); }
+                                               VkPipelineStageFlags stageMask)
+    : _semaphore((MVKSemaphore*)semaphore), value(0), stageMask(stageMask),
+      deviceIndex(0) {
+    if (_semaphore) {
+        _semaphore->retain();
+    }
 }
 
-MVKSemaphoreSubmitInfo::MVKSemaphoreSubmitInfo(const MVKSemaphoreSubmitInfo& other) :
-	_semaphore(other._semaphore),
-	value(other.value),
-	stageMask(other.stageMask),
-	deviceIndex(other.deviceIndex) {
-		if (_semaphore) { _semaphore->retain(); }
+MVKSemaphoreSubmitInfo::MVKSemaphoreSubmitInfo(
+    const MVKSemaphoreSubmitInfo& other)
+    : _semaphore(other._semaphore), value(other.value),
+      stageMask(other.stageMask), deviceIndex(other.deviceIndex) {
+    if (_semaphore) {
+        _semaphore->retain();
+    }
 }
 
-MVKSemaphoreSubmitInfo& MVKSemaphoreSubmitInfo::operator=(const MVKSemaphoreSubmitInfo& other) {
-	// Retain new object first in case it's the same object
-	if (other._semaphore) {other._semaphore->retain(); }
-	if (_semaphore) { _semaphore->release(); }
-	_semaphore = other._semaphore;
+MVKSemaphoreSubmitInfo&
+MVKSemaphoreSubmitInfo::operator=(const MVKSemaphoreSubmitInfo& other) {
+    // Retain new object first in case it's the same object
+    if (other._semaphore) {
+        other._semaphore->retain();
+    }
+    if (_semaphore) {
+        _semaphore->release();
+    }
+    _semaphore = other._semaphore;
 
-	value = other.value;
-	stageMask = other.stageMask;
-	deviceIndex = other.deviceIndex;
-	return *this;
+    value = other.value;
+    stageMask = other.stageMask;
+    deviceIndex = other.deviceIndex;
+    return *this;
 }
 
 MVKSemaphoreSubmitInfo::~MVKSemaphoreSubmitInfo() {
-	if (_semaphore) { _semaphore->release(); }
+    if (_semaphore) {
+        _semaphore->release();
+    }
 }
 
-MVKCommandBufferSubmitInfo::MVKCommandBufferSubmitInfo(const VkCommandBufferSubmitInfo& commandBufferInfo) :
-	commandBuffer(MVKCommandBuffer::getMVKCommandBuffer(commandBufferInfo.commandBuffer)),
-	deviceMask(commandBufferInfo.deviceMask) {}
+MVKCommandBufferSubmitInfo::MVKCommandBufferSubmitInfo(
+    const VkCommandBufferSubmitInfo& commandBufferInfo)
+    : commandBuffer(MVKCommandBuffer::getMVKCommandBuffer(
+          commandBufferInfo.commandBuffer)),
+      deviceMask(commandBufferInfo.deviceMask) {}
 
-MVKCommandBufferSubmitInfo::MVKCommandBufferSubmitInfo(VkCommandBuffer commandBuffer) :
-	commandBuffer(MVKCommandBuffer::getMVKCommandBuffer(commandBuffer)),
-	deviceMask(0) {}
+MVKCommandBufferSubmitInfo::MVKCommandBufferSubmitInfo(
+    VkCommandBuffer commandBuffer)
+    : commandBuffer(MVKCommandBuffer::getMVKCommandBuffer(commandBuffer)),
+      deviceMask(0) {}
 
-MVKQueueSubmission::MVKQueueSubmission(MVKQueue* queue,
-									   uint32_t waitSemaphoreInfoCount,
-									   const VkSemaphoreSubmitInfo* pWaitSemaphoreSubmitInfos) : 
-	MVKBaseDeviceObject(queue->getDevice()),
-	_queue(queue) {
+MVKQueueSubmission::MVKQueueSubmission(
+    MVKQueue* queue, uint32_t waitSemaphoreInfoCount,
+    const VkSemaphoreSubmitInfo* pWaitSemaphoreSubmitInfos)
+    : MVKBaseDeviceObject(queue->getDevice()), _queue(queue) {
 
-	_queue->retain();	// Retain here and release in destructor. See note for MVKQueueCommandBufferSubmission::finish().
-	_creationTime = getPerformanceTimestamp();
+    _queue->retain(); // Retain here and release in destructor. See note for
+                      // MVKQueueCommandBufferSubmission::finish().
+    _creationTime = getPerformanceTimestamp();
 
-	_waitSemaphores.reserve(waitSemaphoreInfoCount);
-	for (uint32_t i = 0; i < waitSemaphoreInfoCount; i++) {
-		_waitSemaphores.emplace_back(pWaitSemaphoreSubmitInfos[i]);
-	}
+    _waitSemaphores.reserve(waitSemaphoreInfoCount);
+    for (uint32_t i = 0; i < waitSemaphoreInfoCount; i++) {
+        _waitSemaphores.emplace_back(pWaitSemaphoreSubmitInfos[i]);
+    }
 }
 
-MVKQueueSubmission::MVKQueueSubmission(MVKQueue* queue,
-									   uint32_t waitSemaphoreCount,
-									   const VkSemaphore* pWaitSemaphores,
-									   const VkPipelineStageFlags* pWaitDstStageMask) :
-	MVKBaseDeviceObject(queue->getDevice()),
-	_queue(queue) {
+MVKQueueSubmission::MVKQueueSubmission(
+    MVKQueue* queue, uint32_t waitSemaphoreCount,
+    const VkSemaphore* pWaitSemaphores,
+    const VkPipelineStageFlags* pWaitDstStageMask)
+    : MVKBaseDeviceObject(queue->getDevice()), _queue(queue) {
 
-	_queue->retain();	// Retain here and release in destructor. See note for MVKQueueCommandBufferSubmission::finish().
-	_creationTime = getPerformanceTimestamp();
+    _queue->retain(); // Retain here and release in destructor. See note for
+                      // MVKQueueCommandBufferSubmission::finish().
+    _creationTime = getPerformanceTimestamp();
 
-	_waitSemaphores.reserve(waitSemaphoreCount);
-	for (uint32_t i = 0; i < waitSemaphoreCount; i++) {
-		_waitSemaphores.emplace_back(pWaitSemaphores[i], pWaitDstStageMask ? pWaitDstStageMask[i] : 0);
-	}
+    _waitSemaphores.reserve(waitSemaphoreCount);
+    for (uint32_t i = 0; i < waitSemaphoreCount; i++) {
+        _waitSemaphores.emplace_back(pWaitSemaphores[i],
+                                     pWaitDstStageMask ? pWaitDstStageMask[i]
+                                                       : 0);
+    }
 }
 
-MVKQueueSubmission::~MVKQueueSubmission() {
-	_queue->release();
-}
-
+MVKQueueSubmission::~MVKQueueSubmission() { _queue->release(); }
 
 #pragma mark -
 #pragma mark MVKQueueCommandBufferSubmission
 
 VkResult MVKQueueCommandBufferSubmission::execute() {
 
-	_queue->_submissionCaptureScope->beginScope();
+    _queue->_submissionCaptureScope->beginScope();
 
-	// If using encoded semaphore waiting, do so now.
-	for (auto& ws : _waitSemaphores) { ws.encodeWait(getActiveMTLCommandBuffer()); }
+    // If using encoded semaphore waiting, do so now.
+    for (auto& ws : _waitSemaphores) {
+        ws.encodeWait(getActiveMTLCommandBuffer());
+    }
 
-	// Wait time from an async vkQueueSubmit() call to starting submit and encoding of the command buffers
-	addPerformanceInterval(_queue->getPerformanceStats().queue.waitSubmitCommandBuffers, _creationTime);
+    // Wait time from an async vkQueueSubmit() call to starting submit and
+    // encoding of the command buffers
+    addPerformanceInterval(_queue->getPerformanceStats()
+                               .queue.waitSubmitCommandBuffers,
+                           _creationTime);
 
-	// Submit each command buffer.
-	submitCommandBuffers();
+    // Submit each command buffer.
+    submitCommandBuffers();
 
-	// If using encoded semaphore signaling, do so now.
-	for (auto& ss : _signalSemaphores) { ss.encodeSignal(getActiveMTLCommandBuffer()); }
+    // If using encoded semaphore signaling, do so now.
+    for (auto& ss : _signalSemaphores) {
+        ss.encodeSignal(getActiveMTLCommandBuffer());
+    }
 
-	// Commit the last MTLCommandBuffer.
-	// Nothing after this because callback might destroy this instance before this function ends.
-	return commitActiveMTLCommandBuffer(true);
+    // Commit the last MTLCommandBuffer.
+    // Nothing after this because callback might destroy this instance before
+    // this function ends.
+    return commitActiveMTLCommandBuffer(true);
 }
 
-// Returns the active MTLCommandBuffer, lazily retrieving it from the queue if needed.
-id<MTLCommandBuffer> MVKQueueCommandBufferSubmission::getActiveMTLCommandBuffer() {
-	if ( !_activeMTLCommandBuffer ) {
-		setActiveMTLCommandBuffer(_queue->getMTLCommandBuffer(_commandUse));
-	}
-	return _activeMTLCommandBuffer;
+// Returns the active MTLCommandBuffer, lazily retrieving it from the queue if
+// needed.
+id<MTLCommandBuffer>
+MVKQueueCommandBufferSubmission::getActiveMTLCommandBuffer() {
+    if (!_activeMTLCommandBuffer) {
+        setActiveMTLCommandBuffer(_queue->getMTLCommandBuffer(_commandUse));
+    }
+    return _activeMTLCommandBuffer;
 }
 
-// Commits the current active MTLCommandBuffer, if it exists, and sets a new active MTLCommandBuffer.
-void MVKQueueCommandBufferSubmission::setActiveMTLCommandBuffer(id<MTLCommandBuffer> mtlCmdBuff) {
+// Commits the current active MTLCommandBuffer, if it exists, and sets a new
+// active MTLCommandBuffer.
+void MVKQueueCommandBufferSubmission::setActiveMTLCommandBuffer(
+    id<MTLCommandBuffer> mtlCmdBuff) {
 
-	if (_activeMTLCommandBuffer) { commitActiveMTLCommandBuffer(); }
+    if (_activeMTLCommandBuffer) {
+        commitActiveMTLCommandBuffer();
+    }
 
-	_activeMTLCommandBuffer = [mtlCmdBuff retain];		// retained to handle prefilled
-	[_activeMTLCommandBuffer enqueue];
+    _activeMTLCommandBuffer =
+        [mtlCmdBuff retain]; // retained to handle prefilled
+    [_activeMTLCommandBuffer enqueue];
 }
 
-// Commits and releases the currently active MTLCommandBuffer, optionally signalling
-// when the MTLCommandBuffer is done. The first time this is called, it will wait on
-// any semaphores. We have delayed signalling the semaphores as long as possible to
-// allow as much filling of the MTLCommandBuffer as possible before forcing a wait.
-VkResult MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool signalCompletion) {
+// Commits and releases the currently active MTLCommandBuffer, optionally
+// signalling when the MTLCommandBuffer is done. The first time this is called,
+// it will wait on any semaphores. We have delayed signalling the semaphores as
+// long as possible to allow as much filling of the MTLCommandBuffer as possible
+// before forcing a wait.
+VkResult MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(
+    bool signalCompletion) {
 
-	// If using inline semaphore waiting, do so now.
-	// When prefilled command buffers are used, multiple commits will happen because native semaphore
-	// waits need to be committed before the prefilled command buffer is committed. Since semaphores
-	// will reset their internal signal flag on wait, we need to make sure that we only wait once, otherwise we will freeze.
-	// Another option to wait on emulated semaphores once is to do it in the execute function, but doing it here
-	// should be more performant when prefilled command buffers aren't used, because we spend time encoding commands
-	// first, thus giving the command buffer signalling these semaphores more time to complete.
-	if ( !_emulatedWaitDone ) {
-		for (auto& ws : _waitSemaphores) { ws.encodeWait(nil); }
-		_emulatedWaitDone = true;
-	}
+    // If using inline semaphore waiting, do so now.
+    // When prefilled command buffers are used, multiple commits will happen
+    // because native semaphore waits need to be committed before the prefilled
+    // command buffer is committed. Since semaphores will reset their internal
+    // signal flag on wait, we need to make sure that we only wait once,
+    // otherwise we will freeze. Another option to wait on emulated semaphores
+    // once is to do it in the execute function, but doing it here should be
+    // more performant when prefilled command buffers aren't used, because we
+    // spend time encoding commands first, thus giving the command buffer
+    // signalling these semaphores more time to complete.
+    if (!_emulatedWaitDone) {
+        for (auto& ws : _waitSemaphores) {
+            ws.encodeWait(nil);
+        }
+        _emulatedWaitDone = true;
+    }
 
-	// The visibility result buffer will be returned to its pool when the active MTLCommandBuffer
-	// finishes executing, and therefore cannot be used beyond the active MTLCommandBuffer.
-	// By now, it's been submitted to the MTLCommandBuffer, so remove it from the encoding context,
-	// to ensure a fresh one will be used by commands executing on any subsequent MTLCommandBuffers.
-	_encodingContext.visibilityResultBuffer = nullptr;
+    // The visibility result buffer will be returned to its pool when the active
+    // MTLCommandBuffer finishes executing, and therefore cannot be used beyond
+    // the active MTLCommandBuffer. By now, it's been submitted to the
+    // MTLCommandBuffer, so remove it from the encoding context, to ensure a
+    // fresh one will be used by commands executing on any subsequent
+    // MTLCommandBuffers.
+    _encodingContext.visibilityResultBuffer = nullptr;
 
-	// If we need to signal completion, use getActiveMTLCommandBuffer() to ensure at least
-	// one MTLCommandBuffer is used, otherwise if this instance has no content, it will not
-	// finish(), signal the fence and semaphores, and be destroyed.
-	// Use temp var for MTLCommandBuffer commit and release because completion callback
-	// may destroy this instance before this function ends.
-	id<MTLCommandBuffer> mtlCmdBuff = signalCompletion ? getActiveMTLCommandBuffer() : _activeMTLCommandBuffer;
-	_activeMTLCommandBuffer = nil;
+    // If we need to signal completion, use getActiveMTLCommandBuffer() to
+    // ensure at least one MTLCommandBuffer is used, otherwise if this instance
+    // has no content, it will not finish(), signal the fence and semaphores,
+    // and be destroyed. Use temp var for MTLCommandBuffer commit and release
+    // because completion callback may destroy this instance before this
+    // function ends.
+    id<MTLCommandBuffer> mtlCmdBuff = signalCompletion
+                                          ? getActiveMTLCommandBuffer()
+                                          : _activeMTLCommandBuffer;
+    _activeMTLCommandBuffer = nil;
 
-	uint64_t startTime = getPerformanceTimestamp();
-	[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) {
-		addPerformanceInterval(getPerformanceStats().queue.mtlCommandBufferExecution, startTime);
-		if (signalCompletion) { this->finish(); }	// Must be the last thing the completetion callback does.
-	}];
+    uint64_t startTime = getPerformanceTimestamp();
+    [mtlCmdBuff addCompletedHandler:^(id<MTLCommandBuffer> mtlCB) {
+      addPerformanceInterval(getPerformanceStats()
+                                 .queue.mtlCommandBufferExecution,
+                             startTime);
+      if (signalCompletion) {
+          this->finish();
+      } // Must be the last thing the completetion callback does.
+    }];
 
-	// Retrieve the result before committing MTLCommandBuffer, because finish() will destroy this instance.
-	VkResult rslt = mtlCmdBuff ? getConfigurationResult() : VK_ERROR_OUT_OF_POOL_MEMORY;
-	[mtlCmdBuff commit];
-	[mtlCmdBuff release];		// retained
+    // Retrieve the result before committing MTLCommandBuffer, because finish()
+    // will destroy this instance.
+    VkResult rslt =
+        mtlCmdBuff ? getConfigurationResult() : VK_ERROR_OUT_OF_POOL_MEMORY;
+    [mtlCmdBuff commit];
+    [mtlCmdBuff release]; // retained
 
-	// If we need to signal completion, but an error occurred and the MTLCommandBuffer
-	// was not created, call the finish() function directly.
-	if (signalCompletion && !mtlCmdBuff) { finish(); }
+    // If we need to signal completion, but an error occurred and the
+    // MTLCommandBuffer was not created, call the finish() function directly.
+    if (signalCompletion && !mtlCmdBuff) {
+        finish();
+    }
 
-	return rslt;
+    return rslt;
 }
 
-// Be sure to retain() any API objects referenced in this function, and release() them in the
-// destructor (or superclass destructor). It is possible for rare race conditions to result
-// in the app destroying API objects before this function completes execution. For example,
-// this may occur if a GPU semaphore here triggers another submission that triggers a fence,
-// and the app immediately destroys objects. Rare, but it has been encountered.
+// Be sure to retain() any API objects referenced in this function, and
+// release() them in the destructor (or superclass destructor). It is possible
+// for rare race conditions to result in the app destroying API objects before
+// this function completes execution. For example, this may occur if a GPU
+// semaphore here triggers another submission that triggers a fence, and the app
+// immediately destroys objects. Rare, but it has been encountered.
 void MVKQueueCommandBufferSubmission::finish() {
 
-	// Performed here instead of as part of execute() for rare case where app destroys queue
-	// immediately after a waitIdle() is cleared by fence below, taking the capture scope with it.
-	_queue->_submissionCaptureScope->endScope();
+    // Performed here instead of as part of execute() for rare case where app
+    // destroys queue immediately after a waitIdle() is cleared by fence below,
+    // taking the capture scope with it.
+    _queue->_submissionCaptureScope->endScope();
 
-	// If using inline semaphore signaling, do so now.
-	for (auto& ss : _signalSemaphores) { ss.encodeSignal(nil); }
+    // If using inline semaphore signaling, do so now.
+    for (auto& ss : _signalSemaphores) {
+        ss.encodeSignal(nil);
+    }
 
-	// If a fence exists, signal it.
-	if (_fence) { _fence->signal(); }
+    // If a fence exists, signal it.
+    if (_fence) {
+        _fence->signal();
+    }
 
-	this->destroy();
+    this->destroy();
 }
 
-// On device loss, the fence and signal semaphores may be signalled early, and they might then
-// be destroyed on the waiting thread before this submission is done with them. We therefore
-// retain() each here to ensure they live long enough for this submission to finish using them.
-MVKQueueCommandBufferSubmission::MVKQueueCommandBufferSubmission(MVKQueue* queue,
-																 const VkSubmitInfo2* pSubmit,
-																 VkFence fence,
-																 MVKCommandUse cmdUse) :
-	MVKQueueSubmission(queue,
-					   pSubmit ? pSubmit->waitSemaphoreInfoCount : 0,
-					   pSubmit ? pSubmit->pWaitSemaphoreInfos : nullptr),
-	_fence((MVKFence*)fence),
-	_commandUse(cmdUse) {
-	
-	if (_fence) { _fence->retain(); }
+// On device loss, the fence and signal semaphores may be signalled early, and
+// they might then be destroyed on the waiting thread before this submission is
+// done with them. We therefore retain() each here to ensure they live long
+// enough for this submission to finish using them.
+MVKQueueCommandBufferSubmission::MVKQueueCommandBufferSubmission(
+    MVKQueue* queue, const VkSubmitInfo2* pSubmit, VkFence fence,
+    MVKCommandUse cmdUse)
+    : MVKQueueSubmission(queue, pSubmit ? pSubmit->waitSemaphoreInfoCount : 0,
+                         pSubmit ? pSubmit->pWaitSemaphoreInfos : nullptr),
+      _fence((MVKFence*)fence), _commandUse(cmdUse) {
 
-	// pSubmit can be null if just tracking the fence alone
-	if (pSubmit) {
-		uint32_t ssCnt = pSubmit->signalSemaphoreInfoCount;
-		_signalSemaphores.reserve(ssCnt);
-		for (uint32_t i = 0; i < ssCnt; i++) {
-			_signalSemaphores.emplace_back(pSubmit->pSignalSemaphoreInfos[i]);
-		}
-	}
-}
-
-// On device loss, the fence and signal semaphores may be signalled early, and they might then
-// be destroyed on the waiting thread before this submission is done with them. We therefore
-// retain() each here to ensure they live long enough for this submission to finish using them.
-MVKQueueCommandBufferSubmission::MVKQueueCommandBufferSubmission(MVKQueue* queue,
-																 const VkSubmitInfo* pSubmit,
-																 VkFence fence,
-																 MVKCommandUse cmdUse)
-	: MVKQueueSubmission(queue,
-						 pSubmit ? pSubmit->waitSemaphoreCount : 0,
-						 pSubmit ? pSubmit->pWaitSemaphores : nullptr,
-						 pSubmit ? pSubmit->pWaitDstStageMask : nullptr),
-
-	_fence((MVKFence*)fence),
-	_commandUse(cmdUse) {
-	
-	if (_fence) { _fence->retain(); }
+    if (_fence) {
+        _fence->retain();
+    }
 
     // pSubmit can be null if just tracking the fence alone
     if (pSubmit) {
-		uint32_t ssCnt = pSubmit->signalSemaphoreCount;
-		_signalSemaphores.reserve(ssCnt);
-		for (uint32_t i = 0; i < ssCnt; i++) {
-			_signalSemaphores.emplace_back(pSubmit->pSignalSemaphores[i], 0);
-		}
+        uint32_t ssCnt = pSubmit->signalSemaphoreInfoCount;
+        _signalSemaphores.reserve(ssCnt);
+        for (uint32_t i = 0; i < ssCnt; i++) {
+            _signalSemaphores.emplace_back(pSubmit->pSignalSemaphoreInfos[i]);
+        }
+    }
+}
 
-		VkTimelineSemaphoreSubmitInfo* pTimelineSubmit = nullptr;
-        for (const auto* next = (const VkBaseInStructure*)pSubmit->pNext; next; next = next->pNext) {
+// On device loss, the fence and signal semaphores may be signalled early, and
+// they might then be destroyed on the waiting thread before this submission is
+// done with them. We therefore retain() each here to ensure they live long
+// enough for this submission to finish using them.
+MVKQueueCommandBufferSubmission::MVKQueueCommandBufferSubmission(
+    MVKQueue* queue, const VkSubmitInfo* pSubmit, VkFence fence,
+    MVKCommandUse cmdUse)
+    : MVKQueueSubmission(queue, pSubmit ? pSubmit->waitSemaphoreCount : 0,
+                         pSubmit ? pSubmit->pWaitSemaphores : nullptr,
+                         pSubmit ? pSubmit->pWaitDstStageMask : nullptr),
+
+      _fence((MVKFence*)fence), _commandUse(cmdUse) {
+
+    if (_fence) {
+        _fence->retain();
+    }
+
+    // pSubmit can be null if just tracking the fence alone
+    if (pSubmit) {
+        uint32_t ssCnt = pSubmit->signalSemaphoreCount;
+        _signalSemaphores.reserve(ssCnt);
+        for (uint32_t i = 0; i < ssCnt; i++) {
+            _signalSemaphores.emplace_back(pSubmit->pSignalSemaphores[i], 0);
+        }
+
+        VkTimelineSemaphoreSubmitInfo* pTimelineSubmit = nullptr;
+        for (const auto* next = (const VkBaseInStructure*)pSubmit->pNext; next;
+             next = next->pNext) {
             switch (next->sType) {
-                case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
-                    pTimelineSubmit = (VkTimelineSemaphoreSubmitInfo*)next;
-                    break;
-                default:
-                    break;
+            case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
+                pTimelineSubmit = (VkTimelineSemaphoreSubmitInfo*)next;
+                break;
+            default:
+                break;
             }
         }
         if (pTimelineSubmit) {
             uint32_t wsvCnt = pTimelineSubmit->waitSemaphoreValueCount;
             for (uint32_t i = 0; i < wsvCnt; i++) {
-                _waitSemaphores[i].value = pTimelineSubmit->pWaitSemaphoreValues[i];
+                _waitSemaphores[i].value =
+                    pTimelineSubmit->pWaitSemaphoreValues[i];
             }
 
-			uint32_t ssvCnt = pTimelineSubmit->signalSemaphoreValueCount;
-			for (uint32_t i = 0; i < ssvCnt; i++) {
-				_signalSemaphores[i].value = pTimelineSubmit->pSignalSemaphoreValues[i];
-			}
+            uint32_t ssvCnt = pTimelineSubmit->signalSemaphoreValueCount;
+            for (uint32_t i = 0; i < ssvCnt; i++) {
+                _signalSemaphores[i].value =
+                    pTimelineSubmit->pSignalSemaphoreValues[i];
+            }
         }
     }
 }
 
 MVKQueueCommandBufferSubmission::~MVKQueueCommandBufferSubmission() {
-	if (_fence) { _fence->release(); }
+    if (_fence) {
+        _fence->release();
+    }
 }
-
 
 template <size_t N>
 void MVKQueueFullCommandBufferSubmission<N>::submitCommandBuffers() {
-	uint64_t startTime = getPerformanceTimestamp();
+    uint64_t startTime = getPerformanceTimestamp();
 
-	for (auto& cbInfo : _cmdBuffers) { cbInfo.commandBuffer->submit(this, &_encodingContext); }
+    for (auto& cbInfo : _cmdBuffers) {
+        cbInfo.commandBuffer->submit(this, &_encodingContext);
+    }
 
-	addPerformanceInterval(getPerformanceStats().queue.submitCommandBuffers, startTime);
+    addPerformanceInterval(getPerformanceStats().queue.submitCommandBuffers,
+                           startTime);
 }
 
 template <size_t N>
-MVKQueueFullCommandBufferSubmission<N>::MVKQueueFullCommandBufferSubmission(MVKQueue* queue,
-																			const VkSubmitInfo2* pSubmit,
-																			VkFence fence,
-																			MVKCommandUse cmdUse)
-	: MVKQueueCommandBufferSubmission(queue, pSubmit, fence, cmdUse) {
+MVKQueueFullCommandBufferSubmission<N>::MVKQueueFullCommandBufferSubmission(
+    MVKQueue* queue, const VkSubmitInfo2* pSubmit, VkFence fence,
+    MVKCommandUse cmdUse)
+    : MVKQueueCommandBufferSubmission(queue, pSubmit, fence, cmdUse) {
 
-	if (pSubmit) {
-		uint32_t cbCnt = pSubmit->commandBufferInfoCount;
-		_cmdBuffers.reserve(cbCnt);
-		for (uint32_t i = 0; i < cbCnt; i++) {
-			_cmdBuffers.emplace_back(pSubmit->pCommandBufferInfos[i]);
-			setConfigurationResult(_cmdBuffers.back().commandBuffer->getConfigurationResult());
-		}
-	}
+    if (pSubmit) {
+        uint32_t cbCnt = pSubmit->commandBufferInfoCount;
+        _cmdBuffers.reserve(cbCnt);
+        for (uint32_t i = 0; i < cbCnt; i++) {
+            _cmdBuffers.emplace_back(pSubmit->pCommandBufferInfos[i]);
+            setConfigurationResult(
+                _cmdBuffers.back().commandBuffer->getConfigurationResult());
+        }
+    }
 }
 
 template <size_t N>
-MVKQueueFullCommandBufferSubmission<N>::MVKQueueFullCommandBufferSubmission(MVKQueue* queue,
-																			const VkSubmitInfo* pSubmit,
-																			VkFence fence,
-																			MVKCommandUse cmdUse)
-	: MVKQueueCommandBufferSubmission(queue, pSubmit, fence, cmdUse) {
+MVKQueueFullCommandBufferSubmission<N>::MVKQueueFullCommandBufferSubmission(
+    MVKQueue* queue, const VkSubmitInfo* pSubmit, VkFence fence,
+    MVKCommandUse cmdUse)
+    : MVKQueueCommandBufferSubmission(queue, pSubmit, fence, cmdUse) {
 
-	if (pSubmit) {
-		uint32_t cbCnt = pSubmit->commandBufferCount;
-		_cmdBuffers.reserve(cbCnt);
-		for (uint32_t i = 0; i < cbCnt; i++) {
-			_cmdBuffers.emplace_back(pSubmit->pCommandBuffers[i]);
-			setConfigurationResult(_cmdBuffers.back().commandBuffer->getConfigurationResult());
-		}
-	}
+    if (pSubmit) {
+        uint32_t cbCnt = pSubmit->commandBufferCount;
+        _cmdBuffers.reserve(cbCnt);
+        for (uint32_t i = 0; i < cbCnt; i++) {
+            _cmdBuffers.emplace_back(pSubmit->pCommandBuffers[i]);
+            setConfigurationResult(
+                _cmdBuffers.back().commandBuffer->getConfigurationResult());
+        }
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKQueuePresentSurfaceSubmission
 
-// If the semaphores are encodable, wait on them by encoding them on the MTLCommandBuffer before presenting.
-// If the semaphores are not encodable, wait on them inline after presenting.
-// The semaphores know what to do.
+// If the semaphores are encodable, wait on them by encoding them on the
+// MTLCommandBuffer before presenting. If the semaphores are not encodable, wait
+// on them inline after presenting. The semaphores know what to do.
 VkResult MVKQueuePresentSurfaceSubmission::execute() {
-	// MTLCommandBuffer retain references to avoid rare case where objects are destroyed too early.
-	// Although testing could not determine which objects were being lost, queue present MTLCommandBuffers
-	// are used only once per frame, and retain so few objects, that blanket retention is still performant.
-	id<MTLCommandBuffer> mtlCmdBuff = _queue->getMTLCommandBuffer(kMVKCommandUseQueuePresent, true);
+    // MTLCommandBuffer retain references to avoid rare case where objects are
+    // destroyed too early. Although testing could not determine which objects
+    // were being lost, queue present MTLCommandBuffers are used only once per
+    // frame, and retain so few objects, that blanket retention is still
+    // performant.
+    id<MTLCommandBuffer> mtlCmdBuff =
+        _queue->getMTLCommandBuffer(kMVKCommandUseQueuePresent, true);
 
-	for (auto& ws : _waitSemaphores) {
-		ws.encodeWait(mtlCmdBuff);	// Encoded semaphore waits
-		ws.encodeWait(nil);			// Inline semaphore waits
-	}
+    for (auto& ws : _waitSemaphores) {
+        ws.encodeWait(mtlCmdBuff); // Encoded semaphore waits
+        ws.encodeWait(nil);        // Inline semaphore waits
+    }
 
-	// Wait time from an async vkQueuePresentKHR() call to starting presentation of the swapchains
-	addPerformanceInterval(getPerformanceStats().queue.waitPresentSwapchains, _creationTime);
+    // Wait time from an async vkQueuePresentKHR() call to starting presentation
+    // of the swapchains
+    addPerformanceInterval(getPerformanceStats().queue.waitPresentSwapchains,
+                           _creationTime);
 
-	for (int i = 0; i < _presentInfo.size(); i++ ) {
-		setConfigurationResult(_presentInfo[i].presentableImage->presentCAMetalDrawable(mtlCmdBuff, _presentInfo[i]));
-	}
+    for (int i = 0; i < _presentInfo.size(); i++) {
+        setConfigurationResult(
+            _presentInfo[i]
+                .presentableImage->presentCAMetalDrawable(mtlCmdBuff,
+                                                          _presentInfo[i]));
+    }
 
-	if (_queue->_queueFamily->getIndex() == getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
-		_queue->_index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
-		getDevice()->stopAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND);
-		getDevice()->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND, _queue->getMTLCommandQueue());
-	}
+    if (_queue->_queueFamily->getIndex() ==
+            getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
+        _queue->_index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
+        getDevice()->stopAutoGPUCapture(
+            MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND);
+        getDevice()
+            ->startAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_ON_DEMAND,
+                                  _queue->getMTLCommandQueue());
+    }
 
-	if ( !mtlCmdBuff ) { setConfigurationResult(VK_ERROR_OUT_OF_POOL_MEMORY); }	// Check after images may set error.
+    if (!mtlCmdBuff) {
+        setConfigurationResult(VK_ERROR_OUT_OF_POOL_MEMORY);
+    } // Check after images may set error.
 
-	// Add completion callback to the MTLCommandBuffer to call finish(), 
-	// or if the MTLCommandBuffer could not be created, call finish() directly.
-	// Retrieve the result first, because finish() will destroy this instance.
-	VkResult rslt = getConfigurationResult();
-	if (mtlCmdBuff) {
-		[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) { this->finish(); }];
-		[mtlCmdBuff commit];
-	} else {
-		finish();
-	}
-	return rslt;
+    // Add completion callback to the MTLCommandBuffer to call finish(),
+    // or if the MTLCommandBuffer could not be created, call finish() directly.
+    // Retrieve the result first, because finish() will destroy this instance.
+    VkResult rslt = getConfigurationResult();
+    if (mtlCmdBuff) {
+        [mtlCmdBuff addCompletedHandler:^(id<MTLCommandBuffer> mtlCB) {
+          this->finish();
+        }];
+        [mtlCmdBuff commit];
+    } else {
+        finish();
+    }
+    return rslt;
 }
 
 void MVKQueuePresentSurfaceSubmission::finish() {
 
-	// Let Xcode know the current frame is done, then start a new frame,
-	// and if auto GPU capture is active, and it's time to stop it, do so.
-	auto cs = _queue->_submissionCaptureScope;
-	cs->endScope();
-	cs->beginScope();
-	if (_queue->_queueFamily->getIndex() == getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
-		_queue->_index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
-		getDevice()->stopAutoGPUCapture(MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME);
-	}
+    // Let Xcode know the current frame is done, then start a new frame,
+    // and if auto GPU capture is active, and it's time to stop it, do so.
+    auto cs = _queue->_submissionCaptureScope;
+    cs->endScope();
+    cs->beginScope();
+    if (_queue->_queueFamily->getIndex() ==
+            getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&
+        _queue->_index == getMVKConfig().defaultGPUCaptureScopeQueueIndex) {
+        getDevice()->stopAutoGPUCapture(
+            MVK_CONFIG_AUTO_GPU_CAPTURE_SCOPE_FRAME);
+    }
 
-	this->destroy();
+    this->destroy();
 }
 
-MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(MVKQueue* queue,
-																   const VkPresentInfoKHR* pPresentInfo)
-	: MVKQueueSubmission(queue, pPresentInfo->waitSemaphoreCount, pPresentInfo->pWaitSemaphores, nullptr) {
+MVKQueuePresentSurfaceSubmission::MVKQueuePresentSurfaceSubmission(
+    MVKQueue* queue, const VkPresentInfoKHR* pPresentInfo)
+    : MVKQueueSubmission(queue, pPresentInfo->waitSemaphoreCount,
+                         pPresentInfo->pWaitSemaphores, nullptr) {
 
-	const VkPresentTimesInfoGOOGLE* pPresentTimesInfo = nullptr;
-	const VkSwapchainPresentFenceInfoEXT* pPresentFenceInfo = nullptr;
-	const VkSwapchainPresentModeInfoEXT* pPresentModeInfo = nullptr;
-	const VkPresentRegionsKHR* pPresentRegions = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pPresentInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
-				pPresentRegions = (const VkPresentRegionsKHR*) next;
-				break;
-			case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT:
-				pPresentFenceInfo = (const VkSwapchainPresentFenceInfoEXT*) next;
-				break;
-			case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_EXT:
-				pPresentModeInfo = (const VkSwapchainPresentModeInfoEXT*) next;
-				break;
-			case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
-				pPresentTimesInfo = (const VkPresentTimesInfoGOOGLE*) next;
-				break;
-			default:
-				break;
-		}
-	}
+    const VkPresentTimesInfoGOOGLE* pPresentTimesInfo = nullptr;
+    const VkSwapchainPresentFenceInfoEXT* pPresentFenceInfo = nullptr;
+    const VkSwapchainPresentModeInfoEXT* pPresentModeInfo = nullptr;
+    const VkPresentRegionsKHR* pPresentRegions = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pPresentInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
+            pPresentRegions = (const VkPresentRegionsKHR*)next;
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT:
+            pPresentFenceInfo = (const VkSwapchainPresentFenceInfoEXT*)next;
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_EXT:
+            pPresentModeInfo = (const VkSwapchainPresentModeInfoEXT*)next;
+            break;
+        case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
+            pPresentTimesInfo = (const VkPresentTimesInfoGOOGLE*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	// Populate the array of swapchain images, testing each one for status
-	uint32_t scCnt = pPresentInfo->swapchainCount;
-	const VkPresentTimeGOOGLE* pPresentTimes = nullptr;
-	if (pPresentTimesInfo) {
-		pPresentTimes = pPresentTimesInfo->pTimes;
-		MVKAssert(pPresentTimesInfo->swapchainCount == scCnt, "VkPresentTimesInfoGOOGLE swapchainCount must match VkPresentInfo swapchainCount.");
-	}
-	const VkPresentModeKHR* pPresentModes = nullptr;
-	if (pPresentModeInfo) {
-		pPresentModes = pPresentModeInfo->pPresentModes;
-		MVKAssert(pPresentModeInfo->swapchainCount == scCnt, "VkSwapchainPresentModeInfoEXT swapchainCount must match VkPresentInfo swapchainCount.");
-	}
-	const VkFence* pFences = nullptr;
-	if (pPresentFenceInfo) {
-		pFences = pPresentFenceInfo->pFences;
-		MVKAssert(pPresentFenceInfo->swapchainCount == scCnt, "VkSwapchainPresentFenceInfoEXT swapchainCount must match VkPresentInfo swapchainCount.");
-	}
-	const VkPresentRegionKHR* pRegions = nullptr;
-	if (pPresentRegions) {
-		pRegions = pPresentRegions->pRegions;
-	}
+    // Populate the array of swapchain images, testing each one for status
+    uint32_t scCnt = pPresentInfo->swapchainCount;
+    const VkPresentTimeGOOGLE* pPresentTimes = nullptr;
+    if (pPresentTimesInfo) {
+        pPresentTimes = pPresentTimesInfo->pTimes;
+        MVKAssert(pPresentTimesInfo->swapchainCount == scCnt,
+                  "VkPresentTimesInfoGOOGLE swapchainCount must match "
+                  "VkPresentInfo swapchainCount.");
+    }
+    const VkPresentModeKHR* pPresentModes = nullptr;
+    if (pPresentModeInfo) {
+        pPresentModes = pPresentModeInfo->pPresentModes;
+        MVKAssert(pPresentModeInfo->swapchainCount == scCnt,
+                  "VkSwapchainPresentModeInfoEXT swapchainCount must match "
+                  "VkPresentInfo swapchainCount.");
+    }
+    const VkFence* pFences = nullptr;
+    if (pPresentFenceInfo) {
+        pFences = pPresentFenceInfo->pFences;
+        MVKAssert(pPresentFenceInfo->swapchainCount == scCnt,
+                  "VkSwapchainPresentFenceInfoEXT swapchainCount must match "
+                  "VkPresentInfo swapchainCount.");
+    }
+    const VkPresentRegionKHR* pRegions = nullptr;
+    if (pPresentRegions) {
+        pRegions = pPresentRegions->pRegions;
+    }
 
-	VkResult* pSCRslts = pPresentInfo->pResults;
-	_presentInfo.reserve(scCnt);
-	for (uint32_t scIdx = 0; scIdx < scCnt; scIdx++) {
-		MVKSwapchain* mvkSC = (MVKSwapchain*)pPresentInfo->pSwapchains[scIdx];
-		MVKImagePresentInfo presentInfo = {};	// Start with everything zeroed
-		presentInfo.queue = _queue;
-		presentInfo.presentableImage = mvkSC->getPresentableImage(pPresentInfo->pImageIndices[scIdx]);
-		presentInfo.presentMode = pPresentModes ? pPresentModes[scIdx] : VK_PRESENT_MODE_MAX_ENUM_KHR;
-		presentInfo.fence = pFences ? (MVKFence*)pFences[scIdx] : nullptr;
-		if (pPresentTimes) {
-			presentInfo.presentID = pPresentTimes[scIdx].presentID;
-			presentInfo.desiredPresentTime = pPresentTimes[scIdx].desiredPresentTime;
-		}
-		mvkSC->setLayerNeedsDisplay(pRegions ? &pRegions[scIdx] : nullptr);
-		_presentInfo.push_back(presentInfo);
-		VkResult scRslt = mvkSC->getSurfaceStatus();
-		if (pSCRslts) { pSCRslts[scIdx] = scRslt; }
-		setConfigurationResult(scRslt);
-	}
+    VkResult* pSCRslts = pPresentInfo->pResults;
+    _presentInfo.reserve(scCnt);
+    for (uint32_t scIdx = 0; scIdx < scCnt; scIdx++) {
+        MVKSwapchain* mvkSC = (MVKSwapchain*)pPresentInfo->pSwapchains[scIdx];
+        MVKImagePresentInfo presentInfo = {}; // Start with everything zeroed
+        presentInfo.queue = _queue;
+        presentInfo.presentableImage =
+            mvkSC->getPresentableImage(pPresentInfo->pImageIndices[scIdx]);
+        presentInfo.presentMode =
+            pPresentModes ? pPresentModes[scIdx] : VK_PRESENT_MODE_MAX_ENUM_KHR;
+        presentInfo.fence = pFences ? (MVKFence*)pFences[scIdx] : nullptr;
+        if (pPresentTimes) {
+            presentInfo.presentID = pPresentTimes[scIdx].presentID;
+            presentInfo.desiredPresentTime =
+                pPresentTimes[scIdx].desiredPresentTime;
+        }
+        mvkSC->setLayerNeedsDisplay(pRegions ? &pRegions[scIdx] : nullptr);
+        _presentInfo.push_back(presentInfo);
+        VkResult scRslt = mvkSC->getSurfaceStatus();
+        if (pSCRslts) {
+            pSCRslts[scIdx] = scRslt;
+        }
+        setConfigurationResult(scRslt);
+    }
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,12 +27,12 @@ class MVKRenderPass;
 class MVKFramebuffer;
 class MVKCommandEncoder;
 
-
 // Parameters to define the sizing of inline collections
 const static uint32_t kMVKDefaultAttachmentCount = 8;
 
 /** Collection of attachment clears . */
-typedef MVKSmallVector<VkClearAttachment, kMVKDefaultAttachmentCount> MVKClearAttachments;
+typedef MVKSmallVector<VkClearAttachment, kMVKDefaultAttachmentCount>
+    MVKClearAttachments;
 
 #pragma mark -
 #pragma mark MVKRenderSubpass
@@ -40,149 +40,187 @@ typedef MVKSmallVector<VkClearAttachment, kMVKDefaultAttachmentCount> MVKClearAt
 /** Represents a Vulkan render subpass. */
 class MVKRenderSubpass : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
+    /** Returns the parent render pass of this subpass. */
+    MVKRenderPass* getRenderPass() { return _renderPass; }
 
-	/** Returns the parent render pass of this subpass. */
-	MVKRenderPass* getRenderPass() { return _renderPass; }
+    /** Returns the index of this subpass in its parent render pass. */
+    uint32_t getSubpassIndex() { return _subpassIndex; }
 
-	/** Returns the index of this subpass in its parent render pass. */
-	uint32_t getSubpassIndex() { return _subpassIndex; }
+    /** Returns whether this subpass has any color attachments. */
+    bool hasColorAttachments();
 
-	/** Returns whether this subpass has any color attachments. */
-	bool hasColorAttachments();
+    /** Returns the number of color attachments, which may be zero for
+     * depth-only rendering. */
+    uint32_t getColorAttachmentCount() {
+        return uint32_t(_colorAttachments.size());
+    }
 
-	/** Returns the number of color attachments, which may be zero for depth-only rendering. */
-	uint32_t getColorAttachmentCount() { return uint32_t(_colorAttachments.size()); }
+    /** Returns the format of the color attachment at the specified index. */
+    VkFormat getColorAttachmentFormat(uint32_t colorAttIdx);
 
-	/** Returns the format of the color attachment at the specified index. */
-	VkFormat getColorAttachmentFormat(uint32_t colorAttIdx);
+    /** Returns whether or not the color attachment at the specified index is
+     * being used. */
+    bool isColorAttachmentUsed(uint32_t colorAttIdx);
 
-	/** Returns whether or not the color attachment at the specified index is being used. */
-	bool isColorAttachmentUsed(uint32_t colorAttIdx);
+    /** Returns whether or not the color attachment is used as both a color
+     * attachment and an input attachment. */
+    bool isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx);
 
-	/** Returns whether or not the color attachment is used as both a color attachment and an input attachment. */
-	bool isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx);
+    /** Returns whether or not the depth attachment is being used. */
+    bool isDepthAttachmentUsed() const {
+        return _depthAttachment.attachment != VK_ATTACHMENT_UNUSED;
+    }
 
-	/** Returns whether or not the depth attachment is being used. */
-	bool isDepthAttachmentUsed() const { return _depthAttachment.attachment != VK_ATTACHMENT_UNUSED; }
+    /** Returns whether or not the stencil attachment is being used. */
+    bool isStencilAttachmentUsed() const {
+        return _stencilAttachment.attachment != VK_ATTACHMENT_UNUSED;
+    }
 
-	/** Returns whether or not the stencil attachment is being used. */
-	bool isStencilAttachmentUsed() const { return _stencilAttachment.attachment != VK_ATTACHMENT_UNUSED; }
+    /** Return the depth attachment format. */
+    VkFormat getDepthFormat();
 
-	/** Return the depth attachment format. */
-	VkFormat getDepthFormat();
+    /** Return the stencil attachment format. */
+    VkFormat getStencilFormat();
 
-	/** Return the stencil attachment format. */
-	VkFormat getStencilFormat();
+    /** Returns the Vulkan sample count of the attachments used in this subpass.
+     */
+    VkSampleCountFlagBits getSampleCount();
 
-	/** Returns the Vulkan sample count of the attachments used in this subpass. */
-	VkSampleCountFlagBits getSampleCount();
+    /** Returns the default sample count for when there are no attachments used
+     * in this subpass. */
+    VkSampleCountFlagBits getDefaultSampleCount() {
+        return _defaultSampleCount;
+    }
 
-	/** Returns the default sample count for when there are no attachments used in this subpass. */
-	VkSampleCountFlagBits getDefaultSampleCount() { return _defaultSampleCount; }
+    /** Sets the default sample count for when there are no attachments used in
+     * this subpass. */
+    void setDefaultSampleCount(VkSampleCountFlagBits count) {
+        _defaultSampleCount = count;
+    }
 
-	/** Sets the default sample count for when there are no attachments used in this subpass. */
-	void setDefaultSampleCount(VkSampleCountFlagBits count) { _defaultSampleCount = count; }
+    /** Returns whether or not this is a multiview subpass. */
+    bool isMultiview() const {
+        return _pipelineRenderingCreateInfo.viewMask != 0;
+    }
 
-	/** Returns whether or not this is a multiview subpass. */
-	bool isMultiview() const { return _pipelineRenderingCreateInfo.viewMask != 0; }
+    /** Returns whether or not the depth stencil is being used as input
+     * attachment */
+    bool isInputAttachmentDepthStencilAttachment() const {
+        return _isInputAttachmentDepthStencilAttachment;
+    }
 
-	/** Returns whether or not the depth stencil is being used as input attachment */
-	bool isInputAttachmentDepthStencilAttachment() const { return _isInputAttachmentDepthStencilAttachment; }
+    /** Returns the multiview view mask. */
+    uint32_t getViewMask() const {
+        return _pipelineRenderingCreateInfo.viewMask;
+    }
 
-	/** Returns the multiview view mask. */
-	uint32_t getViewMask() const { return _pipelineRenderingCreateInfo.viewMask; }
+    /** Returns the number of Metal render passes needed to render all views. */
+    uint32_t getMultiviewMetalPassCount() const;
 
-	/** Returns the number of Metal render passes needed to render all views. */
-	uint32_t getMultiviewMetalPassCount() const;
+    /** Returns the first view to be rendered in the given multiview pass. */
+    uint32_t getFirstViewIndexInMetalPass(uint32_t passIdx) const;
 
-	/** Returns the first view to be rendered in the given multiview pass. */
-	uint32_t getFirstViewIndexInMetalPass(uint32_t passIdx) const;
+    /** Returns the number of views to be rendered in the given multiview pass.
+     */
+    uint32_t getViewCountInMetalPass(uint32_t passIdx) const;
 
-	/** Returns the number of views to be rendered in the given multiview pass. */
-	uint32_t getViewCountInMetalPass(uint32_t passIdx) const;
+    /** Returns the number of views to be rendered in all multiview passes up to
+     * the given one. */
+    uint32_t getViewCountUpToMetalPass(uint32_t passIdx) const;
 
-	/** Returns the number of views to be rendered in all multiview passes up to the given one. */
-	uint32_t getViewCountUpToMetalPass(uint32_t passIdx) const;
+    /** Returns pipeline rendering create info that describes this subpass. */
+    const VkPipelineRenderingCreateInfo* getPipelineRenderingCreateInfo() {
+        return &_pipelineRenderingCreateInfo;
+    }
 
-	/** Returns pipeline rendering create info that describes this subpass. */
-	const VkPipelineRenderingCreateInfo* getPipelineRenderingCreateInfo() { return &_pipelineRenderingCreateInfo; }
+    /**
+     * Populates the specified Metal MTLRenderPassDescriptor with content from
+     * this instance, the specified framebuffer, and the specified array of
+     * clear values for the specified multiview pass.
+     */
+    void populateMTLRenderPassDescriptor(
+        MTLRenderPassDescriptor* mtlRPDesc, uint32_t passIdx,
+        MVKFramebuffer* framebuffer,
+        MVKArrayRef<MVKImageView* const> attachments,
+        MVKArrayRef<const VkClearValue> clearValues,
+        bool isRenderingEntireAttachment, bool loadOverride = false);
 
-	/** 
-	 * Populates the specified Metal MTLRenderPassDescriptor with content from this
-	 * instance, the specified framebuffer, and the specified array of clear values
-	 * for the specified multiview pass.
-	 */
-	void populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* mtlRPDesc,
-										 uint32_t passIdx,
-										 MVKFramebuffer* framebuffer,
-										 MVKArrayRef<MVKImageView*const> attachments,
-										 MVKArrayRef<const VkClearValue> clearValues,
-										 bool isRenderingEntireAttachment,
-                                         bool loadOverride = false);
+    /**
+     * Populates the specified vector with the attachments that need to be
+     * cleared when the render area is smaller than the full framebuffer size.
+     */
+    void populateClearAttachments(MVKClearAttachments& clearAtts,
+                                  MVKArrayRef<const VkClearValue> clearValues);
 
-	/**
-	 * Populates the specified vector with the attachments that need to be cleared
-	 * when the render area is smaller than the full framebuffer size.
-	 */
-	void populateClearAttachments(MVKClearAttachments& clearAtts,
-								  MVKArrayRef<const VkClearValue> clearValues);
+    /**
+     * Populates the specified vector with VkClearRects for clearing views of a
+     * specified multiview attachment on first use, when the render area is
+     * smaller than the full framebuffer size and/or not all views used in this
+     * subpass need to be cleared.
+     */
+    void populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects,
+                                     MVKCommandEncoder* cmdEncoder,
+                                     uint32_t caIdx,
+                                     VkImageAspectFlags aspectMask);
 
-	/**
-	 * Populates the specified vector with VkClearRects for clearing views of a specified multiview
-	 * attachment on first use, when the render area is smaller than the full framebuffer size
-	 * and/or not all views used in this subpass need to be cleared.
-	 */
-	void populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects,
-									 MVKCommandEncoder* cmdEncoder,
-									 uint32_t caIdx, VkImageAspectFlags aspectMask);
+    /** If a render encoder is active, sets the store actions for all
+     * attachments to it. */
+    void encodeStoreActions(MVKCommandEncoder* cmdEncoder,
+                            bool isRenderingEntireAttachment,
+                            MVKArrayRef<MVKImageView* const> attachments,
+                            bool storeOverride = false);
 
-	/** If a render encoder is active, sets the store actions for all attachments to it. */
-	void encodeStoreActions(MVKCommandEncoder* cmdEncoder,
-							bool isRenderingEntireAttachment,
-							MVKArrayRef<MVKImageView*const> attachments,
-							bool storeOverride = false);
+    /** Resolves any resolve attachments that cannot be handled by native Metal
+     * subpass resolve behavior. */
+    void resolveUnresolvableAttachments(
+        MVKCommandEncoder* cmdEncoder,
+        MVKArrayRef<MVKImageView* const> attachments);
 
-	/** Resolves any resolve attachments that cannot be handled by native Metal subpass resolve behavior. */
-	void resolveUnresolvableAttachments(MVKCommandEncoder* cmdEncoder, MVKArrayRef<MVKImageView*const> attachments);
+    MVKRenderSubpass(
+        MVKRenderPass* renderPass, const VkSubpassDescription* pCreateInfo,
+        const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspects,
+        uint32_t viewMask);
 
-	MVKRenderSubpass(MVKRenderPass* renderPass, const VkSubpassDescription* pCreateInfo,
-					 const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspects,
-					 uint32_t viewMask);
+    MVKRenderSubpass(MVKRenderPass* renderPass,
+                     const VkSubpassDescription2* pCreateInfo);
 
-	MVKRenderSubpass(MVKRenderPass* renderPass, const VkSubpassDescription2* pCreateInfo);
+    MVKRenderSubpass(MVKRenderPass* renderPass,
+                     const VkRenderingInfo* pRenderingInfo);
 
-	MVKRenderSubpass(MVKRenderPass* renderPass, const VkRenderingInfo* pRenderingInfo);
+  protected:
+    friend class MVKRenderPass;
+    friend class MVKAttachmentDescription;
 
-protected:
-	friend class MVKRenderPass;
-	friend class MVKAttachmentDescription;
+    uint32_t getViewMaskGroupForMetalPass(uint32_t passIdx);
+    MVKMTLFmtCaps
+    getRequiredFormatCapabilitiesForAttachmentAt(uint32_t rpAttIdx);
+    void populatePipelineRenderingCreateInfo();
 
-	uint32_t getViewMaskGroupForMetalPass(uint32_t passIdx);
-	MVKMTLFmtCaps getRequiredFormatCapabilitiesForAttachmentAt(uint32_t rpAttIdx);
-	void populatePipelineRenderingCreateInfo();
-
-	MVKRenderPass* _renderPass;
-	MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount> _inputAttachments;
-	MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount> _colorAttachments;
-	MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount> _resolveAttachments;
-	MVKSmallVector<uint32_t, kMVKDefaultAttachmentCount> _preserveAttachments;
-	MVKSmallVector<VkFormat, kMVKDefaultAttachmentCount> _colorAttachmentFormats;
-	VkPipelineRenderingCreateInfo _pipelineRenderingCreateInfo;
-	VkAttachmentReference2 _depthAttachment;
-	VkAttachmentReference2 _stencilAttachment;
-	VkAttachmentReference2 _depthResolveAttachment;
-	VkAttachmentReference2 _stencilResolveAttachment;
-	VkResolveModeFlagBits _depthResolveMode = VK_RESOLVE_MODE_NONE;
-	VkResolveModeFlagBits _stencilResolveMode = VK_RESOLVE_MODE_NONE;
-	VkSampleCountFlagBits _defaultSampleCount = VK_SAMPLE_COUNT_1_BIT;
-	uint32_t _subpassIndex;
-	bool _isInputAttachmentDepthStencilAttachment = false;
+    MVKRenderPass* _renderPass;
+    MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount>
+        _inputAttachments;
+    MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount>
+        _colorAttachments;
+    MVKSmallVector<VkAttachmentReference2, kMVKDefaultAttachmentCount>
+        _resolveAttachments;
+    MVKSmallVector<uint32_t, kMVKDefaultAttachmentCount> _preserveAttachments;
+    MVKSmallVector<VkFormat, kMVKDefaultAttachmentCount>
+        _colorAttachmentFormats;
+    VkPipelineRenderingCreateInfo _pipelineRenderingCreateInfo;
+    VkAttachmentReference2 _depthAttachment;
+    VkAttachmentReference2 _stencilAttachment;
+    VkAttachmentReference2 _depthResolveAttachment;
+    VkAttachmentReference2 _stencilResolveAttachment;
+    VkResolveModeFlagBits _depthResolveMode = VK_RESOLVE_MODE_NONE;
+    VkResolveModeFlagBits _stencilResolveMode = VK_RESOLVE_MODE_NONE;
+    VkSampleCountFlagBits _defaultSampleCount = VK_SAMPLE_COUNT_1_BIT;
+    uint32_t _subpassIndex;
+    bool _isInputAttachmentDepthStencilAttachment = false;
 };
-
 
 #pragma mark -
 #pragma mark MVKAttachmentDescription
@@ -190,160 +228,164 @@ protected:
 /** Represents an attachment within a Vulkan render pass. */
 class MVKAttachmentDescription : public MVKBaseObject {
 
-public:
-
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override;
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override;
 
     /** Returns the Vulkan format of this attachment. */
     VkFormat getFormat();
 
-	/** Returns the Vulkan sample count of this attachment. */
-	VkSampleCountFlagBits getSampleCount();
+    /** Returns the Vulkan sample count of this attachment. */
+    VkSampleCountFlagBits getSampleCount();
 
     /**
-     * Populates the specified Metal color attachment description with the load and store actions for
-     * the specified render subpass, and returns whether the load action will clear the attachment.
+     * Populates the specified Metal color attachment description with the load
+     * and store actions for the specified render subpass, and returns whether
+     * the load action will clear the attachment.
      */
-    bool populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc,
-                                                   MVKRenderSubpass* subpass,
-												   MVKImageView* attachment,
-                                                   bool isRenderingEntireAttachment,
-												   bool hasResolveAttachment,
-												   bool canResolveFormat,
-                                                   bool isStencil,
-                                                   bool loadOverride);
+    bool populateMTLRenderPassAttachmentDescriptor(
+        MTLRenderPassAttachmentDescriptor* mtlAttDesc,
+        MVKRenderSubpass* subpass, MVKImageView* attachment,
+        bool isRenderingEntireAttachment, bool hasResolveAttachment,
+        bool canResolveFormat, bool isStencil, bool loadOverride);
 
-	/** If a render encoder is active, sets the store action for this attachment to it. */
-	void encodeStoreAction(MVKCommandEncoder* cmdEncoder,
-						   MVKRenderSubpass* subpass,
-						   MVKImageView* attachment,
-						   bool isRenderingEntireAttachment,
-						   bool hasResolveAttachment,
-						   bool canResolveFormat,
-						   uint32_t caIdx,
-					   	   bool isStencil,
-						   bool storeOverride = false);
+    /** If a render encoder is active, sets the store action for this attachment
+     * to it. */
+    void encodeStoreAction(MVKCommandEncoder* cmdEncoder,
+                           MVKRenderSubpass* subpass, MVKImageView* attachment,
+                           bool isRenderingEntireAttachment,
+                           bool hasResolveAttachment, bool canResolveFormat,
+                           uint32_t caIdx, bool isStencil,
+                           bool storeOverride = false);
 
-	/** Populates the specified vector with VkClearRects for clearing views of a multiview attachment on first use. */
-	void populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects, MVKCommandEncoder* cmdEncoder);
+    /** Populates the specified vector with VkClearRects for clearing views of a
+     * multiview attachment on first use. */
+    void populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects,
+                                     MVKCommandEncoder* cmdEncoder);
 
     /** Returns whether this attachment should be cleared in the subpass. */
     bool shouldClearAttachment(MVKRenderSubpass* subpass, bool isStencil);
 
-	MVKAttachmentDescription(MVKRenderPass* renderPass,
-							const VkAttachmentDescription* pCreateInfo);
+    MVKAttachmentDescription(MVKRenderPass* renderPass,
+                             const VkAttachmentDescription* pCreateInfo);
 
-	MVKAttachmentDescription(MVKRenderPass* renderPass,
-							const VkAttachmentDescription2* pCreateInfo);
+    MVKAttachmentDescription(MVKRenderPass* renderPass,
+                             const VkAttachmentDescription2* pCreateInfo);
 
-	MVKAttachmentDescription(MVKRenderPass* renderPass,
-							const VkRenderingAttachmentInfo* pAttInfo,
-							bool isResolveAttachment);
+    MVKAttachmentDescription(MVKRenderPass* renderPass,
+                             const VkRenderingAttachmentInfo* pAttInfo,
+                             bool isResolveAttachment);
 
-protected:
-	friend class MVKRenderPass;
-	friend class MVKRenderSubpass;
+  protected:
+    friend class MVKRenderPass;
+    friend class MVKRenderSubpass;
 
-	bool isFirstUseOfAttachment(MVKRenderSubpass* subpass);
-	bool isLastUseOfAttachment(MVKRenderSubpass* subpass);
-	MTLStoreAction getMTLStoreAction(MVKRenderSubpass* subpass,
-									 bool isRenderingEntireAttachment,
-									 bool isMemorylessAttachment,
-									 bool hasResolveAttachment,
-									 bool canResolveFormat,
-									 bool isStencil,
-									 bool storeOverride);
-	void linkToSubpasses();
+    bool isFirstUseOfAttachment(MVKRenderSubpass* subpass);
+    bool isLastUseOfAttachment(MVKRenderSubpass* subpass);
+    MTLStoreAction getMTLStoreAction(MVKRenderSubpass* subpass,
+                                     bool isRenderingEntireAttachment,
+                                     bool isMemorylessAttachment,
+                                     bool hasResolveAttachment,
+                                     bool canResolveFormat, bool isStencil,
+                                     bool storeOverride);
+    void linkToSubpasses();
 
-	VkAttachmentDescription2 _info;
-	MVKRenderPass* _renderPass;
-	uint32_t _attachmentIndex;
-	uint32_t _firstUseSubpassIdx;
-	uint32_t _lastUseSubpassIdx;
-	MVKSmallVector<uint32_t> _firstUseViewMasks;
-	MVKSmallVector<uint32_t> _lastUseViewMasks;
+    VkAttachmentDescription2 _info;
+    MVKRenderPass* _renderPass;
+    uint32_t _attachmentIndex;
+    uint32_t _firstUseSubpassIdx;
+    uint32_t _lastUseSubpassIdx;
+    MVKSmallVector<uint32_t> _firstUseViewMasks;
+    MVKSmallVector<uint32_t> _lastUseViewMasks;
 };
-
 
 #pragma mark -
 #pragma mark MVKRenderPass
 
 /** Collects together VkSubpassDependency and VkMemoryBarrier2. */
 typedef struct MVKSubpassDependency {
-	uint32_t              srcSubpass;
-	uint32_t              dstSubpass;
-	VkPipelineStageFlags2 srcStageMask;
-	VkPipelineStageFlags2 dstStageMask;
-	VkAccessFlags2        srcAccessMask;
-	VkAccessFlags2        dstAccessMask;
-	VkDependencyFlags     dependencyFlags;
-	int32_t               viewOffset;
+    uint32_t srcSubpass;
+    uint32_t dstSubpass;
+    VkPipelineStageFlags2 srcStageMask;
+    VkPipelineStageFlags2 dstStageMask;
+    VkAccessFlags2 srcAccessMask;
+    VkAccessFlags2 dstAccessMask;
+    VkDependencyFlags dependencyFlags;
+    int32_t viewOffset;
 
-	MVKSubpassDependency(const VkSubpassDependency& spDep, int32_t viewOffset);
-	MVKSubpassDependency(const VkSubpassDependency2& spDep, const VkMemoryBarrier2* pMemBar);
+    MVKSubpassDependency(const VkSubpassDependency& spDep, int32_t viewOffset);
+    MVKSubpassDependency(const VkSubpassDependency2& spDep,
+                         const VkMemoryBarrier2* pMemBar);
 
 } MVKSubpassDependency;
 
 /** Represents a Vulkan render pass. */
 class MVKRenderPass : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_RENDER_PASS;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_RENDER_PASS; }
-
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT;
+    }
 
     /** Returns the granularity of the render area of this instance.  */
     VkExtent2D getRenderAreaGranularity();
 
-	/** Returns the number of subpasses. */
-	size_t getSubpassCount() { return _subpasses.size(); }
+    /** Returns the number of subpasses. */
+    size_t getSubpassCount() { return _subpasses.size(); }
 
-	/** Returns the subpass at the specified index. */
-	MVKRenderSubpass* getSubpass(uint32_t subpassIndex) { return &_subpasses[subpassIndex]; }
+    /** Returns the subpass at the specified index. */
+    MVKRenderSubpass* getSubpass(uint32_t subpassIndex) {
+        return &_subpasses[subpassIndex];
+    }
 
-	/** Returns whether or not this render pass is a multiview render pass. */
-	bool isMultiview() const;
+    /** Returns whether or not this render pass is a multiview render pass. */
+    bool isMultiview() const;
 
-	/** Returns the dynamic rendering flags. */
-	VkRenderingFlags getRenderingFlags() { return _renderingFlags; }
+    /** Returns the dynamic rendering flags. */
+    VkRenderingFlags getRenderingFlags() { return _renderingFlags; }
 
-	/** Sets the dynamic rendering flags. */
-	void setRenderingFlags(VkRenderingFlags renderingFlags) { _renderingFlags = renderingFlags; }
+    /** Sets the dynamic rendering flags. */
+    void setRenderingFlags(VkRenderingFlags renderingFlags) {
+        _renderingFlags = renderingFlags;
+    }
 
-	MVKRenderPass(MVKDevice* device, const VkRenderPassCreateInfo* pCreateInfo);
+    MVKRenderPass(MVKDevice* device, const VkRenderPassCreateInfo* pCreateInfo);
 
-	MVKRenderPass(MVKDevice* device, const VkRenderPassCreateInfo2* pCreateInfo);
+    MVKRenderPass(MVKDevice* device,
+                  const VkRenderPassCreateInfo2* pCreateInfo);
 
-	MVKRenderPass(MVKDevice* device, const VkRenderingInfo* pRenderingInfo);
+    MVKRenderPass(MVKDevice* device, const VkRenderingInfo* pRenderingInfo);
 
-protected:
-	friend class MVKRenderSubpass;
-	friend class MVKAttachmentDescription;
+  protected:
+    friend class MVKRenderSubpass;
+    friend class MVKAttachmentDescription;
 
-	void propagateDebugName() override {}
+    void propagateDebugName() override {}
 
-	MVKSmallVector<MVKAttachmentDescription> _attachments;
-	MVKSmallVector<MVKRenderSubpass> _subpasses;
-	MVKSmallVector<MVKSubpassDependency> _subpassDependencies;
-	VkRenderingFlags _renderingFlags = 0;
-
+    MVKSmallVector<MVKAttachmentDescription> _attachments;
+    MVKSmallVector<MVKRenderSubpass> _subpasses;
+    MVKSmallVector<MVKSubpassDependency> _subpassDependencies;
+    VkRenderingFlags _renderingFlags = 0;
 };
-
 
 #pragma mark -
 #pragma mark MVKRenderingAttachmentIterator
 
 typedef std::function<void(const VkRenderingAttachmentInfo* pAttInfo,
-						   VkImageAspectFlagBits aspect,
-						   bool isResolveAttachment)> MVKRenderingAttachmentInfoOperation;
+                           VkImageAspectFlagBits aspect,
+                           bool isResolveAttachment)>
+    MVKRenderingAttachmentInfoOperation;
 
 /**
  * Iterates the attachments in a VkRenderingInfo, and processes an operation
- * on each attachment, once for the imageView, and once for the resolveImageView.
+ * on each attachment, once for the imageView, and once for the
+ * resolveImageView.
  *
  * Attachments are sequentially processed in this order:
  *     [color, color-resolve], ...,
@@ -353,35 +395,36 @@ typedef std::function<void(const VkRenderingAttachmentInfo* pAttInfo,
  */
 class MVKRenderingAttachmentIterator : public MVKBaseObject {
 
-public:
+  public:
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; }
 
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; }
+    /** Iterates the attachments with the specified lambda function. */
+    void iterate(MVKRenderingAttachmentInfoOperation attOperation);
 
-	/** Iterates the attachments with the specified lambda function. */
-	void iterate(MVKRenderingAttachmentInfoOperation attOperation);
+    MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo);
 
-	MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo);
+  protected:
+    void handleAttachment(const VkRenderingAttachmentInfo* pAttInfo,
+                          VkImageAspectFlagBits aspect,
+                          MVKRenderingAttachmentInfoOperation attOperation);
+    const VkRenderingAttachmentInfo*
+    getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
+                      const VkRenderingAttachmentInfo* pAltAtt, bool isStencil);
 
-protected:
-	void handleAttachment(const VkRenderingAttachmentInfo* pAttInfo,
-						  VkImageAspectFlagBits aspect,
-						  MVKRenderingAttachmentInfoOperation attOperation);
-	const VkRenderingAttachmentInfo* getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
-													   const VkRenderingAttachmentInfo* pAltAtt,
-													   bool isStencil);
-
-	VkRenderingInfo _renderingInfo;
+    VkRenderingInfo _renderingInfo;
 };
-
 
 #pragma mark -
 #pragma mark Support functions
 
 /** Returns whether the view mask uses multiview. */
-static constexpr bool mvkIsMultiview(uint32_t viewMask) { return viewMask != 0; }
+static constexpr bool mvkIsMultiview(uint32_t viewMask) {
+    return viewMask != 0;
+}
 
 /** Returns whether the attachment is being used. */
-bool mvkIsColorAttachmentUsed(const VkPipelineRenderingCreateInfo* pRendInfo, uint32_t colorAttIdx);
+bool mvkIsColorAttachmentUsed(const VkPipelineRenderingCreateInfo* pRendInfo,
+                              uint32_t colorAttIdx);
 
 /** Returns whether any attachment is being used. */
 bool mvkHasColorAttachments(const VkPipelineRenderingCreateInfo* pRendInfo);
@@ -391,5 +434,5 @@ bool mvkHasColorAttachments(const VkPipelineRenderingCreateInfo* pRendInfo);
  * to be rendered from the lowest clump of set bits in a view mask.
  */
 uint32_t mvkGetNextViewMaskGroup(uint32_t viewMask, uint32_t* startView,
-								 uint32_t* viewCount, uint32_t *groupMask = nullptr);
-
+                                 uint32_t* viewCount,
+                                 uint32_t* groupMask = nullptr);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,1114 +30,1393 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKRenderSubpass
 
-MVKVulkanAPIObject* MVKRenderSubpass::getVulkanAPIObject() { return _renderPass->getVulkanAPIObject(); };
+MVKVulkanAPIObject* MVKRenderSubpass::getVulkanAPIObject() {
+    return _renderPass->getVulkanAPIObject();
+};
 
 bool MVKRenderSubpass::hasColorAttachments() {
-	for (auto& ca : _colorAttachments) {
-		if (ca.attachment != VK_ATTACHMENT_UNUSED) { return true; }
-	}
-	return false;
+    for (auto& ca : _colorAttachments) {
+        if (ca.attachment != VK_ATTACHMENT_UNUSED) {
+            return true;
+        }
+    }
+    return false;
 }
 
 VkFormat MVKRenderSubpass::getColorAttachmentFormat(uint32_t colorAttIdx) {
-	if (colorAttIdx < _colorAttachments.size()) {
-		uint32_t rpAttIdx = _colorAttachments[colorAttIdx].attachment;
-		if (rpAttIdx == VK_ATTACHMENT_UNUSED) { return VK_FORMAT_UNDEFINED; }
-		return _renderPass->_attachments[rpAttIdx].getFormat();
-	}
-	return VK_FORMAT_UNDEFINED;
+    if (colorAttIdx < _colorAttachments.size()) {
+        uint32_t rpAttIdx = _colorAttachments[colorAttIdx].attachment;
+        if (rpAttIdx == VK_ATTACHMENT_UNUSED) {
+            return VK_FORMAT_UNDEFINED;
+        }
+        return _renderPass->_attachments[rpAttIdx].getFormat();
+    }
+    return VK_FORMAT_UNDEFINED;
 }
 
 bool MVKRenderSubpass::isColorAttachmentUsed(uint32_t colorAttIdx) {
-	if (colorAttIdx >= _colorAttachments.size()) { return false; }
-	return _colorAttachments[colorAttIdx].attachment != VK_ATTACHMENT_UNUSED;
+    if (colorAttIdx >= _colorAttachments.size()) {
+        return false;
+    }
+    return _colorAttachments[colorAttIdx].attachment != VK_ATTACHMENT_UNUSED;
 }
 
+bool MVKRenderSubpass::isColorAttachmentAlsoInputAttachment(
+    uint32_t colorAttIdx) {
+    if (colorAttIdx >= _colorAttachments.size()) {
+        return false;
+    }
 
-bool MVKRenderSubpass::isColorAttachmentAlsoInputAttachment(uint32_t colorAttIdx) {
-	if (colorAttIdx >= _colorAttachments.size()) { return false; }
+    uint32_t rspAttIdx = _colorAttachments[colorAttIdx].attachment;
+    if (rspAttIdx == VK_ATTACHMENT_UNUSED) {
+        return false;
+    }
 
-	uint32_t rspAttIdx = _colorAttachments[colorAttIdx].attachment;
-	if (rspAttIdx == VK_ATTACHMENT_UNUSED) { return false; }
-
-	for (auto& inAtt : _inputAttachments) {
-		if (inAtt.attachment == rspAttIdx) { return true; }
-	}
-	return false;
+    for (auto& inAtt : _inputAttachments) {
+        if (inAtt.attachment == rspAttIdx) {
+            return true;
+        }
+    }
+    return false;
 }
 
 VkFormat MVKRenderSubpass::getDepthFormat() {
-	return isDepthAttachmentUsed() ? _renderPass->_attachments[_depthAttachment.attachment].getFormat() : VK_FORMAT_UNDEFINED;
+    return isDepthAttachmentUsed()
+               ? _renderPass->_attachments[_depthAttachment.attachment]
+                     .getFormat()
+               : VK_FORMAT_UNDEFINED;
 }
 
 VkFormat MVKRenderSubpass::getStencilFormat() {
-	return isStencilAttachmentUsed() ? _renderPass->_attachments[_stencilAttachment.attachment].getFormat() : VK_FORMAT_UNDEFINED;
+    return isStencilAttachmentUsed()
+               ? _renderPass->_attachments[_stencilAttachment.attachment]
+                     .getFormat()
+               : VK_FORMAT_UNDEFINED;
 }
 
 VkSampleCountFlagBits MVKRenderSubpass::getSampleCount() {
-	for (auto& ca : _colorAttachments) {
-		uint32_t rpAttIdx = ca.attachment;
-		if (rpAttIdx != VK_ATTACHMENT_UNUSED) {
-			return _renderPass->_attachments[rpAttIdx].getSampleCount();
-		}
-	}
-	if (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
-		return _renderPass->_attachments[_depthAttachment.attachment].getSampleCount();
-	}
-	if (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED) {
-		return _renderPass->_attachments[_stencilAttachment.attachment].getSampleCount();
-	}
-	return VK_SAMPLE_COUNT_1_BIT;
+    for (auto& ca : _colorAttachments) {
+        uint32_t rpAttIdx = ca.attachment;
+        if (rpAttIdx != VK_ATTACHMENT_UNUSED) {
+            return _renderPass->_attachments[rpAttIdx].getSampleCount();
+        }
+    }
+    if (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+        return _renderPass->_attachments[_depthAttachment.attachment]
+            .getSampleCount();
+    }
+    if (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+        return _renderPass->_attachments[_stencilAttachment.attachment]
+            .getSampleCount();
+    }
+    return VK_SAMPLE_COUNT_1_BIT;
 }
 
-// Get the portion of the view mask that will be rendered in the specified Metal render pass.
+// Get the portion of the view mask that will be rendered in the specified Metal
+// render pass.
 uint32_t MVKRenderSubpass::getViewMaskGroupForMetalPass(uint32_t passIdx) {
-	if (!_pipelineRenderingCreateInfo.viewMask) { return 0; }
-	assert(passIdx < getMultiviewMetalPassCount());
-	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
-		return 1 << getFirstViewIndexInMetalPass(passIdx);
-	}
-	uint32_t mask = _pipelineRenderingCreateInfo.viewMask, groupMask = 0;
-	for (uint32_t i = 0; i <= passIdx; ++i) {
-		mask = mvkGetNextViewMaskGroup(mask, nullptr, nullptr, &groupMask);
-	}
-	return groupMask;
+    if (!_pipelineRenderingCreateInfo.viewMask) {
+        return 0;
+    }
+    assert(passIdx < getMultiviewMetalPassCount());
+    if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
+        return 1 << getFirstViewIndexInMetalPass(passIdx);
+    }
+    uint32_t mask = _pipelineRenderingCreateInfo.viewMask, groupMask = 0;
+    for (uint32_t i = 0; i <= passIdx; ++i) {
+        mask = mvkGetNextViewMaskGroup(mask, nullptr, nullptr, &groupMask);
+    }
+    return groupMask;
 }
 
 uint32_t MVKRenderSubpass::getMultiviewMetalPassCount() const {
-	return _renderPass->getDevice()->getMultiviewMetalPassCount(_pipelineRenderingCreateInfo.viewMask);
+    return _renderPass->getDevice()->getMultiviewMetalPassCount(
+        _pipelineRenderingCreateInfo.viewMask);
 }
 
-uint32_t MVKRenderSubpass::getFirstViewIndexInMetalPass(uint32_t passIdx) const {
-	return _renderPass->getDevice()->getFirstViewIndexInMetalPass(_pipelineRenderingCreateInfo.viewMask, passIdx);
+uint32_t
+MVKRenderSubpass::getFirstViewIndexInMetalPass(uint32_t passIdx) const {
+    return _renderPass->getDevice()
+        ->getFirstViewIndexInMetalPass(_pipelineRenderingCreateInfo.viewMask,
+                                       passIdx);
 }
 
 uint32_t MVKRenderSubpass::getViewCountInMetalPass(uint32_t passIdx) const {
-	return _renderPass->getDevice()->getViewCountInMetalPass(_pipelineRenderingCreateInfo.viewMask, passIdx);
+    return _renderPass->getDevice()
+        ->getViewCountInMetalPass(_pipelineRenderingCreateInfo.viewMask,
+                                  passIdx);
 }
 
 uint32_t MVKRenderSubpass::getViewCountUpToMetalPass(uint32_t passIdx) const {
-	if (!_pipelineRenderingCreateInfo.viewMask) { return 0; }
-	if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
-		return passIdx+1;
-	}
-	uint32_t mask = _pipelineRenderingCreateInfo.viewMask;
-	uint32_t totalViewCount = 0;
-	for (uint32_t i = 0; i <= passIdx; ++i) {
-		uint32_t viewCount;
-		mask = mvkGetNextViewMaskGroup(mask, nullptr, &viewCount);
-		totalViewCount += viewCount;
-	}
-	return totalViewCount;
+    if (!_pipelineRenderingCreateInfo.viewMask) {
+        return 0;
+    }
+    if (!_renderPass->getPhysicalDevice()->canUseInstancingForMultiview()) {
+        return passIdx + 1;
+    }
+    uint32_t mask = _pipelineRenderingCreateInfo.viewMask;
+    uint32_t totalViewCount = 0;
+    for (uint32_t i = 0; i <= passIdx; ++i) {
+        uint32_t viewCount;
+        mask = mvkGetNextViewMaskGroup(mask, nullptr, &viewCount);
+        totalViewCount += viewCount;
+    }
+    return totalViewCount;
 }
 
-void MVKRenderSubpass::populateMTLRenderPassDescriptor(MTLRenderPassDescriptor* mtlRPDesc,
-													   uint32_t passIdx,
-													   MVKFramebuffer* framebuffer,
-													   MVKArrayRef<MVKImageView*const> attachments,
-													   MVKArrayRef<const VkClearValue> clearValues,
-													   bool isRenderingEntireAttachment,
-													   bool loadOverride) {
-	MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+void MVKRenderSubpass::populateMTLRenderPassDescriptor(
+    MTLRenderPassDescriptor* mtlRPDesc, uint32_t passIdx,
+    MVKFramebuffer* framebuffer, MVKArrayRef<MVKImageView* const> attachments,
+    MVKArrayRef<const VkClearValue> clearValues,
+    bool isRenderingEntireAttachment, bool loadOverride) {
+    MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
 
-	// Populate the Metal color attachments
-	uint32_t caCnt = getColorAttachmentCount();
-	uint32_t caUsedCnt = 0;
-	for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
-		uint32_t clrRPAttIdx = _colorAttachments[caIdx].attachment;
+    // Populate the Metal color attachments
+    uint32_t caCnt = getColorAttachmentCount();
+    uint32_t caUsedCnt = 0;
+    for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
+        uint32_t clrRPAttIdx = _colorAttachments[caIdx].attachment;
         if (clrRPAttIdx != VK_ATTACHMENT_UNUSED) {
-			++caUsedCnt;
-            MTLRenderPassColorAttachmentDescriptor* mtlColorAttDesc = mtlRPDesc.colorAttachments[caIdx];
+            ++caUsedCnt;
+            MTLRenderPassColorAttachmentDescriptor* mtlColorAttDesc =
+                mtlRPDesc.colorAttachments[caIdx];
 
             // If it exists, configure the resolve attachment first,
             // as it affects the store action of the color attachment.
-            uint32_t rslvRPAttIdx = _resolveAttachments.empty() ? VK_ATTACHMENT_UNUSED : _resolveAttachments[caIdx].attachment;
+            uint32_t rslvRPAttIdx = _resolveAttachments.empty()
+                                        ? VK_ATTACHMENT_UNUSED
+                                        : _resolveAttachments[caIdx].attachment;
             bool hasResolveAttachment = (rslvRPAttIdx != VK_ATTACHMENT_UNUSED);
-			bool canResolveFormat = true;
-			if (hasResolveAttachment) {
-				MVKImageView* raImgView = attachments[rslvRPAttIdx];
-				canResolveFormat = mvkAreAllFlagsEnabled(pixFmts->getCapabilities(raImgView->getMTLPixelFormat()), kMVKMTLFmtCapsResolve);
-				if (canResolveFormat) {
-					raImgView->populateMTLRenderPassAttachmentDescriptorResolve(mtlColorAttDesc);
+            bool canResolveFormat = true;
+            if (hasResolveAttachment) {
+                MVKImageView* raImgView = attachments[rslvRPAttIdx];
+                canResolveFormat =
+                    mvkAreAllFlagsEnabled(pixFmts->getCapabilities(
+                                              raImgView->getMTLPixelFormat()),
+                                          kMVKMTLFmtCapsResolve);
+                if (canResolveFormat) {
+                    raImgView->populateMTLRenderPassAttachmentDescriptorResolve(
+                        mtlColorAttDesc);
 
-					// In a multiview render pass, we need to override the starting layer to ensure
-					// only the enabled views are loaded.
-					if (isMultiview()) {
-						uint32_t startView = getFirstViewIndexInMetalPass(passIdx);
-						if (mtlColorAttDesc.resolveTexture.textureType == MTLTextureType3D)
-							mtlColorAttDesc.resolveDepthPlane += startView;
-						else
-							mtlColorAttDesc.resolveSlice += startView;
-					}
-				}
-			}
+                    // In a multiview render pass, we need to override the
+                    // starting layer to ensure only the enabled views are
+                    // loaded.
+                    if (isMultiview()) {
+                        uint32_t startView =
+                            getFirstViewIndexInMetalPass(passIdx);
+                        if (mtlColorAttDesc.resolveTexture.textureType ==
+                            MTLTextureType3D)
+                            mtlColorAttDesc.resolveDepthPlane += startView;
+                        else
+                            mtlColorAttDesc.resolveSlice += startView;
+                    }
+                }
+            }
 
             // Configure the color attachment
-            MVKAttachmentDescription* clrMVKRPAtt = &_renderPass->_attachments[clrRPAttIdx];
-			if (clrMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(mtlColorAttDesc, this, attachments[clrRPAttIdx],
-                                                                       isRenderingEntireAttachment,
-                                                                       hasResolveAttachment, canResolveFormat,
-																	   false, loadOverride)) {
-				mtlColorAttDesc.clearColor = pixFmts->getMTLClearColor(clearValues[clrRPAttIdx], clrMVKRPAtt->getFormat());
-			}
-			if (isMultiview()) {
-				uint32_t startView = getFirstViewIndexInMetalPass(passIdx);
-				if (mtlColorAttDesc.texture.textureType == MTLTextureType3D)
-					mtlColorAttDesc.depthPlane += startView;
-				else
-					mtlColorAttDesc.slice += startView;
-			}
-		}
-	}
+            MVKAttachmentDescription* clrMVKRPAtt =
+                &_renderPass->_attachments[clrRPAttIdx];
+            if (clrMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(
+                    mtlColorAttDesc, this, attachments[clrRPAttIdx],
+                    isRenderingEntireAttachment, hasResolveAttachment,
+                    canResolveFormat, false, loadOverride)) {
+                mtlColorAttDesc.clearColor =
+                    pixFmts->getMTLClearColor(clearValues[clrRPAttIdx],
+                                              clrMVKRPAtt->getFormat());
+            }
+            if (isMultiview()) {
+                uint32_t startView = getFirstViewIndexInMetalPass(passIdx);
+                if (mtlColorAttDesc.texture.textureType == MTLTextureType3D)
+                    mtlColorAttDesc.depthPlane += startView;
+                else
+                    mtlColorAttDesc.slice += startView;
+            }
+        }
+    }
 
-	// Populate the Metal depth attachment
-	uint32_t depthRPAttIdx = _depthAttachment.attachment;
-	if (depthRPAttIdx != VK_ATTACHMENT_UNUSED) {
-		MVKAttachmentDescription* depthMVKRPAtt = &_renderPass->_attachments[depthRPAttIdx];
-		MVKImageView* depthImage = attachments[depthRPAttIdx];
+    // Populate the Metal depth attachment
+    uint32_t depthRPAttIdx = _depthAttachment.attachment;
+    if (depthRPAttIdx != VK_ATTACHMENT_UNUSED) {
+        MVKAttachmentDescription* depthMVKRPAtt =
+            &_renderPass->_attachments[depthRPAttIdx];
+        MVKImageView* depthImage = attachments[depthRPAttIdx];
 
-		MVKImageView* depthRslvImage = nullptr;
-		uint32_t depthRslvRPAttIdx = _depthResolveAttachment.attachment;
-		if (depthRslvRPAttIdx != VK_ATTACHMENT_UNUSED) {
-			depthRslvImage = attachments[depthRslvRPAttIdx];
-		}
+        MVKImageView* depthRslvImage = nullptr;
+        uint32_t depthRslvRPAttIdx = _depthResolveAttachment.attachment;
+        if (depthRslvRPAttIdx != VK_ATTACHMENT_UNUSED) {
+            depthRslvImage = attachments[depthRslvRPAttIdx];
+        }
 
-		MTLRenderPassDepthAttachmentDescriptor* mtlDepthAttDesc = mtlRPDesc.depthAttachment;
-		bool hasDepthResolve = depthRslvRPAttIdx != VK_ATTACHMENT_UNUSED && _depthResolveMode != VK_RESOLVE_MODE_NONE;
-		if (hasDepthResolve) {
-			depthRslvImage->populateMTLRenderPassAttachmentDescriptorResolve(mtlDepthAttDesc);
-			mtlDepthAttDesc.depthResolveFilterMVK = mvkMTLMultisampleDepthResolveFilterFromVkResolveModeFlagBits(_depthResolveMode);
-			if (isMultiview()) {
-				mtlDepthAttDesc.resolveSlice += getFirstViewIndexInMetalPass(passIdx);
-			}
-		}
-		if (depthMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(mtlDepthAttDesc, this, depthImage,
-																	 isRenderingEntireAttachment,
-																	 hasDepthResolve, true,
-																	 false, loadOverride)) {
-			mtlDepthAttDesc.clearDepth = pixFmts->getMTLClearDepthValue(clearValues[depthRPAttIdx]);
-		}
-		if (isMultiview()) {
-			mtlDepthAttDesc.slice += getFirstViewIndexInMetalPass(passIdx);
-		}
-	}
+        MTLRenderPassDepthAttachmentDescriptor* mtlDepthAttDesc =
+            mtlRPDesc.depthAttachment;
+        bool hasDepthResolve = depthRslvRPAttIdx != VK_ATTACHMENT_UNUSED &&
+                               _depthResolveMode != VK_RESOLVE_MODE_NONE;
+        if (hasDepthResolve) {
+            depthRslvImage->populateMTLRenderPassAttachmentDescriptorResolve(
+                mtlDepthAttDesc);
+            mtlDepthAttDesc.depthResolveFilterMVK =
+                mvkMTLMultisampleDepthResolveFilterFromVkResolveModeFlagBits(
+                    _depthResolveMode);
+            if (isMultiview()) {
+                mtlDepthAttDesc.resolveSlice +=
+                    getFirstViewIndexInMetalPass(passIdx);
+            }
+        }
+        if (depthMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(
+                mtlDepthAttDesc, this, depthImage, isRenderingEntireAttachment,
+                hasDepthResolve, true, false, loadOverride)) {
+            mtlDepthAttDesc.clearDepth =
+                pixFmts->getMTLClearDepthValue(clearValues[depthRPAttIdx]);
+        }
+        if (isMultiview()) {
+            mtlDepthAttDesc.slice += getFirstViewIndexInMetalPass(passIdx);
+        }
+    }
 
-	// Populate the Metal stencil attachment
-	uint32_t stencilRPAttIdx = _stencilAttachment.attachment;
-	if (stencilRPAttIdx != VK_ATTACHMENT_UNUSED) {
-		MVKAttachmentDescription* stencilMVKRPAtt = &_renderPass->_attachments[stencilRPAttIdx];
-		MVKImageView* stencilImage = attachments[stencilRPAttIdx];
+    // Populate the Metal stencil attachment
+    uint32_t stencilRPAttIdx = _stencilAttachment.attachment;
+    if (stencilRPAttIdx != VK_ATTACHMENT_UNUSED) {
+        MVKAttachmentDescription* stencilMVKRPAtt =
+            &_renderPass->_attachments[stencilRPAttIdx];
+        MVKImageView* stencilImage = attachments[stencilRPAttIdx];
 
-		MVKImageView* stencilRslvImage = nullptr;
-		uint32_t stencilRslvRPAttIdx = _stencilResolveAttachment.attachment;
-		if (stencilRslvRPAttIdx != VK_ATTACHMENT_UNUSED) {
-			stencilRslvImage = attachments[stencilRslvRPAttIdx];
-		}
+        MVKImageView* stencilRslvImage = nullptr;
+        uint32_t stencilRslvRPAttIdx = _stencilResolveAttachment.attachment;
+        if (stencilRslvRPAttIdx != VK_ATTACHMENT_UNUSED) {
+            stencilRslvImage = attachments[stencilRslvRPAttIdx];
+        }
 
-		MTLRenderPassStencilAttachmentDescriptor* mtlStencilAttDesc = mtlRPDesc.stencilAttachment;
-		bool hasStencilResolve = (stencilRslvRPAttIdx != VK_ATTACHMENT_UNUSED && _stencilResolveMode != VK_RESOLVE_MODE_NONE);
-		if (hasStencilResolve) {
-			stencilRslvImage->populateMTLRenderPassAttachmentDescriptorResolve(mtlStencilAttDesc);
+        MTLRenderPassStencilAttachmentDescriptor* mtlStencilAttDesc =
+            mtlRPDesc.stencilAttachment;
+        bool hasStencilResolve = (stencilRslvRPAttIdx != VK_ATTACHMENT_UNUSED &&
+                                  _stencilResolveMode != VK_RESOLVE_MODE_NONE);
+        if (hasStencilResolve) {
+            stencilRslvImage->populateMTLRenderPassAttachmentDescriptorResolve(
+                mtlStencilAttDesc);
 #if MVK_MACOS_OR_IOS
-			mtlStencilAttDesc.stencilResolveFilterMVK = mvkMTLMultisampleStencilResolveFilterFromVkResolveModeFlagBits(_stencilResolveMode);
+            mtlStencilAttDesc.stencilResolveFilterMVK =
+                mvkMTLMultisampleStencilResolveFilterFromVkResolveModeFlagBits(
+                    _stencilResolveMode);
 #endif
-			if (isMultiview()) {
-				mtlStencilAttDesc.resolveSlice += getFirstViewIndexInMetalPass(passIdx);
-			}
-		}
-		if (stencilMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(mtlStencilAttDesc, this, stencilImage,
-																	   isRenderingEntireAttachment,
-																	   hasStencilResolve, true,
-																	   true, loadOverride)) {
-			mtlStencilAttDesc.clearStencil = pixFmts->getMTLClearStencilValue(clearValues[stencilRPAttIdx]);
-		}
-		if (isMultiview()) {
-			mtlStencilAttDesc.slice += getFirstViewIndexInMetalPass(passIdx);
-		}
-	}
+            if (isMultiview()) {
+                mtlStencilAttDesc.resolveSlice +=
+                    getFirstViewIndexInMetalPass(passIdx);
+            }
+        }
+        if (stencilMVKRPAtt->populateMTLRenderPassAttachmentDescriptor(
+                mtlStencilAttDesc, this, stencilImage,
+                isRenderingEntireAttachment, hasStencilResolve, true, true,
+                loadOverride)) {
+            mtlStencilAttDesc.clearStencil =
+                pixFmts->getMTLClearStencilValue(clearValues[stencilRPAttIdx]);
+        }
+        if (isMultiview()) {
+            mtlStencilAttDesc.slice += getFirstViewIndexInMetalPass(passIdx);
+        }
+    }
 
-	// Vulkan supports rendering without attachments, but older Metal does not.
-	// If Metal does not support rendering without attachments, create a dummy attachment to pass Metal validation.
-	if (caUsedCnt == 0 && depthRPAttIdx == VK_ATTACHMENT_UNUSED && stencilRPAttIdx == VK_ATTACHMENT_UNUSED) {
+    // Vulkan supports rendering without attachments, but older Metal does not.
+    // If Metal does not support rendering without attachments, create a dummy
+    // attachment to pass Metal validation.
+    if (caUsedCnt == 0 && depthRPAttIdx == VK_ATTACHMENT_UNUSED &&
+        stencilRPAttIdx == VK_ATTACHMENT_UNUSED) {
         if (_renderPass->getMetalFeatures().renderWithoutAttachments) {
-            mtlRPDesc.defaultRasterSampleCount = mvkSampleCountFromVkSampleCountFlagBits(_defaultSampleCount);
-		} else {
-			MTLRenderPassColorAttachmentDescriptor* mtlColorAttDesc = mtlRPDesc.colorAttachments[0];
-			mtlColorAttDesc.texture = framebuffer->getDummyAttachmentMTLTexture(this, passIdx);
-			mtlColorAttDesc.level = 0;
-			mtlColorAttDesc.slice = 0;
-			mtlColorAttDesc.depthPlane = 0;
-			mtlColorAttDesc.loadAction = MTLLoadActionDontCare;
-			mtlColorAttDesc.storeAction = MTLStoreActionDontCare;
-		}
-	}
+            mtlRPDesc.defaultRasterSampleCount =
+                mvkSampleCountFromVkSampleCountFlagBits(_defaultSampleCount);
+        } else {
+            MTLRenderPassColorAttachmentDescriptor* mtlColorAttDesc =
+                mtlRPDesc.colorAttachments[0];
+            mtlColorAttDesc.texture =
+                framebuffer->getDummyAttachmentMTLTexture(this, passIdx);
+            mtlColorAttDesc.level = 0;
+            mtlColorAttDesc.slice = 0;
+            mtlColorAttDesc.depthPlane = 0;
+            mtlColorAttDesc.loadAction = MTLLoadActionDontCare;
+            mtlColorAttDesc.storeAction = MTLStoreActionDontCare;
+        }
+    }
 }
 
-void MVKRenderSubpass::encodeStoreActions(MVKCommandEncoder* cmdEncoder,
-                                          bool isRenderingEntireAttachment,
-                                          MVKArrayRef<MVKImageView*const> attachments,
-                                          bool storeOverride) {
-    if (!cmdEncoder->_mtlRenderEncoder) { return; }
-	if (!_renderPass->getMetalFeatures().deferredStoreActions) { return; }
+void MVKRenderSubpass::encodeStoreActions(
+    MVKCommandEncoder* cmdEncoder, bool isRenderingEntireAttachment,
+    MVKArrayRef<MVKImageView* const> attachments, bool storeOverride) {
+    if (!cmdEncoder->_mtlRenderEncoder) {
+        return;
+    }
+    if (!_renderPass->getMetalFeatures().deferredStoreActions) {
+        return;
+    }
 
-	MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+    MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
     uint32_t caCnt = getColorAttachmentCount();
     for (uint32_t caIdx = 0; caIdx < caCnt; ++caIdx) {
         uint32_t clrRPAttIdx = _colorAttachments[caIdx].attachment;
         if (clrRPAttIdx != VK_ATTACHMENT_UNUSED) {
-			uint32_t rslvRPAttIdx = _resolveAttachments.empty() ? VK_ATTACHMENT_UNUSED : _resolveAttachments[caIdx].attachment;
-			bool hasResolveAttachment = (rslvRPAttIdx != VK_ATTACHMENT_UNUSED);
-			bool canResolveFormat = hasResolveAttachment && mvkAreAllFlagsEnabled(pixFmts->getCapabilities(attachments[rslvRPAttIdx]->getMTLPixelFormat()), kMVKMTLFmtCapsResolve);
-			_renderPass->_attachments[clrRPAttIdx].encodeStoreAction(cmdEncoder, this, attachments[clrRPAttIdx], isRenderingEntireAttachment, hasResolveAttachment, canResolveFormat, caIdx, false, storeOverride);
+            uint32_t rslvRPAttIdx = _resolveAttachments.empty()
+                                        ? VK_ATTACHMENT_UNUSED
+                                        : _resolveAttachments[caIdx].attachment;
+            bool hasResolveAttachment = (rslvRPAttIdx != VK_ATTACHMENT_UNUSED);
+            bool canResolveFormat =
+                hasResolveAttachment &&
+                mvkAreAllFlagsEnabled(pixFmts->getCapabilities(
+                                          attachments[rslvRPAttIdx]
+                                              ->getMTLPixelFormat()),
+                                      kMVKMTLFmtCapsResolve);
+            _renderPass->_attachments[clrRPAttIdx]
+                .encodeStoreAction(cmdEncoder, this, attachments[clrRPAttIdx],
+                                   isRenderingEntireAttachment,
+                                   hasResolveAttachment, canResolveFormat,
+                                   caIdx, false, storeOverride);
         }
     }
-	if (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
-		_renderPass->_attachments[_depthAttachment.attachment].encodeStoreAction(cmdEncoder, this, attachments[_depthAttachment.attachment], isRenderingEntireAttachment,
-																				 (_depthResolveAttachment.attachment != VK_ATTACHMENT_UNUSED && _depthResolveMode != VK_RESOLVE_MODE_NONE),
-																				 true, 0, false, storeOverride);
-	}
-	if (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED) {
-		_renderPass->_attachments[_stencilAttachment.attachment].encodeStoreAction(cmdEncoder, this, attachments[_stencilAttachment.attachment], isRenderingEntireAttachment,
-																				   (_stencilResolveAttachment.attachment != VK_ATTACHMENT_UNUSED && _stencilResolveMode != VK_RESOLVE_MODE_NONE),
-																				   true, 0, true, storeOverride);
-	}
+    if (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+        _renderPass->_attachments[_depthAttachment.attachment]
+            .encodeStoreAction(cmdEncoder, this,
+                               attachments[_depthAttachment.attachment],
+                               isRenderingEntireAttachment,
+                               (_depthResolveAttachment.attachment !=
+                                    VK_ATTACHMENT_UNUSED &&
+                                _depthResolveMode != VK_RESOLVE_MODE_NONE),
+                               true, 0, false, storeOverride);
+    }
+    if (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+        _renderPass->_attachments[_stencilAttachment.attachment]
+            .encodeStoreAction(cmdEncoder, this,
+                               attachments[_stencilAttachment.attachment],
+                               isRenderingEntireAttachment,
+                               (_stencilResolveAttachment.attachment !=
+                                    VK_ATTACHMENT_UNUSED &&
+                                _stencilResolveMode != VK_RESOLVE_MODE_NONE),
+                               true, 0, true, storeOverride);
+    }
 }
 
-void MVKRenderSubpass::populateClearAttachments(MVKClearAttachments& clearAtts,
-												MVKArrayRef<const VkClearValue> clearValues) {
-	uint32_t caCnt = getColorAttachmentCount();
-	for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
-		uint32_t attIdx = _colorAttachments[caIdx].attachment;
-		if ((attIdx != VK_ATTACHMENT_UNUSED) && _renderPass->_attachments[attIdx].shouldClearAttachment(this, false)) {
-			clearAtts.push_back( { VK_IMAGE_ASPECT_COLOR_BIT, caIdx, clearValues[attIdx] } );
-		}
-	}
+void MVKRenderSubpass::populateClearAttachments(
+    MVKClearAttachments& clearAtts,
+    MVKArrayRef<const VkClearValue> clearValues) {
+    uint32_t caCnt = getColorAttachmentCount();
+    for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
+        uint32_t attIdx = _colorAttachments[caIdx].attachment;
+        if ((attIdx != VK_ATTACHMENT_UNUSED) &&
+            _renderPass->_attachments[attIdx].shouldClearAttachment(this,
+                                                                    false)) {
+            clearAtts.push_back(
+                {VK_IMAGE_ASPECT_COLOR_BIT, caIdx, clearValues[attIdx]});
+        }
+    }
 
-	// If depth and stencil both need clearing and are the same attachment, just clear once, otherwise, clear them separately.
-	bool shouldClearDepth = (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED &&
-							 _renderPass->_attachments[_depthAttachment.attachment].shouldClearAttachment(this, false));
-	bool shouldClearStencil = (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED &&
-							   _renderPass->_attachments[_stencilAttachment.attachment].shouldClearAttachment(this, true));
+    // If depth and stencil both need clearing and are the same attachment, just
+    // clear once, otherwise, clear them separately.
+    bool shouldClearDepth =
+        (_depthAttachment.attachment != VK_ATTACHMENT_UNUSED &&
+         _renderPass->_attachments[_depthAttachment.attachment]
+             .shouldClearAttachment(this, false));
+    bool shouldClearStencil =
+        (_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED &&
+         _renderPass->_attachments[_stencilAttachment.attachment]
+             .shouldClearAttachment(this, true));
 
-	if (shouldClearDepth && shouldClearStencil && _depthAttachment.attachment == _stencilAttachment.attachment) {
-		clearAtts.push_back( { VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, clearValues[_depthAttachment.attachment] } );
-	} else {
-		if (shouldClearDepth) {
-			clearAtts.push_back( { VK_IMAGE_ASPECT_DEPTH_BIT, 0, clearValues[_depthAttachment.attachment] } );
-		}
-		if (shouldClearStencil) {
-			clearAtts.push_back( { VK_IMAGE_ASPECT_STENCIL_BIT, 0, clearValues[_stencilAttachment.attachment] } );
-		}
-	}
+    if (shouldClearDepth && shouldClearStencil &&
+        _depthAttachment.attachment == _stencilAttachment.attachment) {
+        clearAtts.push_back(
+            {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0,
+             clearValues[_depthAttachment.attachment]});
+    } else {
+        if (shouldClearDepth) {
+            clearAtts.push_back({VK_IMAGE_ASPECT_DEPTH_BIT, 0,
+                                 clearValues[_depthAttachment.attachment]});
+        }
+        if (shouldClearStencil) {
+            clearAtts.push_back({VK_IMAGE_ASPECT_STENCIL_BIT, 0,
+                                 clearValues[_stencilAttachment.attachment]});
+        }
+    }
 }
 
-void MVKRenderSubpass::populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects,
-												   MVKCommandEncoder* cmdEncoder,
-												   uint32_t caIdx, VkImageAspectFlags aspectMask) {
-	if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_COLOR_BIT)) {
-		uint32_t clrAttIdx = _colorAttachments[caIdx].attachment;
-		if (clrAttIdx != VK_ATTACHMENT_UNUSED) {
-			_renderPass->_attachments[clrAttIdx].populateMultiviewClearRects(clearRects, cmdEncoder);
-		}
-	}
+void MVKRenderSubpass::populateMultiviewClearRects(
+    MVKSmallVector<VkClearRect, 1>& clearRects, MVKCommandEncoder* cmdEncoder,
+    uint32_t caIdx, VkImageAspectFlags aspectMask) {
+    if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_COLOR_BIT)) {
+        uint32_t clrAttIdx = _colorAttachments[caIdx].attachment;
+        if (clrAttIdx != VK_ATTACHMENT_UNUSED) {
+            _renderPass->_attachments[clrAttIdx]
+                .populateMultiviewClearRects(clearRects, cmdEncoder);
+        }
+    }
 
-	// If depth and stencil are the same attachment, only clear once.
-	if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_DEPTH_BIT) &&
-		_depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+    // If depth and stencil are the same attachment, only clear once.
+    if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_DEPTH_BIT) &&
+        _depthAttachment.attachment != VK_ATTACHMENT_UNUSED) {
 
-		_renderPass->_attachments[_depthAttachment.attachment].populateMultiviewClearRects(clearRects, cmdEncoder);
-	}
-	if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT) &&
-		_stencilAttachment.attachment != VK_ATTACHMENT_UNUSED &&
-		_stencilAttachment.attachment != _depthAttachment.attachment) {
+        _renderPass->_attachments[_depthAttachment.attachment]
+            .populateMultiviewClearRects(clearRects, cmdEncoder);
+    }
+    if (mvkIsAnyFlagEnabled(aspectMask, VK_IMAGE_ASPECT_STENCIL_BIT) &&
+        _stencilAttachment.attachment != VK_ATTACHMENT_UNUSED &&
+        _stencilAttachment.attachment != _depthAttachment.attachment) {
 
-		_renderPass->_attachments[_stencilAttachment.attachment].populateMultiviewClearRects(clearRects, cmdEncoder);
-	}
+        _renderPass->_attachments[_stencilAttachment.attachment]
+            .populateMultiviewClearRects(clearRects, cmdEncoder);
+    }
 }
 
 // Returns the format capabilities required by this render subpass.
-// It is possible for a subpass to use a single framebuffer attachment for multiple purposes.
-// For example, a subpass may use a color or depth attachment as an input attachment as well.
-// So, accumulate the capabilities from all possible attachments, just to be safe.
-MVKMTLFmtCaps MVKRenderSubpass::getRequiredFormatCapabilitiesForAttachmentAt(uint32_t rpAttIdx) {
-	MVKMTLFmtCaps caps = kMVKMTLFmtCapsNone;
+// It is possible for a subpass to use a single framebuffer attachment for
+// multiple purposes. For example, a subpass may use a color or depth attachment
+// as an input attachment as well. So, accumulate the capabilities from all
+// possible attachments, just to be safe.
+MVKMTLFmtCaps MVKRenderSubpass::getRequiredFormatCapabilitiesForAttachmentAt(
+    uint32_t rpAttIdx) {
+    MVKMTLFmtCaps caps = kMVKMTLFmtCapsNone;
 
-	for (auto& att : _inputAttachments) {
-		if (att.attachment == rpAttIdx) {
-			mvkEnableFlags(caps, kMVKMTLFmtCapsRead);
-			break;
-		}
-	}
-	for (auto& att : _colorAttachments) {
-		if (att.attachment == rpAttIdx) {
-			mvkEnableFlags(caps, kMVKMTLFmtCapsColorAtt);
-			break;
-		}
-	}
-	for (auto& att : _resolveAttachments) {
-		if (att.attachment == rpAttIdx) {
-			mvkEnableFlags(caps, kMVKMTLFmtCapsResolve);
-			break;
-		}
-	}
-	if (_depthAttachment.attachment == rpAttIdx || _stencilAttachment.attachment == rpAttIdx) {
-		mvkEnableFlags(caps, kMVKMTLFmtCapsDSAtt);
-	}
-	if (_depthResolveAttachment.attachment == rpAttIdx || _stencilResolveAttachment.attachment == rpAttIdx) {
-		mvkEnableFlags(caps, kMVKMTLFmtCapsResolve);
-	}
+    for (auto& att : _inputAttachments) {
+        if (att.attachment == rpAttIdx) {
+            mvkEnableFlags(caps, kMVKMTLFmtCapsRead);
+            break;
+        }
+    }
+    for (auto& att : _colorAttachments) {
+        if (att.attachment == rpAttIdx) {
+            mvkEnableFlags(caps, kMVKMTLFmtCapsColorAtt);
+            break;
+        }
+    }
+    for (auto& att : _resolveAttachments) {
+        if (att.attachment == rpAttIdx) {
+            mvkEnableFlags(caps, kMVKMTLFmtCapsResolve);
+            break;
+        }
+    }
+    if (_depthAttachment.attachment == rpAttIdx ||
+        _stencilAttachment.attachment == rpAttIdx) {
+        mvkEnableFlags(caps, kMVKMTLFmtCapsDSAtt);
+    }
+    if (_depthResolveAttachment.attachment == rpAttIdx ||
+        _stencilResolveAttachment.attachment == rpAttIdx) {
+        mvkEnableFlags(caps, kMVKMTLFmtCapsResolve);
+    }
 
-	return caps;
+    return caps;
 }
 
-void MVKRenderSubpass::resolveUnresolvableAttachments(MVKCommandEncoder* cmdEncoder, MVKArrayRef<MVKImageView*const> attachments) {
-	MVKPixelFormats* pixFmts = cmdEncoder->getPixelFormats();
-	size_t raCnt = _resolveAttachments.size();
-	for (uint32_t raIdx = 0; raIdx < raCnt; raIdx++) {
-		auto& ra = _resolveAttachments[raIdx];
-		auto& ca = _colorAttachments[raIdx];
-		if (ra.attachment != VK_ATTACHMENT_UNUSED && ca.attachment != VK_ATTACHMENT_UNUSED) {
-			MVKImageView* raImgView = attachments[ra.attachment];
-			MVKImageView* caImgView = attachments[ca.attachment];
+void MVKRenderSubpass::resolveUnresolvableAttachments(
+    MVKCommandEncoder* cmdEncoder,
+    MVKArrayRef<MVKImageView* const> attachments) {
+    MVKPixelFormats* pixFmts = cmdEncoder->getPixelFormats();
+    size_t raCnt = _resolveAttachments.size();
+    for (uint32_t raIdx = 0; raIdx < raCnt; raIdx++) {
+        auto& ra = _resolveAttachments[raIdx];
+        auto& ca = _colorAttachments[raIdx];
+        if (ra.attachment != VK_ATTACHMENT_UNUSED &&
+            ca.attachment != VK_ATTACHMENT_UNUSED) {
+            MVKImageView* raImgView = attachments[ra.attachment];
+            MVKImageView* caImgView = attachments[ca.attachment];
 
-			if ( !mvkAreAllFlagsEnabled(pixFmts->getCapabilities(raImgView->getMTLPixelFormat()), kMVKMTLFmtCapsResolve) ) {
-				MVKFormatType mvkFmtType = _renderPass->getPixelFormats()->getFormatType(raImgView->getMTLPixelFormat());
-				const bool isTextureArray = raImgView->getImage()->getLayerCount() != 1u;
-				id<MTLComputePipelineState> mtlRslvState = cmdEncoder->getCommandEncodingPool()->getCmdResolveColorImageMTLComputePipelineState(mvkFmtType, isTextureArray);
-				id<MTLComputeCommandEncoder> mtlComputeEnc = cmdEncoder->getMTLComputeEncoder(kMVKCommandUseResolveImage);
-				[mtlComputeEnc setComputePipelineState: mtlRslvState];
-				[mtlComputeEnc setTexture: raImgView->getMTLTexture() atIndex: 0];
-				[mtlComputeEnc setTexture: caImgView->getMTLTexture() atIndex: 1];
-				MTLSize gridSize = mvkMTLSizeFromVkExtent3D(raImgView->getExtent3D());
-				MTLSize tgSize = MTLSizeMake(mtlRslvState.threadExecutionWidth, 1, 1);
-				if (cmdEncoder->getMetalFeatures().nonUniformThreadgroups) {
-					[mtlComputeEnc dispatchThreads: gridSize threadsPerThreadgroup: tgSize];
-				} else {
-					MTLSize tgCount = MTLSizeMake(gridSize.width / tgSize.width, gridSize.height, gridSize.depth);
-					if (gridSize.width % tgSize.width) { tgCount.width += 1; }
-					[mtlComputeEnc dispatchThreadgroups: tgCount threadsPerThreadgroup: tgSize];
-				}
-			}
-		}
-	}
+            if (!mvkAreAllFlagsEnabled(pixFmts->getCapabilities(
+                                           raImgView->getMTLPixelFormat()),
+                                       kMVKMTLFmtCapsResolve)) {
+                MVKFormatType mvkFmtType =
+                    _renderPass->getPixelFormats()->getFormatType(
+                        raImgView->getMTLPixelFormat());
+                const bool isTextureArray =
+                    raImgView->getImage()->getLayerCount() != 1u;
+                id<MTLComputePipelineState> mtlRslvState =
+                    cmdEncoder->getCommandEncodingPool()
+                        ->getCmdResolveColorImageMTLComputePipelineState(
+                            mvkFmtType, isTextureArray);
+                id<MTLComputeCommandEncoder> mtlComputeEnc =
+                    cmdEncoder->getMTLComputeEncoder(
+                        kMVKCommandUseResolveImage);
+                [mtlComputeEnc setComputePipelineState:mtlRslvState];
+                [mtlComputeEnc setTexture:raImgView->getMTLTexture() atIndex:0];
+                [mtlComputeEnc setTexture:caImgView->getMTLTexture() atIndex:1];
+                MTLSize gridSize =
+                    mvkMTLSizeFromVkExtent3D(raImgView->getExtent3D());
+                MTLSize tgSize =
+                    MTLSizeMake(mtlRslvState.threadExecutionWidth, 1, 1);
+                if (cmdEncoder->getMetalFeatures().nonUniformThreadgroups) {
+                    [mtlComputeEnc dispatchThreads:gridSize
+                             threadsPerThreadgroup:tgSize];
+                } else {
+                    MTLSize tgCount =
+                        MTLSizeMake(gridSize.width / tgSize.width,
+                                    gridSize.height, gridSize.depth);
+                    if (gridSize.width % tgSize.width) {
+                        tgCount.width += 1;
+                    }
+                    [mtlComputeEnc dispatchThreadgroups:tgCount
+                                  threadsPerThreadgroup:tgSize];
+                }
+            }
+        }
+    }
 }
 
 void MVKRenderSubpass::populatePipelineRenderingCreateInfo() {
-	_pipelineRenderingCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
-	_pipelineRenderingCreateInfo.pNext = nullptr;
+    _pipelineRenderingCreateInfo.sType =
+        VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
+    _pipelineRenderingCreateInfo.pNext = nullptr;
 
-	uint32_t caCnt = getColorAttachmentCount();
-	for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
-		_colorAttachmentFormats.push_back(getColorAttachmentFormat(caIdx));
-	}
-	_pipelineRenderingCreateInfo.colorAttachmentCount = caCnt;
-	_pipelineRenderingCreateInfo.pColorAttachmentFormats = _colorAttachmentFormats.data();
-	_pipelineRenderingCreateInfo.depthAttachmentFormat = getDepthFormat();
-	_pipelineRenderingCreateInfo.stencilAttachmentFormat = getStencilFormat();
+    uint32_t caCnt = getColorAttachmentCount();
+    for (uint32_t caIdx = 0; caIdx < caCnt; caIdx++) {
+        _colorAttachmentFormats.push_back(getColorAttachmentFormat(caIdx));
+    }
+    _pipelineRenderingCreateInfo.colorAttachmentCount = caCnt;
+    _pipelineRenderingCreateInfo.pColorAttachmentFormats =
+        _colorAttachmentFormats.data();
+    _pipelineRenderingCreateInfo.depthAttachmentFormat = getDepthFormat();
+    _pipelineRenderingCreateInfo.stencilAttachmentFormat = getStencilFormat();
 
-	// Needed to understand if we need to force the depth/stencil write to post fragment execution
-	// since Metal may try to do the write pre fragment exeuction which is against Vulkan
-	bool depthAttachmentUsed = isDepthAttachmentUsed();
-	bool stencilAttachmentUsed = isStencilAttachmentUsed();
-	for (uint32_t i = 0u; i < _inputAttachments.size(); ++i) {
-		bool isDepthInput = depthAttachmentUsed && (_inputAttachments[i].attachment == _depthAttachment.attachment) &&
-							  (_inputAttachments[i].aspectMask & _depthAttachment.aspectMask);
-		bool isStencilInput = stencilAttachmentUsed && (_inputAttachments[i].attachment == _stencilAttachment.attachment) &&
-							  (_inputAttachments[i].aspectMask & _stencilAttachment.aspectMask);
-		if (isDepthInput || isStencilInput) {
-			_isInputAttachmentDepthStencilAttachment = true;
-			break;
-		}
-	}
+    // Needed to understand if we need to force the depth/stencil write to post
+    // fragment execution since Metal may try to do the write pre fragment
+    // exeuction which is against Vulkan
+    bool depthAttachmentUsed = isDepthAttachmentUsed();
+    bool stencilAttachmentUsed = isStencilAttachmentUsed();
+    for (uint32_t i = 0u; i < _inputAttachments.size(); ++i) {
+        bool isDepthInput =
+            depthAttachmentUsed &&
+            (_inputAttachments[i].attachment == _depthAttachment.attachment) &&
+            (_inputAttachments[i].aspectMask & _depthAttachment.aspectMask);
+        bool isStencilInput =
+            stencilAttachmentUsed &&
+            (_inputAttachments[i].attachment ==
+             _stencilAttachment.attachment) &&
+            (_inputAttachments[i].aspectMask & _stencilAttachment.aspectMask);
+        if (isDepthInput || isStencilInput) {
+            _isInputAttachmentDepthStencilAttachment = true;
+            break;
+        }
+    }
 }
 
-static const VkAttachmentReference2 _unusedAttachment = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_UNDEFINED, 0};
+static const VkAttachmentReference2 _unusedAttachment =
+    {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, VK_ATTACHMENT_UNUSED,
+     VK_IMAGE_LAYOUT_UNDEFINED, 0};
 
-MVKRenderSubpass::MVKRenderSubpass(MVKRenderPass* renderPass, const VkSubpassDescription2* pCreateInfo) {
+MVKRenderSubpass::MVKRenderSubpass(MVKRenderPass* renderPass,
+                                   const VkSubpassDescription2* pCreateInfo) {
 
-	VkSubpassDescriptionDepthStencilResolve* pDSResolveInfo = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
-				pDSResolveInfo = (VkSubpassDescriptionDepthStencilResolve*)next;
-				break;
-			default:
-				break;
-		}
-	}
+    VkSubpassDescriptionDepthStencilResolve* pDSResolveInfo = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
+            pDSResolveInfo = (VkSubpassDescriptionDepthStencilResolve*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	_renderPass = renderPass;
-	_subpassIndex = (uint32_t)_renderPass->_subpasses.size();
-	_pipelineRenderingCreateInfo.viewMask = pCreateInfo->viewMask;
+    _renderPass = renderPass;
+    _subpassIndex = (uint32_t)_renderPass->_subpasses.size();
+    _pipelineRenderingCreateInfo.viewMask = pCreateInfo->viewMask;
 
-	// Add attachments
-	_inputAttachments.reserve(pCreateInfo->inputAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->inputAttachmentCount; i++) {
-		_inputAttachments.push_back(pCreateInfo->pInputAttachments[i]);
-	}
+    // Add attachments
+    _inputAttachments.reserve(pCreateInfo->inputAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->inputAttachmentCount; i++) {
+        _inputAttachments.push_back(pCreateInfo->pInputAttachments[i]);
+    }
 
-	_colorAttachments.reserve(pCreateInfo->colorAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
-		_colorAttachments.push_back(pCreateInfo->pColorAttachments[i]);
-	}
+    _colorAttachments.reserve(pCreateInfo->colorAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
+        _colorAttachments.push_back(pCreateInfo->pColorAttachments[i]);
+    }
 
-	if (pCreateInfo->pResolveAttachments) {
-		_resolveAttachments.reserve(pCreateInfo->colorAttachmentCount);
-		for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
-			_resolveAttachments.push_back(pCreateInfo->pResolveAttachments[i]);
-		}
-	}
+    if (pCreateInfo->pResolveAttachments) {
+        _resolveAttachments.reserve(pCreateInfo->colorAttachmentCount);
+        for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
+            _resolveAttachments.push_back(pCreateInfo->pResolveAttachments[i]);
+        }
+    }
 
-	MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+    MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
 
-	_depthAttachment = _unusedAttachment;
-	_stencilAttachment = _unusedAttachment;
-	const auto* pDSAtt = pCreateInfo->pDepthStencilAttachment;
-	if (pDSAtt && pDSAtt->attachment != VK_ATTACHMENT_UNUSED) {
-		MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(_renderPass->_attachments[pDSAtt->attachment].getFormat());
-		if (pixFmts->isDepthFormat(mtlDSFormat)) {
-			_depthAttachment = *pCreateInfo->pDepthStencilAttachment;
-		}
-		if (pixFmts->isStencilFormat(mtlDSFormat)) {
-			_stencilAttachment = *pCreateInfo->pDepthStencilAttachment;
-		}
-	}
+    _depthAttachment = _unusedAttachment;
+    _stencilAttachment = _unusedAttachment;
+    const auto* pDSAtt = pCreateInfo->pDepthStencilAttachment;
+    if (pDSAtt && pDSAtt->attachment != VK_ATTACHMENT_UNUSED) {
+        MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(
+            _renderPass->_attachments[pDSAtt->attachment].getFormat());
+        if (pixFmts->isDepthFormat(mtlDSFormat)) {
+            _depthAttachment = *pCreateInfo->pDepthStencilAttachment;
+        }
+        if (pixFmts->isStencilFormat(mtlDSFormat)) {
+            _stencilAttachment = *pCreateInfo->pDepthStencilAttachment;
+        }
+    }
 
-	_depthResolveAttachment = _unusedAttachment;
-	_stencilResolveAttachment = _unusedAttachment;
-	const auto* pDSRslvAtt = pDSResolveInfo ? pDSResolveInfo->pDepthStencilResolveAttachment : nullptr;
-	if (pDSRslvAtt && pDSRslvAtt->attachment != VK_ATTACHMENT_UNUSED) {
-		MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(_renderPass->_attachments[pDSRslvAtt->attachment].getFormat());
-		if (pixFmts->isDepthFormat(mtlDSFormat)) {
-			_depthResolveAttachment = *pDSResolveInfo->pDepthStencilResolveAttachment;
-			_depthResolveMode = pDSResolveInfo->depthResolveMode;
-		}
-		if (pixFmts->isStencilFormat(mtlDSFormat)) {
-			_stencilResolveAttachment = *pDSResolveInfo->pDepthStencilResolveAttachment;
-			_stencilResolveMode = pDSResolveInfo->stencilResolveMode;
-		}
-	}
+    _depthResolveAttachment = _unusedAttachment;
+    _stencilResolveAttachment = _unusedAttachment;
+    const auto* pDSRslvAtt =
+        pDSResolveInfo ? pDSResolveInfo->pDepthStencilResolveAttachment
+                       : nullptr;
+    if (pDSRslvAtt && pDSRslvAtt->attachment != VK_ATTACHMENT_UNUSED) {
+        MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(
+            _renderPass->_attachments[pDSRslvAtt->attachment].getFormat());
+        if (pixFmts->isDepthFormat(mtlDSFormat)) {
+            _depthResolveAttachment =
+                *pDSResolveInfo->pDepthStencilResolveAttachment;
+            _depthResolveMode = pDSResolveInfo->depthResolveMode;
+        }
+        if (pixFmts->isStencilFormat(mtlDSFormat)) {
+            _stencilResolveAttachment =
+                *pDSResolveInfo->pDepthStencilResolveAttachment;
+            _stencilResolveMode = pDSResolveInfo->stencilResolveMode;
+        }
+    }
 
-	_preserveAttachments.reserve(pCreateInfo->preserveAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->preserveAttachmentCount; i++) {
-		_preserveAttachments.push_back(pCreateInfo->pPreserveAttachments[i]);
-	}
+    _preserveAttachments.reserve(pCreateInfo->preserveAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->preserveAttachmentCount; i++) {
+        _preserveAttachments.push_back(pCreateInfo->pPreserveAttachments[i]);
+    }
 
-	populatePipelineRenderingCreateInfo();
+    populatePipelineRenderingCreateInfo();
+}
+
+MVKRenderSubpass::MVKRenderSubpass(
+    MVKRenderPass* renderPass, const VkSubpassDescription* pCreateInfo,
+    const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspects,
+    uint32_t viewMask) {
+    _renderPass = renderPass;
+    _subpassIndex = (uint32_t)_renderPass->_subpasses.size();
+    _pipelineRenderingCreateInfo.viewMask = viewMask;
+
+    // Add attachments
+    _inputAttachments.reserve(pCreateInfo->inputAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->inputAttachmentCount; i++) {
+        const VkAttachmentReference& att = pCreateInfo->pInputAttachments[i];
+        _inputAttachments.push_back({VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2,
+                                     nullptr, att.attachment, att.layout,
+                                     VK_IMAGE_ASPECT_COLOR_BIT |
+                                         VK_IMAGE_ASPECT_DEPTH_BIT |
+                                         VK_IMAGE_ASPECT_STENCIL_BIT});
+    }
+    if (pInputAspects && pInputAspects->aspectReferenceCount) {
+        for (uint32_t i = 0; i < pInputAspects->aspectReferenceCount; i++) {
+            const VkInputAttachmentAspectReference& aspectRef =
+                pInputAspects->pAspectReferences[i];
+            if (aspectRef.subpass == _subpassIndex) {
+                _inputAttachments[aspectRef.inputAttachmentIndex].aspectMask =
+                    aspectRef.aspectMask;
+            }
+        }
+    }
+
+    _colorAttachments.reserve(pCreateInfo->colorAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
+        const VkAttachmentReference& att = pCreateInfo->pColorAttachments[i];
+        _colorAttachments.push_back({VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2,
+                                     nullptr, att.attachment, att.layout,
+                                     VK_IMAGE_ASPECT_COLOR_BIT});
+    }
+
+    if (pCreateInfo->pResolveAttachments) {
+        _resolveAttachments.reserve(pCreateInfo->colorAttachmentCount);
+        for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
+            const VkAttachmentReference& att =
+                pCreateInfo->pResolveAttachments[i];
+            _resolveAttachments.push_back(
+                {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr,
+                 att.attachment, att.layout, VK_IMAGE_ASPECT_COLOR_BIT});
+        }
+    }
+
+    _depthAttachment = _unusedAttachment;
+    _stencilAttachment = _unusedAttachment;
+    if (pCreateInfo->pDepthStencilAttachment) {
+        auto* dsAtt = pCreateInfo->pDepthStencilAttachment;
+        uint32_t dsAttIdx = dsAtt->attachment;
+        if (dsAttIdx != VK_ATTACHMENT_UNUSED) {
+            MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+            MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(
+                _renderPass->_attachments[dsAttIdx].getFormat());
+            if (pixFmts->isDepthFormat(mtlDSFormat)) {
+                _depthAttachment = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2,
+                                    nullptr, dsAtt->attachment, dsAtt->layout,
+                                    VK_IMAGE_ASPECT_DEPTH_BIT};
+            }
+            if (pixFmts->isStencilFormat(mtlDSFormat)) {
+                _stencilAttachment = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2,
+                                      nullptr, dsAtt->attachment, dsAtt->layout,
+                                      VK_IMAGE_ASPECT_STENCIL_BIT};
+            }
+        }
+    }
+
+    _depthResolveAttachment = _unusedAttachment;
+    _stencilResolveAttachment = _unusedAttachment;
+
+    _preserveAttachments.reserve(pCreateInfo->preserveAttachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->preserveAttachmentCount; i++) {
+        _preserveAttachments.push_back(pCreateInfo->pPreserveAttachments[i]);
+    }
+
+    populatePipelineRenderingCreateInfo();
 }
 
 MVKRenderSubpass::MVKRenderSubpass(MVKRenderPass* renderPass,
-								   const VkSubpassDescription* pCreateInfo,
-								   const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspects,
-								   uint32_t viewMask) {
-	_renderPass = renderPass;
-	_subpassIndex = (uint32_t)_renderPass->_subpasses.size();
-	_pipelineRenderingCreateInfo.viewMask = viewMask;
+                                   const VkRenderingInfo* pRenderingInfo) {
 
-	// Add attachments
-	_inputAttachments.reserve(pCreateInfo->inputAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->inputAttachmentCount; i++) {
-		const VkAttachmentReference& att = pCreateInfo->pInputAttachments[i];
-		_inputAttachments.push_back({VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, att.attachment, att.layout, VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT});
-	}
-	if (pInputAspects && pInputAspects->aspectReferenceCount) {
-		for (uint32_t i = 0; i < pInputAspects->aspectReferenceCount; i++) {
-			const VkInputAttachmentAspectReference& aspectRef = pInputAspects->pAspectReferences[i];
-			if (aspectRef.subpass == _subpassIndex) {
-				_inputAttachments[aspectRef.inputAttachmentIndex].aspectMask = aspectRef.aspectMask;
-			}
-		}
-	}
+    _renderPass = renderPass;
+    _subpassIndex = (uint32_t)_renderPass->_subpasses.size();
+    _pipelineRenderingCreateInfo.viewMask = pRenderingInfo->viewMask;
 
-	_colorAttachments.reserve(pCreateInfo->colorAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
-		const VkAttachmentReference& att = pCreateInfo->pColorAttachments[i];
-		_colorAttachments.push_back({VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, att.attachment, att.layout, VK_IMAGE_ASPECT_COLOR_BIT});
-	}
+    _depthAttachment = _unusedAttachment;
+    _depthResolveAttachment = _unusedAttachment;
+    _stencilAttachment = _unusedAttachment;
+    _stencilResolveAttachment = _unusedAttachment;
 
-	if (pCreateInfo->pResolveAttachments) {
-		_resolveAttachments.reserve(pCreateInfo->colorAttachmentCount);
-		for (uint32_t i = 0; i < pCreateInfo->colorAttachmentCount; i++) {
-			const VkAttachmentReference& att = pCreateInfo->pResolveAttachments[i];
-			_resolveAttachments.push_back({VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, att.attachment, att.layout, VK_IMAGE_ASPECT_COLOR_BIT});
-		}
-	}
+    uint32_t attIdx = 0;
+    MVKRenderingAttachmentIterator attIter(pRenderingInfo);
+    attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo,
+                        VkImageAspectFlagBits aspect,
+                        bool isResolveAttachment) -> void {
+        VkAttachmentReference2 attRef =
+            {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, attIdx++,
+             pAttInfo->imageLayout, aspect};
+        switch (aspect) {
+        case VK_IMAGE_ASPECT_COLOR_BIT:
+            if (isResolveAttachment) {
+                _resolveAttachments.push_back(attRef);
+            } else {
+                _colorAttachments.push_back(attRef);
+            }
+            break;
 
-	_depthAttachment = _unusedAttachment;
-	_stencilAttachment = _unusedAttachment;
-	if (pCreateInfo->pDepthStencilAttachment) {
-		auto* dsAtt = pCreateInfo->pDepthStencilAttachment;
-		uint32_t dsAttIdx = dsAtt->attachment;
-		if (dsAttIdx != VK_ATTACHMENT_UNUSED) {
-			MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
-			MTLPixelFormat mtlDSFormat = pixFmts->getMTLPixelFormat(_renderPass->_attachments[dsAttIdx].getFormat());
-			if (pixFmts->isDepthFormat(mtlDSFormat)) {
-				_depthAttachment = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, dsAtt->attachment, dsAtt->layout, VK_IMAGE_ASPECT_DEPTH_BIT};
-			}
-			if (pixFmts->isStencilFormat(mtlDSFormat)) {
-				_stencilAttachment = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, dsAtt->attachment, dsAtt->layout, VK_IMAGE_ASPECT_STENCIL_BIT};
-			}
-		}
-	}
+        case VK_IMAGE_ASPECT_DEPTH_BIT:
+            if (isResolveAttachment) {
+                _depthResolveAttachment = attRef;
+                _depthResolveMode = pAttInfo->resolveMode;
+            } else {
+                _depthAttachment = attRef;
+            }
+            break;
+        case VK_IMAGE_ASPECT_STENCIL_BIT:
+            if (isResolveAttachment) {
+                _stencilResolveAttachment = attRef;
+                _stencilResolveMode = pAttInfo->resolveMode;
+            } else {
+                _stencilAttachment = attRef;
+            }
+            break;
 
-	_depthResolveAttachment = _unusedAttachment;
-	_stencilResolveAttachment = _unusedAttachment;
+        default:
+            break;
+        }
+    });
 
-	_preserveAttachments.reserve(pCreateInfo->preserveAttachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->preserveAttachmentCount; i++) {
-		_preserveAttachments.push_back(pCreateInfo->pPreserveAttachments[i]);
-	}
-
-	populatePipelineRenderingCreateInfo();
-
+    populatePipelineRenderingCreateInfo();
 }
-
-MVKRenderSubpass::MVKRenderSubpass(MVKRenderPass* renderPass, const VkRenderingInfo* pRenderingInfo) {
-
-	_renderPass = renderPass;
-	_subpassIndex = (uint32_t)_renderPass->_subpasses.size();
-	_pipelineRenderingCreateInfo.viewMask = pRenderingInfo->viewMask;
-
-	_depthAttachment = _unusedAttachment;
-	_depthResolveAttachment = _unusedAttachment;
-	_stencilAttachment = _unusedAttachment;
-	_stencilResolveAttachment = _unusedAttachment;
-
-	uint32_t attIdx = 0;
-	MVKRenderingAttachmentIterator attIter(pRenderingInfo);
-	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void {
-		VkAttachmentReference2 attRef = {VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, nullptr, attIdx++, pAttInfo->imageLayout, aspect};
-		switch (aspect) {
-			case VK_IMAGE_ASPECT_COLOR_BIT:
-				if (isResolveAttachment) {
-					_resolveAttachments.push_back(attRef);
-				} else {
-					_colorAttachments.push_back(attRef);
-				}
-				break;
-
-			case VK_IMAGE_ASPECT_DEPTH_BIT:
-				if (isResolveAttachment) {
-					_depthResolveAttachment = attRef;
-					_depthResolveMode = pAttInfo->resolveMode;
-				} else {
-					_depthAttachment = attRef;
-				}
-				break;
-			case VK_IMAGE_ASPECT_STENCIL_BIT:
-				if (isResolveAttachment) {
-					_stencilResolveAttachment = attRef;
-					_stencilResolveMode = pAttInfo->resolveMode;
-				} else {
-					_stencilAttachment = attRef;
-				}
-				break;
-
-			default:
-				break;
-		}
-	});
-
-	populatePipelineRenderingCreateInfo();
-}
-
 
 #pragma mark -
 #pragma mark MVKAttachmentDescription
 
-MVKVulkanAPIObject* MVKAttachmentDescription::getVulkanAPIObject() { return _renderPass->getVulkanAPIObject(); };
+MVKVulkanAPIObject* MVKAttachmentDescription::getVulkanAPIObject() {
+    return _renderPass->getVulkanAPIObject();
+};
 
 VkFormat MVKAttachmentDescription::getFormat() { return _info.format; }
 
-VkSampleCountFlagBits MVKAttachmentDescription::getSampleCount() { return _info.samples; }
+VkSampleCountFlagBits MVKAttachmentDescription::getSampleCount() {
+    return _info.samples;
+}
 
-bool MVKAttachmentDescription::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttachmentDescriptor* mtlAttDesc,
-																		 MVKRenderSubpass* subpass,
-																		 MVKImageView* attachment,
-																		 bool isRenderingEntireAttachment,
-																		 bool hasResolveAttachment,
-																		 bool canResolveFormat,
-																		 bool isStencil,
-																		 bool loadOverride) {
-	// Populate from the attachment image view
-	attachment->populateMTLRenderPassAttachmentDescriptor(mtlAttDesc);
+bool MVKAttachmentDescription::populateMTLRenderPassAttachmentDescriptor(
+    MTLRenderPassAttachmentDescriptor* mtlAttDesc, MVKRenderSubpass* subpass,
+    MVKImageView* attachment, bool isRenderingEntireAttachment,
+    bool hasResolveAttachment, bool canResolveFormat, bool isStencil,
+    bool loadOverride) {
+    // Populate from the attachment image view
+    attachment->populateMTLRenderPassAttachmentDescriptor(mtlAttDesc);
 
-	bool isMemorylessAttachment = false;
+    bool isMemorylessAttachment = false;
 #if MVK_APPLE_SILICON
-	isMemorylessAttachment = attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
+    isMemorylessAttachment =
+        attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
 #endif
-	bool isResuming = mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(), VK_RENDERING_RESUMING_BIT);
+    bool isResuming = mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(),
+                                          VK_RENDERING_RESUMING_BIT);
 
-	// Only allow clearing of entire attachment if we're actually
-	// rendering to the entire attachment AND we're in the first subpass.
-	// If the renderpass was suspended, and is now being resumed, load the contents.
-	MTLLoadAction mtlLA;
-	if (loadOverride || isResuming || !isRenderingEntireAttachment || !isFirstUseOfAttachment(subpass)) {
-		mtlLA = MTLLoadActionLoad;
+    // Only allow clearing of entire attachment if we're actually
+    // rendering to the entire attachment AND we're in the first subpass.
+    // If the renderpass was suspended, and is now being resumed, load the
+    // contents.
+    MTLLoadAction mtlLA;
+    if (loadOverride || isResuming || !isRenderingEntireAttachment ||
+        !isFirstUseOfAttachment(subpass)) {
+        mtlLA = MTLLoadActionLoad;
     } else {
-        VkAttachmentLoadOp loadOp = isStencil ? _info.stencilLoadOp : _info.loadOp;
-		mtlLA = mvkMTLLoadActionFromVkAttachmentLoadOp(loadOp);
+        VkAttachmentLoadOp loadOp =
+            isStencil ? _info.stencilLoadOp : _info.loadOp;
+        mtlLA = mvkMTLLoadActionFromVkAttachmentLoadOp(loadOp);
     }
 
-	// Memoryless can be cleared, but can't be loaded, so force load to don't care.
-	if (isMemorylessAttachment && mtlLA == MTLLoadActionLoad) { mtlLA = MTLLoadActionDontCare; }
+    // Memoryless can be cleared, but can't be loaded, so force load to don't
+    // care.
+    if (isMemorylessAttachment && mtlLA == MTLLoadActionLoad) {
+        mtlLA = MTLLoadActionDontCare;
+    }
 
-	mtlAttDesc.loadAction = mtlLA;
+    mtlAttDesc.loadAction = mtlLA;
 
-    // If the device supports late-specified store actions, we'll use those, and then set them later.
-    // That way, if we wind up doing a tessellated draw, we can set the store action to store then,
-    // and then when the render pass actually ends, we can use the true store action.
+    // If the device supports late-specified store actions, we'll use those, and
+    // then set them later. That way, if we wind up doing a tessellated draw, we
+    // can set the store action to store then, and then when the render pass
+    // actually ends, we can use the true store action.
     if (_renderPass->getMetalFeatures().deferredStoreActions) {
         mtlAttDesc.storeAction = MTLStoreActionUnknown;
     } else {
-		// For a combined depth-stencil format in an attachment with VK_IMAGE_ASPECT_STENCIL_BIT,
-		// the attachment format may have been swizzled to a stencil-only format. In this case,
-		// we want to guard against an attempt to store the non-existent depth component.
-		MTLPixelFormat mtlFmt = attachment->getMTLPixelFormat();
-		MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
-		bool isDepthFormat = pixFmts->isDepthFormat(mtlFmt);
-		bool isStencilFormat = pixFmts->isStencilFormat(mtlFmt);
-		if (isStencilFormat && !isStencil && !isDepthFormat) {
-			mtlAttDesc.storeAction = MTLStoreActionDontCare;
-		} else {
-			mtlAttDesc.storeAction = getMTLStoreAction(subpass, isRenderingEntireAttachment, isMemorylessAttachment, hasResolveAttachment, canResolveFormat, isStencil, false);
-		}
+        // For a combined depth-stencil format in an attachment with
+        // VK_IMAGE_ASPECT_STENCIL_BIT, the attachment format may have been
+        // swizzled to a stencil-only format. In this case, we want to guard
+        // against an attempt to store the non-existent depth component.
+        MTLPixelFormat mtlFmt = attachment->getMTLPixelFormat();
+        MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+        bool isDepthFormat = pixFmts->isDepthFormat(mtlFmt);
+        bool isStencilFormat = pixFmts->isStencilFormat(mtlFmt);
+        if (isStencilFormat && !isStencil && !isDepthFormat) {
+            mtlAttDesc.storeAction = MTLStoreActionDontCare;
+        } else {
+            mtlAttDesc.storeAction =
+                getMTLStoreAction(subpass, isRenderingEntireAttachment,
+                                  isMemorylessAttachment, hasResolveAttachment,
+                                  canResolveFormat, isStencil, false);
+        }
     }
     return (mtlLA == MTLLoadActionClear);
 }
 
-void MVKAttachmentDescription::encodeStoreAction(MVKCommandEncoder* cmdEncoder,
-												 MVKRenderSubpass* subpass,
-												 MVKImageView* attachment,
-												 bool isRenderingEntireAttachment,
-												 bool hasResolveAttachment,
-												 bool canResolveFormat,
-												 uint32_t caIdx,
-												 bool isStencil,
-												 bool storeOverride) {
-	// For a combined depth-stencil format in an attachment with VK_IMAGE_ASPECT_STENCIL_BIT,
-	// the attachment format may have been swizzled to a stencil-only format. In this case,
-	// we must avoid either storing, or leaving unknown, the non-existent depth component.
-	// We check for depth swizzling by looking at the original image format as well.
-	MTLPixelFormat mtlFmt = attachment->getMTLPixelFormat();
-	MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
-	bool isStencilFormat = pixFmts->isStencilFormat(mtlFmt);
-	bool isDepthFormat = pixFmts->isDepthFormat(mtlFmt);
-	bool isDepthSwizzled = false;
-	if (isStencilFormat && !isDepthFormat) {
-		isDepthFormat = pixFmts->isDepthFormat(attachment->getImage()->getMTLPixelFormat());
-		isDepthSwizzled = isDepthFormat;
-	}
-	bool isColorFormat = !(isDepthFormat || isStencilFormat);
+void MVKAttachmentDescription::encodeStoreAction(
+    MVKCommandEncoder* cmdEncoder, MVKRenderSubpass* subpass,
+    MVKImageView* attachment, bool isRenderingEntireAttachment,
+    bool hasResolveAttachment, bool canResolveFormat, uint32_t caIdx,
+    bool isStencil, bool storeOverride) {
+    // For a combined depth-stencil format in an attachment with
+    // VK_IMAGE_ASPECT_STENCIL_BIT, the attachment format may have been swizzled
+    // to a stencil-only format. In this case, we must avoid either storing, or
+    // leaving unknown, the non-existent depth component. We check for depth
+    // swizzling by looking at the original image format as well.
+    MTLPixelFormat mtlFmt = attachment->getMTLPixelFormat();
+    MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+    bool isStencilFormat = pixFmts->isStencilFormat(mtlFmt);
+    bool isDepthFormat = pixFmts->isDepthFormat(mtlFmt);
+    bool isDepthSwizzled = false;
+    if (isStencilFormat && !isDepthFormat) {
+        isDepthFormat =
+            pixFmts->isDepthFormat(attachment->getImage()->getMTLPixelFormat());
+        isDepthSwizzled = isDepthFormat;
+    }
+    bool isColorFormat = !(isDepthFormat || isStencilFormat);
 
-	bool isMemorylessAttachment = false;
+    bool isMemorylessAttachment = false;
 #if MVK_APPLE_SILICON
-	isMemorylessAttachment = attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
+    isMemorylessAttachment =
+        attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
 #endif
-	MTLStoreAction storeAction = getMTLStoreAction(subpass, isRenderingEntireAttachment, isMemorylessAttachment,
-												   hasResolveAttachment, canResolveFormat, isStencil, storeOverride);
-	if (isColorFormat) {
-		[cmdEncoder->_mtlRenderEncoder setColorStoreAction: storeAction atIndex: caIdx];
-	} else if (isDepthFormat && !isStencil) {
-		[cmdEncoder->_mtlRenderEncoder setDepthStoreAction: (isDepthSwizzled ? MTLStoreActionDontCare : storeAction)];
-	} else if (isStencilFormat && isStencil) {
-		[cmdEncoder->_mtlRenderEncoder setStencilStoreAction: storeAction];
-	}
+    MTLStoreAction storeAction =
+        getMTLStoreAction(subpass, isRenderingEntireAttachment,
+                          isMemorylessAttachment, hasResolveAttachment,
+                          canResolveFormat, isStencil, storeOverride);
+    if (isColorFormat) {
+        [cmdEncoder->_mtlRenderEncoder setColorStoreAction:storeAction
+                                                   atIndex:caIdx];
+    } else if (isDepthFormat && !isStencil) {
+        [cmdEncoder->_mtlRenderEncoder
+            setDepthStoreAction:(isDepthSwizzled ? MTLStoreActionDontCare
+                                                 : storeAction)];
+    } else if (isStencilFormat && isStencil) {
+        [cmdEncoder->_mtlRenderEncoder setStencilStoreAction:storeAction];
+    }
 }
 
-void MVKAttachmentDescription::populateMultiviewClearRects(MVKSmallVector<VkClearRect, 1>& clearRects, MVKCommandEncoder* cmdEncoder) {
-	MVKRenderSubpass* subpass = cmdEncoder->getSubpass();
-	uint32_t clearMask = subpass->getViewMaskGroupForMetalPass(cmdEncoder->getMultiviewPassIndex()) & _firstUseViewMasks[subpass->_subpassIndex];
+void MVKAttachmentDescription::populateMultiviewClearRects(
+    MVKSmallVector<VkClearRect, 1>& clearRects, MVKCommandEncoder* cmdEncoder) {
+    MVKRenderSubpass* subpass = cmdEncoder->getSubpass();
+    uint32_t clearMask = subpass->getViewMaskGroupForMetalPass(
+                             cmdEncoder->getMultiviewPassIndex()) &
+                         _firstUseViewMasks[subpass->_subpassIndex];
 
-	if (!clearMask) { return; }
-	VkRect2D renderArea = cmdEncoder->clipToRenderArea({{0, 0}, {kMVKUndefinedLargeUInt32, kMVKUndefinedLargeUInt32}});
-	uint32_t startView, viewCount;
-	do {
-		clearMask = mvkGetNextViewMaskGroup(clearMask, &startView, &viewCount);
-		clearRects.push_back({renderArea, startView, viewCount});
-	} while (clearMask);
+    if (!clearMask) {
+        return;
+    }
+    VkRect2D renderArea = cmdEncoder->clipToRenderArea(
+        {{0, 0}, {kMVKUndefinedLargeUInt32, kMVKUndefinedLargeUInt32}});
+    uint32_t startView, viewCount;
+    do {
+        clearMask = mvkGetNextViewMaskGroup(clearMask, &startView, &viewCount);
+        clearRects.push_back({renderArea, startView, viewCount});
+    } while (clearMask);
 }
 
-bool MVKAttachmentDescription::isFirstUseOfAttachment(MVKRenderSubpass* subpass) {
-	if ( subpass->isMultiview() ) {
-		return _firstUseViewMasks[subpass->_subpassIndex] == subpass->_pipelineRenderingCreateInfo.viewMask;
-	} else {
-		return _firstUseSubpassIdx == subpass->_subpassIndex;
-	}
+bool MVKAttachmentDescription::isFirstUseOfAttachment(
+    MVKRenderSubpass* subpass) {
+    if (subpass->isMultiview()) {
+        return _firstUseViewMasks[subpass->_subpassIndex] ==
+               subpass->_pipelineRenderingCreateInfo.viewMask;
+    } else {
+        return _firstUseSubpassIdx == subpass->_subpassIndex;
+    }
 }
 
-bool MVKAttachmentDescription::isLastUseOfAttachment(MVKRenderSubpass* subpass) {
-	if ( subpass->isMultiview() ) {
-		return _lastUseViewMasks[subpass->_subpassIndex] == subpass->_pipelineRenderingCreateInfo.viewMask;
-	} else {
-		return _lastUseSubpassIdx == subpass->_subpassIndex;
-	}
+bool MVKAttachmentDescription::isLastUseOfAttachment(
+    MVKRenderSubpass* subpass) {
+    if (subpass->isMultiview()) {
+        return _lastUseViewMasks[subpass->_subpassIndex] ==
+               subpass->_pipelineRenderingCreateInfo.viewMask;
+    } else {
+        return _lastUseSubpassIdx == subpass->_subpassIndex;
+    }
 }
 
-MTLStoreAction MVKAttachmentDescription::getMTLStoreAction(MVKRenderSubpass* subpass,
-														   bool isRenderingEntireAttachment,
-														   bool isMemorylessAttachment,
-														   bool hasResolveAttachment,
-														   bool canResolveFormat,
-														   bool isStencil,
-														   bool storeOverride) {
+MTLStoreAction MVKAttachmentDescription::getMTLStoreAction(
+    MVKRenderSubpass* subpass, bool isRenderingEntireAttachment,
+    bool isMemorylessAttachment, bool hasResolveAttachment,
+    bool canResolveFormat, bool isStencil, bool storeOverride) {
 
-	// If the renderpass is going to be suspended, and resumed later, store the contents to preserve them until then.
-	if (mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(), VK_RENDERING_SUSPENDING_BIT)) {
-		return MTLStoreActionStore;
-	}
+    // If the renderpass is going to be suspended, and resumed later, store the
+    // contents to preserve them until then.
+    if (mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(),
+                            VK_RENDERING_SUSPENDING_BIT)) {
+        return MTLStoreActionStore;
+    }
 
-	// If a resolve attachment exists, this attachment must resolve once complete.
-    if (hasResolveAttachment && canResolveFormat && !_renderPass->getMetalFeatures().combinedStoreResolveAction) {
+    // If a resolve attachment exists, this attachment must resolve once
+    // complete.
+    if (hasResolveAttachment && canResolveFormat &&
+        !_renderPass->getMetalFeatures().combinedStoreResolveAction) {
         return MTLStoreActionMultisampleResolve;
     }
-	// Memoryless can't be stored.
-	if (isMemorylessAttachment) {
-		return hasResolveAttachment ? MTLStoreActionMultisampleResolve : MTLStoreActionDontCare;
-	}
+    // Memoryless can't be stored.
+    if (isMemorylessAttachment) {
+        return hasResolveAttachment ? MTLStoreActionMultisampleResolve
+                                    : MTLStoreActionDontCare;
+    }
 
-	// Only allow the attachment to be discarded if we're actually
-	// rendering to the entire attachment and we're in the last subpass.
-	if (storeOverride || !isRenderingEntireAttachment || !isLastUseOfAttachment(subpass)) {
-		return hasResolveAttachment && canResolveFormat ? MTLStoreActionStoreAndMultisampleResolve : MTLStoreActionStore;
-	}
-	VkAttachmentStoreOp storeOp = isStencil ? _info.stencilStoreOp : _info.storeOp;
-	return mvkMTLStoreActionFromVkAttachmentStoreOp(storeOp, hasResolveAttachment, canResolveFormat);
+    // Only allow the attachment to be discarded if we're actually
+    // rendering to the entire attachment and we're in the last subpass.
+    if (storeOverride || !isRenderingEntireAttachment ||
+        !isLastUseOfAttachment(subpass)) {
+        return hasResolveAttachment && canResolveFormat
+                   ? MTLStoreActionStoreAndMultisampleResolve
+                   : MTLStoreActionStore;
+    }
+    VkAttachmentStoreOp storeOp =
+        isStencil ? _info.stencilStoreOp : _info.storeOp;
+    return mvkMTLStoreActionFromVkAttachmentStoreOp(storeOp,
+                                                    hasResolveAttachment,
+                                                    canResolveFormat);
 }
 
-bool MVKAttachmentDescription::shouldClearAttachment(MVKRenderSubpass* subpass, bool isStencil) {
+bool MVKAttachmentDescription::shouldClearAttachment(MVKRenderSubpass* subpass,
+                                                     bool isStencil) {
 
-	// If the renderpass is being resumed after being suspended, don't clear this attachment.
-	if (mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(), VK_RENDERING_RESUMING_BIT_KHR)) { return false; }
+    // If the renderpass is being resumed after being suspended, don't clear
+    // this attachment.
+    if (mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(),
+                            VK_RENDERING_RESUMING_BIT_KHR)) {
+        return false;
+    }
 
-	// If the subpass is not the first subpass to use this attachment, don't clear this attachment.
-	if (subpass->isMultiview()) {
-		if (_firstUseViewMasks[subpass->_subpassIndex] == 0) { return false; }
-	} else {
-		if (subpass->_subpassIndex != _firstUseSubpassIdx) { return false; }
-	}
-	VkAttachmentLoadOp loadOp = isStencil ? _info.stencilLoadOp : _info.loadOp;
-	return loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR;
+    // If the subpass is not the first subpass to use this attachment, don't
+    // clear this attachment.
+    if (subpass->isMultiview()) {
+        if (_firstUseViewMasks[subpass->_subpassIndex] == 0) {
+            return false;
+        }
+    } else {
+        if (subpass->_subpassIndex != _firstUseSubpassIdx) {
+            return false;
+        }
+    }
+    VkAttachmentLoadOp loadOp = isStencil ? _info.stencilLoadOp : _info.loadOp;
+    return loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR;
 }
 
 // Must be called after renderpass has both subpasses and attachments bound
 void MVKAttachmentDescription::linkToSubpasses() {
-	// Validate pixel format is supported
-	MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
-	if ( !pixFmts->isSupportedOrSubstitutable(_info.format) ) {
-		_renderPass->setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateRenderPass(): Attachment format %s is not supported on this device.", _renderPass->getPixelFormats()->getName(_info.format)));
-	}
+    // Validate pixel format is supported
+    MVKPixelFormats* pixFmts = _renderPass->getPixelFormats();
+    if (!pixFmts->isSupportedOrSubstitutable(_info.format)) {
+        _renderPass->setConfigurationResult(
+            reportError(VK_ERROR_FORMAT_NOT_SUPPORTED,
+                        "vkCreateRenderPass(): Attachment format %s is not "
+                        "supported on this device.",
+                        _renderPass->getPixelFormats()->getName(_info.format)));
+    }
 
-	// Determine the indices of the first and last render subpasses to use this attachment.
-	_firstUseSubpassIdx = kMVKUndefinedLargeUInt32;
-	_lastUseSubpassIdx = 0;
-	if (_renderPass->_subpasses[0].isMultiview()) {
-		_firstUseViewMasks.reserve(_renderPass->_subpasses.size());
-		_lastUseViewMasks.reserve(_renderPass->_subpasses.size());
-	}
-	for (auto& subPass : _renderPass->_subpasses) {
-		// If it uses this attachment, the subpass will identify required format capabilities.
-		MVKMTLFmtCaps reqCaps = subPass.getRequiredFormatCapabilitiesForAttachmentAt(_attachmentIndex);
-		if (reqCaps) {
-			uint32_t spIdx = subPass._subpassIndex;
-			_firstUseSubpassIdx = min(spIdx, _firstUseSubpassIdx);
-			_lastUseSubpassIdx = max(spIdx, _lastUseSubpassIdx);
-			if ( subPass.isMultiview() ) {
-				uint32_t viewMask = subPass._pipelineRenderingCreateInfo.viewMask;
-				std::for_each(_lastUseViewMasks.begin(), _lastUseViewMasks.end(), [viewMask](uint32_t& mask) { mask &= ~viewMask; });
-				_lastUseViewMasks.push_back(viewMask);
-				std::for_each(_firstUseViewMasks.begin(), _firstUseViewMasks.end(), [&viewMask](uint32_t mask) { viewMask &= ~mask; });
-				_firstUseViewMasks.push_back(viewMask);
-			}
+    // Determine the indices of the first and last render subpasses to use this
+    // attachment.
+    _firstUseSubpassIdx = kMVKUndefinedLargeUInt32;
+    _lastUseSubpassIdx = 0;
+    if (_renderPass->_subpasses[0].isMultiview()) {
+        _firstUseViewMasks.reserve(_renderPass->_subpasses.size());
+        _lastUseViewMasks.reserve(_renderPass->_subpasses.size());
+    }
+    for (auto& subPass : _renderPass->_subpasses) {
+        // If it uses this attachment, the subpass will identify required format
+        // capabilities.
+        MVKMTLFmtCaps reqCaps =
+            subPass.getRequiredFormatCapabilitiesForAttachmentAt(
+                _attachmentIndex);
+        if (reqCaps) {
+            uint32_t spIdx = subPass._subpassIndex;
+            _firstUseSubpassIdx = min(spIdx, _firstUseSubpassIdx);
+            _lastUseSubpassIdx = max(spIdx, _lastUseSubpassIdx);
+            if (subPass.isMultiview()) {
+                uint32_t viewMask =
+                    subPass._pipelineRenderingCreateInfo.viewMask;
+                std::for_each(_lastUseViewMasks.begin(),
+                              _lastUseViewMasks.end(),
+                              [viewMask](uint32_t& mask) {
+                                  mask &= ~viewMask;
+                              });
+                _lastUseViewMasks.push_back(viewMask);
+                std::for_each(_firstUseViewMasks.begin(),
+                              _firstUseViewMasks.end(),
+                              [&viewMask](uint32_t mask) {
+                                  viewMask &= ~mask;
+                              });
+                _firstUseViewMasks.push_back(viewMask);
+            }
 
-			// Validate that the attachment pixel format supports the capabilities required by the subpass.
-			// Use MTLPixelFormat to look up capabilities to permit Metal format substitution.
-			// It's okay if the format does not support the resolve capability, as this can be handled via a compute shader.
-			MVKMTLFmtCaps availCaps = pixFmts->getCapabilities(pixFmts->getMTLPixelFormat(_info.format));
-			mvkEnableFlags(availCaps, kMVKMTLFmtCapsResolve);
-			if ( !mvkAreAllFlagsEnabled(availCaps, reqCaps) ) {
-				_renderPass->setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateRenderPass(): Attachment format %s on this device does not support the VkFormat attachment capabilities required by the subpass at index %d.", _renderPass->getPixelFormats()->getName(_info.format), spIdx));
-			}
-		}
-	}
+            // Validate that the attachment pixel format supports the
+            // capabilities required by the subpass. Use MTLPixelFormat to look
+            // up capabilities to permit Metal format substitution. It's okay if
+            // the format does not support the resolve capability, as this can
+            // be handled via a compute shader.
+            MVKMTLFmtCaps availCaps = pixFmts->getCapabilities(
+                pixFmts->getMTLPixelFormat(_info.format));
+            mvkEnableFlags(availCaps, kMVKMTLFmtCapsResolve);
+            if (!mvkAreAllFlagsEnabled(availCaps, reqCaps)) {
+                _renderPass->setConfigurationResult(
+                    reportError(VK_ERROR_FORMAT_NOT_SUPPORTED,
+                                "vkCreateRenderPass(): Attachment format %s on "
+                                "this device does not support the "
+                                "VkFormat attachment capabilities required by "
+                                "the subpass at index %d.",
+                                _renderPass->getPixelFormats()->getName(
+                                    _info.format),
+                                spIdx));
+            }
+        }
+    }
 }
 
-MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
-												   const VkAttachmentDescription* pCreateInfo) {
-	_info.flags = pCreateInfo->flags;
-	_info.format = pCreateInfo->format;
-	_info.samples = pCreateInfo->samples;
-	_info.loadOp = pCreateInfo->loadOp;
-	_info.storeOp = pCreateInfo->storeOp;
-	_info.stencilLoadOp = pCreateInfo->stencilLoadOp;
-	_info.stencilStoreOp = pCreateInfo->stencilStoreOp;
-	_info.initialLayout = pCreateInfo->initialLayout;
-	_info.finalLayout = pCreateInfo->finalLayout;
-	_renderPass = renderPass;
-	_attachmentIndex = uint32_t(_renderPass->_attachments.size());
+MVKAttachmentDescription::MVKAttachmentDescription(
+    MVKRenderPass* renderPass, const VkAttachmentDescription* pCreateInfo) {
+    _info.flags = pCreateInfo->flags;
+    _info.format = pCreateInfo->format;
+    _info.samples = pCreateInfo->samples;
+    _info.loadOp = pCreateInfo->loadOp;
+    _info.storeOp = pCreateInfo->storeOp;
+    _info.stencilLoadOp = pCreateInfo->stencilLoadOp;
+    _info.stencilStoreOp = pCreateInfo->stencilStoreOp;
+    _info.initialLayout = pCreateInfo->initialLayout;
+    _info.finalLayout = pCreateInfo->finalLayout;
+    _renderPass = renderPass;
+    _attachmentIndex = uint32_t(_renderPass->_attachments.size());
 }
 
-MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
-												   const VkAttachmentDescription2* pCreateInfo) {
-	_info = *pCreateInfo;
-	_renderPass = renderPass;
-	_attachmentIndex = uint32_t(_renderPass->_attachments.size());
+MVKAttachmentDescription::MVKAttachmentDescription(
+    MVKRenderPass* renderPass, const VkAttachmentDescription2* pCreateInfo) {
+    _info = *pCreateInfo;
+    _renderPass = renderPass;
+    _attachmentIndex = uint32_t(_renderPass->_attachments.size());
 }
 
-MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
-												   const VkRenderingAttachmentInfo* pAttInfo,
-												   bool isResolveAttachment) {
-	if (isResolveAttachment) {
-		_info.flags = 0;
-		_info.format = ((MVKImageView*)pAttInfo->resolveImageView)->getVkFormat();
-		_info.samples = VK_SAMPLE_COUNT_1_BIT;
-		_info.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		_info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-		_info.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		_info.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-		_info.initialLayout = pAttInfo->resolveImageLayout;
-		_info.finalLayout = pAttInfo->resolveImageLayout;
-	} else {
-		_info.flags = 0;
-		_info.format = ((MVKImageView*)pAttInfo->imageView)->getVkFormat();
-		_info.samples = ((MVKImageView*)pAttInfo->imageView)->getSampleCount();
-		_info.loadOp = pAttInfo->loadOp;
-		_info.storeOp = pAttInfo->storeOp;
-		_info.stencilLoadOp = pAttInfo->loadOp;
-		_info.stencilStoreOp = pAttInfo->storeOp;
-		_info.initialLayout = pAttInfo->imageLayout;
-		_info.finalLayout = pAttInfo->imageLayout;
-	}
-	_renderPass = renderPass;
-	_attachmentIndex = uint32_t(_renderPass->_attachments.size());
+MVKAttachmentDescription::MVKAttachmentDescription(
+    MVKRenderPass* renderPass, const VkRenderingAttachmentInfo* pAttInfo,
+    bool isResolveAttachment) {
+    if (isResolveAttachment) {
+        _info.flags = 0;
+        _info.format =
+            ((MVKImageView*)pAttInfo->resolveImageView)->getVkFormat();
+        _info.samples = VK_SAMPLE_COUNT_1_BIT;
+        _info.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        _info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        _info.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        _info.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+        _info.initialLayout = pAttInfo->resolveImageLayout;
+        _info.finalLayout = pAttInfo->resolveImageLayout;
+    } else {
+        _info.flags = 0;
+        _info.format = ((MVKImageView*)pAttInfo->imageView)->getVkFormat();
+        _info.samples = ((MVKImageView*)pAttInfo->imageView)->getSampleCount();
+        _info.loadOp = pAttInfo->loadOp;
+        _info.storeOp = pAttInfo->storeOp;
+        _info.stencilLoadOp = pAttInfo->loadOp;
+        _info.stencilStoreOp = pAttInfo->storeOp;
+        _info.initialLayout = pAttInfo->imageLayout;
+        _info.finalLayout = pAttInfo->imageLayout;
+    }
+    _renderPass = renderPass;
+    _attachmentIndex = uint32_t(_renderPass->_attachments.size());
 }
-
 
 #pragma mark -
 #pragma mark MVKRenderPass
 
-MVKSubpassDependency::MVKSubpassDependency(const VkSubpassDependency& spDep, int32_t viewOffset) :
-	srcSubpass(spDep.srcSubpass),
-	dstSubpass(spDep.dstSubpass),
-	srcStageMask(spDep.srcStageMask),
-	dstStageMask(spDep.dstStageMask),
-	srcAccessMask(spDep.srcAccessMask),
-	dstAccessMask(spDep.dstAccessMask),
-	dependencyFlags(spDep.dependencyFlags),
-	viewOffset(viewOffset) {}
+MVKSubpassDependency::MVKSubpassDependency(const VkSubpassDependency& spDep,
+                                           int32_t viewOffset)
+    : srcSubpass(spDep.srcSubpass), dstSubpass(spDep.dstSubpass),
+      srcStageMask(spDep.srcStageMask), dstStageMask(spDep.dstStageMask),
+      srcAccessMask(spDep.srcAccessMask), dstAccessMask(spDep.dstAccessMask),
+      dependencyFlags(spDep.dependencyFlags), viewOffset(viewOffset) {}
 
-MVKSubpassDependency::MVKSubpassDependency(const VkSubpassDependency2& spDep, const VkMemoryBarrier2* pMemBar) :
-	srcSubpass(spDep.srcSubpass),
-	dstSubpass(spDep.dstSubpass),
-	srcStageMask(pMemBar ? pMemBar->srcStageMask : spDep.srcStageMask),
-	dstStageMask(pMemBar ? pMemBar->dstStageMask : spDep.dstStageMask),
-	srcAccessMask(pMemBar ? pMemBar->srcAccessMask : spDep.srcAccessMask),
-	dstAccessMask(pMemBar ? pMemBar->dstAccessMask : spDep.dstAccessMask),
-	dependencyFlags(spDep.dependencyFlags),
-	viewOffset(spDep.viewOffset) {}
+MVKSubpassDependency::MVKSubpassDependency(const VkSubpassDependency2& spDep,
+                                           const VkMemoryBarrier2* pMemBar)
+    : srcSubpass(spDep.srcSubpass), dstSubpass(spDep.dstSubpass),
+      srcStageMask(pMemBar ? pMemBar->srcStageMask : spDep.srcStageMask),
+      dstStageMask(pMemBar ? pMemBar->dstStageMask : spDep.dstStageMask),
+      srcAccessMask(pMemBar ? pMemBar->srcAccessMask : spDep.srcAccessMask),
+      dstAccessMask(pMemBar ? pMemBar->dstAccessMask : spDep.dstAccessMask),
+      dependencyFlags(spDep.dependencyFlags), viewOffset(spDep.viewOffset) {}
 
 VkExtent2D MVKRenderPass::getRenderAreaGranularity() {
     if (getMetalFeatures().tileBasedDeferredRendering) {
         // This is the tile area.
-        // FIXME: We really ought to use MTLRenderCommandEncoder.tile{Width,Height}, but that requires
+        // FIXME: We really ought to use
+        // MTLRenderCommandEncoder.tile{Width,Height}, but that requires
         // creating a command buffer.
-        return { 32, 32 };
+        return {32, 32};
     }
-    return { 1, 1 };
+    return {1, 1};
 }
 
 MVKRenderPass::MVKRenderPass(MVKDevice* device,
-							 const VkRenderPassCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
+                             const VkRenderPassCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
 
-	const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspectCreateInfo = nullptr;
-	const VkRenderPassMultiviewCreateInfo* pMultiviewCreateInfo = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-		case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
-			pInputAspectCreateInfo = (const VkRenderPassInputAttachmentAspectCreateInfo*)next;
-			break;
-		case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
-			pMultiviewCreateInfo = (const VkRenderPassMultiviewCreateInfo*)next;
-			break;
-		default:
-			break;
-		}
-	}
+    const VkRenderPassInputAttachmentAspectCreateInfo* pInputAspectCreateInfo =
+        nullptr;
+    const VkRenderPassMultiviewCreateInfo* pMultiviewCreateInfo = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
+            pInputAspectCreateInfo =
+                (const VkRenderPassInputAttachmentAspectCreateInfo*)next;
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
+            pMultiviewCreateInfo = (const VkRenderPassMultiviewCreateInfo*)next;
+            break;
+        default:
+            break;
+        }
+    }
 
-	const uint32_t* viewMasks = nullptr;
-	const int32_t* viewOffsets = nullptr;
-	if (pMultiviewCreateInfo && pMultiviewCreateInfo->subpassCount) {
-		viewMasks = pMultiviewCreateInfo->pViewMasks;
-	}
-	if (pMultiviewCreateInfo && pMultiviewCreateInfo->dependencyCount) {
-		viewOffsets = pMultiviewCreateInfo->pViewOffsets;
-	}
+    const uint32_t* viewMasks = nullptr;
+    const int32_t* viewOffsets = nullptr;
+    if (pMultiviewCreateInfo && pMultiviewCreateInfo->subpassCount) {
+        viewMasks = pMultiviewCreateInfo->pViewMasks;
+    }
+    if (pMultiviewCreateInfo && pMultiviewCreateInfo->dependencyCount) {
+        viewOffsets = pMultiviewCreateInfo->pViewOffsets;
+    }
 
-	// Add attachments first so subpasses can access them during creation
-	_attachments.reserve(pCreateInfo->attachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
-		_attachments.emplace_back(this, &pCreateInfo->pAttachments[i]);
-	}
+    // Add attachments first so subpasses can access them during creation
+    _attachments.reserve(pCreateInfo->attachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
+        _attachments.emplace_back(this, &pCreateInfo->pAttachments[i]);
+    }
 
-	// Add subpasses and dependencies
-	_subpasses.reserve(pCreateInfo->subpassCount);
-	for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
-		_subpasses.emplace_back(this, &pCreateInfo->pSubpasses[i], pInputAspectCreateInfo, viewMasks ? viewMasks[i] : 0);
-	}
-	_subpassDependencies.reserve(pCreateInfo->dependencyCount);
-	for (uint32_t i = 0; i < pCreateInfo->dependencyCount; i++) {
-		_subpassDependencies.emplace_back(pCreateInfo->pDependencies[i], viewOffsets ? viewOffsets[i] : 0);
-	}
+    // Add subpasses and dependencies
+    _subpasses.reserve(pCreateInfo->subpassCount);
+    for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
+        _subpasses.emplace_back(this, &pCreateInfo->pSubpasses[i],
+                                pInputAspectCreateInfo,
+                                viewMasks ? viewMasks[i] : 0);
+    }
+    _subpassDependencies.reserve(pCreateInfo->dependencyCount);
+    for (uint32_t i = 0; i < pCreateInfo->dependencyCount; i++) {
+        _subpassDependencies.emplace_back(pCreateInfo->pDependencies[i],
+                                          viewOffsets ? viewOffsets[i] : 0);
+    }
 
-	// Link attachments to subpasses
-	for (auto& att : _attachments) {
-		att.linkToSubpasses();
-	}
+    // Link attachments to subpasses
+    for (auto& att : _attachments) {
+        att.linkToSubpasses();
+    }
 }
 
 MVKRenderPass::MVKRenderPass(MVKDevice* device,
-							 const VkRenderPassCreateInfo2* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
+                             const VkRenderPassCreateInfo2* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device) {
 
-	// Add attachments first so subpasses can access them during creation
-	_attachments.reserve(pCreateInfo->attachmentCount);
-	for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
-		_attachments.emplace_back(this, &pCreateInfo->pAttachments[i]);
-	}
+    // Add attachments first so subpasses can access them during creation
+    _attachments.reserve(pCreateInfo->attachmentCount);
+    for (uint32_t i = 0; i < pCreateInfo->attachmentCount; i++) {
+        _attachments.emplace_back(this, &pCreateInfo->pAttachments[i]);
+    }
 
-	// Add subpasses and dependencies
-	_subpasses.reserve(pCreateInfo->subpassCount);
-	for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
-		_subpasses.emplace_back(this, &pCreateInfo->pSubpasses[i]);
-	}
-	_subpassDependencies.reserve(pCreateInfo->dependencyCount);
-	for (uint32_t i = 0; i < pCreateInfo->dependencyCount; i++) {
-		auto& spDep = pCreateInfo->pDependencies[i];
+    // Add subpasses and dependencies
+    _subpasses.reserve(pCreateInfo->subpassCount);
+    for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
+        _subpasses.emplace_back(this, &pCreateInfo->pSubpasses[i]);
+    }
+    _subpassDependencies.reserve(pCreateInfo->dependencyCount);
+    for (uint32_t i = 0; i < pCreateInfo->dependencyCount; i++) {
+        auto& spDep = pCreateInfo->pDependencies[i];
 
-		const VkMemoryBarrier2* pMemoryBarrier2 = nullptr;
-		for (auto* next = (const VkBaseInStructure*)spDep.pNext; next; next = next->pNext) {
-			switch (next->sType) {
-				case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
-					pMemoryBarrier2 = (const VkMemoryBarrier2*)next;
-					break;
-				default:
-					break;
-			}
-		}
-		_subpassDependencies.emplace_back(spDep, pMemoryBarrier2);
-	}
+        const VkMemoryBarrier2* pMemoryBarrier2 = nullptr;
+        for (auto* next = (const VkBaseInStructure*)spDep.pNext; next;
+             next = next->pNext) {
+            switch (next->sType) {
+            case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
+                pMemoryBarrier2 = (const VkMemoryBarrier2*)next;
+                break;
+            default:
+                break;
+            }
+        }
+        _subpassDependencies.emplace_back(spDep, pMemoryBarrier2);
+    }
 
-	// Link attachments to subpasses
-	for (auto& att : _attachments) {
-		att.linkToSubpasses();
-	}
+    // Link attachments to subpasses
+    for (auto& att : _attachments) {
+        att.linkToSubpasses();
+    }
 }
 
-MVKRenderPass::MVKRenderPass(MVKDevice* device, const VkRenderingInfo* pRenderingInfo) : MVKVulkanAPIDeviceObject(device) {
+MVKRenderPass::MVKRenderPass(MVKDevice* device,
+                             const VkRenderingInfo* pRenderingInfo)
+    : MVKVulkanAPIDeviceObject(device) {
 
-	_renderingFlags = pRenderingInfo->flags;
+    _renderingFlags = pRenderingInfo->flags;
 
-	// Add attachments first so subpasses can access them during creation
-	uint32_t attCnt = 0;
-	MVKRenderingAttachmentIterator attIter(pRenderingInfo);
-	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void { attCnt++; });
-	_attachments.reserve(attCnt);
-	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void {
-		_attachments.emplace_back(this, pAttInfo, isResolveAttachment);
-	});
+    // Add attachments first so subpasses can access them during creation
+    uint32_t attCnt = 0;
+    MVKRenderingAttachmentIterator attIter(pRenderingInfo);
+    attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo,
+                        VkImageAspectFlagBits aspect,
+                        bool isResolveAttachment) -> void { attCnt++; });
+    _attachments.reserve(attCnt);
+    attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo,
+                        VkImageAspectFlagBits aspect,
+                        bool isResolveAttachment) -> void {
+        _attachments.emplace_back(this, pAttInfo, isResolveAttachment);
+    });
 
-	// Add subpass
-	_subpasses.emplace_back(this, pRenderingInfo);
+    // Add subpass
+    _subpasses.emplace_back(this, pRenderingInfo);
 
-	// Link attachments to subpasses
-	for (auto& att : _attachments) {
-		att.linkToSubpasses();
-	}
+    // Link attachments to subpasses
+    for (auto& att : _attachments) {
+        att.linkToSubpasses();
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKRenderingAttachmentIterator
 
-void MVKRenderingAttachmentIterator::iterate(MVKRenderingAttachmentInfoOperation attOperation) {
-	for (uint32_t caIdx = 0; caIdx < _renderingInfo.colorAttachmentCount; caIdx++) {
-		handleAttachment(&_renderingInfo.pColorAttachments[caIdx], VK_IMAGE_ASPECT_COLOR_BIT, attOperation);
-	}
-	handleAttachment(_renderingInfo.pDepthAttachment, VK_IMAGE_ASPECT_DEPTH_BIT, attOperation);
-	handleAttachment(_renderingInfo.pStencilAttachment, VK_IMAGE_ASPECT_STENCIL_BIT, attOperation);
+void MVKRenderingAttachmentIterator::iterate(
+    MVKRenderingAttachmentInfoOperation attOperation) {
+    for (uint32_t caIdx = 0; caIdx < _renderingInfo.colorAttachmentCount;
+         caIdx++) {
+        handleAttachment(&_renderingInfo.pColorAttachments[caIdx],
+                         VK_IMAGE_ASPECT_COLOR_BIT, attOperation);
+    }
+    handleAttachment(_renderingInfo.pDepthAttachment, VK_IMAGE_ASPECT_DEPTH_BIT,
+                     attOperation);
+    handleAttachment(_renderingInfo.pStencilAttachment,
+                     VK_IMAGE_ASPECT_STENCIL_BIT, attOperation);
 }
 
-void MVKRenderingAttachmentIterator::handleAttachment(const VkRenderingAttachmentInfo* pAttInfo,
-													  VkImageAspectFlagBits aspect,
-													  MVKRenderingAttachmentInfoOperation attOperation) {
-	if (pAttInfo && pAttInfo->imageView) {
-		attOperation(pAttInfo, aspect, false);
-		if (pAttInfo->resolveImageView && pAttInfo->resolveMode != VK_RESOLVE_MODE_NONE) {
-			attOperation(pAttInfo, aspect, true);
-		}
-	}
+void MVKRenderingAttachmentIterator::handleAttachment(
+    const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect,
+    MVKRenderingAttachmentInfoOperation attOperation) {
+    if (pAttInfo && pAttInfo->imageView) {
+        attOperation(pAttInfo, aspect, false);
+        if (pAttInfo->resolveImageView &&
+            pAttInfo->resolveMode != VK_RESOLVE_MODE_NONE) {
+            attOperation(pAttInfo, aspect, true);
+        }
+    }
 }
 
-MVKRenderingAttachmentIterator::MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo) {
-	_renderingInfo = *pRenderingInfo;
-	_renderingInfo.pDepthAttachment   = getAttachmentInfo(pRenderingInfo->pDepthAttachment, pRenderingInfo->pStencilAttachment, false);
-	_renderingInfo.pStencilAttachment = getAttachmentInfo(pRenderingInfo->pStencilAttachment, pRenderingInfo->pDepthAttachment, true);
+MVKRenderingAttachmentIterator::MVKRenderingAttachmentIterator(
+    const VkRenderingInfo* pRenderingInfo) {
+    _renderingInfo = *pRenderingInfo;
+    _renderingInfo.pDepthAttachment =
+        getAttachmentInfo(pRenderingInfo->pDepthAttachment,
+                          pRenderingInfo->pStencilAttachment, false);
+    _renderingInfo.pStencilAttachment =
+        getAttachmentInfo(pRenderingInfo->pStencilAttachment,
+                          pRenderingInfo->pDepthAttachment, true);
 }
 
-// If the depth/stencil attachment is not in use, but the alternate stencil/depth attachment is,
-// and the MTLPixelFormat is usable by both attachments, force the use of the alternate attachment
-// for both attachments, to avoid Metal validation errors when a pipeline expects both depth and
+// If the depth/stencil attachment is not in use, but the alternate
+// stencil/depth attachment is, and the MTLPixelFormat is usable by both
+// attachments, force the use of the alternate attachment for both attachments,
+// to avoid Metal validation errors when a pipeline expects both depth and
 // stencil, but only one of the attachments has been provided here.
-// Check the MTLPixelFormat of the MVKImage underlying the MVKImageView, to bypass possible
-// substitution of MTLPixelFormat in the MVKImageView due to swizzling, or stencil-only access.
-const VkRenderingAttachmentInfo* MVKRenderingAttachmentIterator::getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
-																				   const VkRenderingAttachmentInfo* pAltAtt,
-																				   bool isStencil) {
-	bool useAlt = false;
-	if ( !(pAtt && pAtt->imageView) && (pAltAtt && pAltAtt->imageView) ) {
-		MVKImage* mvkImg = ((MVKImageView*)pAltAtt->imageView)->getImage();
-		useAlt = (isStencil
-				  ? mvkImg->getPixelFormats()->isStencilFormat(mvkImg->getMTLPixelFormat())
-				  : mvkImg->getPixelFormats()->isDepthFormat(mvkImg->getMTLPixelFormat()));
-	}
-	return useAlt ? pAltAtt : pAtt;
+// Check the MTLPixelFormat of the MVKImage underlying the MVKImageView, to
+// bypass possible substitution of MTLPixelFormat in the MVKImageView due to
+// swizzling, or stencil-only access.
+const VkRenderingAttachmentInfo*
+MVKRenderingAttachmentIterator::getAttachmentInfo(
+    const VkRenderingAttachmentInfo* pAtt,
+    const VkRenderingAttachmentInfo* pAltAtt, bool isStencil) {
+    bool useAlt = false;
+    if (!(pAtt && pAtt->imageView) && (pAltAtt && pAltAtt->imageView)) {
+        MVKImage* mvkImg = ((MVKImageView*)pAltAtt->imageView)->getImage();
+        useAlt = (isStencil ? mvkImg->getPixelFormats()->isStencilFormat(
+                                  mvkImg->getMTLPixelFormat())
+                            : mvkImg->getPixelFormats()->isDepthFormat(
+                                  mvkImg->getMTLPixelFormat()));
+    }
+    return useAlt ? pAltAtt : pAtt;
 }
-
 
 #pragma mark -
 #pragma mark Support functions
 
-bool mvkIsColorAttachmentUsed(const VkPipelineRenderingCreateInfo* pRendInfo, uint32_t colorAttIdx) {
-	return pRendInfo && pRendInfo->pColorAttachmentFormats[colorAttIdx];
+bool mvkIsColorAttachmentUsed(const VkPipelineRenderingCreateInfo* pRendInfo,
+                              uint32_t colorAttIdx) {
+    return pRendInfo && pRendInfo->pColorAttachmentFormats[colorAttIdx];
 }
 
 bool mvkHasColorAttachments(const VkPipelineRenderingCreateInfo* pRendInfo) {
-	if (pRendInfo) {
-		for (uint32_t caIdx = 0; caIdx < pRendInfo->colorAttachmentCount; caIdx++) {
-			if (mvkIsColorAttachmentUsed(pRendInfo, caIdx)) { return true; }
-		}
-	}
-	return false;
+    if (pRendInfo) {
+        for (uint32_t caIdx = 0; caIdx < pRendInfo->colorAttachmentCount;
+             caIdx++) {
+            if (mvkIsColorAttachmentUsed(pRendInfo, caIdx)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
-uint32_t mvkGetNextViewMaskGroup(uint32_t viewMask, uint32_t* startView, uint32_t* viewCount, uint32_t *groupMask) {
-	// First, find the first set bit. This is the start of the next clump of views to be rendered.
-	// n.b. ffs(3) returns a 1-based index. This actually bit me during development of this feature.
-	int pos = ffs(viewMask) - 1;
-	int end = pos;
-	if (groupMask) { *groupMask = 0; }
-	// Now we'll step through the bits one at a time until we find a bit that isn't set.
-	// This is one past the end of the next clump. Clear the bits as we go, so we can use
-	// ffs(3) again on the next clump.
-	// TODO: Find a way to make this faster.
-	while (viewMask & (1 << end)) {
-		if (groupMask) { *groupMask |= viewMask & (1 << end); }
-		viewMask &= ~(1 << (end++));
-	}
-	if (startView) { *startView = pos; }
-	if (viewCount) { *viewCount = end - pos; }
-	return viewMask;
+uint32_t mvkGetNextViewMaskGroup(uint32_t viewMask, uint32_t* startView,
+                                 uint32_t* viewCount, uint32_t* groupMask) {
+    // First, find the first set bit. This is the start of the next clump of
+    // views to be rendered. n.b. ffs(3) returns a 1-based index. This actually
+    // bit me during development of this feature.
+    int pos = ffs(viewMask) - 1;
+    int end = pos;
+    if (groupMask) {
+        *groupMask = 0;
+    }
+    // Now we'll step through the bits one at a time until we find a bit that
+    // isn't set. This is one past the end of the next clump. Clear the bits as
+    // we go, so we can use ffs(3) again on the next clump.
+    // TODO: Find a way to make this faster.
+    while (viewMask & (1 << end)) {
+        if (groupMask) {
+            *groupMask |= viewMask & (1 << end);
+        }
+        viewMask &= ~(1 << (end++));
+    }
+    if (startView) {
+        *startView = pos;
+    }
+    if (viewCount) {
+        *viewCount = end - pos;
+    }
+    return viewMask;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,57 +24,66 @@
 
 class MVKCommandEncoder;
 
-
 #pragma mark -
 #pragma mark MVKResource
 
-/** Represents an abstract Vulkan resource. Specialized subclasses include MVKBuffer and MVKImage. */
+/** Represents an abstract Vulkan resource. Specialized subclasses include
+ * MVKBuffer and MVKImage. */
 class MVKResource : public MVKVulkanAPIDeviceObject {
 
-public:
-
-	/** Returns the number of bytes required for the entire resource. */
+  public:
+    /** Returns the number of bytes required for the entire resource. */
     VkDeviceSize getByteCount() { return _byteCount; }
 
     /** Returns the byte offset in the bound device memory. */
     VkDeviceSize getDeviceMemoryOffset() { return _deviceMemoryOffset; }
 
-	/** Binds this resource to the specified offset within the specified memory allocation. */
-	virtual VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset);
+    /** Binds this resource to the specified offset within the specified memory
+     * allocation. */
+    virtual VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                      VkDeviceSize memOffset);
 
-	/** Returns the device memory underlying this resource. */
-	MVKDeviceMemory* getDeviceMemory() { return _deviceMemory; }
+    /** Returns the device memory underlying this resource. */
+    MVKDeviceMemory* getDeviceMemory() { return _deviceMemory; }
 
-	/** Returns whether the memory is accessible from the host. */
-	bool isMemoryHostAccessible() { return _deviceMemory && _deviceMemory->isMemoryHostAccessible(); }
+    /** Returns whether the memory is accessible from the host. */
+    bool isMemoryHostAccessible() {
+        return _deviceMemory && _deviceMemory->isMemoryHostAccessible();
+    }
 
-	/** Returns whether the memory is automatically coherent between device and host. */
-	bool isMemoryHostCoherent() { return _deviceMemory && _deviceMemory->isMemoryHostCoherent(); }
+    /** Returns whether the memory is automatically coherent between device and
+     * host. */
+    bool isMemoryHostCoherent() {
+        return _deviceMemory && _deviceMemory->isMemoryHostCoherent();
+    }
 
-	/**
-	 * Returns the host memory address of this resource, or NULL if the memory is not mapped to a 
-	 * host address yet, or if the memory is marked as device-only and cannot be mapped to a host address.
-	 */
-	void* getHostMemoryAddress() {
-		void* devMemHostAddr = _deviceMemory ? _deviceMemory->getHostMemoryAddress() : nullptr;
-		return devMemHostAddr ? (void*)((uintptr_t)devMemHostAddr + _deviceMemoryOffset) : nullptr;
-	}
+    /**
+     * Returns the host memory address of this resource, or NULL if the memory
+     * is not mapped to a host address yet, or if the memory is marked as
+     * device-only and cannot be mapped to a host address.
+     */
+    void* getHostMemoryAddress() {
+        void* devMemHostAddr =
+            _deviceMemory ? _deviceMemory->getHostMemoryAddress() : nullptr;
+        return devMemHostAddr
+                   ? (void*)((uintptr_t)devMemHostAddr + _deviceMemoryOffset)
+                   : nullptr;
+    }
 
-	/** Applies the specified global memory barrier. */
-	virtual void applyMemoryBarrier(MVKPipelineBarrier& barrier,
-									MVKCommandEncoder* cmdEncoder,
-									MVKCommandUse cmdUse) = 0;
+    /** Applies the specified global memory barrier. */
+    virtual void applyMemoryBarrier(MVKPipelineBarrier& barrier,
+                                    MVKCommandEncoder* cmdEncoder,
+                                    MVKCommandUse cmdUse) = 0;
 
-	
 #pragma mark Construction
 
     MVKResource(MVKDevice* device) : MVKVulkanAPIDeviceObject(device) {}
 
-protected:
-	MVKDeviceMemory* _deviceMemory = nullptr;
-	VkDeviceSize _deviceMemoryOffset = 0;
+  protected:
+    MVKDeviceMemory* _deviceMemory = nullptr;
+    VkDeviceSize _deviceMemoryOffset = 0;
     VkDeviceSize _byteCount = 0;
     VkDeviceSize _byteAlignment = 0;
-	VkExternalMemoryHandleTypeFlags _externalMemoryHandleTypes = 0;
-	bool _requiresDedicatedMemoryAllocation = false;
+    VkExternalMemoryHandleTypeFlags _externalMemoryHandleTypes = 0;
+    bool _requiresDedicatedMemoryAllocation = false;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKResource.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKResource.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,17 +19,16 @@
 #include "MVKResource.h"
 #include "MVKCommandBuffer.h"
 
-
 #pragma mark MVKResource
 
-VkResult MVKResource::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) {
-	// Don't do anything with a non-zero offset into a dedicated allocation.
-	if (mvkMem && mvkMem->isDedicatedAllocation() && memOffset) {
-		_deviceMemory = nullptr;
-		return VK_SUCCESS;
-	}
-	_deviceMemory = mvkMem;
-	_deviceMemoryOffset = memOffset;
-	return VK_SUCCESS;
+VkResult MVKResource::bindDeviceMemory(MVKDeviceMemory* mvkMem,
+                                       VkDeviceSize memOffset) {
+    // Don't do anything with a non-zero offset into a dedicated allocation.
+    if (mvkMem && mvkMem->isDedicatedAllocation() && memOffset) {
+        _deviceMemory = nullptr;
+        return VK_SUCCESS;
+    }
+    _deviceMemory = mvkMem;
+    _deviceMemoryOffset = memOffset;
+    return VK_SUCCESS;
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,90 +36,101 @@ class MVKShaderModule;
 #pragma mark -
 #pragma mark MVKShaderLibrary
 
-/** A MTLFunction and corresponding result information resulting from a shader conversion. */
+/** A MTLFunction and corresponding result information resulting from a shader
+ * conversion. */
 typedef struct MVKMTLFunction {
-  mvk::SPIRVToMSLConversionResultInfo shaderConversionResults;
-	MTLSize threadGroupSize;
-	id<MTLFunction> getMTLFunction() { return _mtlFunction; }
+    mvk::SPIRVToMSLConversionResultInfo shaderConversionResults;
+    MTLSize threadGroupSize;
+    id<MTLFunction> getMTLFunction() { return _mtlFunction; }
 
-	MVKMTLFunction(id<MTLFunction> mtlFunc, const mvk::SPIRVToMSLConversionResultInfo scRslts, MTLSize tgSize);
-	MVKMTLFunction(const MVKMTLFunction& other);
-	MVKMTLFunction& operator=(const MVKMTLFunction& other);
-	MVKMTLFunction() {}
-	~MVKMTLFunction();
+    MVKMTLFunction(id<MTLFunction> mtlFunc,
+                   const mvk::SPIRVToMSLConversionResultInfo scRslts,
+                   MTLSize tgSize);
+    MVKMTLFunction(const MVKMTLFunction& other);
+    MVKMTLFunction& operator=(const MVKMTLFunction& other);
+    MVKMTLFunction() {}
+    ~MVKMTLFunction();
 
-private:
-	id<MTLFunction> _mtlFunction = nil;
+  private:
+    id<MTLFunction> _mtlFunction = nil;
 
 } MVKMTLFunction;
 
-/** A MVKMTLFunction indicating an invalid MTLFunction. The mtlFunction member is nil. */
-const MVKMTLFunction MVKMTLFunctionNull(nil, mvk::SPIRVToMSLConversionResultInfo(), MTLSizeMake(1, 1, 1));
+/** A MVKMTLFunction indicating an invalid MTLFunction. The mtlFunction member
+ * is nil. */
+const MVKMTLFunction MVKMTLFunctionNull(nil,
+                                        mvk::SPIRVToMSLConversionResultInfo(),
+                                        MTLSizeMake(1, 1, 1));
 
 /** Wraps a single MTLLibrary. */
 class MVKShaderLibrary : public MVKBaseDeviceObject {
 
-public:
-
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _owner->getVulkanAPIObject(); };
-
-	/**
-	 * Sets the entry point function name.
-	 *
-	 * This is usually set automatically during shader conversion from SPIR-V to MSL.
-	 * For a library that was created directly from MSL, this function can be used to
-	 * set the name of the function if it has a different name than the default main0().
-	 */
-	void setEntryPointName(std::string& funcName);
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _owner->getVulkanAPIObject();
+    };
 
     /**
-	 * Sets the number of threads in a single compute kernel workgroup, per dimension.
-	 *
-	 * This is usually set automatically during shader conversion from SPIR-V to MSL.
-	 * For a library that was created directly from MSL, this function can be used to
-	 * set the workgroup size..
-	 */
+     * Sets the entry point function name.
+     *
+     * This is usually set automatically during shader conversion from SPIR-V to
+     * MSL. For a library that was created directly from MSL, this function can
+     * be used to set the name of the function if it has a different name than
+     * the default main0().
+     */
+    void setEntryPointName(std::string& funcName);
+
+    /**
+     * Sets the number of threads in a single compute kernel workgroup, per
+     * dimension.
+     *
+     * This is usually set automatically during shader conversion from SPIR-V to
+     * MSL. For a library that was created directly from MSL, this function can
+     * be used to set the workgroup size..
+     */
     void setWorkgroupSize(uint32_t x, uint32_t y, uint32_t z);
-    
-	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
-					 const mvk::SPIRVToMSLConversionResult& conversionResult);
 
-	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
-					 const mvk::SPIRVToMSLConversionResultInfo& resultInfo,
-					 const MVKCompressor<std::string> compressedMSL);
+    MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
+                     const mvk::SPIRVToMSLConversionResult& conversionResult);
 
-	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
-					 const void* mslCompiledCodeData,
-					 size_t mslCompiledCodeLength);
+    MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
+                     const mvk::SPIRVToMSLConversionResultInfo& resultInfo,
+                     const MVKCompressor<std::string> compressedMSL);
 
-	MVKShaderLibrary(const MVKShaderLibrary& other);
+    MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
+                     const void* mslCompiledCodeData,
+                     size_t mslCompiledCodeLength);
 
-	MVKShaderLibrary& operator=(const MVKShaderLibrary& other);
+    MVKShaderLibrary(const MVKShaderLibrary& other);
 
-	~MVKShaderLibrary() override;
+    MVKShaderLibrary& operator=(const MVKShaderLibrary& other);
 
-protected:
-	friend MVKShaderCacheIterator;
-	friend MVKShaderLibraryCache;
-	friend MVKShaderModule;
+    ~MVKShaderLibrary() override;
 
-	MVKMTLFunction getMTLFunction(const VkSpecializationInfo* pSpecializationInfo,
-								  VkPipelineCreationFeedback* pShaderFeedback,
-								  MVKShaderModule* shaderModule);
-	void handleCompilationError(NSError* err, const char* opDesc);
-    MTLFunctionConstant* getFunctionConstant(NSArray<MTLFunctionConstant*>* mtlFCs, NSUInteger mtlFCID);
-	void compileLibrary(const std::string& msl);
-	void compressMSL(const std::string& msl);
-	void decompressMSL(std::string& msl);
-	MVKCompressor<std::string>& getCompressedMSL() { return _compressedMSL; }
+  protected:
+    friend MVKShaderCacheIterator;
+    friend MVKShaderLibraryCache;
+    friend MVKShaderModule;
 
-	MVKVulkanAPIDeviceObject* _owner;
-	id<MTLLibrary> _mtlLibrary;
-	MVKCompressor<std::string> _compressedMSL;
-  mvk::SPIRVToMSLConversionResultInfo _shaderConversionResultInfo;
+    MVKMTLFunction
+    getMTLFunction(const VkSpecializationInfo* pSpecializationInfo,
+                   VkPipelineCreationFeedback* pShaderFeedback,
+                   MVKShaderModule* shaderModule);
+    void handleCompilationError(NSError* err, const char* opDesc);
+    MTLFunctionConstant*
+    getFunctionConstant(NSArray<MTLFunctionConstant*>* mtlFCs,
+                        NSUInteger mtlFCID);
+    void compileLibrary(const std::string& msl);
+    void compressMSL(const std::string& msl);
+    void decompressMSL(std::string& msl);
+    MVKCompressor<std::string>& getCompressedMSL() { return _compressedMSL; }
+
+    MVKVulkanAPIDeviceObject* _owner;
+    id<MTLLibrary> _mtlLibrary;
+    MVKCompressor<std::string> _compressedMSL;
+    mvk::SPIRVToMSLConversionResultInfo _shaderConversionResultInfo;
 };
-
 
 #pragma mark -
 #pragma mark MVKShaderLibraryCache
@@ -127,122 +138,142 @@ protected:
 /** Represents a cache of shader libraries for one shader module. */
 class MVKShaderLibraryCache : public MVKBaseDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _owner->getVulkanAPIObject();
+    };
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _owner->getVulkanAPIObject(); };
+    /**
+     * Returns a shader library from the shader conversion configuration sourced
+     * from the shader module, lazily creating the shader library from source
+     * code in the shader module, if needed, and if the pipeline is not
+     * configured to fail if a pipeline compile is required. In that case, the
+     * new shader library is not created, and nil is returned.
+     *
+     * If pWasAdded is not nil, this function will set it to true if a new
+     * shader library was created, and to false if an existing shader library
+     * was found and returned.
+     */
+    MVKShaderLibrary* getShaderLibrary(
+        mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+        MVKShaderModule* shaderModule, MVKPipeline* pipeline, bool* pWasAdded,
+        VkPipelineCreationFeedback* pShaderFeedback, uint64_t startTime = 0);
 
-	/**
-	 * Returns a shader library from the shader conversion configuration sourced from the
-	 * shader module, lazily creating the shader library from source code in the shader
-	 * module, if needed, and if the pipeline is not configured to fail if a pipeline compile
-	 * is required. In that case, the new shader library is not created, and nil is returned.
-	 *
-	 * If pWasAdded is not nil, this function will set it to true if a new shader library was created,
-	 * and to false if an existing shader library was found and returned.
-	 */
-	MVKShaderLibrary* getShaderLibrary(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-									   MVKShaderModule* shaderModule, MVKPipeline* pipeline,
-									   bool* pWasAdded, VkPipelineCreationFeedback* pShaderFeedback,
-									   uint64_t startTime = 0);
+    MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner)
+        : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {};
 
-	MVKShaderLibraryCache(MVKVulkanAPIDeviceObject* owner) : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {};
+    ~MVKShaderLibraryCache() override;
 
-	~MVKShaderLibraryCache() override;
+  protected:
+    friend MVKShaderCacheIterator;
+    friend MVKPipelineCache;
+    friend MVKShaderModule;
 
-protected:
-	friend MVKShaderCacheIterator;
-	friend MVKPipelineCache;
-	friend MVKShaderModule;
+    MVKShaderLibrary*
+    findShaderLibrary(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+                      VkPipelineCreationFeedback* pShaderFeedback = nullptr,
+                      uint64_t startTime = 0);
+    MVKShaderLibrary* addShaderLibrary(
+        const mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+        const mvk::SPIRVToMSLConversionResult& conversionResult);
+    MVKShaderLibrary* addShaderLibrary(
+        const mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+        const mvk::SPIRVToMSLConversionResultInfo& resultInfo,
+        const MVKCompressor<std::string> compressedMSL);
+    void merge(MVKShaderLibraryCache* other);
 
-	MVKShaderLibrary* findShaderLibrary(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-										VkPipelineCreationFeedback* pShaderFeedback = nullptr,
-										uint64_t startTime = 0);
-	MVKShaderLibrary* addShaderLibrary(const mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-									   const mvk::SPIRVToMSLConversionResult& conversionResult);
-	MVKShaderLibrary* addShaderLibrary(const mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-									   const mvk::SPIRVToMSLConversionResultInfo& resultInfo,
-									   const MVKCompressor<std::string> compressedMSL);
-	void merge(MVKShaderLibraryCache* other);
-
-	MVKVulkanAPIDeviceObject* _owner;
-	MVKSmallVector<std::pair<mvk::SPIRVToMSLConversionConfiguration, MVKShaderLibrary*>> _shaderLibraries;
+    MVKVulkanAPIDeviceObject* _owner;
+    MVKSmallVector<
+        std::pair<mvk::SPIRVToMSLConversionConfiguration, MVKShaderLibrary*>>
+        _shaderLibraries;
 };
-
 
 #pragma mark -
 #pragma mark MVKShaderModule
 
 typedef struct MVKShaderModuleKey {
-	std::size_t codeSize;
-	std::size_t codeHash;
+    std::size_t codeSize;
+    std::size_t codeHash;
 
-	bool operator==(const MVKShaderModuleKey& rhs) const {
-		return ((codeSize == rhs.codeSize) && (codeHash == rhs.codeHash));
-	}
-	MVKShaderModuleKey(std::size_t codeSize, std::size_t codeHash) : codeSize(codeSize), codeHash(codeHash) {}
-	MVKShaderModuleKey() :  MVKShaderModuleKey(0, 0) {}
+    bool operator==(const MVKShaderModuleKey& rhs) const {
+        return ((codeSize == rhs.codeSize) && (codeHash == rhs.codeHash));
+    }
+    MVKShaderModuleKey(std::size_t codeSize, std::size_t codeHash)
+        : codeSize(codeSize), codeHash(codeHash) {}
+    MVKShaderModuleKey() : MVKShaderModuleKey(0, 0) {}
 } MVKShaderModuleKey;
 
 /**
  * Hash structure implementation for MVKShaderModuleKey in std namespace,
- * so MVKShaderModuleKey can be used as a key in a std::map and std::unordered_map.
+ * so MVKShaderModuleKey can be used as a key in a std::map and
+ * std::unordered_map.
  */
 namespace std {
-	template <>
-	struct hash<MVKShaderModuleKey> {
-		std::size_t operator()(const MVKShaderModuleKey& k) const { return k.codeHash; }
-	};
-}
+template <> struct hash<MVKShaderModuleKey> {
+    std::size_t operator()(const MVKShaderModuleKey& k) const {
+        return k.codeHash;
+    }
+};
+} // namespace std
 
 /** Represents a Vulkan shader module. */
 class MVKShaderModule : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_SHADER_MODULE;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SHADER_MODULE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT; }
+    /** Returns the Metal shader function, possibly specialized. */
+    MVKMTLFunction
+    getMTLFunction(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+                   const VkSpecializationInfo* pSpecializationInfo,
+                   MVKPipeline* pipeline,
+                   VkPipelineCreationFeedback* pShaderFeedback);
 
-	/** Returns the Metal shader function, possibly specialized. */
-	MVKMTLFunction getMTLFunction(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-								  const VkSpecializationInfo* pSpecializationInfo,
-								  MVKPipeline* pipeline,
-								  VkPipelineCreationFeedback* pShaderFeedback);
+    /** Convert the SPIR-V to MSL, using the specified shader conversion
+     * configuration. */
+    bool convert(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
+                 mvk::SPIRVToMSLConversionResult& conversionResult);
 
-	/** Convert the SPIR-V to MSL, using the specified shader conversion configuration. */
-	bool convert(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig,
-               mvk::SPIRVToMSLConversionResult& conversionResult);
+    /** Returns the original SPIR-V code that was specified when this object was
+     * created. */
+    const std::vector<uint32_t>& getSPIRV() { return _spvConverter.getSPIRV(); }
 
-	/** Returns the original SPIR-V code that was specified when this object was created. */
-	const std::vector<uint32_t>& getSPIRV() { return _spvConverter.getSPIRV(); }
-
-    /** Sets the number of threads in a single compute kernel workgroup, per dimension. */
+    /** Sets the number of threads in a single compute kernel workgroup, per
+     * dimension. */
     void setWorkgroupSize(uint32_t x, uint32_t y, uint32_t z);
-    
-	/** Returns a key as a means of identifying this shader module in a pipeline cache. */
-	MVKShaderModuleKey getKey() { return _key; }
 
-	MVKShaderModule(MVKDevice* device, const VkShaderModuleCreateInfo* pCreateInfo);
+    /** Returns a key as a means of identifying this shader module in a pipeline
+     * cache. */
+    MVKShaderModuleKey getKey() { return _key; }
 
-	~MVKShaderModule() override;
+    MVKShaderModule(MVKDevice* device,
+                    const VkShaderModuleCreateInfo* pCreateInfo);
 
-protected:
-	friend MVKShaderCacheIterator;
+    ~MVKShaderModule() override;
 
-	void propagateDebugName() override {}
-	MVKGLSLConversionShaderStage getMVKGLSLConversionShaderStage(mvk::SPIRVToMSLConversionConfiguration* pShaderConfig);
+  protected:
+    friend MVKShaderCacheIterator;
 
-	MVKShaderLibraryCache _shaderLibraryCache;
-  mvk::SPIRVToMSLConverter _spvConverter;
-  mvk::GLSLToSPIRVConverter _glslConverter;
-	MVKShaderLibrary* _directMSLLibrary;
-	MVKShaderModuleKey _key;
+    void propagateDebugName() override {}
+    MVKGLSLConversionShaderStage getMVKGLSLConversionShaderStage(
+        mvk::SPIRVToMSLConversionConfiguration* pShaderConfig);
+
+    MVKShaderLibraryCache _shaderLibraryCache;
+    mvk::SPIRVToMSLConverter _spvConverter;
+    mvk::GLSLToSPIRVConverter _glslConverter;
+    MVKShaderLibrary* _directMSLLibrary;
+    MVKShaderModuleKey _key;
     std::mutex _accessLock;
 };
-
 
 #pragma mark -
 #pragma mark MVKShaderLibraryCompiler
@@ -250,38 +281,41 @@ protected:
 /**
  * Creates a MTLLibrary from source code.
  *
- * Instances of this class are one-shot, and can only be used for a single library compilation.
+ * Instances of this class are one-shot, and can only be used for a single
+ * library compilation.
  */
 class MVKShaderLibraryCompiler : public MVKMetalCompiler {
 
-public:
-
-	/**
-	 * Returns a new (retained) MTLLibrary object compiled from the MSL source code.
-	 *
-	 * If the Metal library compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLLibrary> newMTLLibrary(NSString* mslSourceCode,
-								 const mvk::SPIRVToMSLConversionResultInfo& shaderConversionResults);
-
+  public:
+    /**
+     * Returns a new (retained) MTLLibrary object compiled from the MSL source
+     * code.
+     *
+     * If the Metal library compiler does not return within
+     * MVKConfiguration::metalCompileTimeout nanoseconds, an error will be
+     * generated and logged, and nil will be returned.
+     */
+    id<MTLLibrary> newMTLLibrary(
+        NSString* mslSourceCode,
+        const mvk::SPIRVToMSLConversionResultInfo& shaderConversionResults);
 
 #pragma mark Construction
 
-	MVKShaderLibraryCompiler(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
-		_compilerType = "Shader library";
-		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.mslCompile;
-	}
+    MVKShaderLibraryCompiler(MVKVulkanAPIDeviceObject* owner)
+        : MVKMetalCompiler(owner) {
+        _compilerType = "Shader library";
+        _pPerformanceTracker =
+            &getPerformanceStats().shaderCompilation.mslCompile;
+    }
 
-	~MVKShaderLibraryCompiler() override;
+    ~MVKShaderLibraryCompiler() override;
 
-protected:
-	bool compileComplete(id<MTLLibrary> mtlLibrary, NSError *error);
-	void handleError() override;
+  protected:
+    bool compileComplete(id<MTLLibrary> mtlLibrary, NSError* error);
+    void handleError() override;
 
-	id<MTLLibrary> _mtlLibrary = nil;
+    id<MTLLibrary> _mtlLibrary = nil;
 };
-
 
 #pragma mark -
 #pragma mark MVKFunctionSpecializer
@@ -289,32 +323,37 @@ protected:
 /**
  * Compiles a specialized MTLFunction.
  *
- * Instances of this class are one-shot, and can only be used for a single function compilation.
+ * Instances of this class are one-shot, and can only be used for a single
+ * function compilation.
  */
 class MVKFunctionSpecializer : public MVKMetalCompiler {
 
-public:
-
-	/**
-	 * Returns a new (retained) MTLFunction object compiled from the MTLLibrary and specialization constants.
-	 *
-	 * If the Metal function compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLFunction> newMTLFunction(id<MTLLibrary> mtlLibrary, NSString* funcName, MTLFunctionConstantValues* constantValues);
-
+  public:
+    /**
+     * Returns a new (retained) MTLFunction object compiled from the MTLLibrary
+     * and specialization constants.
+     *
+     * If the Metal function compiler does not return within
+     * MVKConfiguration::metalCompileTimeout nanoseconds, an error will be
+     * generated and logged, and nil will be returned.
+     */
+    id<MTLFunction> newMTLFunction(id<MTLLibrary> mtlLibrary,
+                                   NSString* funcName,
+                                   MTLFunctionConstantValues* constantValues);
 
 #pragma mark Construction
 
-	MVKFunctionSpecializer(MVKVulkanAPIDeviceObject* owner) : MVKMetalCompiler(owner) {
-		_compilerType = "Function specialization";
-		_pPerformanceTracker = &getPerformanceStats().shaderCompilation.functionSpecialization;
-	}
+    MVKFunctionSpecializer(MVKVulkanAPIDeviceObject* owner)
+        : MVKMetalCompiler(owner) {
+        _compilerType = "Function specialization";
+        _pPerformanceTracker =
+            &getPerformanceStats().shaderCompilation.functionSpecialization;
+    }
 
-	~MVKFunctionSpecializer() override;
+    ~MVKFunctionSpecializer() override;
 
-protected:
-	bool compileComplete(id<MTLFunction> mtlFunction, NSError *error);
+  protected:
+    bool compileComplete(id<MTLFunction> mtlFunction, NSError* error);
 
-	id<MTLFunction> _mtlFunction = nil;
+    id<MTLFunction> _mtlFunction = nil;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,601 +24,758 @@
 using namespace std;
 using namespace mvk;
 
-MVKMTLFunction::MVKMTLFunction(id<MTLFunction> mtlFunc, const SPIRVToMSLConversionResultInfo scRslts, MTLSize tgSize) {
-	_mtlFunction = [mtlFunc retain];		// retained
-	shaderConversionResults = scRslts;
-	threadGroupSize = tgSize;
+MVKMTLFunction::MVKMTLFunction(id<MTLFunction> mtlFunc,
+                               const SPIRVToMSLConversionResultInfo scRslts,
+                               MTLSize tgSize) {
+    _mtlFunction = [mtlFunc retain]; // retained
+    shaderConversionResults = scRslts;
+    threadGroupSize = tgSize;
 }
 
 MVKMTLFunction::MVKMTLFunction(const MVKMTLFunction& other) {
-	_mtlFunction = [other._mtlFunction retain];		// retained
-	shaderConversionResults = other.shaderConversionResults;
-	threadGroupSize = other.threadGroupSize;
+    _mtlFunction = [other._mtlFunction retain]; // retained
+    shaderConversionResults = other.shaderConversionResults;
+    threadGroupSize = other.threadGroupSize;
 }
 
 MVKMTLFunction& MVKMTLFunction::operator=(const MVKMTLFunction& other) {
-	// Retain new object first in case it's the same object
-	[other._mtlFunction retain];
-	[_mtlFunction release];
-	_mtlFunction = other._mtlFunction;
+    // Retain new object first in case it's the same object
+    [other._mtlFunction retain];
+    [_mtlFunction release];
+    _mtlFunction = other._mtlFunction;
 
-	shaderConversionResults = other.shaderConversionResults;
-	threadGroupSize = other.threadGroupSize;
-	return *this;
+    shaderConversionResults = other.shaderConversionResults;
+    threadGroupSize = other.threadGroupSize;
+    return *this;
 }
 
-MVKMTLFunction::~MVKMTLFunction() {
-	[_mtlFunction release];
-}
-
+MVKMTLFunction::~MVKMTLFunction() { [_mtlFunction release]; }
 
 #pragma mark -
 #pragma mark MVKShaderLibrary
 
 // If the size of the workgroup dimension is specialized, extract it from the
-// specialization info, otherwise use the value specified in the SPIR-V shader code.
-static uint32_t getWorkgroupDimensionSize(const SPIRVWorkgroupSizeDimension& wgDim, const VkSpecializationInfo* pSpecInfo) {
-	if (wgDim.isSpecialized && pSpecInfo) {
-		for (uint32_t specIdx = 0; specIdx < pSpecInfo->mapEntryCount; specIdx++) {
-			const VkSpecializationMapEntry* pMapEntry = &pSpecInfo->pMapEntries[specIdx];
-			if (pMapEntry->constantID == wgDim.specializationID) {
-				return *reinterpret_cast<uint32_t*>((uintptr_t)pSpecInfo->pData + pMapEntry->offset) ;
-			}
-		}
-	}
-	return wgDim.size;
+// specialization info, otherwise use the value specified in the SPIR-V shader
+// code.
+static uint32_t
+getWorkgroupDimensionSize(const SPIRVWorkgroupSizeDimension& wgDim,
+                          const VkSpecializationInfo* pSpecInfo) {
+    if (wgDim.isSpecialized && pSpecInfo) {
+        for (uint32_t specIdx = 0; specIdx < pSpecInfo->mapEntryCount;
+             specIdx++) {
+            const VkSpecializationMapEntry* pMapEntry =
+                &pSpecInfo->pMapEntries[specIdx];
+            if (pMapEntry->constantID == wgDim.specializationID) {
+                return *reinterpret_cast<uint32_t*>(
+                    (uintptr_t)pSpecInfo->pData + pMapEntry->offset);
+            }
+        }
+    }
+    return wgDim.size;
 }
 
-MVKMTLFunction MVKShaderLibrary::getMTLFunction(const VkSpecializationInfo* pSpecializationInfo,
-												VkPipelineCreationFeedback* pShaderFeedback,
-												MVKShaderModule* shaderModule) {
+MVKMTLFunction MVKShaderLibrary::getMTLFunction(
+    const VkSpecializationInfo* pSpecializationInfo,
+    VkPipelineCreationFeedback* pShaderFeedback,
+    MVKShaderModule* shaderModule) {
 
-	if ( !_mtlLibrary ) { return MVKMTLFunctionNull; }
+    if (!_mtlLibrary) {
+        return MVKMTLFunctionNull;
+    }
 
-	@synchronized (getMTLDevice()) {
-		@autoreleasepool {
-			NSString* mtlFuncName = @(_shaderConversionResultInfo.entryPoint.mtlFunctionName.c_str());
+    @synchronized(getMTLDevice()) {
+        @autoreleasepool {
+            NSString* mtlFuncName = @(
+                _shaderConversionResultInfo.entryPoint.mtlFunctionName.c_str());
 
-			uint64_t startTime = pShaderFeedback ? mvkGetTimestamp() : getPerformanceTimestamp();
-			id<MTLFunction> mtlFunc = [[_mtlLibrary newFunctionWithName: mtlFuncName] autorelease];
-			addPerformanceInterval(getPerformanceStats().shaderCompilation.functionRetrieval, startTime);
-			if (pShaderFeedback) {
-				if (mtlFunc) {
-					mvkEnableFlags(pShaderFeedback->flags, VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
-				}
-				pShaderFeedback->duration += mvkGetElapsedNanoseconds(startTime);
-			}
+            uint64_t startTime =
+                pShaderFeedback ? mvkGetTimestamp() : getPerformanceTimestamp();
+            id<MTLFunction> mtlFunc =
+                [[_mtlLibrary newFunctionWithName:mtlFuncName] autorelease];
+            addPerformanceInterval(getPerformanceStats()
+                                       .shaderCompilation.functionRetrieval,
+                                   startTime);
+            if (pShaderFeedback) {
+                if (mtlFunc) {
+                    mvkEnableFlags(pShaderFeedback->flags,
+                                   VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT);
+                }
+                pShaderFeedback->duration +=
+                    mvkGetElapsedNanoseconds(startTime);
+            }
 
-			if (mtlFunc) {
-				// If the Metal device supports shader specialization, and the Metal function expects to be specialized,
-				// populate Metal function constant values from the Vulkan specialization info, and compile a specialized
-				// Metal function, otherwise simply use the unspecialized Metal function.
-				if (getMetalFeatures().shaderSpecialization) {
-					NSArray<MTLFunctionConstant*>* mtlFCs = mtlFunc.functionConstantsDictionary.allValues;
-					if (mtlFCs.count > 0) {
-						// The Metal shader contains function constants and expects to be specialized.
-						// Populate the Metal function constant values from the Vulkan specialization info.
-						MTLFunctionConstantValues* mtlFCVals = [[MTLFunctionConstantValues new] autorelease];
-						if (pSpecializationInfo) {
-							// Iterate through the provided Vulkan specialization entries, and populate the
-							// Metal function constant value that matches the Vulkan specialization constantID.
-							for (uint32_t specIdx = 0; specIdx < pSpecializationInfo->mapEntryCount; specIdx++) {
-								const VkSpecializationMapEntry* pMapEntry = &pSpecializationInfo->pMapEntries[specIdx];
-								for (MTLFunctionConstant* mfc in mtlFCs) {
-									if (mfc.index == pMapEntry->constantID) {
-										[mtlFCVals setConstantValue: ((char*)pSpecializationInfo->pData + pMapEntry->offset)
-															   type: mfc.type
-															atIndex: mfc.index];
-										break;
-									}
-								}
-							}
-						}
+            if (mtlFunc) {
+                // If the Metal device supports shader specialization, and the
+                // Metal function expects to be specialized, populate Metal
+                // function constant values from the Vulkan specialization info,
+                // and compile a specialized Metal function, otherwise simply
+                // use the unspecialized Metal function.
+                if (getMetalFeatures().shaderSpecialization) {
+                    NSArray<MTLFunctionConstant*>* mtlFCs =
+                        mtlFunc.functionConstantsDictionary.allValues;
+                    if (mtlFCs.count > 0) {
+                        // The Metal shader contains function constants and
+                        // expects to be specialized. Populate the Metal
+                        // function constant values from the Vulkan
+                        // specialization info.
+                        MTLFunctionConstantValues* mtlFCVals =
+                            [[MTLFunctionConstantValues new] autorelease];
+                        if (pSpecializationInfo) {
+                            // Iterate through the provided Vulkan
+                            // specialization entries, and populate the Metal
+                            // function constant value that matches the Vulkan
+                            // specialization constantID.
+                            for (uint32_t specIdx = 0;
+                                 specIdx < pSpecializationInfo->mapEntryCount;
+                                 specIdx++) {
+                                const VkSpecializationMapEntry* pMapEntry =
+                                    &pSpecializationInfo->pMapEntries[specIdx];
+                                for (MTLFunctionConstant* mfc in mtlFCs) {
+                                    if (mfc.index == pMapEntry->constantID) {
+                                        [mtlFCVals
+                                            setConstantValue:
+                                                ((char*)pSpecializationInfo
+                                                     ->pData +
+                                                 pMapEntry->offset)
+                                                        type:mfc.type
+                                                     atIndex:mfc.index];
+                                        break;
+                                    }
+                                }
+                            }
+                        }
 
-						// Compile the specialized Metal function, and use it instead of the unspecialized Metal function.
-						MVKFunctionSpecializer fs(_owner);
-						if (pShaderFeedback) {
-							startTime = mvkGetTimestamp();
-						}
-						mtlFunc = [fs.newMTLFunction(_mtlLibrary, mtlFuncName, mtlFCVals) autorelease];
-						if (pShaderFeedback) {
-							pShaderFeedback->duration += mvkGetElapsedNanoseconds(startTime);
-						}
-					}
-				}
-			}
+                        // Compile the specialized Metal function, and use it
+                        // instead of the unspecialized Metal function.
+                        MVKFunctionSpecializer fs(_owner);
+                        if (pShaderFeedback) {
+                            startTime = mvkGetTimestamp();
+                        }
+                        mtlFunc = [fs.newMTLFunction(_mtlLibrary, mtlFuncName,
+                                                     mtlFCVals) autorelease];
+                        if (pShaderFeedback) {
+                            pShaderFeedback->duration +=
+                                mvkGetElapsedNanoseconds(startTime);
+                        }
+                    }
+                }
+            }
 
-			// Set the debug name. First try name of shader module, otherwise try name of owner.
-			NSString* dbName = shaderModule->getDebugName();
-			if ( !dbName ) { dbName = _owner->getDebugName(); }
-			_owner->setMetalObjectLabel(mtlFunc, dbName);
+            // Set the debug name. First try name of shader module, otherwise
+            // try name of owner.
+            NSString* dbName = shaderModule->getDebugName();
+            if (!dbName) {
+                dbName = _owner->getDebugName();
+            }
+            _owner->setMetalObjectLabel(mtlFunc, dbName);
 
-			auto& wgSize = _shaderConversionResultInfo.entryPoint.workgroupSize;
-			return MVKMTLFunction(mtlFunc, _shaderConversionResultInfo, MTLSizeMake(getWorkgroupDimensionSize(wgSize.width, pSpecializationInfo),
-																				 getWorkgroupDimensionSize(wgSize.height, pSpecializationInfo),
-																				 getWorkgroupDimensionSize(wgSize.depth, pSpecializationInfo)));
-		}
-	}
+            auto& wgSize = _shaderConversionResultInfo.entryPoint.workgroupSize;
+            return MVKMTLFunction(
+                mtlFunc, _shaderConversionResultInfo,
+                MTLSizeMake(getWorkgroupDimensionSize(wgSize.width,
+                                                      pSpecializationInfo),
+                            getWorkgroupDimensionSize(wgSize.height,
+                                                      pSpecializationInfo),
+                            getWorkgroupDimensionSize(wgSize.depth,
+                                                      pSpecializationInfo)));
+        }
+    }
 }
 
 void MVKShaderLibrary::setEntryPointName(string& funcName) {
-	_shaderConversionResultInfo.entryPoint.mtlFunctionName = funcName;
+    _shaderConversionResultInfo.entryPoint.mtlFunctionName = funcName;
 }
 
 void MVKShaderLibrary::setWorkgroupSize(uint32_t x, uint32_t y, uint32_t z) {
-	auto& wgSize = _shaderConversionResultInfo.entryPoint.workgroupSize;
-	wgSize.width.size = x;
-	wgSize.height.size = y;
-	wgSize.depth.size = z;
+    auto& wgSize = _shaderConversionResultInfo.entryPoint.workgroupSize;
+    wgSize.width.size = x;
+    wgSize.height.size = y;
+    wgSize.depth.size = z;
 }
 
 // Sets the cached MSL source code, after first compressing it.
 void MVKShaderLibrary::compressMSL(const string& msl) {
-	uint64_t startTime = getPerformanceTimestamp();
-	_compressedMSL.compress(msl, getMVKConfig().shaderSourceCompressionAlgorithm);
-	addPerformanceInterval(getPerformanceStats().shaderCompilation.mslCompress, startTime);
+    uint64_t startTime = getPerformanceTimestamp();
+    _compressedMSL.compress(msl,
+                            getMVKConfig().shaderSourceCompressionAlgorithm);
+    addPerformanceInterval(getPerformanceStats().shaderCompilation.mslCompress,
+                           startTime);
 }
 
 // Decompresses the cached MSL into the string.
 void MVKShaderLibrary::decompressMSL(string& msl) {
-	uint64_t startTime = getPerformanceTimestamp();
-	_compressedMSL.decompress(msl);
-	addPerformanceInterval(getPerformanceStats().shaderCompilation.mslDecompress, startTime);
+    uint64_t startTime = getPerformanceTimestamp();
+    _compressedMSL.decompress(msl);
+    addPerformanceInterval(getPerformanceStats()
+                               .shaderCompilation.mslDecompress,
+                           startTime);
 }
 
-MVKShaderLibrary::MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
-								   const SPIRVToMSLConversionResult& conversionResult) :
-	MVKBaseDeviceObject(owner->getDevice()),
-	_owner(owner) {
+MVKShaderLibrary::MVKShaderLibrary(
+    MVKVulkanAPIDeviceObject* owner,
+    const SPIRVToMSLConversionResult& conversionResult)
+    : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {
 
-	_shaderConversionResultInfo = conversionResult.resultInfo;
-	compressMSL(conversionResult.msl);
-	compileLibrary(conversionResult.msl);
+    _shaderConversionResultInfo = conversionResult.resultInfo;
+    compressMSL(conversionResult.msl);
+    compileLibrary(conversionResult.msl);
 }
 
-MVKShaderLibrary::MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
-								   const SPIRVToMSLConversionResultInfo& resultInfo,
-								   const MVKCompressor<std::string> compressedMSL) :
-	MVKBaseDeviceObject(owner->getDevice()),
-	_owner(owner) {
+MVKShaderLibrary::MVKShaderLibrary(
+    MVKVulkanAPIDeviceObject* owner,
+    const SPIRVToMSLConversionResultInfo& resultInfo,
+    const MVKCompressor<std::string> compressedMSL)
+    : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {
 
-	_shaderConversionResultInfo = resultInfo;
-	_compressedMSL = compressedMSL;
-	string msl;
-	decompressMSL(msl);
-	compileLibrary(msl);
+    _shaderConversionResultInfo = resultInfo;
+    _compressedMSL = compressedMSL;
+    string msl;
+    decompressMSL(msl);
+    compileLibrary(msl);
 }
 
 void MVKShaderLibrary::compileLibrary(const string& msl) {
-	MVKShaderLibraryCompiler* slc = new MVKShaderLibraryCompiler(_owner);
-	NSString* nsSrc = [[NSString alloc] initWithUTF8String: msl.c_str()];	// temp retained
-	_mtlLibrary = slc->newMTLLibrary(nsSrc, _shaderConversionResultInfo);	// retained
-	[nsSrc release];														// release temp string
-	slc->destroy();
+    MVKShaderLibraryCompiler* slc = new MVKShaderLibraryCompiler(_owner);
+    NSString* nsSrc =
+        [[NSString alloc] initWithUTF8String:msl.c_str()]; // temp retained
+    _mtlLibrary =
+        slc->newMTLLibrary(nsSrc, _shaderConversionResultInfo); // retained
+    [nsSrc release]; // release temp string
+    slc->destroy();
 }
 
 MVKShaderLibrary::MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
                                    const void* mslCompiledCodeData,
-                                   size_t mslCompiledCodeLength) :
-	MVKBaseDeviceObject(owner->getDevice()),
-	_owner(owner) {
+                                   size_t mslCompiledCodeLength)
+    : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {
 
     uint64_t startTime = getPerformanceTimestamp();
     @autoreleasepool {
-        dispatch_data_t shdrData = dispatch_data_create(mslCompiledCodeData,
-                                                        mslCompiledCodeLength,
-                                                        NULL,
-                                                        DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+        dispatch_data_t shdrData =
+            dispatch_data_create(mslCompiledCodeData, mslCompiledCodeLength,
+                                 NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
         NSError* err = nil;
-        _mtlLibrary = [getMTLDevice() newLibraryWithData: shdrData error: &err];    // retained
+        _mtlLibrary = [getMTLDevice() newLibraryWithData:shdrData
+                                                   error:&err]; // retained
         handleCompilationError(err, "Compiled shader module creation");
         [shdrData release];
     }
-	addPerformanceInterval(getPerformanceStats().shaderCompilation.mslLoad, startTime);
+    addPerformanceInterval(getPerformanceStats().shaderCompilation.mslLoad,
+                           startTime);
 }
 
-MVKShaderLibrary::MVKShaderLibrary(const MVKShaderLibrary& other) :
-	MVKBaseDeviceObject(other._device),
-	_owner(other._owner) {
+MVKShaderLibrary::MVKShaderLibrary(const MVKShaderLibrary& other)
+    : MVKBaseDeviceObject(other._device), _owner(other._owner) {
 
-	_mtlLibrary = [other._mtlLibrary retain];
-	_shaderConversionResultInfo = other._shaderConversionResultInfo;
-	_compressedMSL = other._compressedMSL;
+    _mtlLibrary = [other._mtlLibrary retain];
+    _shaderConversionResultInfo = other._shaderConversionResultInfo;
+    _compressedMSL = other._compressedMSL;
 }
 
 MVKShaderLibrary& MVKShaderLibrary::operator=(const MVKShaderLibrary& other) {
-	if (_mtlLibrary != other._mtlLibrary) {
-		[_mtlLibrary release];
-		_mtlLibrary = [other._mtlLibrary retain];
-	}
-	_owner = other._owner;
-	_shaderConversionResultInfo = other._shaderConversionResultInfo;
-	_compressedMSL = other._compressedMSL;
-	return *this;
+    if (_mtlLibrary != other._mtlLibrary) {
+        [_mtlLibrary release];
+        _mtlLibrary = [other._mtlLibrary retain];
+    }
+    _owner = other._owner;
+    _shaderConversionResultInfo = other._shaderConversionResultInfo;
+    _compressedMSL = other._compressedMSL;
+    return *this;
 }
 
 // If err object is nil, the compilation succeeded without any warnings.
-// If err object exists, and the MTLLibrary was created, the compilation succeeded, but with warnings.
-// If err object exists, and the MTLLibrary was not created, the compilation failed.
-void MVKShaderLibrary::handleCompilationError(NSError* err, const char* opDesc) {
-    if ( !err ) return;
+// If err object exists, and the MTLLibrary was created, the compilation
+// succeeded, but with warnings. If err object exists, and the MTLLibrary was
+// not created, the compilation failed.
+void MVKShaderLibrary::handleCompilationError(NSError* err,
+                                              const char* opDesc) {
+    if (!err) return;
 
     if (_mtlLibrary) {
-        MVKLogInfo("%s succeeded with warnings (Error code %li):\n%s", opDesc, (long)err.code, err.localizedDescription.UTF8String);
+        MVKLogInfo("%s succeeded with warnings (Error code %li):\n%s", opDesc,
+                   (long)err.code, err.localizedDescription.UTF8String);
     } else {
-		_owner->setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV,
-												   "%s failed (Error code %li):\n%s",
-												   opDesc, (long)err.code,
-												   err.localizedDescription.UTF8String));
+        _owner->setConfigurationResult(
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "%s failed (Error code %li):\n%s", opDesc,
+                        (long)err.code, err.localizedDescription.UTF8String));
     }
 }
 
-MVKShaderLibrary::~MVKShaderLibrary() {
-	[_mtlLibrary release];
-}
-
+MVKShaderLibrary::~MVKShaderLibrary() { [_mtlLibrary release]; }
 
 #pragma mark -
 #pragma mark MVKShaderLibraryCache
 
-MVKShaderLibrary* MVKShaderLibraryCache::getShaderLibrary(SPIRVToMSLConversionConfiguration* pShaderConfig,
-														  MVKShaderModule* shaderModule, MVKPipeline* pipeline,
-														  bool* pWasAdded, VkPipelineCreationFeedback* pShaderFeedback,
-														  uint64_t startTime) {
-	bool wasAdded = false;
-	MVKShaderLibrary* shLib = findShaderLibrary(pShaderConfig, pShaderFeedback, startTime);
-	if ( !shLib && !pipeline->shouldFailOnPipelineCompileRequired() ) {
-		SPIRVToMSLConversionResult conversionResult;
-		if (shaderModule->convert(pShaderConfig, conversionResult)) {
-			shLib = addShaderLibrary(pShaderConfig, conversionResult);
-			if (pShaderFeedback) {
-				pShaderFeedback->duration += mvkGetElapsedNanoseconds(startTime);
-			}
-			wasAdded = true;
-		}
-	}
+MVKShaderLibrary* MVKShaderLibraryCache::getShaderLibrary(
+    SPIRVToMSLConversionConfiguration* pShaderConfig,
+    MVKShaderModule* shaderModule, MVKPipeline* pipeline, bool* pWasAdded,
+    VkPipelineCreationFeedback* pShaderFeedback, uint64_t startTime) {
+    bool wasAdded = false;
+    MVKShaderLibrary* shLib =
+        findShaderLibrary(pShaderConfig, pShaderFeedback, startTime);
+    if (!shLib && !pipeline->shouldFailOnPipelineCompileRequired()) {
+        SPIRVToMSLConversionResult conversionResult;
+        if (shaderModule->convert(pShaderConfig, conversionResult)) {
+            shLib = addShaderLibrary(pShaderConfig, conversionResult);
+            if (pShaderFeedback) {
+                pShaderFeedback->duration +=
+                    mvkGetElapsedNanoseconds(startTime);
+            }
+            wasAdded = true;
+        }
+    }
 
-	if (pWasAdded) { *pWasAdded = wasAdded; }
+    if (pWasAdded) {
+        *pWasAdded = wasAdded;
+    }
 
-	return shLib;
+    return shLib;
 }
 
-// Finds and returns a shader library matching the shader config, or returns nullptr if it doesn't exist.
-// If a match is found, the shader config is aligned with the shader config of the matching library.
-MVKShaderLibrary* MVKShaderLibraryCache::findShaderLibrary(SPIRVToMSLConversionConfiguration* pShaderConfig,
-														   VkPipelineCreationFeedback* pShaderFeedback,
-														   uint64_t startTime) {
-	for (auto& slPair : _shaderLibraries) {
-		if (slPair.first.matches(*pShaderConfig)) {
-			pShaderConfig->alignWith(slPair.first);
-			addPerformanceInterval(getPerformanceStats().shaderCompilation.shaderLibraryFromCache, startTime);
-			if (pShaderFeedback) {
-				pShaderFeedback->duration += mvkGetElapsedNanoseconds(startTime);
-			}
-			return slPair.second;
-		}
-	}
-	return nullptr;
+// Finds and returns a shader library matching the shader config, or returns
+// nullptr if it doesn't exist. If a match is found, the shader config is
+// aligned with the shader config of the matching library.
+MVKShaderLibrary* MVKShaderLibraryCache::findShaderLibrary(
+    SPIRVToMSLConversionConfiguration* pShaderConfig,
+    VkPipelineCreationFeedback* pShaderFeedback, uint64_t startTime) {
+    for (auto& slPair : _shaderLibraries) {
+        if (slPair.first.matches(*pShaderConfig)) {
+            pShaderConfig->alignWith(slPair.first);
+            addPerformanceInterval(getPerformanceStats()
+                                       .shaderCompilation
+                                       .shaderLibraryFromCache,
+                                   startTime);
+            if (pShaderFeedback) {
+                pShaderFeedback->duration +=
+                    mvkGetElapsedNanoseconds(startTime);
+            }
+            return slPair.second;
+        }
+    }
+    return nullptr;
 }
 
-// Adds and returns a new shader library configured from the specified conversion configuration.
-MVKShaderLibrary* MVKShaderLibraryCache::addShaderLibrary(const SPIRVToMSLConversionConfiguration* pShaderConfig,
-														  const SPIRVToMSLConversionResult& conversionResult) {
-	MVKShaderLibrary* shLib = new MVKShaderLibrary(_owner, conversionResult);
-	_shaderLibraries.emplace_back(*pShaderConfig, shLib);
-	return shLib;
+// Adds and returns a new shader library configured from the specified
+// conversion configuration.
+MVKShaderLibrary* MVKShaderLibraryCache::addShaderLibrary(
+    const SPIRVToMSLConversionConfiguration* pShaderConfig,
+    const SPIRVToMSLConversionResult& conversionResult) {
+    MVKShaderLibrary* shLib = new MVKShaderLibrary(_owner, conversionResult);
+    _shaderLibraries.emplace_back(*pShaderConfig, shLib);
+    return shLib;
 }
 
-// Adds and returns a new shader library configured from contents read from a pipeline cache.
-MVKShaderLibrary* MVKShaderLibraryCache::addShaderLibrary(const SPIRVToMSLConversionConfiguration* pShaderConfig,
-														  const SPIRVToMSLConversionResultInfo& resultInfo,
-														  const MVKCompressor<std::string> compressedMSL) {
-	MVKShaderLibrary* shLib = new MVKShaderLibrary(_owner, resultInfo, compressedMSL);
-	_shaderLibraries.emplace_back(*pShaderConfig, shLib);
-	return shLib;
+// Adds and returns a new shader library configured from contents read from a
+// pipeline cache.
+MVKShaderLibrary* MVKShaderLibraryCache::addShaderLibrary(
+    const SPIRVToMSLConversionConfiguration* pShaderConfig,
+    const SPIRVToMSLConversionResultInfo& resultInfo,
+    const MVKCompressor<std::string> compressedMSL) {
+    MVKShaderLibrary* shLib =
+        new MVKShaderLibrary(_owner, resultInfo, compressedMSL);
+    _shaderLibraries.emplace_back(*pShaderConfig, shLib);
+    return shLib;
 }
 
 // Merge another shader library cache with this one. Handle null input.
 void MVKShaderLibraryCache::merge(MVKShaderLibraryCache* other) {
-	if ( !other ) { return; }
-	for (auto& otherPair : other->_shaderLibraries) {
-		if ( !findShaderLibrary(&otherPair.first) ) {
-			_shaderLibraries.emplace_back(otherPair.first, new MVKShaderLibrary(*otherPair.second));
-			_shaderLibraries.back().second->_owner = _owner;
-		}
-	}
+    if (!other) {
+        return;
+    }
+    for (auto& otherPair : other->_shaderLibraries) {
+        if (!findShaderLibrary(&otherPair.first)) {
+            _shaderLibraries.emplace_back(otherPair.first,
+                                          new MVKShaderLibrary(
+                                              *otherPair.second));
+            _shaderLibraries.back().second->_owner = _owner;
+        }
+    }
 }
 
 MVKShaderLibraryCache::~MVKShaderLibraryCache() {
-	for (auto& slPair : _shaderLibraries) { slPair.second->destroy(); }
+    for (auto& slPair : _shaderLibraries) {
+        slPair.second->destroy();
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKShaderModule
 
-MVKMTLFunction MVKShaderModule::getMTLFunction(SPIRVToMSLConversionConfiguration* pShaderConfig,
-											   const VkSpecializationInfo* pSpecializationInfo,
-											   MVKPipeline* pipeline,
-											   VkPipelineCreationFeedback* pShaderFeedback) {
-	MVKShaderLibrary* mvkLib = _directMSLLibrary;
-	if ( !mvkLib ) {
-		uint64_t startTime = pShaderFeedback ? mvkGetTimestamp() : getPerformanceTimestamp();
-		MVKPipelineCache* pipelineCache = pipeline->getPipelineCache();
-		if (pipelineCache) {
-			mvkLib = pipelineCache->getShaderLibrary(pShaderConfig, this, pipeline, pShaderFeedback, startTime);
-		} else {
-			lock_guard<mutex> lock(_accessLock);
-			mvkLib = _shaderLibraryCache.getShaderLibrary(pShaderConfig, this, pipeline, nullptr, pShaderFeedback, startTime);
-		}
-	} else {
-		mvkLib->setEntryPointName(pShaderConfig->options.entryPointName);
-		pShaderConfig->markAllInterfaceVarsAndResourcesUsed();
-	}
+MVKMTLFunction MVKShaderModule::getMTLFunction(
+    SPIRVToMSLConversionConfiguration* pShaderConfig,
+    const VkSpecializationInfo* pSpecializationInfo, MVKPipeline* pipeline,
+    VkPipelineCreationFeedback* pShaderFeedback) {
+    MVKShaderLibrary* mvkLib = _directMSLLibrary;
+    if (!mvkLib) {
+        uint64_t startTime =
+            pShaderFeedback ? mvkGetTimestamp() : getPerformanceTimestamp();
+        MVKPipelineCache* pipelineCache = pipeline->getPipelineCache();
+        if (pipelineCache) {
+            mvkLib =
+                pipelineCache->getShaderLibrary(pShaderConfig, this, pipeline,
+                                                pShaderFeedback, startTime);
+        } else {
+            lock_guard<mutex> lock(_accessLock);
+            mvkLib = _shaderLibraryCache.getShaderLibrary(pShaderConfig, this,
+                                                          pipeline, nullptr,
+                                                          pShaderFeedback,
+                                                          startTime);
+        }
+    } else {
+        mvkLib->setEntryPointName(pShaderConfig->options.entryPointName);
+        pShaderConfig->markAllInterfaceVarsAndResourcesUsed();
+    }
 
-	return mvkLib ? mvkLib->getMTLFunction(pSpecializationInfo, pShaderFeedback, this) : MVKMTLFunctionNull;
+    return mvkLib ? mvkLib->getMTLFunction(pSpecializationInfo, pShaderFeedback,
+                                           this)
+                  : MVKMTLFunctionNull;
 }
 
 bool MVKShaderModule::convert(SPIRVToMSLConversionConfiguration* pShaderConfig,
-							  SPIRVToMSLConversionResult& conversionResult) {
-	const auto& mvkCfg = getMVKConfig();
-	bool shouldLogCode = mvkCfg.debugMode;
-	bool shouldLogEstimatedGLSL = shouldLogCode && mvkCfg.shaderLogEstimatedGLSL;
+                              SPIRVToMSLConversionResult& conversionResult) {
+    const auto& mvkCfg = getMVKConfig();
+    bool shouldLogCode = mvkCfg.debugMode;
+    bool shouldLogEstimatedGLSL =
+        shouldLogCode && mvkCfg.shaderLogEstimatedGLSL;
 
-	// If the SPIR-V converter does not have any code, but the GLSL converter does,
-	// convert the GLSL code to SPIR-V and set it into the SPIR-V conveter.
-	if ( !_spvConverter.hasSPIRV() && _glslConverter.hasGLSL() ) {
+    // If the SPIR-V converter does not have any code, but the GLSL converter
+    // does, convert the GLSL code to SPIR-V and set it into the SPIR-V
+    // conveter.
+    if (!_spvConverter.hasSPIRV() && _glslConverter.hasGLSL()) {
 
-		GLSLToSPIRVConversionResult glslConversionResult;
-		uint64_t startTime = getPerformanceTimestamp();
-		bool wasConverted = _glslConverter.convert(getMVKGLSLConversionShaderStage(pShaderConfig), glslConversionResult, shouldLogCode, false);
-		addPerformanceInterval(getPerformanceStats().shaderCompilation.glslToSPRIV, startTime);
+        GLSLToSPIRVConversionResult glslConversionResult;
+        uint64_t startTime = getPerformanceTimestamp();
+        bool wasConverted =
+            _glslConverter.convert(getMVKGLSLConversionShaderStage(
+                                       pShaderConfig),
+                                   glslConversionResult, shouldLogCode, false);
+        addPerformanceInterval(getPerformanceStats()
+                                   .shaderCompilation.glslToSPRIV,
+                               startTime);
 
-		if (wasConverted) {
-			if (shouldLogCode) { MVKLogInfo("%s", glslConversionResult.resultLog.c_str()); }
-			_spvConverter.setSPIRV(glslConversionResult.spirv);
-		} else {
-			reportError(VK_ERROR_INVALID_SHADER_NV, "Unable to convert GLSL to SPIR-V:\n%s", glslConversionResult.resultLog.c_str());
-		}
-		shouldLogEstimatedGLSL = false;
-	}
+        if (wasConverted) {
+            if (shouldLogCode) {
+                MVKLogInfo("%s", glslConversionResult.resultLog.c_str());
+            }
+            _spvConverter.setSPIRV(glslConversionResult.spirv);
+        } else {
+            reportError(VK_ERROR_INVALID_SHADER_NV,
+                        "Unable to convert GLSL to SPIR-V:\n%s",
+                        glslConversionResult.resultLog.c_str());
+        }
+        shouldLogEstimatedGLSL = false;
+    }
 
-	uint64_t startTime = getPerformanceTimestamp();
-	bool wasConverted = _spvConverter.convert(*pShaderConfig, conversionResult, shouldLogCode, shouldLogCode, shouldLogEstimatedGLSL);
-	addPerformanceInterval(getPerformanceStats().shaderCompilation.spirvToMSL, startTime);
+    uint64_t startTime = getPerformanceTimestamp();
+    bool wasConverted =
+        _spvConverter.convert(*pShaderConfig, conversionResult, shouldLogCode,
+                              shouldLogCode, shouldLogEstimatedGLSL);
+    addPerformanceInterval(getPerformanceStats().shaderCompilation.spirvToMSL,
+                           startTime);
 
-	const char* dumpDir = getMVKConfig().shaderDumpDir;
-	if (dumpDir && *dumpDir) {
-		char path[PATH_MAX];
-		const char* type;
-		switch (pShaderConfig->options.entryPointStage) {
-			case spv::ExecutionModelVertex:                 type = "-vs"; break;
-			case spv::ExecutionModelTessellationControl:    type = "-tcs"; break;
-			case spv::ExecutionModelTessellationEvaluation: type = "-tes"; break;
-			case spv::ExecutionModelFragment:               type = "-fs"; break;
-			case spv::ExecutionModelGeometry:               type = "-gs"; break;
-			case spv::ExecutionModelTaskNV:                 type = "-ts"; break;
-			case spv::ExecutionModelMeshNV:                 type = "-ms"; break;
-			case spv::ExecutionModelGLCompute:              type = "-cs"; break;
-			default:                                        type = "";    break;
-		}
-		mkdir(dumpDir, 0755);
-		snprintf(path, sizeof(path), "%s/shader%s-%016zx.spv", dumpDir, type, _key.codeHash);
-		FILE* file = fopen(path, "wb");
-		if (file) {
-			fwrite(_spvConverter.getSPIRV().data(), sizeof(uint32_t), _spvConverter.getSPIRV().size(), file);
-			fclose(file);
-		}
-		snprintf(path, sizeof(path), "%s/shader%s-%016zx.metal", dumpDir, type, _key.codeHash);
-		file = fopen(path, "wb");
-		if (file) {
-			if (wasConverted) {
-				fwrite(conversionResult.msl.data(), 1, conversionResult.msl.size(), file);
-				fclose(file);
-			} else {
-				fputs("Failed to convert:\n", file);
-				fwrite(conversionResult.resultLog.data(), 1, conversionResult.resultLog.size(), file);
-				fclose(file);
-			}
-		}
-	}
+    const char* dumpDir = getMVKConfig().shaderDumpDir;
+    if (dumpDir && *dumpDir) {
+        char path[PATH_MAX];
+        const char* type;
+        switch (pShaderConfig->options.entryPointStage) {
+        case spv::ExecutionModelVertex:
+            type = "-vs";
+            break;
+        case spv::ExecutionModelTessellationControl:
+            type = "-tcs";
+            break;
+        case spv::ExecutionModelTessellationEvaluation:
+            type = "-tes";
+            break;
+        case spv::ExecutionModelFragment:
+            type = "-fs";
+            break;
+        case spv::ExecutionModelGeometry:
+            type = "-gs";
+            break;
+        case spv::ExecutionModelTaskNV:
+            type = "-ts";
+            break;
+        case spv::ExecutionModelMeshNV:
+            type = "-ms";
+            break;
+        case spv::ExecutionModelGLCompute:
+            type = "-cs";
+            break;
+        default:
+            type = "";
+            break;
+        }
+        mkdir(dumpDir, 0755);
+        snprintf(path, sizeof(path), "%s/shader%s-%016zx.spv", dumpDir, type,
+                 _key.codeHash);
+        FILE* file = fopen(path, "wb");
+        if (file) {
+            fwrite(_spvConverter.getSPIRV().data(), sizeof(uint32_t),
+                   _spvConverter.getSPIRV().size(), file);
+            fclose(file);
+        }
+        snprintf(path, sizeof(path), "%s/shader%s-%016zx.metal", dumpDir, type,
+                 _key.codeHash);
+        file = fopen(path, "wb");
+        if (file) {
+            if (wasConverted) {
+                fwrite(conversionResult.msl.data(), 1,
+                       conversionResult.msl.size(), file);
+                fclose(file);
+            } else {
+                fputs("Failed to convert:\n", file);
+                fwrite(conversionResult.resultLog.data(), 1,
+                       conversionResult.resultLog.size(), file);
+                fclose(file);
+            }
+        }
+    }
 
-	if (wasConverted) {
-		if (shouldLogCode) { MVKLogInfo("%s", conversionResult.resultLog.c_str()); }
-	} else {
-		reportError(VK_ERROR_INVALID_SHADER_NV, "Unable to convert SPIR-V to MSL:\n%s", conversionResult.resultLog.c_str());
-	}
-	return wasConverted;
+    if (wasConverted) {
+        if (shouldLogCode) {
+            MVKLogInfo("%s", conversionResult.resultLog.c_str());
+        }
+    } else {
+        reportError(VK_ERROR_INVALID_SHADER_NV,
+                    "Unable to convert SPIR-V to MSL:\n%s",
+                    conversionResult.resultLog.c_str());
+    }
+    return wasConverted;
 }
 
-// Returns the MVKGLSLConversionShaderStage corresponding to the shader stage in the SPIR-V conversion configuration.
-MVKGLSLConversionShaderStage MVKShaderModule::getMVKGLSLConversionShaderStage(SPIRVToMSLConversionConfiguration* pShaderConfig) {
-	switch (pShaderConfig->options.entryPointStage) {
-		case spv::ExecutionModelVertex:						return kMVKGLSLConversionShaderStageVertex;
-		case spv::ExecutionModelTessellationControl:		return kMVKGLSLConversionShaderStageTessControl;
-		case spv::ExecutionModelTessellationEvaluation:		return kMVKGLSLConversionShaderStageTessEval;
-		case spv::ExecutionModelGeometry:					return kMVKGLSLConversionShaderStageGeometry;
-		case spv::ExecutionModelFragment:					return kMVKGLSLConversionShaderStageFragment;
-		case spv::ExecutionModelGLCompute:					return kMVKGLSLConversionShaderStageCompute;
-		case spv::ExecutionModelKernel:						return kMVKGLSLConversionShaderStageCompute;
+// Returns the MVKGLSLConversionShaderStage corresponding to the shader stage in
+// the SPIR-V conversion configuration.
+MVKGLSLConversionShaderStage MVKShaderModule::getMVKGLSLConversionShaderStage(
+    SPIRVToMSLConversionConfiguration* pShaderConfig) {
+    switch (pShaderConfig->options.entryPointStage) {
+    case spv::ExecutionModelVertex:
+        return kMVKGLSLConversionShaderStageVertex;
+    case spv::ExecutionModelTessellationControl:
+        return kMVKGLSLConversionShaderStageTessControl;
+    case spv::ExecutionModelTessellationEvaluation:
+        return kMVKGLSLConversionShaderStageTessEval;
+    case spv::ExecutionModelGeometry:
+        return kMVKGLSLConversionShaderStageGeometry;
+    case spv::ExecutionModelFragment:
+        return kMVKGLSLConversionShaderStageFragment;
+    case spv::ExecutionModelGLCompute:
+        return kMVKGLSLConversionShaderStageCompute;
+    case spv::ExecutionModelKernel:
+        return kMVKGLSLConversionShaderStageCompute;
 
-		default:
-			MVKAssert(false, "Bad shader stage provided for GLSL to SPIR-V conversion.");
-			return kMVKGLSLConversionShaderStageAuto;
-	}
+    default:
+        MVKAssert(false,
+                  "Bad shader stage provided for GLSL to SPIR-V conversion.");
+        return kMVKGLSLConversionShaderStageAuto;
+    }
 }
 
 void MVKShaderModule::setWorkgroupSize(uint32_t x, uint32_t y, uint32_t z) {
-	if(_directMSLLibrary) { _directMSLLibrary->setWorkgroupSize(x, y, z); }
+    if (_directMSLLibrary) {
+        _directMSLLibrary->setWorkgroupSize(x, y, z);
+    }
 }
-
 
 #pragma mark Construction
 
 MVKShaderModule::MVKShaderModule(MVKDevice* device,
-								 const VkShaderModuleCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device), _shaderLibraryCache(this) {
+                                 const VkShaderModuleCreateInfo* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device), _shaderLibraryCache(this) {
 
-	_directMSLLibrary = nullptr;
+    _directMSLLibrary = nullptr;
 
-	size_t codeSize = pCreateInfo->codeSize;
+    size_t codeSize = pCreateInfo->codeSize;
 
     // Ensure something is there.
-    if ( (pCreateInfo->pCode == VK_NULL_HANDLE) || (codeSize < 4) ) {
-		setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "vkCreateShaderModule(): Shader module contains no shader code."));
-		return;
-	}
+    if ((pCreateInfo->pCode == VK_NULL_HANDLE) || (codeSize < 4)) {
+        setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV,
+                                           "vkCreateShaderModule(): Shader "
+                                           "module contains no shader code."));
+        return;
+    }
 
-	size_t codeHash = 0;
+    size_t codeHash = 0;
 
-	// Retrieve the magic number to determine what type of shader code has been loaded.
-	// NOTE: Shader code should be submitted as SPIR-V. Although some simple direct MSL shaders may work,
-	// direct loading of MSL source code or compiled MSL code is not officially supported at this time.
-	// Future versions of MoltenVK may support direct MSL submission again.
-	uint32_t magicNum = *pCreateInfo->pCode;
-	switch (magicNum) {
-		case kMVKMagicNumberSPIRVCode: {					// SPIR-V code
-			size_t spvCount = (codeSize + 3) >> 2;			// Round up if byte length not exactly on uint32_t boundary
+    // Retrieve the magic number to determine what type of shader code has been
+    // loaded. NOTE: Shader code should be submitted as SPIR-V. Although some
+    // simple direct MSL shaders may work, direct loading of MSL source code or
+    // compiled MSL code is not officially supported at this time. Future
+    // versions of MoltenVK may support direct MSL submission again.
+    uint32_t magicNum = *pCreateInfo->pCode;
+    switch (magicNum) {
+    case kMVKMagicNumberSPIRVCode: { // SPIR-V code
+        size_t spvCount =
+            (codeSize + 3) >>
+            2; // Round up if byte length not exactly on uint32_t boundary
 
-			uint64_t startTime = getPerformanceTimestamp();
-			codeHash = mvkHash(pCreateInfo->pCode, spvCount);
-			addPerformanceInterval(getPerformanceStats().shaderCompilation.hashShaderCode, startTime);
+        uint64_t startTime = getPerformanceTimestamp();
+        codeHash = mvkHash(pCreateInfo->pCode, spvCount);
+        addPerformanceInterval(getPerformanceStats()
+                                   .shaderCompilation.hashShaderCode,
+                               startTime);
 
-			_spvConverter.setSPIRV(pCreateInfo->pCode, spvCount);
+        _spvConverter.setSPIRV(pCreateInfo->pCode, spvCount);
 
-			break;
-		}
-		case kMVKMagicNumberMSLSourceCode: {				// MSL source code
-			size_t hdrSize = sizeof(MVKMSLSPIRVHeader);
-			char* pMSLCode = (char*)(uintptr_t(pCreateInfo->pCode) + hdrSize);
-			size_t mslCodeLen = codeSize - hdrSize;
+        break;
+    }
+    case kMVKMagicNumberMSLSourceCode: { // MSL source code
+        size_t hdrSize = sizeof(MVKMSLSPIRVHeader);
+        char* pMSLCode = (char*)(uintptr_t(pCreateInfo->pCode) + hdrSize);
+        size_t mslCodeLen = codeSize - hdrSize;
 
-			uint64_t startTime = getPerformanceTimestamp();
-			codeHash = mvkHash(&magicNum);
-			codeHash = mvkHash(pMSLCode, mslCodeLen, codeHash);
-			addPerformanceInterval(getPerformanceStats().shaderCompilation.hashShaderCode, startTime);
+        uint64_t startTime = getPerformanceTimestamp();
+        codeHash = mvkHash(&magicNum);
+        codeHash = mvkHash(pMSLCode, mslCodeLen, codeHash);
+        addPerformanceInterval(getPerformanceStats()
+                                   .shaderCompilation.hashShaderCode,
+                               startTime);
 
-			SPIRVToMSLConversionResult conversionResult;
-			conversionResult.msl = pMSLCode;
-			_directMSLLibrary = new MVKShaderLibrary(this, conversionResult);
+        SPIRVToMSLConversionResult conversionResult;
+        conversionResult.msl = pMSLCode;
+        _directMSLLibrary = new MVKShaderLibrary(this, conversionResult);
 
-			break;
-		}
-		case kMVKMagicNumberMSLCompiledCode: {				// MSL compiled binary code
-			size_t hdrSize = sizeof(MVKMSLSPIRVHeader);
-			char* pMSLCode = (char*)(uintptr_t(pCreateInfo->pCode) + hdrSize);
-			size_t mslCodeLen = codeSize - hdrSize;
+        break;
+    }
+    case kMVKMagicNumberMSLCompiledCode: { // MSL compiled binary code
+        size_t hdrSize = sizeof(MVKMSLSPIRVHeader);
+        char* pMSLCode = (char*)(uintptr_t(pCreateInfo->pCode) + hdrSize);
+        size_t mslCodeLen = codeSize - hdrSize;
 
-			uint64_t startTime = getPerformanceTimestamp();
-			codeHash = mvkHash(&magicNum);
-			codeHash = mvkHash(pMSLCode, mslCodeLen, codeHash);
-			addPerformanceInterval(getPerformanceStats().shaderCompilation.hashShaderCode, startTime);
+        uint64_t startTime = getPerformanceTimestamp();
+        codeHash = mvkHash(&magicNum);
+        codeHash = mvkHash(pMSLCode, mslCodeLen, codeHash);
+        addPerformanceInterval(getPerformanceStats()
+                                   .shaderCompilation.hashShaderCode,
+                               startTime);
 
-			_directMSLLibrary = new MVKShaderLibrary(this, (void*)(pMSLCode), mslCodeLen);
+        _directMSLLibrary =
+            new MVKShaderLibrary(this, (void*)(pMSLCode), mslCodeLen);
 
-			break;
-		}
-		default:											// Could be GLSL source code
-			if (getEnabledExtensions().vk_NV_glsl_shader.enabled) {
-				const char* pGLSL = (char*)pCreateInfo->pCode;
-				size_t glslLen = codeSize - 1;
+        break;
+    }
+    default: // Could be GLSL source code
+        if (getEnabledExtensions().vk_NV_glsl_shader.enabled) {
+            const char* pGLSL = (char*)pCreateInfo->pCode;
+            size_t glslLen = codeSize - 1;
 
-				uint64_t startTime = getPerformanceTimestamp();
-				codeHash = mvkHash(pGLSL, codeSize);
-				addPerformanceInterval(getPerformanceStats().shaderCompilation.hashShaderCode, startTime);
+            uint64_t startTime = getPerformanceTimestamp();
+            codeHash = mvkHash(pGLSL, codeSize);
+            addPerformanceInterval(getPerformanceStats()
+                                       .shaderCompilation.hashShaderCode,
+                                   startTime);
 
-				_glslConverter.setGLSL(pGLSL, glslLen);
-			} else {
-				setConfigurationResult(reportError(VK_ERROR_INVALID_SHADER_NV, "vkCreateShaderModule(): The SPIR-V contains an invalid magic number %x.", magicNum));
-			}
-			break;
-	}
+            _glslConverter.setGLSL(pGLSL, glslLen);
+        } else {
+            setConfigurationResult(
+                reportError(VK_ERROR_INVALID_SHADER_NV,
+                            "vkCreateShaderModule(): The SPIR-V contains an "
+                            "invalid magic number %x.",
+                            magicNum));
+        }
+        break;
+    }
 
-	_key = MVKShaderModuleKey(codeSize, codeHash);
+    _key = MVKShaderModuleKey(codeSize, codeHash);
 }
 
 MVKShaderModule::~MVKShaderModule() {
-	if (_directMSLLibrary) { _directMSLLibrary->destroy(); }
+    if (_directMSLLibrary) {
+        _directMSLLibrary->destroy();
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKShaderLibraryCompiler
 
-id<MTLLibrary> MVKShaderLibraryCompiler::newMTLLibrary(NSString* mslSourceCode,
-													   const SPIRVToMSLConversionResultInfo& shaderConversionResults) {
-	unique_lock<mutex> lock(_completionLock);
+id<MTLLibrary> MVKShaderLibraryCompiler::newMTLLibrary(
+    NSString* mslSourceCode,
+    const SPIRVToMSLConversionResultInfo& shaderConversionResults) {
+    unique_lock<mutex> lock(_completionLock);
 
-	compile(lock, ^{
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			auto mtlCompileOptions = getDevice()->getMTLCompileOptions(shaderConversionResults.entryPoint.supportsFastMath,
-																			   shaderConversionResults.isPositionInvariant);
-			MVKLogInfoIf(getMVKConfig().debugMode, "Compiling Metal shader%s.", mtlCompileOptions.fastMathEnabled ? " with FastMath enabled" : "");
-			[mtlDev newLibraryWithSource: mslSourceCode
-								 options: mtlCompileOptions
-					   completionHandler: ^(id<MTLLibrary> mtlLib, NSError* error) {
-						   bool isLate = compileComplete(mtlLib, error);
-						   if (isLate) { destroy(); }
-					   }];
-		}
-	});
+    compile(lock, ^{
+      auto mtlDev = getMTLDevice();
+      @synchronized(mtlDev) {
+          auto mtlCompileOptions =
+              getDevice()
+                  ->getMTLCompileOptions(shaderConversionResults.entryPoint
+                                             .supportsFastMath,
+                                         shaderConversionResults
+                                             .isPositionInvariant);
+          MVKLogInfoIf(getMVKConfig().debugMode, "Compiling Metal shader%s.",
+                       mtlCompileOptions.fastMathEnabled
+                           ? " with FastMath enabled"
+                           : "");
+          [mtlDev
+              newLibraryWithSource:mslSourceCode
+                           options:mtlCompileOptions
+                 completionHandler:^(id<MTLLibrary> mtlLib, NSError* error) {
+                   bool isLate = compileComplete(mtlLib, error);
+                   if (isLate) {
+                       destroy();
+                   }
+                 }];
+      }
+    });
 
-	return [_mtlLibrary retain];
+    return [_mtlLibrary retain];
 }
 
 void MVKShaderLibraryCompiler::handleError() {
-	if (_mtlLibrary) {
-		MVKLogInfo("%s compilation succeeded with warnings (Error code %li):\n%s", _compilerType.c_str(),
-				   (long)_compileError.code, _compileError.localizedDescription.UTF8String);
-	} else {
-		MVKMetalCompiler::handleError();
-	}
+    if (_mtlLibrary) {
+        MVKLogInfo("%s compilation succeeded with warnings (Error code "
+                   "%li):\n%s",
+                   _compilerType.c_str(), (long)_compileError.code,
+                   _compileError.localizedDescription.UTF8String);
+    } else {
+        MVKMetalCompiler::handleError();
+    }
 }
 
-bool MVKShaderLibraryCompiler::compileComplete(id<MTLLibrary> mtlLibrary, NSError* compileError) {
-	lock_guard<mutex> lock(_completionLock);
+bool MVKShaderLibraryCompiler::compileComplete(id<MTLLibrary> mtlLibrary,
+                                               NSError* compileError) {
+    lock_guard<mutex> lock(_completionLock);
 
-	_mtlLibrary = [mtlLibrary retain];		// retained
-	return endCompile(compileError);
+    _mtlLibrary = [mtlLibrary retain]; // retained
+    return endCompile(compileError);
 }
 
 #pragma mark Construction
 
-MVKShaderLibraryCompiler::~MVKShaderLibraryCompiler() {
-	[_mtlLibrary release];
-}
-
+MVKShaderLibraryCompiler::~MVKShaderLibraryCompiler() { [_mtlLibrary release]; }
 
 #pragma mark -
 #pragma mark MVKFunctionSpecializer
 
-id<MTLFunction> MVKFunctionSpecializer::newMTLFunction(id<MTLLibrary> mtlLibrary,
-													   NSString* funcName,
-													   MTLFunctionConstantValues* constantValues) {
-	unique_lock<mutex> lock(_completionLock);
+id<MTLFunction> MVKFunctionSpecializer::newMTLFunction(
+    id<MTLLibrary> mtlLibrary, NSString* funcName,
+    MTLFunctionConstantValues* constantValues) {
+    unique_lock<mutex> lock(_completionLock);
 
-	compile(lock, ^{
-		[mtlLibrary newFunctionWithName: funcName
-						 constantValues: constantValues
-					  completionHandler: ^(id<MTLFunction> mtlFunc, NSError* error) {
-						  bool isLate = compileComplete(mtlFunc, error);
-						  if (isLate) { destroy(); }
-					  }];
-	});
+    compile(lock, ^{
+      [mtlLibrary
+          newFunctionWithName:funcName
+               constantValues:constantValues
+            completionHandler:^(id<MTLFunction> mtlFunc, NSError* error) {
+              bool isLate = compileComplete(mtlFunc, error);
+              if (isLate) {
+                  destroy();
+              }
+            }];
+    });
 
-	return [_mtlFunction retain];
+    return [_mtlFunction retain];
 }
 
-bool MVKFunctionSpecializer::compileComplete(id<MTLFunction> mtlFunction, NSError* compileError) {
-	lock_guard<mutex> lock(_completionLock);
+bool MVKFunctionSpecializer::compileComplete(id<MTLFunction> mtlFunction,
+                                             NSError* compileError) {
+    lock_guard<mutex> lock(_completionLock);
 
-	_mtlFunction = [mtlFunction retain];		// retained
-	return endCompile(compileError);
+    _mtlFunction = [mtlFunction retain]; // retained
+    return endCompile(compileError);
 }
 
 #pragma mark Construction
 
-MVKFunctionSpecializer::~MVKFunctionSpecializer() {
-	[_mtlFunction release];
-}
-
+MVKFunctionSpecializer::~MVKFunctionSpecializer() { [_mtlFunction release]; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,63 +29,68 @@ class MVKSwapchain;
 
 @class MVKBlockObserver;
 
-
 #pragma mark MVKSurface
 
 /** Represents a Vulkan WSI surface. */
 class MVKSurface : public MVKVulkanAPIObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_SURFACE_KHR;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SURFACE_KHR; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT; }
-
-	/** Returns a pointer to the Vulkan instance. */
-	MVKInstance* getInstance() override { return _mvkInstance; }
+    /** Returns a pointer to the Vulkan instance. */
+    MVKInstance* getInstance() override { return _mvkInstance; }
 
     /** Returns the CAMetalLayer underlying this surface. */
-	CAMetalLayer* getCAMetalLayer();
+    CAMetalLayer* getCAMetalLayer();
 
-	/** Returns the extent of this surface. */
-	VkExtent2D getExtent();
+    /** Returns the extent of this surface. */
+    VkExtent2D getExtent();
 
-	/** Returns the extent for which the underlying CAMetalLayer will not need to be scaled when composited. */
-	VkExtent2D getNaturalExtent();
+    /** Returns the extent for which the underlying CAMetalLayer will not need
+     * to be scaled when composited. */
+    VkExtent2D getNaturalExtent();
 
-	/** Returns whether this surface is headless. */
-	bool isHeadless() { return !_mtlCAMetalLayer && wasConfigurationSuccessful(); }
+    /** Returns whether this surface is headless. */
+    bool isHeadless() {
+        return !_mtlCAMetalLayer && wasConfigurationSuccessful();
+    }
 
 #pragma mark Construction
 
-	MVKSurface(MVKInstance* mvkInstance,
-			   const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
-			   const VkAllocationCallbacks* pAllocator);
+    MVKSurface(MVKInstance* mvkInstance,
+               const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+               const VkAllocationCallbacks* pAllocator);
 
-	MVKSurface(MVKInstance* mvkInstance,
-			   const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
-			   const VkAllocationCallbacks* pAllocator);
+    MVKSurface(MVKInstance* mvkInstance,
+               const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
+               const VkAllocationCallbacks* pAllocator);
 
-	MVKSurface(MVKInstance* mvkInstance,
-			   const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
-			   const VkAllocationCallbacks* pAllocator);
+    MVKSurface(MVKInstance* mvkInstance,
+               const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
+               const VkAllocationCallbacks* pAllocator);
 
-	~MVKSurface() override;
+    ~MVKSurface() override;
 
-protected:
-	friend class MVKSwapchain;
+  protected:
+    friend class MVKSwapchain;
 
-	void propagateDebugName() override {}
-	void setActiveSwapchain(MVKSwapchain* swapchain);
-	void initLayer(CAMetalLayer* mtlLayer, const char* vkFuncName, bool isHeadless);
-	void releaseLayer();
+    void propagateDebugName() override {}
+    void setActiveSwapchain(MVKSwapchain* swapchain);
+    void initLayer(CAMetalLayer* mtlLayer, const char* vkFuncName,
+                   bool isHeadless);
+    void releaseLayer();
 
-	std::mutex _layerLock;
-	MVKInstance* _mvkInstance = nullptr;
-	CAMetalLayer* _mtlCAMetalLayer = nil;
-	MVKBlockObserver* _layerObserver = nil;
-	MVKSwapchain* _activeSwapchain = nullptr;
+    std::mutex _layerLock;
+    MVKInstance* _mvkInstance = nullptr;
+    CAMetalLayer* _mtlCAMetalLayer = nil;
+    MVKBlockObserver* _layerObserver = nil;
+    MVKSwapchain* _activeSwapchain = nullptr;
 };
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSurface.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,100 +27,122 @@
 #import "MVKBlockObserver.h"
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-#	define PLATFORM_VIEW_CLASS	UIView
-#	import <UIKit/UIView.h>
+#define PLATFORM_VIEW_CLASS UIView
+#import <UIKit/UIView.h>
 #endif
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-#	define PLATFORM_VIEW_CLASS	NSView
-#	import <AppKit/NSView.h>
+#define PLATFORM_VIEW_CLASS NSView
+#import <AppKit/NSView.h>
 #endif
 
-
-// We need to double-dereference the name to first convert to the platform symbol, then to a string.
+// We need to double-dereference the name to first convert to the platform
+// symbol, then to a string.
 #define STR_PLATFORM(NAME) #NAME
 #define STR(NAME) STR_PLATFORM(NAME)
 
 // As defined in the Vulkan spec, represents an undefined extent.
-// Spec is currently somewhat ambiguous about whether an undefined surface extent should be updated
-// once a swapchain is attached, but consensus amoung the spec authors is that it should not.
+// Spec is currently somewhat ambiguous about whether an undefined surface
+// extent should be updated once a swapchain is attached, but consensus amoung
+// the spec authors is that it should not.
 static constexpr VkExtent2D kMVKUndefinedExtent = {0xFFFFFFFF, 0xFFFFFFFF};
-
 
 #pragma mark MVKSurface
 
 CAMetalLayer* MVKSurface::getCAMetalLayer() {
-	std::lock_guard<std::mutex> lock(_layerLock);
-	return _mtlCAMetalLayer;
+    std::lock_guard<std::mutex> lock(_layerLock);
+    return _mtlCAMetalLayer;
 }
 
 VkExtent2D MVKSurface::getExtent() {
-	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.drawableSize) : kMVKUndefinedExtent;
+    return _mtlCAMetalLayer
+               ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.drawableSize)
+               : kMVKUndefinedExtent;
 }
 
 VkExtent2D MVKSurface::getNaturalExtent() {
-	return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(_mtlCAMetalLayer.naturalDrawableSizeMVK) : kMVKUndefinedExtent;
+    return _mtlCAMetalLayer ? mvkVkExtent2DFromCGSize(
+                                  _mtlCAMetalLayer.naturalDrawableSizeMVK)
+                            : kMVKUndefinedExtent;
 }
 
 void MVKSurface::setActiveSwapchain(MVKSwapchain* swapchain) {
-	_activeSwapchain = swapchain;
+    _activeSwapchain = swapchain;
 }
 
 MVKSurface::MVKSurface(MVKInstance* mvkInstance,
-					   const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
-					   const VkAllocationCallbacks* pAllocator) : _mvkInstance(mvkInstance) {
-	initLayer((CAMetalLayer*)pCreateInfo->pLayer, "vkCreateMetalSurfaceEXT", false);
+                       const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator)
+    : _mvkInstance(mvkInstance) {
+    initLayer((CAMetalLayer*)pCreateInfo->pLayer, "vkCreateMetalSurfaceEXT",
+              false);
 }
 
 MVKSurface::MVKSurface(MVKInstance* mvkInstance,
-					   const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
-					   const VkAllocationCallbacks* pAllocator) : _mvkInstance(mvkInstance) {
-	initLayer(nil, "vkCreateHeadlessSurfaceEXT", true);
+                       const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator)
+    : _mvkInstance(mvkInstance) {
+    initLayer(nil, "vkCreateHeadlessSurfaceEXT", true);
 }
 
 // pCreateInfo->pView can be either a CAMetalLayer or a view (NSView/UIView).
 MVKSurface::MVKSurface(MVKInstance* mvkInstance,
-					   const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
-					   const VkAllocationCallbacks* pAllocator) : _mvkInstance(mvkInstance) {
-	MVKLogWarn("%s() is deprecated. Use vkCreateMetalSurfaceEXT() from the VK_EXT_metal_surface extension.", STR(vkCreate_PLATFORM_SurfaceMVK));
+                       const Vk_PLATFORM_SurfaceCreateInfoMVK* pCreateInfo,
+                       const VkAllocationCallbacks* pAllocator)
+    : _mvkInstance(mvkInstance) {
+    MVKLogWarn("%s() is deprecated. Use vkCreateMetalSurfaceEXT() from the "
+               "VK_EXT_metal_surface extension.",
+               STR(vkCreate_PLATFORM_SurfaceMVK));
 
-	// Get the platform object contained in pView
-	// If it's a view (NSView/UIView), extract the layer, otherwise assume it's already a CAMetalLayer.
-	id<NSObject> obj = (id<NSObject>)pCreateInfo->pView;
-	if ([obj isKindOfClass: [PLATFORM_VIEW_CLASS class]]) {
-		__block id<NSObject> layer;
-		mvkDispatchToMainAndWait(^{ layer = ((PLATFORM_VIEW_CLASS*)obj).layer; });
-		obj = layer;
-	}
+    // Get the platform object contained in pView
+    // If it's a view (NSView/UIView), extract the layer, otherwise assume it's
+    // already a CAMetalLayer.
+    id<NSObject> obj = (id<NSObject>)pCreateInfo->pView;
+    if ([obj isKindOfClass:[PLATFORM_VIEW_CLASS class]]) {
+        __block id<NSObject> layer;
+        mvkDispatchToMainAndWait(^{
+          layer = ((PLATFORM_VIEW_CLASS*)obj).layer;
+        });
+        obj = layer;
+    }
 
-	// Confirm that we were provided with a CAMetalLayer
-	initLayer([obj isKindOfClass: CAMetalLayer.class] ? (CAMetalLayer*)obj : nil, STR(vkCreate_PLATFORM_SurfaceMVK), false);
+    // Confirm that we were provided with a CAMetalLayer
+    initLayer([obj isKindOfClass:CAMetalLayer.class] ? (CAMetalLayer*)obj : nil,
+              STR(vkCreate_PLATFORM_SurfaceMVK), false);
 }
 
-void MVKSurface::initLayer(CAMetalLayer* mtlLayer, const char* vkFuncName, bool isHeadless) {
+void MVKSurface::initLayer(CAMetalLayer* mtlLayer, const char* vkFuncName,
+                           bool isHeadless) {
 
-	_mtlCAMetalLayer = [mtlLayer retain];	// retained
-	if ( !_mtlCAMetalLayer && !isHeadless ) { setConfigurationResult(reportError(VK_ERROR_SURFACE_LOST_KHR, "%s(): On-screen rendering requires a layer of type CAMetalLayer.", vkFuncName)); }
+    _mtlCAMetalLayer = [mtlLayer retain]; // retained
+    if (!_mtlCAMetalLayer && !isHeadless) {
+        setConfigurationResult(reportError(VK_ERROR_SURFACE_LOST_KHR,
+                                           "%s(): On-screen rendering requires "
+                                           "a layer of type CAMetalLayer.",
+                                           vkFuncName));
+    }
 
-	// Sometimes, the owning view can replace its CAMetalLayer.
-	// When that happens, the app needs to recreate the surface.
-	if ([_mtlCAMetalLayer.delegate isKindOfClass: [PLATFORM_VIEW_CLASS class]]) {
-		_layerObserver = [MVKBlockObserver observerWithBlock: ^(NSString* path, id, NSDictionary*, void*) {
-			if ([path isEqualToString: @"layer"]) { this->releaseLayer(); }
-		} forObject: _mtlCAMetalLayer.delegate atKeyPath: @"layer"];
-	}
+    // Sometimes, the owning view can replace its CAMetalLayer.
+    // When that happens, the app needs to recreate the surface.
+    if ([_mtlCAMetalLayer.delegate isKindOfClass:[PLATFORM_VIEW_CLASS class]]) {
+        _layerObserver = [MVKBlockObserver
+            observerWithBlock:^(NSString* path, id, NSDictionary*, void*) {
+              if ([path isEqualToString:@"layer"]) {
+                  this->releaseLayer();
+              }
+            }
+                    forObject:_mtlCAMetalLayer.delegate
+                    atKeyPath:@"layer"];
+    }
 }
 
 void MVKSurface::releaseLayer() {
-	std::lock_guard<std::mutex> lock(_layerLock);
-	setConfigurationResult(VK_ERROR_SURFACE_LOST_KHR);
-	[_mtlCAMetalLayer release];
-	_mtlCAMetalLayer = nil;
-	[_layerObserver release];
-	_layerObserver = nil;
+    std::lock_guard<std::mutex> lock(_layerLock);
+    setConfigurationResult(VK_ERROR_SURFACE_LOST_KHR);
+    [_mtlCAMetalLayer release];
+    _mtlCAMetalLayer = nil;
+    [_layerObserver release];
+    _layerObserver = nil;
 }
 
-MVKSurface::~MVKSurface() {
-	releaseLayer();
-}
-
+MVKSurface::~MVKSurface() { releaseLayer(); }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,115 +27,130 @@
 
 class MVKWatermark;
 
-
 #pragma mark -
 #pragma mark MVKSwapchain
 
 /** Represents a Vulkan swapchain. */
 class MVKSwapchain : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_SWAPCHAIN_KHR;
+    }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SWAPCHAIN_KHR; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT; }
+    /** Returns the CAMetalLayer underlying the surface used by this swapchain.
+     */
+    CAMetalLayer* getCAMetalLayer();
 
-	/** Returns the CAMetalLayer underlying the surface used by this swapchain. */
-	CAMetalLayer* getCAMetalLayer();
+    /** Returns whether the surface is headless. */
+    bool isHeadless();
 
-	/** Returns whether the surface is headless. */
-	bool isHeadless();
+    /** Returns the number of images in this swapchain. */
+    uint32_t getImageCount() { return (uint32_t)_presentableImages.size(); }
 
-	/** Returns the number of images in this swapchain. */
-	uint32_t getImageCount() { return (uint32_t)_presentableImages.size(); }
+    /** Returns the size of the images in this swapchain. */
+    VkExtent2D getImageExtent() { return _imageExtent; }
 
-	/** Returns the size of the images in this swapchain. */
-	VkExtent2D getImageExtent() { return _imageExtent; }
+    /** Returns the image at the specified index. */
+    MVKPresentableSwapchainImage* getPresentableImage(uint32_t index) {
+        return _presentableImages[index];
+    }
 
-	/** Returns the image at the specified index. */
-	MVKPresentableSwapchainImage* getPresentableImage(uint32_t index) { return _presentableImages[index]; }
+    /**
+     * Returns the array of presentable images associated with this swapchain.
+     *
+     * If pSwapchainImages is null, the value of pCount is updated with the
+     * number of presentable images associated with this swapchain.
+     *
+     * If pSwapchainImages is not null, then pCount images are copied into the
+     * array. If the number of available images is less than pCount, the value
+     * of pCount is updated to indicate the number of images actually returned
+     * in the array.
+     *
+     * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of
+     * supported images is larger than pCount. Returns other values if an error
+     * occurs.
+     */
+    VkResult getImages(uint32_t* pCount, VkImage* pSwapchainImages);
 
-	/**
-	 * Returns the array of presentable images associated with this swapchain.
-	 *
-	 * If pSwapchainImages is null, the value of pCount is updated with the number of
-	 * presentable images associated with this swapchain.
-	 *
-	 * If pSwapchainImages is not null, then pCount images are copied into the array.
-	 * If the number of available images is less than pCount, the value of pCount is
-	 * updated to indicate the number of images actually returned in the array.
-	 *
-	 * Returns VK_SUCCESS if successful. Returns VK_INCOMPLETE if the number of supported
-	 * images is larger than pCount. Returns other values if an error occurs.
-	 */
-	VkResult getImages(uint32_t* pCount, VkImage* pSwapchainImages);
+    /** Returns the index of the next acquireable image. */
+    VkResult acquireNextImage(uint64_t timeout, VkSemaphore semaphore,
+                              VkFence fence, uint32_t deviceMask,
+                              uint32_t* pImageIndex);
 
-	/** Returns the index of the next acquireable image. */
-	VkResult acquireNextImage(uint64_t timeout,
-							  VkSemaphore semaphore,
-							  VkFence fence,
-							  uint32_t deviceMask,
-							  uint32_t* pImageIndex);
+    /** Releases swapchain images. */
+    VkResult releaseImages(const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo);
 
-	/** Releases swapchain images. */
-	VkResult releaseImages(const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo);
+    /** Returns the status of the surface. Surface loss takes precedence over
+     * sub-optimal errors. */
+    VkResult getSurfaceStatus();
 
-	/** Returns the status of the surface. Surface loss takes precedence over sub-optimal errors. */
-	VkResult getSurfaceStatus();
+    /** Adds HDR metadata to this swapchain. */
+    void setHDRMetadataEXT(const VkHdrMetadataEXT& metadata);
 
-	/** Adds HDR metadata to this swapchain. */
-	void setHDRMetadataEXT(const VkHdrMetadataEXT& metadata);
-	
-	/** VK_GOOGLE_display_timing - returns the duration of the refresh cycle */
-	VkResult getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRefreshCycleDuration);
-	
-	/** VK_GOOGLE_display_timing - returns past presentation times */
-	VkResult getPastPresentationTiming(uint32_t *pCount, VkPastPresentationTimingGOOGLE *pPresentationTimings);
+    /** VK_GOOGLE_display_timing - returns the duration of the refresh cycle */
+    VkResult getRefreshCycleDuration(
+        VkRefreshCycleDurationGOOGLE* pRefreshCycleDuration);
 
-	/** Marks parts of the underlying CAMetalLayer as needing update. */
-	void setLayerNeedsDisplay(const VkPresentRegionKHR* pRegion);
+    /** VK_GOOGLE_display_timing - returns past presentation times */
+    VkResult getPastPresentationTiming(
+        uint32_t* pCount, VkPastPresentationTimingGOOGLE* pPresentationTimings);
 
-	void destroy() override;
+    /** Marks parts of the underlying CAMetalLayer as needing update. */
+    void setLayerNeedsDisplay(const VkPresentRegionKHR* pRegion);
+
+    void destroy() override;
 
 #pragma mark Construction
-	
-	MVKSwapchain(MVKDevice* device, const VkSwapchainCreateInfoKHR* pCreateInfo);
 
-	~MVKSwapchain() override;
+    MVKSwapchain(MVKDevice* device,
+                 const VkSwapchainCreateInfoKHR* pCreateInfo);
 
-protected:
-	friend class MVKPresentableSwapchainImage;
+    ~MVKSwapchain() override;
 
-	void propagateDebugName() override;
-	void initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
-						  VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo,
-						  uint32_t imgCnt);
-	void initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt);
-	bool getIsSurfaceLost();
-	bool hasOptimalSurface();
-	uint64_t getNextAcquisitionID();
-    void renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffer> mtlCmdBuff);
+  protected:
+    friend class MVKPresentableSwapchainImage;
+
+    void propagateDebugName() override;
+    void initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                          VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo,
+                          uint32_t imgCnt);
+    void initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                           uint32_t imgCnt);
+    bool getIsSurfaceLost();
+    bool hasOptimalSurface();
+    uint64_t getNextAcquisitionID();
+    void renderWatermark(id<MTLTexture> mtlTexture,
+                         id<MTLCommandBuffer> mtlCmdBuff);
     void markFrameInterval();
-	void beginPresentation(const MVKImagePresentInfo& presentInfo);
-	void endPresentation(const MVKImagePresentInfo& presentInfo, uint64_t beginPresentTime, uint64_t actualPresentTime = 0);
-	void forceUnpresentedImageCompletion();
+    void beginPresentation(const MVKImagePresentInfo& presentInfo);
+    void endPresentation(const MVKImagePresentInfo& presentInfo,
+                         uint64_t beginPresentTime,
+                         uint64_t actualPresentTime = 0);
+    void forceUnpresentedImageCompletion();
 
-	MVKSurface* _surface = nullptr;
+    MVKSurface* _surface = nullptr;
     MVKWatermark* _licenseWatermark = nullptr;
-	MVKSmallVector<MVKPresentableSwapchainImage*, kMVKMaxSwapchainImageCount> _presentableImages;
-	MVKSmallVector<VkPresentModeKHR, 2> _compatiblePresentModes;
-	static const int kMaxPresentationHistory = 60;
-	VkPastPresentationTimingGOOGLE _presentTimingHistory[kMaxPresentationHistory];
-	std::atomic<uint64_t> _currentAcquisitionID = 0;
-	std::mutex _presentHistoryLock;
-	uint64_t _lastFrameTime = 0;
-	VkExtent2D _imageExtent = {0, 0};
-	std::atomic<uint32_t> _unpresentedImageCount = 0;
-	uint32_t _currentPerfLogFrameCount = 0;
-	uint32_t _presentHistoryCount = 0;
-	uint32_t _presentHistoryIndex = 0;
-	uint32_t _presentHistoryHeadIndex = 0;
-	bool _isDeliberatelyScaled = false;
+    MVKSmallVector<MVKPresentableSwapchainImage*, kMVKMaxSwapchainImageCount>
+        _presentableImages;
+    MVKSmallVector<VkPresentModeKHR, 2> _compatiblePresentModes;
+    static const int kMaxPresentationHistory = 60;
+    VkPastPresentationTimingGOOGLE
+        _presentTimingHistory[kMaxPresentationHistory];
+    std::atomic<uint64_t> _currentAcquisitionID = 0;
+    std::mutex _presentHistoryLock;
+    uint64_t _lastFrameTime = 0;
+    VkExtent2D _imageExtent = {0, 0};
+    std::atomic<uint32_t> _unpresentedImageCount = 0;
+    uint32_t _currentPerfLogFrameCount = 0;
+    uint32_t _presentHistoryCount = 0;
+    uint32_t _presentHistoryIndex = 0;
+    uint32_t _presentHistoryHeadIndex = 0;
+    bool _isDeliberatelyScaled = false;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,128 +31,151 @@
 #import "CAMetalLayer+MoltenVK.h"
 #import "MVKBlockObserver.h"
 
-
 using namespace std;
-
 
 #pragma mark -
 #pragma mark MVKSwapchain
 
 void MVKSwapchain::propagateDebugName() {
-	if (_debugName) {
-		size_t imgCnt = _presentableImages.size();
-		for (size_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
-			_presentableImages[imgIdx]->setDebugName([NSString stringWithFormat: @"%@(%lu)", _debugName, imgIdx].UTF8String);
-		}
-	}
+    if (_debugName) {
+        size_t imgCnt = _presentableImages.size();
+        for (size_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
+            _presentableImages[imgIdx]->setDebugName(
+                [NSString stringWithFormat:@"%@(%lu)", _debugName, imgIdx]
+                    .UTF8String);
+        }
+    }
 }
 
-CAMetalLayer* MVKSwapchain::getCAMetalLayer() { return _surface->getCAMetalLayer(); }
+CAMetalLayer* MVKSwapchain::getCAMetalLayer() {
+    return _surface->getCAMetalLayer();
+}
 
 bool MVKSwapchain::isHeadless() { return _surface->isHeadless(); }
 
 VkResult MVKSwapchain::getImages(uint32_t* pCount, VkImage* pSwapchainImages) {
 
-	// Get the number of surface images
-	uint32_t imgCnt = getImageCount();
+    // Get the number of surface images
+    uint32_t imgCnt = getImageCount();
 
-	// If images aren't actually being requested yet, simply update the returned count
-	if ( !pSwapchainImages ) {
-		*pCount = imgCnt;
-		return VK_SUCCESS;
-	}
+    // If images aren't actually being requested yet, simply update the returned
+    // count
+    if (!pSwapchainImages) {
+        *pCount = imgCnt;
+        return VK_SUCCESS;
+    }
 
-	// Determine how many images we'll return, and return that number
-	VkResult result = (*pCount >= imgCnt) ? VK_SUCCESS : VK_INCOMPLETE;
-	*pCount = min(*pCount, imgCnt);
+    // Determine how many images we'll return, and return that number
+    VkResult result = (*pCount >= imgCnt) ? VK_SUCCESS : VK_INCOMPLETE;
+    *pCount = min(*pCount, imgCnt);
 
-	// Now populate the images
-	for (uint32_t imgIdx = 0; imgIdx < *pCount; imgIdx++) {
-		pSwapchainImages[imgIdx] = (VkImage)_presentableImages[imgIdx];
-	}
+    // Now populate the images
+    for (uint32_t imgIdx = 0; imgIdx < *pCount; imgIdx++) {
+        pSwapchainImages[imgIdx] = (VkImage)_presentableImages[imgIdx];
+    }
 
-	return result;
+    return result;
 }
 
-VkResult MVKSwapchain::acquireNextImage(uint64_t timeout,
-										VkSemaphore semaphore,
-										VkFence fence,
-										uint32_t deviceMask,
-										uint32_t* pImageIndex) {
+VkResult MVKSwapchain::acquireNextImage(uint64_t timeout, VkSemaphore semaphore,
+                                        VkFence fence, uint32_t deviceMask,
+                                        uint32_t* pImageIndex) {
 
-	if ( _device->getConfigurationResult() != VK_SUCCESS ) { return _device->getConfigurationResult(); }
-	if ( getIsSurfaceLost() ) { return VK_ERROR_SURFACE_LOST_KHR; }
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
+    if (getIsSurfaceLost()) {
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
 
-	// Find the image that has the shortest wait by finding the smallest availability measure.
-	MVKPresentableSwapchainImage* minWaitImage = nullptr;
-	MVKSwapchainImageAvailability minAvailability = { kMVKUndefinedLargeUInt64, false };
-	uint32_t imgCnt = getImageCount();
-	for (uint32_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
-		auto* img = getPresentableImage(imgIdx);
-		auto imgAvail = img->getAvailability();
-		if (imgAvail < minAvailability) {
-			minAvailability = imgAvail;
-			minWaitImage = img;
-		}
-	}
+    // Find the image that has the shortest wait by finding the smallest
+    // availability measure.
+    MVKPresentableSwapchainImage* minWaitImage = nullptr;
+    MVKSwapchainImageAvailability minAvailability = {kMVKUndefinedLargeUInt64,
+                                                     false};
+    uint32_t imgCnt = getImageCount();
+    for (uint32_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
+        auto* img = getPresentableImage(imgIdx);
+        auto imgAvail = img->getAvailability();
+        if (imgAvail < minAvailability) {
+            minAvailability = imgAvail;
+            minWaitImage = img;
+        }
+    }
 
-	// Return the index of the image with the shortest wait,
-	// and signal the semaphore and fence when it's available
-	*pImageIndex = minWaitImage->_swapchainIndex;
-	VkResult rslt = minWaitImage->acquireAndSignalWhenAvailable((MVKSemaphore*)semaphore, (MVKFence*)fence);
-	return rslt ? rslt : getSurfaceStatus();
+    // Return the index of the image with the shortest wait,
+    // and signal the semaphore and fence when it's available
+    *pImageIndex = minWaitImage->_swapchainIndex;
+    VkResult rslt =
+        minWaitImage->acquireAndSignalWhenAvailable((MVKSemaphore*)semaphore,
+                                                    (MVKFence*)fence);
+    return rslt ? rslt : getSurfaceStatus();
 }
 
-VkResult MVKSwapchain::releaseImages(const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo) {
-	for (uint32_t imgIdxIdx = 0; imgIdxIdx < pReleaseInfo->imageIndexCount; imgIdxIdx++) {
-		getPresentableImage(pReleaseInfo->pImageIndices[imgIdxIdx])->makeAvailable();
-	}
+VkResult MVKSwapchain::releaseImages(
+    const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo) {
+    for (uint32_t imgIdxIdx = 0; imgIdxIdx < pReleaseInfo->imageIndexCount;
+         imgIdxIdx++) {
+        getPresentableImage(pReleaseInfo->pImageIndices[imgIdxIdx])
+            ->makeAvailable();
+    }
 
-	return _surface->getConfigurationResult();
+    return _surface->getConfigurationResult();
 }
 
-uint64_t MVKSwapchain::getNextAcquisitionID() { return ++_currentAcquisitionID; }
+uint64_t MVKSwapchain::getNextAcquisitionID() {
+    return ++_currentAcquisitionID;
+}
 
 bool MVKSwapchain::getIsSurfaceLost() {
-	VkResult surfRslt = _surface->getConfigurationResult();
-	setConfigurationResult(surfRslt);
-	return surfRslt != VK_SUCCESS;
+    VkResult surfRslt = _surface->getConfigurationResult();
+    setConfigurationResult(surfRslt);
+    return surfRslt != VK_SUCCESS;
 }
 
 VkResult MVKSwapchain::getSurfaceStatus() {
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
-	if (getIsSurfaceLost()) { return VK_ERROR_SURFACE_LOST_KHR; }
-	if ( !hasOptimalSurface() ) { return VK_SUBOPTIMAL_KHR; }
-	return VK_SUCCESS;
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
+    if (getIsSurfaceLost()) {
+        return VK_ERROR_SURFACE_LOST_KHR;
+    }
+    if (!hasOptimalSurface()) {
+        return VK_SUBOPTIMAL_KHR;
+    }
+    return VK_SUCCESS;
 }
 
-// This swapchain is optimally sized for the surface if the app has specified deliberate
-// swapchain scaling, or if the surface is headless, or if the surface extent has not changed 
-// since the swapchain was created, and the surface will not need to be scaled when composited.
+// This swapchain is optimally sized for the surface if the app has specified
+// deliberate swapchain scaling, or if the surface is headless, or if the
+// surface extent has not changed since the swapchain was created, and the
+// surface will not need to be scaled when composited.
 bool MVKSwapchain::hasOptimalSurface() {
-	if (_isDeliberatelyScaled || isHeadless()) { return true; }
+    if (_isDeliberatelyScaled || isHeadless()) {
+        return true;
+    }
 
-	VkExtent2D surfExtent = _surface->getExtent();
-	return (mvkVkExtent2DsAreEqual(surfExtent, _imageExtent) &&
-			mvkVkExtent2DsAreEqual(surfExtent, _surface->getNaturalExtent()));
+    VkExtent2D surfExtent = _surface->getExtent();
+    return (mvkVkExtent2DsAreEqual(surfExtent, _imageExtent) &&
+            mvkVkExtent2DsAreEqual(surfExtent, _surface->getNaturalExtent()));
 }
-
 
 #pragma mark Rendering
 
 // Renders the watermark image to the surface.
-void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffer> mtlCmdBuff) {
+void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture,
+                                   id<MTLCommandBuffer> mtlCmdBuff) {
     if (getMVKConfig().displayWatermark) {
-        if ( !_licenseWatermark ) {
-            _licenseWatermark = new MVKWatermarkRandom(getMTLDevice(),
-                                                       __watermarkTextureContent,
-                                                       __watermarkTextureWidth,
-                                                       __watermarkTextureHeight,
-                                                       __watermarkTextureFormat,
-                                                       getPixelFormats()->getBytesPerRow(__watermarkTextureFormat, __watermarkTextureWidth),
-                                                       __watermarkShaderSource);
+        if (!_licenseWatermark) {
+            _licenseWatermark = new MVKWatermarkRandom(
+                getMTLDevice(), __watermarkTextureContent,
+                __watermarkTextureWidth, __watermarkTextureHeight,
+                __watermarkTextureFormat,
+                getPixelFormats()->getBytesPerRow(__watermarkTextureFormat,
+                                                  __watermarkTextureWidth),
+                __watermarkShaderSource);
         }
-		_licenseWatermark->render(mtlTexture, mtlCmdBuff, 0.02f);
+        _licenseWatermark->render(mtlTexture, mtlCmdBuff, 0.02f);
     } else {
         if (_licenseWatermark) {
             _licenseWatermark->destroy();
@@ -164,419 +187,514 @@ void MVKSwapchain::renderWatermark(id<MTLTexture> mtlTexture, id<MTLCommandBuffe
 // Calculates and remembers the time interval between frames.
 // Not threadsafe. Ensure this is called from a threadsafe environment.
 void MVKSwapchain::markFrameInterval() {
-	uint64_t prevFrameTime = _lastFrameTime;
-	_lastFrameTime = mvkGetTimestamp();
+    uint64_t prevFrameTime = _lastFrameTime;
+    _lastFrameTime = mvkGetTimestamp();
 
-	if (prevFrameTime == 0) { return; }		// First frame starts at first presentation
+    if (prevFrameTime == 0) {
+        return;
+    } // First frame starts at first presentation
 
-	addPerformanceInterval(getPerformanceStats().queue.frameInterval, prevFrameTime, _lastFrameTime, true);
+    addPerformanceInterval(getPerformanceStats().queue.frameInterval,
+                           prevFrameTime, _lastFrameTime, true);
 
-	auto& mvkCfg = getMVKConfig();
-	bool shouldLogOnFrames = mvkCfg.performanceTracking && mvkCfg.activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT;
-	if (shouldLogOnFrames && (mvkCfg.performanceLoggingFrameCount > 0) && (++_currentPerfLogFrameCount >= mvkCfg.performanceLoggingFrameCount)) {
-		_currentPerfLogFrameCount = 0;
-		MVKLogInfo("Performance statistics reporting every: %d frames, avg FPS: %.2f, elapsed time: %.3f seconds:",
-				   mvkCfg.performanceLoggingFrameCount,
-				   (1000.0 / getPerformanceStats().queue.frameInterval.average),
-				   mvkGetElapsedMilliseconds() / 1000.0);
-		if (getMVKConfig().activityPerformanceLoggingStyle == MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT) {
-			_device->logPerformanceSummary();
-		}
-	}
+    auto& mvkCfg = getMVKConfig();
+    bool shouldLogOnFrames =
+        mvkCfg.performanceTracking &&
+        mvkCfg.activityPerformanceLoggingStyle ==
+            MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT;
+    if (shouldLogOnFrames && (mvkCfg.performanceLoggingFrameCount > 0) &&
+        (++_currentPerfLogFrameCount >= mvkCfg.performanceLoggingFrameCount)) {
+        _currentPerfLogFrameCount = 0;
+        MVKLogInfo("Performance statistics reporting every: %d frames, avg "
+                   "FPS: %.2f, elapsed time: %.3f seconds:",
+                   mvkCfg.performanceLoggingFrameCount,
+                   (1000.0 / getPerformanceStats().queue.frameInterval.average),
+                   mvkGetElapsedMilliseconds() / 1000.0);
+        if (getMVKConfig().activityPerformanceLoggingStyle ==
+            MVK_CONFIG_ACTIVITY_PERFORMANCE_LOGGING_STYLE_FRAME_COUNT) {
+            _device->logPerformanceSummary();
+        }
+    }
 }
 
-VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRefreshCycleDuration) {
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+VkResult MVKSwapchain::getRefreshCycleDuration(
+    VkRefreshCycleDurationGOOGLE* pRefreshCycleDuration) {
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
 
 #if MVK_MACOS && !MVK_MACCAT
-    auto* screen = getCAMetalLayer().screenMVK;        // Will be nil if headless
-	double framesPerSecond = 60;
-	if (screen) {
-		CGDirectDisplayID displayId = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
-		CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
-		framesPerSecond = CGDisplayModeGetRefreshRate(mode);
-		CGDisplayModeRelease(mode);
+    auto* screen = getCAMetalLayer().screenMVK; // Will be nil if headless
+    double framesPerSecond = 60;
+    if (screen) {
+        CGDirectDisplayID displayId = [[[screen deviceDescription]
+            objectForKey:@"NSScreenNumber"] unsignedIntValue];
+        CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
+        framesPerSecond = CGDisplayModeGetRefreshRate(mode);
+        CGDisplayModeRelease(mode);
 #if MVK_XCODE_13
-		if (framesPerSecond == 0 && [screen respondsToSelector: @selector(maximumFramesPerSecond)])
-			framesPerSecond = [screen maximumFramesPerSecond];
+        if (framesPerSecond == 0 &&
+            [screen respondsToSelector:@selector(maximumFramesPerSecond)])
+            framesPerSecond = [screen maximumFramesPerSecond];
 #endif
-		// Builtin panels, e.g., on MacBook, report a zero refresh rate.
-		if (framesPerSecond == 0)
-			framesPerSecond = 60.0;
-	}
+        // Builtin panels, e.g., on MacBook, report a zero refresh rate.
+        if (framesPerSecond == 0) framesPerSecond = 60.0;
+    }
 #elif MVK_IOS_OR_TVOS || MVK_MACCAT
-    auto* screen = getCAMetalLayer().screenMVK;        // Will be nil if headless
-	NSInteger framesPerSecond = 60;
-	if ([screen respondsToSelector: @selector(maximumFramesPerSecond)]) {
-		framesPerSecond = screen.maximumFramesPerSecond;
-	}
+    auto* screen = getCAMetalLayer().screenMVK; // Will be nil if headless
+    NSInteger framesPerSecond = 60;
+    if ([screen respondsToSelector:@selector(maximumFramesPerSecond)]) {
+        framesPerSecond = screen.maximumFramesPerSecond;
+    }
 #elif MVK_VISIONOS
-	NSInteger framesPerSecond = 90;		// TODO: See if this can be obtained from OS instead
+    NSInteger framesPerSecond =
+        90; // TODO: See if this can be obtained from OS instead
 #endif
 
-	pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;
-	return VK_SUCCESS;
+    pRefreshCycleDuration->refreshDuration = (uint64_t)1e9 / framesPerSecond;
+    return VK_SUCCESS;
 }
 
-VkResult MVKSwapchain::getPastPresentationTiming(uint32_t *pCount, VkPastPresentationTimingGOOGLE *pPresentationTimings) {
-	if (_device->getConfigurationResult() != VK_SUCCESS) { return _device->getConfigurationResult(); }
+VkResult MVKSwapchain::getPastPresentationTiming(
+    uint32_t* pCount, VkPastPresentationTimingGOOGLE* pPresentationTimings) {
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return _device->getConfigurationResult();
+    }
 
-	VkResult res = VK_SUCCESS;
+    VkResult res = VK_SUCCESS;
 
-	std::lock_guard<std::mutex> lock(_presentHistoryLock);
-	if (pPresentationTimings == nullptr) {
-		*pCount = _presentHistoryCount;
-	} else {
-		uint32_t countRemaining = std::min(_presentHistoryCount, *pCount);
-		uint32_t outIndex = 0;
+    std::lock_guard<std::mutex> lock(_presentHistoryLock);
+    if (pPresentationTimings == nullptr) {
+        *pCount = _presentHistoryCount;
+    } else {
+        uint32_t countRemaining = std::min(_presentHistoryCount, *pCount);
+        uint32_t outIndex = 0;
 
-		res = (*pCount >= _presentHistoryCount) ? VK_SUCCESS : VK_INCOMPLETE;
-		*pCount = countRemaining;
+        res = (*pCount >= _presentHistoryCount) ? VK_SUCCESS : VK_INCOMPLETE;
+        *pCount = countRemaining;
 
-		while (countRemaining > 0) {
-			pPresentationTimings[outIndex] = _presentTimingHistory[_presentHistoryHeadIndex];
-			countRemaining--;
-			_presentHistoryCount--;
-			_presentHistoryHeadIndex = (_presentHistoryHeadIndex + 1) % kMaxPresentationHistory;
-			outIndex++;
-		}
-	}
+        while (countRemaining > 0) {
+            pPresentationTimings[outIndex] =
+                _presentTimingHistory[_presentHistoryHeadIndex];
+            countRemaining--;
+            _presentHistoryCount--;
+            _presentHistoryHeadIndex =
+                (_presentHistoryHeadIndex + 1) % kMaxPresentationHistory;
+            outIndex++;
+        }
+    }
 
-	return res;
+    return res;
 }
 
 void MVKSwapchain::beginPresentation(const MVKImagePresentInfo& presentInfo) {
-	_unpresentedImageCount++;
+    _unpresentedImageCount++;
 }
 
-void MVKSwapchain::endPresentation(const MVKImagePresentInfo& presentInfo, uint64_t beginPresentTime, uint64_t actualPresentTime) {
-	_unpresentedImageCount--;
+void MVKSwapchain::endPresentation(const MVKImagePresentInfo& presentInfo,
+                                   uint64_t beginPresentTime,
+                                   uint64_t actualPresentTime) {
+    _unpresentedImageCount--;
 
-	std::lock_guard<std::mutex> lock(_presentHistoryLock);
+    std::lock_guard<std::mutex> lock(_presentHistoryLock);
 
-	markFrameInterval();
-	if (_presentHistoryCount < kMaxPresentationHistory) {
-		_presentHistoryCount++;
-	} else {
-		_presentHistoryHeadIndex = (_presentHistoryHeadIndex + 1) % kMaxPresentationHistory;
-	}
+    markFrameInterval();
+    if (_presentHistoryCount < kMaxPresentationHistory) {
+        _presentHistoryCount++;
+    } else {
+        _presentHistoryHeadIndex =
+            (_presentHistoryHeadIndex + 1) % kMaxPresentationHistory;
+    }
 
-	_presentTimingHistory[_presentHistoryIndex].presentID = presentInfo.presentID;
-	_presentTimingHistory[_presentHistoryIndex].desiredPresentTime = presentInfo.desiredPresentTime;
-	_presentTimingHistory[_presentHistoryIndex].actualPresentTime = actualPresentTime;
-	// These details are not available in Metal, but can estimate earliestPresentTime by using actualPresentTime instead
-	_presentTimingHistory[_presentHistoryIndex].earliestPresentTime = actualPresentTime;
-	_presentTimingHistory[_presentHistoryIndex].presentMargin = actualPresentTime > beginPresentTime ? actualPresentTime - beginPresentTime : 0;
-	_presentHistoryIndex = (_presentHistoryIndex + 1) % kMaxPresentationHistory;
+    _presentTimingHistory[_presentHistoryIndex].presentID =
+        presentInfo.presentID;
+    _presentTimingHistory[_presentHistoryIndex].desiredPresentTime =
+        presentInfo.desiredPresentTime;
+    _presentTimingHistory[_presentHistoryIndex].actualPresentTime =
+        actualPresentTime;
+    // These details are not available in Metal, but can estimate
+    // earliestPresentTime by using actualPresentTime instead
+    _presentTimingHistory[_presentHistoryIndex].earliestPresentTime =
+        actualPresentTime;
+    _presentTimingHistory[_presentHistoryIndex].presentMargin =
+        actualPresentTime > beginPresentTime
+            ? actualPresentTime - beginPresentTime
+            : 0;
+    _presentHistoryIndex = (_presentHistoryIndex + 1) % kMaxPresentationHistory;
 }
 
-// Because of a regression in Metal, the most recent one or two presentations may not complete
-// and call back. To work around this, if there are any uncompleted presentations, change the
-// drawableSize of the CAMetalLayer, which will trigger presentation completion and callbacks.
-// The drawableSize will be set to a correct size by the next swapchain created on the same surface.
+// Because of a regression in Metal, the most recent one or two presentations
+// may not complete and call back. To work around this, if there are any
+// uncompleted presentations, change the drawableSize of the CAMetalLayer, which
+// will trigger presentation completion and callbacks. The drawableSize will be
+// set to a correct size by the next swapchain created on the same surface.
 void MVKSwapchain::forceUnpresentedImageCompletion() {
-	if (_unpresentedImageCount) {
-		getCAMetalLayer().drawableSize = { 1,1 };
-	}
+    if (_unpresentedImageCount) {
+        getCAMetalLayer().drawableSize = {1, 1};
+    }
 }
 
 void MVKSwapchain::setLayerNeedsDisplay(const VkPresentRegionKHR* pRegion) {
-	auto* mtlLayer = getCAMetalLayer();
-	if (!pRegion || pRegion->rectangleCount == 0) {
-		[mtlLayer setNeedsDisplay];
-		return;
-	}
+    auto* mtlLayer = getCAMetalLayer();
+    if (!pRegion || pRegion->rectangleCount == 0) {
+        [mtlLayer setNeedsDisplay];
+        return;
+    }
 
-	for (uint32_t i = 0; i < pRegion->rectangleCount; ++i) {
-		CGRect cgRect = mvkCGRectFromVkRectLayerKHR(pRegion->pRectangles[i]);
+    for (uint32_t i = 0; i < pRegion->rectangleCount; ++i) {
+        CGRect cgRect = mvkCGRectFromVkRectLayerKHR(pRegion->pRectangles[i]);
 #if MVK_MACOS
-		// VK_KHR_incremental_present specifies an upper-left origin, but macOS by default
-		// uses a lower-left origin.
-		cgRect.origin.y = mtlLayer.bounds.size.height - cgRect.origin.y;
+        // VK_KHR_incremental_present specifies an upper-left origin, but macOS
+        // by default uses a lower-left origin.
+        cgRect.origin.y = mtlLayer.bounds.size.height - cgRect.origin.y;
 #endif
-		// We were given rectangles in pixels, but -[CALayer setNeedsDisplayInRect:] wants them
-		// in points, which is pixels / contentsScale.
-		CGFloat scaleFactor = mtlLayer.contentsScale;
-		cgRect.origin.x /= scaleFactor;
-		cgRect.origin.y /= scaleFactor;
-		cgRect.size.width /= scaleFactor;
-		cgRect.size.height /= scaleFactor;
-		[mtlLayer setNeedsDisplayInRect:cgRect];
-	}
+        // We were given rectangles in pixels, but -[CALayer
+        // setNeedsDisplayInRect:] wants them in points, which is pixels /
+        // contentsScale.
+        CGFloat scaleFactor = mtlLayer.contentsScale;
+        cgRect.origin.x /= scaleFactor;
+        cgRect.origin.y /= scaleFactor;
+        cgRect.size.width /= scaleFactor;
+        cgRect.size.height /= scaleFactor;
+        [mtlLayer setNeedsDisplayInRect:cgRect];
+    }
 }
 
 #if MVK_MACOS
 struct CIE1931XY {
-	uint16_t x;
-	uint16_t y;
+    uint16_t x;
+    uint16_t y;
 } __attribute__((packed));
 
 // According to D.3.28:
-//   "[x and y] specify the normalized x and y chromaticity coordinates, respectively...
+//   "[x and y] specify the normalized x and y chromaticity coordinates,
+//   respectively...
 //    in normalized increments of 0.00002."
-static constexpr uint16_t FloatToCIE1931Unorm(float x) { return OSSwapHostToBigInt16((uint16_t)(x * 100000 / 2)); }
+static constexpr uint16_t FloatToCIE1931Unorm(float x) {
+    return OSSwapHostToBigInt16((uint16_t)(x * 100000 / 2));
+}
 static inline CIE1931XY VkXYColorEXTToCIE1931XY(VkXYColorEXT xy) {
-	return { FloatToCIE1931Unorm(xy.x), FloatToCIE1931Unorm(xy.y) };
+    return {FloatToCIE1931Unorm(xy.x), FloatToCIE1931Unorm(xy.y)};
 }
 #endif
 
 void MVKSwapchain::setHDRMetadataEXT(const VkHdrMetadataEXT& metadata) {
 #if MVK_MACOS
-	// We were given metadata as floats, but CA wants it as specified in H.265.
-	// More specifically, it wants "Mastering display colour volume" (D.2.28) and
-	// "Content light level information" (D.2.35) SEI messages, with big-endian
-	// integers. We have to convert.
-	struct ColorVolumeSEI {
-		CIE1931XY display_primaries[3];  // Green, blue, red
-		CIE1931XY white_point;
-		uint32_t max_display_mastering_luminance;
-		uint32_t min_display_mastering_luminance;
-	} __attribute__((packed));
-	struct LightLevelSEI {
-		uint16_t max_content_light_level;
-		uint16_t max_pic_average_light_level;
-	} __attribute__((packed));
-	ColorVolumeSEI colorVol;
-	LightLevelSEI lightLevel;
-	// According to D.3.28:
-	//   "For describing mastering displays that use red, green, and blue colour
-	//    primaries, it is suggested that index value c equal to 0 should correspond
-	//    to the green primary, c equal to 1 should correspond to the blue primary
-	//    and c equal to 2 should correspond to the red colour primary."
-	colorVol.display_primaries[0] = VkXYColorEXTToCIE1931XY(metadata.displayPrimaryGreen);
-	colorVol.display_primaries[1] = VkXYColorEXTToCIE1931XY(metadata.displayPrimaryBlue);
-	colorVol.display_primaries[2] = VkXYColorEXTToCIE1931XY(metadata.displayPrimaryRed);
-	colorVol.white_point = VkXYColorEXTToCIE1931XY(metadata.whitePoint);
-	// Later in D.3.28:
-	//   "max_display_mastering_luminance and min_display_mastering_luminance specify
-	//    the nominal maximum and minimum display luminance, respectively, of the mastering
-	//    display in units of 0.0001 candelas [sic] per square metre."
-	// N.B. 1 nit = 1 cd/m^2
-	colorVol.max_display_mastering_luminance = OSSwapHostToBigInt32((uint32_t)(metadata.maxLuminance * 10000));
-	colorVol.min_display_mastering_luminance = OSSwapHostToBigInt32((uint32_t)(metadata.minLuminance * 10000));
-	lightLevel.max_content_light_level = OSSwapHostToBigInt16((uint16_t)metadata.maxContentLightLevel);
-	lightLevel.max_pic_average_light_level = OSSwapHostToBigInt16((uint16_t)metadata.maxFrameAverageLightLevel);
-	NSData* colorVolData = [NSData dataWithBytes: &colorVol length: sizeof(colorVol)];
-	NSData* lightLevelData = [NSData dataWithBytes: &lightLevel length: sizeof(lightLevel)];
-	CAEDRMetadata* caMetadata = [CAEDRMetadata HDR10MetadataWithDisplayInfo: colorVolData
-																contentInfo: lightLevelData
-														 opticalOutputScale: 1];
-	auto* mtlLayer = getCAMetalLayer();
-	mtlLayer.EDRMetadata = caMetadata;
-	mtlLayer.wantsExtendedDynamicRangeContent = YES;
-	[caMetadata release];
-	[colorVolData release];
-	[lightLevelData release];
+    // We were given metadata as floats, but CA wants it as specified in H.265.
+    // More specifically, it wants "Mastering display colour volume" (D.2.28)
+    // and "Content light level information" (D.2.35) SEI messages, with
+    // big-endian integers. We have to convert.
+    struct ColorVolumeSEI {
+        CIE1931XY display_primaries[3]; // Green, blue, red
+        CIE1931XY white_point;
+        uint32_t max_display_mastering_luminance;
+        uint32_t min_display_mastering_luminance;
+    } __attribute__((packed));
+    struct LightLevelSEI {
+        uint16_t max_content_light_level;
+        uint16_t max_pic_average_light_level;
+    } __attribute__((packed));
+    ColorVolumeSEI colorVol;
+    LightLevelSEI lightLevel;
+    // According to D.3.28:
+    //   "For describing mastering displays that use red, green, and blue colour
+    //    primaries, it is suggested that index value c equal to 0 should
+    //    correspond to the green primary, c equal to 1 should correspond to the
+    //    blue primary and c equal to 2 should correspond to the red colour
+    //    primary."
+    colorVol.display_primaries[0] =
+        VkXYColorEXTToCIE1931XY(metadata.displayPrimaryGreen);
+    colorVol.display_primaries[1] =
+        VkXYColorEXTToCIE1931XY(metadata.displayPrimaryBlue);
+    colorVol.display_primaries[2] =
+        VkXYColorEXTToCIE1931XY(metadata.displayPrimaryRed);
+    colorVol.white_point = VkXYColorEXTToCIE1931XY(metadata.whitePoint);
+    // Later in D.3.28:
+    //   "max_display_mastering_luminance and min_display_mastering_luminance
+    //   specify
+    //    the nominal maximum and minimum display luminance, respectively, of
+    //    the mastering display in units of 0.0001 candelas [sic] per square
+    //    metre."
+    // N.B. 1 nit = 1 cd/m^2
+    colorVol.max_display_mastering_luminance =
+        OSSwapHostToBigInt32((uint32_t)(metadata.maxLuminance * 10000));
+    colorVol.min_display_mastering_luminance =
+        OSSwapHostToBigInt32((uint32_t)(metadata.minLuminance * 10000));
+    lightLevel.max_content_light_level =
+        OSSwapHostToBigInt16((uint16_t)metadata.maxContentLightLevel);
+    lightLevel.max_pic_average_light_level =
+        OSSwapHostToBigInt16((uint16_t)metadata.maxFrameAverageLightLevel);
+    NSData* colorVolData = [NSData dataWithBytes:&colorVol
+                                          length:sizeof(colorVol)];
+    NSData* lightLevelData = [NSData dataWithBytes:&lightLevel
+                                            length:sizeof(lightLevel)];
+    CAEDRMetadata* caMetadata =
+        [CAEDRMetadata HDR10MetadataWithDisplayInfo:colorVolData
+                                        contentInfo:lightLevelData
+                                 opticalOutputScale:1];
+    auto* mtlLayer = getCAMetalLayer();
+    mtlLayer.EDRMetadata = caMetadata;
+    mtlLayer.wantsExtendedDynamicRangeContent = YES;
+    [caMetadata release];
+    [colorVolData release];
+    [lightLevelData release];
 #endif
 }
-
 
 #pragma mark Construction
 
-MVKSwapchain::MVKSwapchain(MVKDevice* device, const VkSwapchainCreateInfoKHR* pCreateInfo)
-	: MVKVulkanAPIDeviceObject(device),
-	_surface((MVKSurface*)pCreateInfo->surface),
-	_imageExtent(pCreateInfo->imageExtent) {
+MVKSwapchain::MVKSwapchain(MVKDevice* device,
+                           const VkSwapchainCreateInfoKHR* pCreateInfo)
+    : MVKVulkanAPIDeviceObject(device),
+      _surface((MVKSurface*)pCreateInfo->surface),
+      _imageExtent(pCreateInfo->imageExtent) {
 
-	// Check if oldSwapchain is properly set
-	auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
-	if (oldSwapchain == _surface->_activeSwapchain) {
-		_surface->setActiveSwapchain(this);
-	} else {
-		setConfigurationResult(reportError(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR, "vkCreateSwapchainKHR(): pCreateInfo->oldSwapchain does not match the VkSwapchain that is in use by the surface"));
-		return;
-	}
+    // Check if oldSwapchain is properly set
+    auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
+    if (oldSwapchain == _surface->_activeSwapchain) {
+        _surface->setActiveSwapchain(this);
+    } else {
+        setConfigurationResult(
+            reportError(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR,
+                        "vkCreateSwapchainKHR(): pCreateInfo->oldSwapchain "
+                        "does not "
+                        "match the VkSwapchain that is in use by the surface"));
+        return;
+    }
 
-	memset(_presentTimingHistory, 0, sizeof(_presentTimingHistory));
+    memset(_presentTimingHistory, 0, sizeof(_presentTimingHistory));
 
-	// Retrieve the scaling and present mode structs if they are supplied.
-	VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo = nullptr;
-	VkSwapchainPresentModesCreateInfoEXT* pPresentModesInfo = nullptr;
-	for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_EXT: {
-				pScalingInfo = (VkSwapchainPresentScalingCreateInfoEXT*)next;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT: {
-				pPresentModesInfo = (VkSwapchainPresentModesCreateInfoEXT*)next;
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    // Retrieve the scaling and present mode structs if they are supplied.
+    VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo = nullptr;
+    VkSwapchainPresentModesCreateInfoEXT* pPresentModesInfo = nullptr;
+    for (auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_EXT: {
+            pScalingInfo = (VkSwapchainPresentScalingCreateInfoEXT*)next;
+            break;
+        }
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT: {
+            pPresentModesInfo = (VkSwapchainPresentModesCreateInfoEXT*)next;
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
-	_isDeliberatelyScaled = pScalingInfo && pScalingInfo->scalingBehavior;
+    _isDeliberatelyScaled = pScalingInfo && pScalingInfo->scalingBehavior;
 
-	// Set the list of present modes that can be specified in a queue
-	// present submission without causing the swapchain to be rebuilt.
-	if (pPresentModesInfo) {
-		for (uint32_t pmIdx = 0; pmIdx < pPresentModesInfo->presentModeCount; pmIdx++) {
-			_compatiblePresentModes.push_back(pPresentModesInfo->pPresentModes[pmIdx]);
-		}
-	}
+    // Set the list of present modes that can be specified in a queue
+    // present submission without causing the swapchain to be rebuilt.
+    if (pPresentModesInfo) {
+        for (uint32_t pmIdx = 0; pmIdx < pPresentModesInfo->presentModeCount;
+             pmIdx++) {
+            _compatiblePresentModes.push_back(
+                pPresentModesInfo->pPresentModes[pmIdx]);
+        }
+    }
 
-	auto& mtlFeats = getMetalFeatures();
-	uint32_t imgCnt = mvkClamp(pCreateInfo->minImageCount,
-							   mtlFeats.minSwapchainImageCount,
-							   mtlFeats.maxSwapchainImageCount);
-	initCAMetalLayer(pCreateInfo, pScalingInfo, imgCnt);
-    initSurfaceImages(pCreateInfo, imgCnt);		// After initCAMetalLayer()
+    auto& mtlFeats = getMetalFeatures();
+    uint32_t imgCnt =
+        mvkClamp(pCreateInfo->minImageCount, mtlFeats.minSwapchainImageCount,
+                 mtlFeats.maxSwapchainImageCount);
+    initCAMetalLayer(pCreateInfo, pScalingInfo, imgCnt);
+    initSurfaceImages(pCreateInfo, imgCnt); // After initCAMetalLayer()
 }
 
 // kCAGravityResize is the Metal default
-static CALayerContentsGravity getCALayerContentsGravity(VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo) {
+static CALayerContentsGravity getCALayerContentsGravity(
+    VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo) {
 
-	if( !pScalingInfo ) {                                         return kCAGravityResize; }
+    if (!pScalingInfo) {
+        return kCAGravityResize;
+    }
 
-	switch (pScalingInfo->scalingBehavior) {
-		case VK_PRESENT_SCALING_STRETCH_BIT_EXT:                  return kCAGravityResize;
-		case VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT:     return kCAGravityResizeAspect;
-		case VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT:
-			switch (pScalingInfo->presentGravityY) {
-				case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
-					switch (pScalingInfo->presentGravityX) {
-						case VK_PRESENT_GRAVITY_MIN_BIT_EXT:      return kCAGravityTopLeft;
-						case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT: return kCAGravityTop;
-						case VK_PRESENT_GRAVITY_MAX_BIT_EXT:      return kCAGravityTopRight;
-						default:                                  return kCAGravityTop;
-					}
-				case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT:
-					switch (pScalingInfo->presentGravityX) {
-						case VK_PRESENT_GRAVITY_MIN_BIT_EXT:      return kCAGravityLeft;
-						case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT: return kCAGravityCenter;
-						case VK_PRESENT_GRAVITY_MAX_BIT_EXT:      return kCAGravityRight;
-						default:                                  return kCAGravityCenter;
-					}
-				case VK_PRESENT_GRAVITY_MAX_BIT_EXT:
-					switch (pScalingInfo->presentGravityX) {
-						case VK_PRESENT_GRAVITY_MIN_BIT_EXT:      return kCAGravityBottomLeft;
-						case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT: return kCAGravityBottom;
-						case VK_PRESENT_GRAVITY_MAX_BIT_EXT:      return kCAGravityBottomRight;
-						default:                                  return kCAGravityBottom;
-					}
-				default:                                          return kCAGravityCenter;
-			}
-		default:                                                  return kCAGravityResize;
-	}
+    switch (pScalingInfo->scalingBehavior) {
+    case VK_PRESENT_SCALING_STRETCH_BIT_EXT:
+        return kCAGravityResize;
+    case VK_PRESENT_SCALING_ASPECT_RATIO_STRETCH_BIT_EXT:
+        return kCAGravityResizeAspect;
+    case VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT:
+        switch (pScalingInfo->presentGravityY) {
+        case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
+            switch (pScalingInfo->presentGravityX) {
+            case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
+                return kCAGravityTopLeft;
+            case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT:
+                return kCAGravityTop;
+            case VK_PRESENT_GRAVITY_MAX_BIT_EXT:
+                return kCAGravityTopRight;
+            default:
+                return kCAGravityTop;
+            }
+        case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT:
+            switch (pScalingInfo->presentGravityX) {
+            case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
+                return kCAGravityLeft;
+            case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT:
+                return kCAGravityCenter;
+            case VK_PRESENT_GRAVITY_MAX_BIT_EXT:
+                return kCAGravityRight;
+            default:
+                return kCAGravityCenter;
+            }
+        case VK_PRESENT_GRAVITY_MAX_BIT_EXT:
+            switch (pScalingInfo->presentGravityX) {
+            case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
+                return kCAGravityBottomLeft;
+            case VK_PRESENT_GRAVITY_CENTERED_BIT_EXT:
+                return kCAGravityBottom;
+            case VK_PRESENT_GRAVITY_MAX_BIT_EXT:
+                return kCAGravityBottomRight;
+            default:
+                return kCAGravityBottom;
+            }
+        default:
+            return kCAGravityCenter;
+        }
+    default:
+        return kCAGravityResize;
+    }
 }
 
 // Initializes the CAMetalLayer underlying the surface of this swapchain.
-void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
-									VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo,
-									uint32_t imgCnt) {
+void MVKSwapchain::initCAMetalLayer(
+    const VkSwapchainCreateInfoKHR* pCreateInfo,
+    VkSwapchainPresentScalingCreateInfoEXT* pScalingInfo, uint32_t imgCnt) {
 
-	auto* mtlLayer = getCAMetalLayer();
-	if ( !mtlLayer || getIsSurfaceLost() ) { return; }
+    auto* mtlLayer = getCAMetalLayer();
+    if (!mtlLayer || getIsSurfaceLost()) {
+        return;
+    }
 
-	auto minMagFilter = getMVKConfig().swapchainMinMagFilterUseNearest ? kCAFilterNearest : kCAFilterLinear;
-	mtlLayer.drawableSize = mvkCGSizeFromVkExtent2D(_imageExtent);
-	mtlLayer.device = getMTLDevice();
-	mtlLayer.pixelFormat = getPixelFormats()->getMTLPixelFormat(pCreateInfo->imageFormat);
-	mtlLayer.maximumDrawableCountMVK = imgCnt;
-	mtlLayer.displaySyncEnabledMVK = (pCreateInfo->presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
-	mtlLayer.minificationFilter = minMagFilter;
-	mtlLayer.magnificationFilter = minMagFilter;
-	mtlLayer.contentsGravity = getCALayerContentsGravity(pScalingInfo);
-	mtlLayer.framebufferOnly = !mvkIsAnyFlagEnabled(pCreateInfo->imageUsage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-																			  VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-																			  VK_IMAGE_USAGE_SAMPLED_BIT |
-																			  VK_IMAGE_USAGE_STORAGE_BIT));
+    auto minMagFilter = getMVKConfig().swapchainMinMagFilterUseNearest
+                            ? kCAFilterNearest
+                            : kCAFilterLinear;
+    mtlLayer.drawableSize = mvkCGSizeFromVkExtent2D(_imageExtent);
+    mtlLayer.device = getMTLDevice();
+    mtlLayer.pixelFormat =
+        getPixelFormats()->getMTLPixelFormat(pCreateInfo->imageFormat);
+    mtlLayer.maximumDrawableCountMVK = imgCnt;
+    mtlLayer.displaySyncEnabledMVK =
+        (pCreateInfo->presentMode != VK_PRESENT_MODE_IMMEDIATE_KHR);
+    mtlLayer.minificationFilter = minMagFilter;
+    mtlLayer.magnificationFilter = minMagFilter;
+    mtlLayer.contentsGravity = getCALayerContentsGravity(pScalingInfo);
+    mtlLayer.framebufferOnly =
+        !mvkIsAnyFlagEnabled(pCreateInfo->imageUsage,
+                             (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                              VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                              VK_IMAGE_USAGE_SAMPLED_BIT |
+                              VK_IMAGE_USAGE_STORAGE_BIT));
 
-	// Because of a regression in Metal, the most recent one or two presentations may not
-	// complete and call back. Changing the CAMetalLayer drawableSize will force any incomplete
-	// presentations on the oldSwapchain to complete and call back, but if the drawableSize
-	// is not changing from the previous, we force those completions first.
-	auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
-	if (oldSwapchain && mvkVkExtent2DsAreEqual(pCreateInfo->imageExtent, _surface->getExtent())) {
-		oldSwapchain->forceUnpresentedImageCompletion();
-	}
+    // Because of a regression in Metal, the most recent one or two
+    // presentations may not complete and call back. Changing the CAMetalLayer
+    // drawableSize will force any incomplete presentations on the oldSwapchain
+    // to complete and call back, but if the drawableSize is not changing from
+    // the previous, we force those completions first.
+    auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
+    if (oldSwapchain && mvkVkExtent2DsAreEqual(pCreateInfo->imageExtent,
+                                               _surface->getExtent())) {
+        oldSwapchain->forceUnpresentedImageCompletion();
+    }
 
-	if (pCreateInfo->compositeAlpha != VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
-		mtlLayer.opaque = pCreateInfo->compositeAlpha == VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-	}
+    if (pCreateInfo->compositeAlpha != VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
+        mtlLayer.opaque =
+            pCreateInfo->compositeAlpha == VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    }
 
-	switch (pCreateInfo->imageColorSpace) {
-		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceSRGB;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
-			break;
-		case VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceDisplayP3;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearSRGB;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedSRGB;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearDisplayP3;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceDCIP3;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_BT709_NONLINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_709;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
-			break;
-		case VK_COLOR_SPACE_BT2020_LINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearITUR_2020;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
+    switch (pCreateInfo->imageColorSpace) {
+    case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceSRGB;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
+        break;
+    case VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceDisplayP3;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearSRGB;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedSRGB;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearDisplayP3;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceDCIP3;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_BT709_NONLINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_709;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
+        break;
+    case VK_COLOR_SPACE_BT2020_LINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceExtendedLinearITUR_2020;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
 #if MVK_XCODE_12
-		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_PQ;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
-		case VK_COLOR_SPACE_HDR10_HLG_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_HLG;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
-			break;
+    case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_PQ;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
+    case VK_COLOR_SPACE_HDR10_HLG_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceITUR_2100_HLG;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = YES;
+        break;
 #endif
-		case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
-			mtlLayer.colorspaceNameMVK = kCGColorSpaceAdobeRGB1998;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
-			break;
-		case VK_COLOR_SPACE_PASS_THROUGH_EXT:
-			mtlLayer.colorspace = nil;
-			mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
-			break;
-		default:
-			setConfigurationResult(reportError(VK_ERROR_FORMAT_NOT_SUPPORTED, "vkCreateSwapchainKHR(): Metal does not support VkColorSpaceKHR value %d.", pCreateInfo->imageColorSpace));
-			break;
-	}
+    case VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT:
+        mtlLayer.colorspaceNameMVK = kCGColorSpaceAdobeRGB1998;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
+        break;
+    case VK_COLOR_SPACE_PASS_THROUGH_EXT:
+        mtlLayer.colorspace = nil;
+        mtlLayer.wantsExtendedDynamicRangeContentMVK = NO;
+        break;
+    default:
+        setConfigurationResult(
+            reportError(VK_ERROR_FORMAT_NOT_SUPPORTED,
+                        "vkCreateSwapchainKHR(): Metal does not support "
+                        "VkColorSpaceKHR value %d.",
+                        pCreateInfo->imageColorSpace));
+        break;
+    }
 
-	// TODO: set additional CAMetalLayer properties before extracting drawables:
-	//	- presentsWithTransaction
-	//	- drawsAsynchronously
+    // TODO: set additional CAMetalLayer properties before extracting drawables:
+    //	- presentsWithTransaction
+    //	- drawsAsynchronously
 }
 
 // Initializes the array of images used for the surface of this swapchain.
 // The CAMetalLayer should already be initialized when this is called.
-void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt) {
+void MVKSwapchain::initSurfaceImages(
+    const VkSwapchainCreateInfoKHR* pCreateInfo, uint32_t imgCnt) {
 
-    if ( _device->getConfigurationResult() != VK_SUCCESS ) { return; }
-    if ( getIsSurfaceLost() ) { return; }
+    if (_device->getConfigurationResult() != VK_SUCCESS) {
+        return;
+    }
+    if (getIsSurfaceLost()) {
+        return;
+    }
 
-	VkImageFormatListCreateInfo fmtListInfo;
-	for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-		switch (next->sType) {
-			case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
-				fmtListInfo = *(VkImageFormatListCreateInfo*)next;
-				fmtListInfo.pNext = VK_NULL_HANDLE;		// Terminate the new chain
-				break;
-			}
-			default:
-				break;
-		}
-	}
+    VkImageFormatListCreateInfo fmtListInfo;
+    for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next;
+         next = next->pNext) {
+        switch (next->sType) {
+        case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO: {
+            fmtListInfo = *(VkImageFormatListCreateInfo*)next;
+            fmtListInfo.pNext = VK_NULL_HANDLE; // Terminate the new chain
+            break;
+        }
+        default:
+            break;
+        }
+    }
 
     VkExtent2D imgExtent = pCreateInfo->imageExtent;
     VkImageCreateInfo imgInfo = {
@@ -593,54 +711,73 @@ void MVKSwapchain::initSurfaceImages(const VkSwapchainCreateInfoKHR* pCreateInfo
         .flags = 0,
     };
 
-	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)) {
-		mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
-		imgInfo.pNext = &fmtListInfo;
-	}
-	if (mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR)) {
-		// We don't really support this, but set the flag anyway.
-		mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT);
-	}
+    if (mvkAreAllFlagsEnabled(pCreateInfo->flags,
+                              VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR)) {
+        mvkEnableFlags(imgInfo.flags, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT |
+                                          VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+        imgInfo.pNext = &fmtListInfo;
+    }
+    if (mvkAreAllFlagsEnabled(
+            pCreateInfo->flags,
+            VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR)) {
+        // We don't really support this, but set the flag anyway.
+        mvkEnableFlags(imgInfo.flags,
+                       VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT);
+    }
 
-	// The VK_SWAPCHAIN_CREATE_DEFERRED_MEMORY_ALLOCATION_BIT_EXT flag is ignored, because
-	// swapchain image memory allocation is provided by a MTLDrawable, which is retrieved
-	// lazily, and hence is already deferred (or as deferred as we can make it).
+    // The VK_SWAPCHAIN_CREATE_DEFERRED_MEMORY_ALLOCATION_BIT_EXT flag is
+    // ignored, because swapchain image memory allocation is provided by a
+    // MTLDrawable, which is retrieved lazily, and hence is already deferred (or
+    // as deferred as we can make it).
 
-	for (uint32_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
-		_presentableImages.push_back(_device->createPresentableSwapchainImage(&imgInfo, this, imgIdx, nullptr));
-	}
+    for (uint32_t imgIdx = 0; imgIdx < imgCnt; imgIdx++) {
+        _presentableImages.push_back(
+            _device->createPresentableSwapchainImage(&imgInfo, this, imgIdx,
+                                                     nullptr));
+    }
 
-	auto* mtlLayer = getCAMetalLayer();
-	if (mtlLayer) {
-		NSString* screenName = @"Main Screen";
+    auto* mtlLayer = getCAMetalLayer();
+    if (mtlLayer) {
+        NSString* screenName = @"Main Screen";
 #if MVK_MACOS && !MVK_MACCAT
-		// To prevent deadlocks, avoid dispatching screenMVK to the main thread at the cost of a less informative log.
-		if (NSThread.isMainThread) {
-			auto* screen = mtlLayer.screenMVK;
-			if ([screen respondsToSelector:@selector(localizedName)]) {
-				screenName = screen.localizedName;
-			}
-		}
+        // To prevent deadlocks, avoid dispatching screenMVK to the main thread
+        // at the cost of a less informative log.
+        if (NSThread.isMainThread) {
+            auto* screen = mtlLayer.screenMVK;
+            if ([screen respondsToSelector:@selector(localizedName)]) {
+                screenName = screen.localizedName;
+            }
+        }
 #endif
-		MVKLogInfo("Created %d swapchain images with size (%d, %d) and contents scale %.1f in layer %s (%p) on screen %s.",
-				   imgCnt, imgExtent.width, imgExtent.height, mtlLayer.contentsScale, mtlLayer.name.UTF8String, mtlLayer, screenName.UTF8String);
-	} else {
-		MVKLogInfo("Created %d swapchain images with size (%d, %d) on headless surface.", imgCnt, imgExtent.width, imgExtent.height);
-	}
+        MVKLogInfo("Created %d swapchain images with size (%d, %d) and "
+                   "contents scale %.1f in layer %s (%p) on screen "
+                   "%s.",
+                   imgCnt, imgExtent.width, imgExtent.height,
+                   mtlLayer.contentsScale, mtlLayer.name.UTF8String, mtlLayer,
+                   screenName.UTF8String);
+    } else {
+        MVKLogInfo("Created %d swapchain images with size (%d, %d) on headless "
+                   "surface.",
+                   imgCnt, imgExtent.width, imgExtent.height);
+    }
 }
 
 void MVKSwapchain::destroy() {
-	// If this swapchain was not replaced by a new swapchain, remove this swapchain
-	// from the surface, and force any outstanding presentations to complete.
-	if (_surface->_activeSwapchain == this) {
-		_surface->_activeSwapchain = nullptr;
-		forceUnpresentedImageCompletion();
-	}
-	for (auto& img : _presentableImages) { _device->destroyPresentableSwapchainImage(img, NULL); }
-	MVKVulkanAPIDeviceObject::destroy();
+    // If this swapchain was not replaced by a new swapchain, remove this
+    // swapchain from the surface, and force any outstanding presentations to
+    // complete.
+    if (_surface->_activeSwapchain == this) {
+        _surface->_activeSwapchain = nullptr;
+        forceUnpresentedImageCompletion();
+    }
+    for (auto& img : _presentableImages) {
+        _device->destroyPresentableSwapchainImage(img, NULL);
+    }
+    MVKVulkanAPIDeviceObject::destroy();
 }
 
 MVKSwapchain::~MVKSwapchain() {
-    if (_licenseWatermark) { _licenseWatermark->destroy(); }
+    if (_licenseWatermark) {
+        _licenseWatermark->destroy();
+    }
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,87 +26,91 @@
 
 class MVKFenceSitter;
 
-
 #pragma mark -
 #pragma mark MVKSemaphoreImpl
 
-/** 
- * A general utility semaphore object. Reservations can be made with an instance, 
- * and it will block waiting threads until reservations have been released.
+/**
+ * A general utility semaphore object. Reservations can be made with an
+ * instance, and it will block waiting threads until reservations have been
+ * released.
  *
- * An instance can be configured so that each call to the reserve() function must be
- * matched with a separate call to the release() function before waiting threads are
- * unblocked, or it can be configured so that a single call to the release() function
- * will release all outstanding reservations and unblock all threads immediately.
+ * An instance can be configured so that each call to the reserve() function
+ * must be matched with a separate call to the release() function before waiting
+ * threads are unblocked, or it can be configured so that a single call to the
+ * release() function will release all outstanding reservations and unblock all
+ * threads immediately.
  */
 class MVKSemaphoreImpl : public MVKBaseObject {
 
-public:
+  public:
+    /** Returns nil as this object has no need to track the Vulkan object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
 
-	/** Returns nil as this object has no need to track the Vulkan object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; };
+    /**
+     * Adds a reservation to this semaphore, incrementing the reservation count.
+     * Subsequent calls to a wait() function will block until a corresponding
+     * call is made to the release() function.
+     */
+    void reserve();
 
-	/**
-	 * Adds a reservation to this semaphore, incrementing the reservation count.
-	 * Subsequent calls to a wait() function will block until a corresponding call
-     * is made to the release() function.
-	 */
-	void reserve();
+    /**
+     * Depending on configuration, releases one or all reservations. When all
+     * reservations have been released, unblocks all waiting threads to continue
+     * processing. Returns true if the last reservation was released.
+     */
+    bool release();
 
-	/**
-	 * Depending on configuration, releases one or all reservations. When all reservations
-	 * have been released, unblocks all waiting threads to continue processing.
-	 * Returns true if the last reservation was released.
-	 */
-	bool release();
+    /** Returns whether this instance is in a reserved state. */
+    bool isReserved();
 
-	/** Returns whether this instance is in a reserved state. */
-	bool isReserved();
+    /** Returns the number of outstanding reservations. */
+    uint32_t getReservationCount();
 
-	/** Returns the number of outstanding reservations. */
-	uint32_t getReservationCount();
-
-	/**
-	 * Blocks processing on the current thread until any or all (depending on configuration) outstanding
-     * reservations have been released, or until the specified timeout interval in nanoseconds expires.
-	 *
-	 * If timeout is the special value UINT64_MAX the timeout is treated as infinite.
+    /**
+     * Blocks processing on the current thread until any or all (depending on
+     * configuration) outstanding reservations have been released, or until the
+     * specified timeout interval in nanoseconds expires.
      *
-     * If reserveAgain is set to true, a single reservation will be added once this wait is finished.
-	 *
-	 * Returns true if all reservations were cleared, or false if the timeout interval expired.
-	 */
-	bool wait(uint64_t timeout = UINT64_MAX, bool reserveAgain = false);
-
+     * If timeout is the special value UINT64_MAX the timeout is treated as
+     * infinite.
+     *
+     * If reserveAgain is set to true, a single reservation will be added once
+     * this wait is finished.
+     *
+     * Returns true if all reservations were cleared, or false if the timeout
+     * interval expired.
+     */
+    bool wait(uint64_t timeout = UINT64_MAX, bool reserveAgain = false);
 
 #pragma mark Construction
 
-	/** 
-	 * Constructs an instance with the specified number of initial reservations. 
-	 * This value defaults to zero, starting the semaphore in an unblocking state.
-	 *
-	 * The waitAll parameter indicates whether a call to the release() function is required
-	 * for each call to the reserve() function (waitAll = true), or whether a single call 
-	 * to the release() function will release all outstanding reservations (waitAll = false). 
-	 * This value defaults to true, indicating that each call to the reserve() function will
-	 * require a separate call to the release() function to cause the semaphore to stop blocking.
-	 */
+    /**
+     * Constructs an instance with the specified number of initial reservations.
+     * This value defaults to zero, starting the semaphore in an unblocking
+     * state.
+     *
+     * The waitAll parameter indicates whether a call to the release() function
+     * is required for each call to the reserve() function (waitAll = true), or
+     * whether a single call to the release() function will release all
+     * outstanding reservations (waitAll = false). This value defaults to true,
+     * indicating that each call to the reserve() function will require a
+     * separate call to the release() function to cause the semaphore to stop
+     * blocking.
+     */
     MVKSemaphoreImpl(bool waitAll = true, uint32_t reservationCount = 0)
         : _reservationCount(reservationCount), _shouldWaitAll(waitAll) {}
 
     ~MVKSemaphoreImpl();
 
+  private:
+    bool operator()();
+    bool isClear() { return _reservationCount == 0; } // Not thread-safe
 
-private:
-	bool operator()();
-    bool isClear() { return _reservationCount == 0; }    // Not thread-safe
-
-	std::mutex _lock;
-	std::condition_variable _blocker;
-	uint32_t _reservationCount;
-	bool _shouldWaitAll;
+    std::mutex _lock;
+    std::condition_variable _blocker;
+    uint32_t _reservationCount;
+    bool _shouldWaitAll;
 };
-
 
 #pragma mark -
 #pragma mark MVKSemaphore
@@ -114,120 +118,134 @@ private:
 /** Abstract class that represents a Vulkan semaphore. */
 class MVKSemaphore : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SEMAPHORE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_SEMAPHORE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT; }
+    /** Returns the type of this semaphore. */
+    virtual VkSemaphoreType getSemaphoreType() {
+        return VK_SEMAPHORE_TYPE_BINARY;
+    }
 
-	/** Returns the type of this semaphore. */
-	virtual VkSemaphoreType getSemaphoreType() { return VK_SEMAPHORE_TYPE_BINARY; }
+    /**
+     * Wait for this semaphore to be signaled.
+     *
+     * If the subclass uses command encoding AND the mtlCmdBuff is not nil, a
+     * wait is encoded on the mtlCmdBuff, and this call returns immediately.
+     * Otherwise, if the subclass does NOT use command encoding, AND the
+     * mtlCmdBuff is nil, this call blocks indefinitely until this semaphore is
+     * signaled. Other combinations do nothing.
+     *
+     * This design allows this function to be blindly called twice, from
+     * different points in the code path, once with a mtlCmdBuff to support
+     * encoding a wait on the command buffer if the subclass supports command
+     * encoding, and once without a mtlCmdBuff, at the point in the code path
+     * where the code should block if the subclass does not support command
+     * encoding.
+     *
+     * 'value' only applies if this semaphore is a timeline semaphore. It is the
+     * value to wait for the semaphore to have.
+     */
+    virtual void encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                            uint64_t value) = 0;
 
-	/**
-	 * Wait for this semaphore to be signaled.
-	 *
-	 * If the subclass uses command encoding AND the mtlCmdBuff is not nil, a wait
-	 * is encoded on the mtlCmdBuff, and this call returns immediately. Otherwise, if the
-	 * subclass does NOT use command encoding, AND the mtlCmdBuff is nil, this call blocks
-	 * indefinitely until this semaphore is signaled. Other combinations do nothing.
-	 *
-	 * This design allows this function to be blindly called twice, from different points in the
-	 * code path, once with a mtlCmdBuff to support encoding a wait on the command buffer if the
-	 * subclass supports command encoding, and once without a mtlCmdBuff, at the point in the
-	 * code path where the code should block if the subclass does not support command encoding.
-	 *
-	 * 'value' only applies if this semaphore is a timeline semaphore. It is the value to wait for the
-	 * semaphore to have.
-	 */
-	virtual void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) = 0;
+    /**
+     * Signals this semaphore.
+     *
+     * If the subclass uses command encoding AND the mtlCmdBuff is not nil, a
+     * signal is encoded on the mtlCmdBuff. Otherwise, if the subclass does NOT
+     * use command encoding, AND the mtlCmdBuff is nil, this call immediately
+     * signals any waiting calls. Either way, this call returns immediately.
+     * Other combinations do nothing.
+     *
+     * This design allows this function to be blindly called twice, from
+     * different points in the code path, once with a mtlCmdBuff to support
+     * encoding a wait on the command buffer if the subclass supports command
+     * encoding, and once without a mtlCmdBuff, at the point in the code path
+     * where the code should block if the subclass does not support command
+     * encoding.
+     *
+     * 'value' only applies if this semaphore is a timeline semaphore. It is the
+     * value to assign the semaphore upon completion.
+     */
+    virtual void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                              uint64_t value) = 0;
 
-	/**
-	 * Signals this semaphore.
-	 *
-	 * If the subclass uses command encoding AND the mtlCmdBuff is not nil, a signal is
-	 * encoded on the mtlCmdBuff. Otherwise, if the subclass does NOT use command encoding,
-	 * AND the mtlCmdBuff is nil, this call immediately signals any waiting calls.
-	 * Either way, this call returns immediately. Other combinations do nothing.
-	 *
-	 * This design allows this function to be blindly called twice, from different points in the
-	 * code path, once with a mtlCmdBuff to support encoding a wait on the command buffer if the
-	 * subclass supports command encoding, and once without a mtlCmdBuff, at the point in the
-	 * code path where the code should block if the subclass does not support command encoding.
-	 *
-	 * 'value' only applies if this semaphore is a timeline semaphore. It is the value to assign the semaphore
-	 * upon completion.
-	 */
-	virtual void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) = 0;
+    /**
+     * Begin a deferred signal operation.
+     *
+     * A deferred signal acts like a normal signal operation, except that the
+     * signal op itself is not actually executed. A token is returned, which
+     * must be passed to encodeDeferredSignal() to complete the signal
+     * operation.
+     *
+     * This is intended to be used by MVKSwapchain, in order to properly
+     * implement semaphores for image availability, particularly with
+     * MTLEvent-based semaphores, to ensure the correct value is used in
+     * signal/wait operations.
+     */
+    virtual uint64_t deferSignal() = 0;
 
-	/**
-	 * Begin a deferred signal operation.
-	 *
-	 * A deferred signal acts like a normal signal operation, except that the signal op itself
-	 * is not actually executed. A token is returned, which must be passed to encodeDeferredSignal()
-	 * to complete the signal operation.
-	 *
-	 * This is intended to be used by MVKSwapchain, in order to properly implement semaphores
-	 * for image availability, particularly with MTLEvent-based semaphores, to ensure the correct
-	 * value is used in signal/wait operations.
-	 */
-	virtual uint64_t deferSignal() = 0;
+    /**
+     * Complete a deferred signal operation.
+     *
+     * This is the other half of the deferSignal() method. The token that was
+     * returned from deferSignal() must be passed here.
+     */
+    virtual void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                      uint64_t deferToken) = 0;
 
-	/**
-	 * Complete a deferred signal operation.
-	 *
-	 * This is the other half of the deferSignal() method. The token that was returned
-	 * from deferSignal() must be passed here.
-	 */
-	virtual void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t deferToken) = 0;
+    /** Returns whether this semaphore uses command encoding. */
+    virtual bool isUsingCommandEncoding() = 0;
 
-	/** Returns whether this semaphore uses command encoding. */
-	virtual bool isUsingCommandEncoding() = 0;
-
-	/**
-	 * Returns the MTLSharedEvent underlying this Vulkan semaphore,
-	 * or nil if this semaphore is not underpinned by a MTLSharedEvent.
-	 */
-	virtual id<MTLSharedEvent> getMTLSharedEvent() { return nil; };
-
+    /**
+     * Returns the MTLSharedEvent underlying this Vulkan semaphore,
+     * or nil if this semaphore is not underpinned by a MTLSharedEvent.
+     */
+    virtual id<MTLSharedEvent> getMTLSharedEvent() { return nil; };
 
 #pragma mark Construction
 
-    MVKSemaphore(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {}
+    MVKSemaphore(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo)
+        : MVKVulkanAPIDeviceObject(device) {}
 
-protected:
-	void propagateDebugName() override {}
-
+  protected:
+    void propagateDebugName() override {}
 };
-
 
 #pragma mark -
 #pragma mark MVKSemaphoreSingleQueue
 
 /**
- * An MVKSemaphore that uses Metal's built-in guarantees on single-queue submission to provide semaphore-like guarantees.
+ * An MVKSemaphore that uses Metal's built-in guarantees on single-queue
+ * submission to provide semaphore-like guarantees.
  *
- * Relies on Metal's enabled-by-default hazard tracking, and will need to start doing things with MTLFences
- * if we start using things with MTLHazardTrackingModeUntracked
+ * Relies on Metal's enabled-by-default hazard tracking, and will need to start
+ * doing things with MTLFences if we start using things with
+ * MTLHazardTrackingModeUntracked
  */
 class MVKSemaphoreSingleQueue : public MVKSemaphore {
 
-public:
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	uint64_t deferSignal() override;
-	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	bool isUsingCommandEncoding() override { return false; }
+  public:
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
+    uint64_t deferSignal() override;
+    void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                              uint64_t) override;
+    bool isUsingCommandEncoding() override { return false; }
 
-	MVKSemaphoreSingleQueue(MVKDevice* device,
-	                        const VkSemaphoreCreateInfo* pCreateInfo,
-	                        const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-	                        const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKSemaphoreSingleQueue(MVKDevice* device,
+                            const VkSemaphoreCreateInfo* pCreateInfo,
+                            const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+                            const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-	~MVKSemaphoreSingleQueue() override;
+    ~MVKSemaphoreSingleQueue() override;
 };
-
 
 #pragma mark -
 #pragma mark MVKSemaphoreMTLEvent
@@ -235,48 +253,49 @@ public:
 /** An MVKSemaphore that uses MTLEvent to provide synchronization. */
 class MVKSemaphoreMTLEvent : public MVKSemaphore {
 
-public:
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	uint64_t deferSignal() override;
-	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t deferToken) override;
-	bool isUsingCommandEncoding() override { return true; }
+  public:
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    uint64_t deferSignal() override;
+    void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                              uint64_t deferToken) override;
+    bool isUsingCommandEncoding() override { return true; }
 
-	MVKSemaphoreMTLEvent(MVKDevice* device,
-						 const VkSemaphoreCreateInfo* pCreateInfo,
-						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-						 const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKSemaphoreMTLEvent(MVKDevice* device,
+                         const VkSemaphoreCreateInfo* pCreateInfo,
+                         const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+                         const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-	~MVKSemaphoreMTLEvent() override;
+    ~MVKSemaphoreMTLEvent() override;
 
-protected:
-	id<MTLEvent> _mtlEvent;
-	std::atomic<uint64_t> _mtlEventValue;
+  protected:
+    id<MTLEvent> _mtlEvent;
+    std::atomic<uint64_t> _mtlEventValue;
 };
-
 
 #pragma mark -
 #pragma mark MVKSemaphoreEmulated
 
-/** An MVKSemaphore that uses CPU synchronization to provide synchronization functionality. */
+/** An MVKSemaphore that uses CPU synchronization to provide synchronization
+ * functionality. */
 class MVKSemaphoreEmulated : public MVKSemaphore {
 
-public:
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	uint64_t deferSignal() override;
-	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
-	bool isUsingCommandEncoding() override { return false; }
+  public:
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) override;
+    uint64_t deferSignal() override;
+    void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                              uint64_t) override;
+    bool isUsingCommandEncoding() override { return false; }
 
-	MVKSemaphoreEmulated(MVKDevice* device,
-						 const VkSemaphoreCreateInfo* pCreateInfo,
-						 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-						 const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKSemaphoreEmulated(MVKDevice* device,
+                         const VkSemaphoreCreateInfo* pCreateInfo,
+                         const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+                         const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-protected:
-	MVKSemaphoreImpl _blocker;
+  protected:
+    MVKSemaphoreImpl _blocker;
 };
-
 
 #pragma mark -
 #pragma mark MVKTimelineSemaphore
@@ -284,99 +303,109 @@ protected:
 /** Abstract class that represents a Vulkan timeline semaphore. */
 class MVKTimelineSemaphore : public MVKSemaphore {
 
-public:
+  public:
+    VkSemaphoreType getSemaphoreType() override {
+        return VK_SEMAPHORE_TYPE_TIMELINE;
+    }
+    uint64_t deferSignal() override { return 0; }
+    // Timeline semaphores cannot yet be used for signaling swapchain
+    // availability, because no interaction is yet defined. When it is, though,
+    // it's likely that a value must be supplied, just like when using them with
+    // command buffers.
+    void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                              uint64_t deferToken) override {
+        return encodeSignal(mtlCmdBuff, deferToken);
+    }
 
-	VkSemaphoreType getSemaphoreType() override { return VK_SEMAPHORE_TYPE_TIMELINE; }
-	uint64_t deferSignal() override { return 0; }
-	// Timeline semaphores cannot yet be used for signaling swapchain availability, because
-	// no interaction is yet defined. When it is, though, it's likely that a value must
-	// be supplied, just like when using them with command buffers.
-	void encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t deferToken) override {
-		return encodeSignal(mtlCmdBuff, deferToken);
-	}
+    /** Returns the current value of the semaphore counter. */
+    virtual uint64_t getCounterValue() = 0;
 
-	/** Returns the current value of the semaphore counter. */
-	virtual uint64_t getCounterValue() = 0;
+    /** Signals this semaphore on the host. */
+    virtual void signal(const VkSemaphoreSignalInfo* pSignalInfo) = 0;
 
-	/** Signals this semaphore on the host. */
-	virtual void signal(const VkSemaphoreSignalInfo* pSignalInfo) = 0;
+    /** Registers a wait for this semaphore on the host. Returns true if the
+     * semaphore is already signaled. */
+    virtual bool registerWait(MVKFenceSitter* sitter,
+                              const VkSemaphoreWaitInfo* pWaitInfo,
+                              uint32_t index) = 0;
 
-	/** Registers a wait for this semaphore on the host. Returns true if the semaphore is already signaled. */
-	virtual bool registerWait(MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo, uint32_t index) = 0;
-
-	/** Stops waiting for this semaphore. */
-	virtual void unregisterWait(MVKFenceSitter* sitter) = 0;
+    /** Stops waiting for this semaphore. */
+    virtual void unregisterWait(MVKFenceSitter* sitter) = 0;
 
 #pragma mark Construction
 
-	MVKTimelineSemaphore(MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo) : MVKSemaphore(device, pCreateInfo) {}
-
+    MVKTimelineSemaphore(MVKDevice* device,
+                         const VkSemaphoreCreateInfo* pCreateInfo)
+        : MVKSemaphore(device, pCreateInfo) {}
 };
-
 
 #pragma mark -
 #pragma mark MVKTimelineSemaphoreMTLEvent
 
-/** An MVKTimelineSemaphore that uses MTLSharedEvent to provide synchronization. */
+/** An MVKTimelineSemaphore that uses MTLSharedEvent to provide synchronization.
+ */
 class MVKTimelineSemaphoreMTLEvent : public MVKTimelineSemaphore {
 
-public:
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	bool isUsingCommandEncoding() override { return true; }
-	id<MTLSharedEvent> getMTLSharedEvent() override { return _mtlEvent; };
+  public:
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    bool isUsingCommandEncoding() override { return true; }
+    id<MTLSharedEvent> getMTLSharedEvent() override { return _mtlEvent; };
 
-	uint64_t getCounterValue() override { return _mtlEvent.signaledValue; }
-	void signal(const VkSemaphoreSignalInfo* pSignalInfo) override;
-	bool registerWait(MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo, uint32_t index) override;
-	void unregisterWait(MVKFenceSitter* sitter) override;
+    uint64_t getCounterValue() override { return _mtlEvent.signaledValue; }
+    void signal(const VkSemaphoreSignalInfo* pSignalInfo) override;
+    bool registerWait(MVKFenceSitter* sitter,
+                      const VkSemaphoreWaitInfo* pWaitInfo,
+                      uint32_t index) override;
+    void unregisterWait(MVKFenceSitter* sitter) override;
 
-	MVKTimelineSemaphoreMTLEvent(MVKDevice* device,
-								 const VkSemaphoreCreateInfo* pCreateInfo,
-								 const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
-								 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-								 const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKTimelineSemaphoreMTLEvent(
+        MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+        const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
+        const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+        const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-	~MVKTimelineSemaphoreMTLEvent() override;
+    ~MVKTimelineSemaphoreMTLEvent() override;
 
-protected:
-	id<MTLSharedEvent> _mtlEvent = nil;
-	std::mutex _lock;
-	std::unordered_set<MVKFenceSitter*> _sitters;
+  protected:
+    id<MTLSharedEvent> _mtlEvent = nil;
+    std::mutex _lock;
+    std::unordered_set<MVKFenceSitter*> _sitters;
 };
-
 
 #pragma mark -
 #pragma mark MVKTimelineSemaphoreEmulated
 
-/** An MVKTimelineSemaphore that uses CPU synchronization to provide synchronization functionality. */
+/** An MVKTimelineSemaphore that uses CPU synchronization to provide
+ * synchronization functionality. */
 class MVKTimelineSemaphoreEmulated : public MVKTimelineSemaphore {
 
-public:
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
-	bool isUsingCommandEncoding() override { return false; }
+  public:
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) override;
+    bool isUsingCommandEncoding() override { return false; }
 
-	uint64_t getCounterValue() override { return _value; }
-	void signal(const VkSemaphoreSignalInfo* pSignalInfo) override;
-	bool registerWait(MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo, uint32_t index) override;
-	void unregisterWait(MVKFenceSitter* sitter) override;
+    uint64_t getCounterValue() override { return _value; }
+    void signal(const VkSemaphoreSignalInfo* pSignalInfo) override;
+    bool registerWait(MVKFenceSitter* sitter,
+                      const VkSemaphoreWaitInfo* pWaitInfo,
+                      uint32_t index) override;
+    void unregisterWait(MVKFenceSitter* sitter) override;
 
-	MVKTimelineSemaphoreEmulated(MVKDevice* device,
-								 const VkSemaphoreCreateInfo* pCreateInfo,
-								 const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
-								 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-								 const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKTimelineSemaphoreEmulated(
+        MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+        const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
+        const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+        const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-protected:
-	void signalImpl(uint64_t value);
+  protected:
+    void signalImpl(uint64_t value);
 
-	std::atomic<uint64_t> _value;
-	std::mutex _lock;
-	std::condition_variable _blocker;
-	std::unordered_map<uint64_t, std::unordered_set<MVKFenceSitter*>> _sitters;
+    std::atomic<uint64_t> _value;
+    std::mutex _lock;
+    std::condition_variable _blocker;
+    std::unordered_map<uint64_t, std::unordered_set<MVKFenceSitter*>> _sitters;
 };
-
 
 #pragma mark -
 #pragma mark MVKFence
@@ -384,99 +413,104 @@ protected:
 /** Represents a Vulkan fence. */
 class MVKFence : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_FENCE; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_FENCE; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT; }
+    /**
+     * If this fence has not been signaled yet, adds the specified fence sitter
+     * to the internal list of fence sitters that will be notified when this
+     * fence is signaled, and then calls await() on the fence sitter so it is
+     * aware that it will be signaled.
+     *
+     * Does nothing if this fence has already been signaled, and does not call
+     * await() on the fence sitter.
+     *
+     * Each fence sitter should only listen once for each fence. Adding the same
+     * fence sitter more than once in between each fence reset and signal
+     * results in undefined behaviour.
+     */
+    void addSitter(MVKFenceSitter* fenceSitter);
 
-	/**
-	 * If this fence has not been signaled yet, adds the specified fence sitter to the
-	 * internal list of fence sitters that will be notified when this fence is signaled,
-	 * and then calls await() on the fence sitter so it is aware that it will be signaled.
-	 *
-	 * Does nothing if this fence has already been signaled, and does not call 
-	 * await() on the fence sitter.
-	 *
-	 * Each fence sitter should only listen once for each fence. Adding the same fence sitter
-	 * more than once in between each fence reset and signal results in undefined behaviour.
-	 */
-	void addSitter(MVKFenceSitter* fenceSitter);
+    /** Removes the specified fence sitter. */
+    void removeSitter(MVKFenceSitter* fenceSitter);
 
-	/** Removes the specified fence sitter. */
-	void removeSitter(MVKFenceSitter* fenceSitter);
+    /** Signals this fence. Notifies all waiting fence sitters. */
+    void signal();
 
-	/** Signals this fence. Notifies all waiting fence sitters. */
-	void signal();
+    /** Rremoves all fence sitters and resets this fence back to unsignaled
+     * state again. */
+    void reset();
 
-	/** Rremoves all fence sitters and resets this fence back to unsignaled state again. */
-	void reset();
+    /** Returns whether this fence has been signaled and not reset. */
+    bool getIsSignaled();
 
-	/** Returns whether this fence has been signaled and not reset. */
-	bool getIsSignaled();
-
-	
 #pragma mark Construction
 
-    MVKFence(MVKDevice* device, const VkFenceCreateInfo* pCreateInfo) :
-		MVKVulkanAPIDeviceObject(device), _isSignaled(mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_FENCE_CREATE_SIGNALED_BIT)) {}
+    MVKFence(MVKDevice* device, const VkFenceCreateInfo* pCreateInfo)
+        : MVKVulkanAPIDeviceObject(device),
+          _isSignaled(mvkAreAllFlagsEnabled(pCreateInfo->flags,
+                                            VK_FENCE_CREATE_SIGNALED_BIT)) {}
 
-protected:
-	void propagateDebugName() override {}
-	void notifySitters();
+  protected:
+    void propagateDebugName() override {}
+    void notifySitters();
 
-	std::mutex _lock;
-	std::unordered_set<MVKFenceSitter*> _fenceSitters;
-	bool _isSignaled;
+    std::mutex _lock;
+    std::unordered_set<MVKFenceSitter*> _fenceSitters;
+    bool _isSignaled;
 };
-
 
 #pragma mark -
 #pragma mark MVKFenceSitter
 
-/** An object that responds to signals from MVKFences and MVKTimelineSemaphores. */
+/** An object that responds to signals from MVKFences and MVKTimelineSemaphores.
+ */
 class MVKFenceSitter : public MVKBaseObject {
 
-public:
+  public:
+    /** This is a temporarily instantiated helper class. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; }
 
-	/** This is a temporarily instantiated helper class. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return nullptr; }
-
-	/**
-	 * If this instance has been configured to wait for fences, blocks processing on the
-	 * current thread until any or all of the fences that this instance is waiting for are
-	 * signaled, or until the specified timeout in nanoseconds expires. If this instance
-	 * has not been configured to wait for fences, this function immediately returns true.
-	 *
-	 * If timeout is the special value UINT64_MAX the timeout is treated as infinite.
-	 *
-	 * Returns true if the required fences were triggered, or false if the timeout interval expired.
-	 */
-	bool wait(uint64_t timeout = UINT64_MAX) { return _blocker.wait(timeout); }
-
+    /**
+     * If this instance has been configured to wait for fences, blocks
+     * processing on the current thread until any or all of the fences that this
+     * instance is waiting for are signaled, or until the specified timeout in
+     * nanoseconds expires. If this instance has not been configured to wait for
+     * fences, this function immediately returns true.
+     *
+     * If timeout is the special value UINT64_MAX the timeout is treated as
+     * infinite.
+     *
+     * Returns true if the required fences were triggered, or false if the
+     * timeout interval expired.
+     */
+    bool wait(uint64_t timeout = UINT64_MAX) { return _blocker.wait(timeout); }
 
 #pragma mark Construction
 
-	MVKFenceSitter(bool waitAll) : _blocker(waitAll, 0) {}
+    MVKFenceSitter(bool waitAll) : _blocker(waitAll, 0) {}
 
-	~MVKFenceSitter() override { [_listener release]; }
+    ~MVKFenceSitter() override { [_listener release]; }
 
-private:
-	friend class MVKFence;
-	friend class MVKTimelineSemaphoreMTLEvent;
-	friend class MVKTimelineSemaphoreEmulated;
+  private:
+    friend class MVKFence;
+    friend class MVKTimelineSemaphoreMTLEvent;
+    friend class MVKTimelineSemaphoreEmulated;
 
-	MTLSharedEventListener* getMTLSharedEventListener();
+    MTLSharedEventListener* getMTLSharedEventListener();
 
-	void await() { _blocker.reserve(); }
-	void signaled() { _blocker.release(); }
+    void await() { _blocker.reserve(); }
+    void signaled() { _blocker.release(); }
 
-	MVKSemaphoreImpl _blocker;
-	MTLSharedEventListener* _listener = nil;
+    MVKSemaphoreImpl _blocker;
+    MTLSharedEventListener* _listener = nil;
 };
-
 
 #pragma mark -
 #pragma mark MVKEvent
@@ -484,91 +518,88 @@ private:
 /** Abstract class that represents a Vulkan event. */
 class MVKEvent : public MVKVulkanAPIDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan type of this object. */
+    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_EVENT; }
 
-	/** Returns the Vulkan type of this object. */
-	VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_EVENT; }
+    /** Returns the debug report object type of this object. */
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT;
+    }
 
-	/** Returns the debug report object type of this object. */
-	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT; }
+    /** Returns whether this event is set. */
+    virtual bool isSet() = 0;
 
-	/** Returns whether this event is set. */
-	virtual bool isSet() = 0;
+    /** Sets the signal status. */
+    virtual void signal(bool status) = 0;
 
-	/** Sets the signal status. */
-	virtual void signal(bool status) = 0;
+    /** Encodes an operation to signal the event with a status. */
+    virtual void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) = 0;
 
-	/** Encodes an operation to signal the event with a status. */
-	virtual void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) = 0;
+    /** Encodes an operation to block command buffer operation until this event
+     * is signaled. */
+    virtual void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) = 0;
 
-	/** Encodes an operation to block command buffer operation until this event is signaled. */
-	virtual void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) = 0;
-
-	/** Returns the MTLSharedEvent underlying this Vulkan event. */
-	virtual id<MTLSharedEvent> getMTLSharedEvent() = 0;
-
+    /** Returns the MTLSharedEvent underlying this Vulkan event. */
+    virtual id<MTLSharedEvent> getMTLSharedEvent() = 0;
 
 #pragma mark Construction
 
-	MVKEvent(MVKDevice* device,
-			 const VkEventCreateInfo* pCreateInfo,
-			 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-			 const VkImportMetalSharedEventInfoEXT* pImportInfo) : MVKVulkanAPIDeviceObject(device) {}
+    MVKEvent(MVKDevice* device, const VkEventCreateInfo* pCreateInfo,
+             const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+             const VkImportMetalSharedEventInfoEXT* pImportInfo)
+        : MVKVulkanAPIDeviceObject(device) {}
 
-protected:
-	void propagateDebugName() override {}
-
+  protected:
+    void propagateDebugName() override {}
 };
-
 
 #pragma mark -
 #pragma mark MVKEventNative
 
-/** An MVKEvent that uses native MTLSharedEvent to provide VkEvent functionality. */
+/** An MVKEvent that uses native MTLSharedEvent to provide VkEvent
+ * functionality. */
 class MVKEventNative : public MVKEvent {
 
-public:
-	bool isSet() override;
-	void signal(bool status) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) override;
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) override;
-	id<MTLSharedEvent> getMTLSharedEvent() override { return _mtlEvent; };
+  public:
+    bool isSet() override;
+    void signal(bool status) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) override;
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) override;
+    id<MTLSharedEvent> getMTLSharedEvent() override { return _mtlEvent; };
 
-	MVKEventNative(MVKDevice* device,
-				   const VkEventCreateInfo* pCreateInfo,
-				   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-				   const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKEventNative(MVKDevice* device, const VkEventCreateInfo* pCreateInfo,
+                   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+                   const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-	~MVKEventNative() override;
+    ~MVKEventNative() override;
 
-protected:
-	id<MTLSharedEvent> _mtlEvent;
+  protected:
+    id<MTLSharedEvent> _mtlEvent;
 };
-
 
 #pragma mark -
 #pragma mark MVKEventEmulated
 
-/** An MVKEvent that uses CPU synchronization to provide VkEvent functionality. */
+/** An MVKEvent that uses CPU synchronization to provide VkEvent functionality.
+ */
 class MVKEventEmulated : public MVKEvent {
 
-public:
-	bool isSet() override;
-	void signal(bool status) override;
-	void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) override;
-	void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) override;
-	id<MTLSharedEvent> getMTLSharedEvent() override { return nil; };
+  public:
+    bool isSet() override;
+    void signal(bool status) override;
+    void encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) override;
+    void encodeWait(id<MTLCommandBuffer> mtlCmdBuff) override;
+    id<MTLSharedEvent> getMTLSharedEvent() override { return nil; };
 
-	MVKEventEmulated(MVKDevice* device,
-					 const VkEventCreateInfo* pCreateInfo,
-					 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-					 const VkImportMetalSharedEventInfoEXT* pImportInfo);
+    MVKEventEmulated(MVKDevice* device, const VkEventCreateInfo* pCreateInfo,
+                     const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+                     const VkImportMetalSharedEventInfoEXT* pImportInfo);
 
-protected:
-	MVKSemaphoreImpl _blocker;
-	bool _inlineSignalStatus;
+  protected:
+    MVKSemaphoreImpl _blocker;
+    bool _inlineSignalStatus;
 };
-
 
 #pragma mark -
 #pragma mark Support functions
@@ -576,82 +607,85 @@ protected:
 /** Resets the specified fences. */
 VkResult mvkResetFences(uint32_t fenceCount, const VkFence* pFences);
 
-/** 
- * Blocks the current thread until any or all of the specified 
+/**
+ * Blocks the current thread until any or all of the specified
  * fences have been signaled, or the specified timeout occurs.
  */
-VkResult mvkWaitForFences(MVKDevice* device,
-						  uint32_t fenceCount,
-						  const VkFence* pFences,
-						  VkBool32 waitAll,
-						  uint64_t timeout = UINT64_MAX);
+VkResult mvkWaitForFences(MVKDevice* device, uint32_t fenceCount,
+                          const VkFence* pFences, VkBool32 waitAll,
+                          uint64_t timeout = UINT64_MAX);
 
-/** 
- * Blocks the current thread until any or all of the specified 
+/**
+ * Blocks the current thread until any or all of the specified
  * semaphores have been signaled at the specified values, or the
  * specified timeout occurs.
  */
 VkResult mvkWaitSemaphores(MVKDevice* device,
-						   const VkSemaphoreWaitInfo* pWaitInfo,
-						   uint64_t timeout = UINT64_MAX);
-
+                           const VkSemaphoreWaitInfo* pWaitInfo,
+                           uint64_t timeout = UINT64_MAX);
 
 #pragma mark -
 #pragma mark MVKMetalCompiler
 
 /**
  * Abstract class that creates Metal objects that require compilation, such as
- * MTLShaderLibrary, MTLFunction, MTLRenderPipelineState and MTLComputePipelineState.
+ * MTLShaderLibrary, MTLFunction, MTLRenderPipelineState and
+ * MTLComputePipelineState.
  *
- * Instances of this class are one-shot, and can only be used for a single compilation.
+ * Instances of this class are one-shot, and can only be used for a single
+ * compilation.
  */
 class MVKMetalCompiler : public MVKBaseDeviceObject {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override {
+        return _owner->getVulkanAPIObject();
+    };
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return _owner->getVulkanAPIObject(); };
-
-	/** If this object is waiting for compilation to complete, deletion will be deferred until then. */
-	void destroy() override;
-
+    /** If this object is waiting for compilation to complete, deletion will be
+     * deferred until then. */
+    void destroy() override;
 
 #pragma mark Construction
 
-	MVKMetalCompiler(MVKVulkanAPIDeviceObject* owner) : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {}
+    MVKMetalCompiler(MVKVulkanAPIDeviceObject* owner)
+        : MVKBaseDeviceObject(owner->getDevice()), _owner(owner) {}
 
-	~MVKMetalCompiler() override;
+    ~MVKMetalCompiler() override;
 
-protected:
-	void compile(std::unique_lock<std::mutex>& lock, dispatch_block_t block);
-	virtual void handleError();
-	bool endCompile(NSError* compileError);
-	bool markDestroyed();
+  protected:
+    void compile(std::unique_lock<std::mutex>& lock, dispatch_block_t block);
+    virtual void handleError();
+    bool endCompile(NSError* compileError);
+    bool markDestroyed();
 
-	MVKVulkanAPIDeviceObject* _owner;
-	NSError* _compileError = nil;
-	uint64_t _startTime = 0;
-	bool _isCompileDone = false;
-	bool _isDestroyed = false;
-	std::mutex _completionLock;
-	std::condition_variable _blocker;
-	std::string _compilerType = "Unknown";
-	MVKPerformanceTracker* _pPerformanceTracker = nullptr;
+    MVKVulkanAPIDeviceObject* _owner;
+    NSError* _compileError = nil;
+    uint64_t _startTime = 0;
+    bool _isCompileDone = false;
+    bool _isDestroyed = false;
+    std::mutex _completionLock;
+    std::condition_variable _blocker;
+    std::string _compilerType = "Unknown";
+    MVKPerformanceTracker* _pPerformanceTracker = nullptr;
 };
 
 #pragma mark -
 #pragma mark MVKDeferredOperation
 
-/** The maximum number of function parameters for all functions added to MVKDeferredOperationFunctionPointer. */
+/** The maximum number of function parameters for all functions added to
+ * MVKDeferredOperationFunctionPointer. */
 static const int kMVKMaxDeferredFunctionParameters = 3;
 
 /** Defines the function pointer for each dependent function. */
 union MVKDeferredOperationFunctionPointer {
     // Empty until deferred functions from other extensions have been defined.
-	// Planning to use std::functions
-	// Each function should take a pointer to a MVKDeferredOperation instance, to allow
-	// the function to call setMaxConcurrency() and setOperationResult(), and should
-	// return a VkResult representing the value returned by vkDeferredOperationJoinKHR().
+    // Planning to use std::functions
+    // Each function should take a pointer to a MVKDeferredOperation instance,
+    // to allow the function to call setMaxConcurrency() and
+    // setOperationResult(), and should return a VkResult representing the value
+    // returned by vkDeferredOperationJoinKHR().
 };
 
 /** Indicates what kind of function is being deferred. */
@@ -662,65 +696,72 @@ enum MVKDeferredOperationFunctionType {
 /**
  * Holds and invokes a deferred operation.
  *
- * Deferred operations are added by as required by future extensions that require them,
- * and are implemented by each of those extensions as a function pointer added to
- * MVKDeferredOperationFunctionPointer, plus a corresponding type identifier added
- * to MVKDeferredOperationFunctionType.
+ * Deferred operations are added by as required by future extensions that
+ * require them, and are implemented by each of those extensions as a function
+ * pointer added to MVKDeferredOperationFunctionPointer, plus a corresponding
+ * type identifier added to MVKDeferredOperationFunctionType.
  */
 class MVKDeferredOperation : public MVKVulkanAPIDeviceObject {
-public:
-    VkObjectType getVkObjectType() override { return VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR; }
-    
-    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT; }
-    
+  public:
+    VkObjectType getVkObjectType() override {
+        return VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR;
+    }
+
+    VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override {
+        return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
+
     /** Begins executing the deferred operation on the current thread. */
     VkResult join();
 
-	/** Gets the result of the execution of the deferred operation */
-	VkResult getOperationResult();
-
-	/**
-	 * Sets the result of the execution of the deferred operation.
-	 * Called from the function that is implementing the deferred operation.
-	 */
-	void setOperationResult(VkResult opResult);
-
-    /** Gets the max number of threads that can execute the deferred operation concurrently. */
-	uint32_t getMaxConcurrency();
-
-	/**
-	 * Sets the max number of threads that can execute the deferred operation concurrently.
-	 * Called from the function that is implementing the deferred operation.
-	 */
-	void setMaxConcurrency(uint32_t maxConCurr);
-
-	/**
-	 * Sets the result of the execution of the deferred operation, and updates the max concurrently.
-	 * Equivalent to calling setOperationResult() and setMaxConcurrency(), but with a single concurrency mutex lock.
-	 * Called from the function that is implementing the deferred operation.
-	 */
-	void updateResults(VkResult opResult, uint32_t maxConCurr);
+    /** Gets the result of the execution of the deferred operation */
+    VkResult getOperationResult();
 
     /**
-	 * Sets all the variables needed for a deferred operation.
-	 * Called from the code that implements a deferred operation.
-	 */
+     * Sets the result of the execution of the deferred operation.
+     * Called from the function that is implementing the deferred operation.
+     */
+    void setOperationResult(VkResult opResult);
+
+    /** Gets the max number of threads that can execute the deferred operation
+     * concurrently. */
+    uint32_t getMaxConcurrency();
+
+    /**
+     * Sets the max number of threads that can execute the deferred operation
+     * concurrently. Called from the function that is implementing the deferred
+     * operation.
+     */
+    void setMaxConcurrency(uint32_t maxConCurr);
+
+    /**
+     * Sets the result of the execution of the deferred operation, and updates
+     * the max concurrently. Equivalent to calling setOperationResult() and
+     * setMaxConcurrency(), but with a single concurrency mutex lock. Called
+     * from the function that is implementing the deferred operation.
+     */
+    void updateResults(VkResult opResult, uint32_t maxConCurr);
+
+    /**
+     * Sets all the variables needed for a deferred operation.
+     * Called from the code that implements a deferred operation.
+     */
     void deferOperation(const MVKDeferredOperationFunctionPointer& pointer,
-						MVKDeferredOperationFunctionType type,
-						void** parameters,
-						uint32_t paramCount);
+                        MVKDeferredOperationFunctionType type,
+                        void** parameters, uint32_t paramCount);
 
 #pragma mark Construction
-    MVKDeferredOperation(MVKDevice* device) : MVKVulkanAPIDeviceObject(device) {}
+    MVKDeferredOperation(MVKDevice* device)
+        : MVKVulkanAPIDeviceObject(device) {}
 
-protected:
-	void propagateDebugName() override {}
+  protected:
+    void propagateDebugName() override {}
 
-	std::mutex _lock;
-	MVKSmallVector<void*, kMVKMaxDeferredFunctionParameters>  _functionParameters;
-	MVKDeferredOperationFunctionPointer _functionPointer = {};
-	MVKDeferredOperationFunctionType _functionType;
-	VkResult _operationResult = VK_SUCCESS;
+    std::mutex _lock;
+    MVKSmallVector<void*, kMVKMaxDeferredFunctionParameters>
+        _functionParameters;
+    MVKDeferredOperationFunctionPointer _functionPointer = {};
+    MVKDeferredOperationFunctionType _functionType;
+    VkResult _operationResult = VK_SUCCESS;
     uint32_t _maxConcurrency = 0;
-
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSync.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,38 +21,43 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKSemaphoreImpl
 
 bool MVKSemaphoreImpl::release() {
-	lock_guard<mutex> lock(_lock);
-    if (isClear()) { return true; }
+    lock_guard<mutex> lock(_lock);
+    if (isClear()) {
+        return true;
+    }
 
     // Either decrement the reservation counter, or clear it altogether
     if (_shouldWaitAll) {
-		if (_reservationCount > 0) { _reservationCount--; }
+        if (_reservationCount > 0) {
+            _reservationCount--;
+        }
     } else {
         _reservationCount = 0;
     }
     // If all reservations have been released, unblock all waiting threads
-    if ( isClear() ) { _blocker.notify_all(); }
+    if (isClear()) {
+        _blocker.notify_all();
+    }
     return isClear();
 }
 
 void MVKSemaphoreImpl::reserve() {
-	lock_guard<mutex> lock(_lock);
-	_reservationCount++;
+    lock_guard<mutex> lock(_lock);
+    _reservationCount++;
 }
 
 bool MVKSemaphoreImpl::isReserved() {
-	lock_guard<mutex> lock(_lock);
-	return !isClear();
+    lock_guard<mutex> lock(_lock);
+    return !isClear();
 }
 
 uint32_t MVKSemaphoreImpl::getReservationCount() {
-	lock_guard<mutex> lock(_lock);
-	return _reservationCount;
+    lock_guard<mutex> lock(_lock);
+    return _reservationCount;
 }
 
 bool MVKSemaphoreImpl::wait(uint64_t timeout, bool reserveAgain) {
@@ -60,18 +65,20 @@ bool MVKSemaphoreImpl::wait(uint64_t timeout, bool reserveAgain) {
 
     bool isDone;
     if (timeout == 0) {
-		isDone = isClear();
-	} else if (timeout == UINT64_MAX) {
-		_blocker.wait(lock, [this]{ return isClear(); });
-		isDone = true;
-	} else {
+        isDone = isClear();
+    } else if (timeout == UINT64_MAX) {
+        _blocker.wait(lock, [this] { return isClear(); });
+        isDone = true;
+    } else {
         // Limit timeout to avoid overflow since wait_for() uses wait_until()
         uint64_t nanoTimeout = min(timeout, kMVKUndefinedLargeUInt64);
         chrono::nanoseconds nanos(nanoTimeout);
-        isDone = _blocker.wait_for(lock, nanos, [this]{ return isClear(); });
+        isDone = _blocker.wait_for(lock, nanos, [this] { return isClear(); });
     }
 
-	if (reserveAgain) { _reservationCount++; }
+    if (reserveAgain) {
+        _reservationCount++;
+    }
     return isDone;
 }
 
@@ -80,315 +87,366 @@ MVKSemaphoreImpl::~MVKSemaphoreImpl() {
     lock_guard<mutex> lock(_lock);
 }
 
-
 #pragma mark -
 #pragma mark MVKSemaphoreSingleQueue
 
-void MVKSemaphoreSingleQueue::encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	// Metal will handle all synchronization for us automatically
+void MVKSemaphoreSingleQueue::encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                                         uint64_t) {
+    // Metal will handle all synchronization for us automatically
 }
 
-void MVKSemaphoreSingleQueue::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	// Metal will handle all synchronization for us automatically
+void MVKSemaphoreSingleQueue::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                           uint64_t) {
+    // Metal will handle all synchronization for us automatically
 }
 
-uint64_t MVKSemaphoreSingleQueue::deferSignal() {
-	return 0;
+uint64_t MVKSemaphoreSingleQueue::deferSignal() { return 0; }
+
+void MVKSemaphoreSingleQueue::encodeDeferredSignal(
+    id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
+    encodeSignal(mtlCmdBuff, 0);
 }
 
-void MVKSemaphoreSingleQueue::encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	encodeSignal(mtlCmdBuff, 0);
-}
-
-MVKSemaphoreSingleQueue::MVKSemaphoreSingleQueue(MVKDevice* device,
-                                                 const VkSemaphoreCreateInfo* pCreateInfo,
-                                                 const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-                                                 const VkImportMetalSharedEventInfoEXT* pImportInfo) : MVKSemaphore(device, pCreateInfo) {
-	if ((pImportInfo && pImportInfo->mtlSharedEvent) || (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkCreateEvent(): MTLSharedEvent is not available with VkSemaphores that use implicit synchronization."));
-	}
+MVKSemaphoreSingleQueue::MVKSemaphoreSingleQueue(
+    MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKSemaphore(device, pCreateInfo) {
+    if ((pImportInfo && pImportInfo->mtlSharedEvent) ||
+        (pExportInfo &&
+         pExportInfo->exportObjectType ==
+             VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "vkCreateEvent(): MTLSharedEvent is not available with "
+                        "VkSemaphores that use implicit synchronization."));
+    }
 }
 
 MVKSemaphoreSingleQueue::~MVKSemaphoreSingleQueue() = default;
 
-
 #pragma mark -
 #pragma mark MVKSemaphoreMTLEvent
 
-void MVKSemaphoreMTLEvent::encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	if (mtlCmdBuff) { [mtlCmdBuff encodeWaitForEvent: _mtlEvent value: _mtlEventValue++]; }
+void MVKSemaphoreMTLEvent::encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                                      uint64_t) {
+    if (mtlCmdBuff) {
+        [mtlCmdBuff encodeWaitForEvent:_mtlEvent value:_mtlEventValue++];
+    }
 }
 
-void MVKSemaphoreMTLEvent::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	if (mtlCmdBuff) { [mtlCmdBuff encodeSignalEvent: _mtlEvent value: _mtlEventValue]; }
+void MVKSemaphoreMTLEvent::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                        uint64_t) {
+    if (mtlCmdBuff) {
+        [mtlCmdBuff encodeSignalEvent:_mtlEvent value:_mtlEventValue];
+    }
 }
 
-uint64_t MVKSemaphoreMTLEvent::deferSignal() {
-	return _mtlEventValue;
+uint64_t MVKSemaphoreMTLEvent::deferSignal() { return _mtlEventValue; }
+
+void MVKSemaphoreMTLEvent::encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                                uint64_t deferToken) {
+    [mtlCmdBuff encodeSignalEvent:_mtlEvent value:deferToken];
 }
 
-void MVKSemaphoreMTLEvent::encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t deferToken) {
-	[mtlCmdBuff encodeSignalEvent: _mtlEvent value: deferToken];
+MVKSemaphoreMTLEvent::MVKSemaphoreMTLEvent(
+    MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKSemaphore(device, pCreateInfo) {
+    // In order of preference, import a MTLSharedEvent,
+    // create a MTLSharedEvent, or create a MTLEvent.
+    if (pImportInfo && pImportInfo->mtlSharedEvent) {
+        _mtlEvent = [pImportInfo->mtlSharedEvent retain]; // retained
+        _mtlEventValue = pImportInfo->mtlSharedEvent.signaledValue + 1;
+    } else if (pExportInfo &&
+               pExportInfo->exportObjectType ==
+                   VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) {
+        _mtlEvent = [getMTLDevice() newSharedEvent]; // retained
+        _mtlEventValue = ((id<MTLSharedEvent>)_mtlEvent).signaledValue + 1;
+    } else {
+        _mtlEvent = [getMTLDevice() newEvent]; // retained
+        _mtlEventValue = 1;
+    }
 }
 
-MVKSemaphoreMTLEvent::MVKSemaphoreMTLEvent(MVKDevice* device,
-										   const VkSemaphoreCreateInfo* pCreateInfo,
-										   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-										   const VkImportMetalSharedEventInfoEXT* pImportInfo) : MVKSemaphore(device, pCreateInfo) {
-	// In order of preference, import a MTLSharedEvent,
-	// create a MTLSharedEvent, or create a MTLEvent.
-	if (pImportInfo && pImportInfo->mtlSharedEvent) {
-		_mtlEvent = [pImportInfo->mtlSharedEvent retain];		// retained
-		_mtlEventValue = pImportInfo->mtlSharedEvent.signaledValue + 1;
-	} else if (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) {
-		_mtlEvent = [getMTLDevice() newSharedEvent];	//retained
-		_mtlEventValue = ((id<MTLSharedEvent>)_mtlEvent).signaledValue + 1;
-	} else {
-		_mtlEvent = [getMTLDevice() newEvent];			//retained
-		_mtlEventValue = 1;
-	}
-}
-
-MVKSemaphoreMTLEvent::~MVKSemaphoreMTLEvent() {
-    [_mtlEvent release];
-}
-
+MVKSemaphoreMTLEvent::~MVKSemaphoreMTLEvent() { [_mtlEvent release]; }
 
 #pragma mark -
 #pragma mark MVKSemaphoreEmulated
 
-void MVKSemaphoreEmulated::encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	if ( !mtlCmdBuff ) {
-		_device->addSemaphore(&_blocker);
-		_blocker.wait(UINT64_MAX, true);
-		_device->removeSemaphore(&_blocker);
-	}
+void MVKSemaphoreEmulated::encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                                      uint64_t) {
+    if (!mtlCmdBuff) {
+        _device->addSemaphore(&_blocker);
+        _blocker.wait(UINT64_MAX, true);
+        _device->removeSemaphore(&_blocker);
+    }
 }
 
-void MVKSemaphoreEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	if ( !mtlCmdBuff ) { _blocker.release(); }
+void MVKSemaphoreEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                        uint64_t) {
+    if (!mtlCmdBuff) {
+        _blocker.release();
+    }
 }
 
-uint64_t MVKSemaphoreEmulated::deferSignal() {
-	return 0;
+uint64_t MVKSemaphoreEmulated::deferSignal() { return 0; }
+
+void MVKSemaphoreEmulated::encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                                uint64_t) {
+    encodeSignal(mtlCmdBuff, 0);
 }
 
-void MVKSemaphoreEmulated::encodeDeferredSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t) {
-	encodeSignal(mtlCmdBuff, 0);
+MVKSemaphoreEmulated::MVKSemaphoreEmulated(
+    MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKSemaphore(device, pCreateInfo), _blocker(false, 1) {
+
+    if ((pImportInfo && pImportInfo->mtlSharedEvent) ||
+        (pExportInfo &&
+         pExportInfo->exportObjectType ==
+             VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
+        setConfigurationResult(
+            reportError(VK_ERROR_INITIALIZATION_FAILED,
+                        "vkCreateEvent(): MTLSharedEvent is not available with "
+                        "VkSemaphores that use CPU emulation."));
+    }
 }
-
-MVKSemaphoreEmulated::MVKSemaphoreEmulated(MVKDevice* device,
-										   const VkSemaphoreCreateInfo* pCreateInfo,
-										   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-										   const VkImportMetalSharedEventInfoEXT* pImportInfo) :
-	MVKSemaphore(device, pCreateInfo),
-	_blocker(false, 1) {
-
-	if ((pImportInfo && pImportInfo->mtlSharedEvent) || (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkCreateEvent(): MTLSharedEvent is not available with VkSemaphores that use CPU emulation."));
-	}
-}
-
 
 #pragma mark -
 #pragma mark MVKTimelineSemaphoreMTLEvent
 
 // Nil mtlCmdBuff will do nothing.
-void MVKTimelineSemaphoreMTLEvent::encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) {
-	[mtlCmdBuff encodeWaitForEvent: _mtlEvent value: value];
+void MVKTimelineSemaphoreMTLEvent::encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                                              uint64_t value) {
+    [mtlCmdBuff encodeWaitForEvent:_mtlEvent value:value];
 }
 
 // Nil mtlCmdBuff will do nothing.
-void MVKTimelineSemaphoreMTLEvent::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) {
-	[mtlCmdBuff encodeSignalEvent: _mtlEvent value: value];
+void MVKTimelineSemaphoreMTLEvent::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                                uint64_t value) {
+    [mtlCmdBuff encodeSignalEvent:_mtlEvent value:value];
 }
 
-void MVKTimelineSemaphoreMTLEvent::signal(const VkSemaphoreSignalInfo* pSignalInfo) {
-	_mtlEvent.signaledValue = pSignalInfo->value;
+void MVKTimelineSemaphoreMTLEvent::signal(
+    const VkSemaphoreSignalInfo* pSignalInfo) {
+    _mtlEvent.signaledValue = pSignalInfo->value;
 }
 
-bool MVKTimelineSemaphoreMTLEvent::registerWait(MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo, uint32_t index) {
-	if (_mtlEvent.signaledValue >= pWaitInfo->pValues[index]) { return true; }
-	lock_guard<mutex> lock(_lock);
-	sitter->await();
-	auto addRslt = _sitters.insert(sitter);
-	if (addRslt.second) {
-		retain();
-		_device->addSemaphore(&sitter->_blocker);
-		[_mtlEvent notifyListener: sitter->getMTLSharedEventListener()
-						  atValue: pWaitInfo->pValues[index]
-							block: ^(id<MTLSharedEvent>, uint64_t) {
-			lock_guard<mutex> blockLock(_lock);
-			if (_sitters.count(sitter)) { sitter->signaled(); }
-			release();
-		}];
-	}
-	return false;
+bool MVKTimelineSemaphoreMTLEvent::registerWait(
+    MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo,
+    uint32_t index) {
+    if (_mtlEvent.signaledValue >= pWaitInfo->pValues[index]) {
+        return true;
+    }
+    lock_guard<mutex> lock(_lock);
+    sitter->await();
+    auto addRslt = _sitters.insert(sitter);
+    if (addRslt.second) {
+        retain();
+        _device->addSemaphore(&sitter->_blocker);
+        [_mtlEvent notifyListener:sitter->getMTLSharedEventListener()
+                          atValue:pWaitInfo->pValues[index]
+                            block:^(id<MTLSharedEvent>, uint64_t) {
+                              lock_guard<mutex> blockLock(_lock);
+                              if (_sitters.count(sitter)) {
+                                  sitter->signaled();
+                              }
+                              release();
+                            }];
+    }
+    return false;
 }
 
 void MVKTimelineSemaphoreMTLEvent::unregisterWait(MVKFenceSitter* sitter) {
-	lock_guard<mutex> lock(_lock);
-	_device->removeSemaphore(&sitter->_blocker);
-	_sitters.erase(sitter);
+    lock_guard<mutex> lock(_lock);
+    _device->removeSemaphore(&sitter->_blocker);
+    _sitters.erase(sitter);
 }
 
-MVKTimelineSemaphoreMTLEvent::MVKTimelineSemaphoreMTLEvent(MVKDevice* device,
-														   const VkSemaphoreCreateInfo* pCreateInfo,
-														   const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
-														   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-														   const VkImportMetalSharedEventInfoEXT* pImportInfo) : MVKTimelineSemaphore(device, pCreateInfo) {
+MVKTimelineSemaphoreMTLEvent::MVKTimelineSemaphoreMTLEvent(
+    MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+    const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKTimelineSemaphore(device, pCreateInfo) {
 
-	// Import or create a Metal event
-	_mtlEvent = (pImportInfo && pImportInfo->mtlSharedEvent
-				 ? [pImportInfo->mtlSharedEvent retain]
-				 : [getMTLDevice() newSharedEvent]);	//retained
+    // Import or create a Metal event
+    _mtlEvent = (pImportInfo && pImportInfo->mtlSharedEvent
+                     ? [pImportInfo->mtlSharedEvent retain]
+                     : [getMTLDevice() newSharedEvent]); // retained
 
-	if (pTypeCreateInfo) {
-		_mtlEvent.signaledValue = pTypeCreateInfo->initialValue;
-	}
+    if (pTypeCreateInfo) {
+        _mtlEvent.signaledValue = pTypeCreateInfo->initialValue;
+    }
 }
 
 MVKTimelineSemaphoreMTLEvent::~MVKTimelineSemaphoreMTLEvent() {
     [_mtlEvent release];
 }
 
-
 #pragma mark -
 #pragma mark MVKTimelineSemaphoreEmulated
 
-void MVKTimelineSemaphoreEmulated::encodeWait(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) {
-	unique_lock<mutex> lock(_lock);
-	if ( !mtlCmdBuff ) {
-		_device->addTimelineSemaphore(this, value);
-		_blocker.wait(lock, [=]() { return _value >= value; });
-		_device->removeTimelineSemaphore(this, value);
-	}
+void MVKTimelineSemaphoreEmulated::encodeWait(id<MTLCommandBuffer> mtlCmdBuff,
+                                              uint64_t value) {
+    unique_lock<mutex> lock(_lock);
+    if (!mtlCmdBuff) {
+        _device->addTimelineSemaphore(this, value);
+        _blocker.wait(lock, [=]() { return _value >= value; });
+        _device->removeTimelineSemaphore(this, value);
+    }
 }
 
-void MVKTimelineSemaphoreEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, uint64_t value) {
-	lock_guard<mutex> lock(_lock);
-	if ( !mtlCmdBuff ) { signalImpl(value); }
+void MVKTimelineSemaphoreEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                                uint64_t value) {
+    lock_guard<mutex> lock(_lock);
+    if (!mtlCmdBuff) {
+        signalImpl(value);
+    }
 }
 
-void MVKTimelineSemaphoreEmulated::signal(const VkSemaphoreSignalInfo* pSignalInfo) {
-	lock_guard<mutex> lock(_lock);
-	signalImpl(pSignalInfo->value);
+void MVKTimelineSemaphoreEmulated::signal(
+    const VkSemaphoreSignalInfo* pSignalInfo) {
+    lock_guard<mutex> lock(_lock);
+    signalImpl(pSignalInfo->value);
 }
 
 void MVKTimelineSemaphoreEmulated::signalImpl(uint64_t value) {
-	if (value > _value) {
-		_value = value;
-		_blocker.notify_all();
-		for (auto& sittersForValue : _sitters) {
-			if (sittersForValue.first > value) { continue; }
-			for (auto* sitter : sittersForValue.second) {
-				sitter->signaled();
-			}
-		}
-	}
+    if (value > _value) {
+        _value = value;
+        _blocker.notify_all();
+        for (auto& sittersForValue : _sitters) {
+            if (sittersForValue.first > value) {
+                continue;
+            }
+            for (auto* sitter : sittersForValue.second) {
+                sitter->signaled();
+            }
+        }
+    }
 }
 
-bool MVKTimelineSemaphoreEmulated::registerWait(MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo, uint32_t index) {
-	lock_guard<mutex> lock(_lock);
-	if (pWaitInfo->pValues[index] >= _value) { return true; }
-	uint64_t value = pWaitInfo->pValues[index];
-	if (!_sitters.count(value)) { _sitters.emplace(make_pair(value, unordered_set<MVKFenceSitter*>())); }
-	auto addRslt = _sitters[value].insert(sitter);
-	if (addRslt.second) {
-		_device->addSemaphore(&sitter->_blocker);
-		sitter->await();
-	}
-	return false;
+bool MVKTimelineSemaphoreEmulated::registerWait(
+    MVKFenceSitter* sitter, const VkSemaphoreWaitInfo* pWaitInfo,
+    uint32_t index) {
+    lock_guard<mutex> lock(_lock);
+    if (pWaitInfo->pValues[index] >= _value) {
+        return true;
+    }
+    uint64_t value = pWaitInfo->pValues[index];
+    if (!_sitters.count(value)) {
+        _sitters.emplace(make_pair(value, unordered_set<MVKFenceSitter*>()));
+    }
+    auto addRslt = _sitters[value].insert(sitter);
+    if (addRslt.second) {
+        _device->addSemaphore(&sitter->_blocker);
+        sitter->await();
+    }
+    return false;
 }
 
 void MVKTimelineSemaphoreEmulated::unregisterWait(MVKFenceSitter* sitter) {
-	MVKSmallVector<uint64_t> emptySets;
-	for (auto& sittersForValue : _sitters) {
-		_device->removeSemaphore(&sitter->_blocker);
-		sittersForValue.second.erase(sitter);
-		// Can't destroy while iterating...
-		if (sittersForValue.second.empty()) {
-			emptySets.push_back(sittersForValue.first);
-		}
-	}
-	for (auto value : emptySets) { _sitters.erase(value); }
+    MVKSmallVector<uint64_t> emptySets;
+    for (auto& sittersForValue : _sitters) {
+        _device->removeSemaphore(&sitter->_blocker);
+        sittersForValue.second.erase(sitter);
+        // Can't destroy while iterating...
+        if (sittersForValue.second.empty()) {
+            emptySets.push_back(sittersForValue.first);
+        }
+    }
+    for (auto value : emptySets) {
+        _sitters.erase(value);
+    }
 }
 
-MVKTimelineSemaphoreEmulated::MVKTimelineSemaphoreEmulated(MVKDevice* device,
-														   const VkSemaphoreCreateInfo* pCreateInfo,
-														   const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
-														   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-														   const VkImportMetalSharedEventInfoEXT* pImportInfo) :
-	MVKTimelineSemaphore(device, pCreateInfo),
-	_value(pTypeCreateInfo ? pTypeCreateInfo->initialValue : 0) {
+MVKTimelineSemaphoreEmulated::MVKTimelineSemaphoreEmulated(
+    MVKDevice* device, const VkSemaphoreCreateInfo* pCreateInfo,
+    const VkSemaphoreTypeCreateInfo* pTypeCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKTimelineSemaphore(device, pCreateInfo),
+      _value(pTypeCreateInfo ? pTypeCreateInfo->initialValue : 0) {
 
-	if ((pImportInfo && pImportInfo->mtlSharedEvent) || (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkCreateEvent(): MTLSharedEvent is not available on this platform."));
-	}
+    if ((pImportInfo && pImportInfo->mtlSharedEvent) ||
+        (pExportInfo &&
+         pExportInfo->exportObjectType ==
+             VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT)) {
+        setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                           "vkCreateEvent(): MTLSharedEvent is "
+                                           "not available on this platform."));
+    }
 }
-
 
 #pragma mark -
 #pragma mark MVKFence
 
 void MVKFence::addSitter(MVKFenceSitter* fenceSitter) {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	// We only care about unsignaled fences. If already signaled,
-	// don't add myself to the sitter and don't signal the sitter.
-	if (_isSignaled) { return; }
+    // We only care about unsignaled fences. If already signaled,
+    // don't add myself to the sitter and don't signal the sitter.
+    if (_isSignaled) {
+        return;
+    }
 
-	// Ensure each fence only added once to each fence sitter
-	auto addRslt = _fenceSitters.insert(fenceSitter);	// pair with second element true if was added
-	if (addRslt.second) {
-		_device->addSemaphore(&fenceSitter->_blocker);
-		fenceSitter->await();
-	}
+    // Ensure each fence only added once to each fence sitter
+    auto addRslt = _fenceSitters.insert(
+        fenceSitter); // pair with second element true if was added
+    if (addRslt.second) {
+        _device->addSemaphore(&fenceSitter->_blocker);
+        fenceSitter->await();
+    }
 }
 
 void MVKFence::removeSitter(MVKFenceSitter* fenceSitter) {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	_device->removeSemaphore(&fenceSitter->_blocker);
-	_fenceSitters.erase(fenceSitter);
+    _device->removeSemaphore(&fenceSitter->_blocker);
+    _fenceSitters.erase(fenceSitter);
 }
 
 void MVKFence::signal() {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	if (_isSignaled) { return; }	// Only signal once
-	_isSignaled = true;
+    if (_isSignaled) {
+        return;
+    } // Only signal once
+    _isSignaled = true;
 
-	// Notify all the fence sitters, and clear them from this instance.
+    // Notify all the fence sitters, and clear them from this instance.
     for (auto& fs : _fenceSitters) {
         fs->signaled();
     }
-	_fenceSitters.clear();
+    _fenceSitters.clear();
 }
 
 void MVKFence::reset() {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	_isSignaled = false;
-	_fenceSitters.clear();
+    _isSignaled = false;
+    _fenceSitters.clear();
 }
 
 bool MVKFence::getIsSignaled() {
-	lock_guard<mutex> lock(_lock);
+    lock_guard<mutex> lock(_lock);
 
-	return _isSignaled;
+    return _isSignaled;
 }
-
 
 #pragma mark -
 #pragma mark MVKFenceSitter
 
 MTLSharedEventListener* MVKFenceSitter::getMTLSharedEventListener() {
-	// TODO: Use dispatch queue from device?
-	if (!_listener) { _listener = [MTLSharedEventListener new]; }
-	return _listener;
+    // TODO: Use dispatch queue from device?
+    if (!_listener) {
+        _listener = [MTLSharedEventListener new];
+    }
+    return _listener;
 }
-
 
 #pragma mark -
 #pragma mark MVKEventNative
@@ -397,39 +455,38 @@ MTLSharedEventListener* MVKFenceSitter::getMTLSharedEventListener() {
 bool MVKEventNative::isSet() { return _mtlEvent.signaledValue & 1; }
 
 void MVKEventNative::signal(bool status) {
-	if (isSet() != status) {
-		_mtlEvent.signaledValue += 1;
-	}
+    if (isSet() != status) {
+        _mtlEvent.signaledValue += 1;
+    }
 }
 
-void MVKEventNative::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) {
-	if (isSet() != status) {
-		[mtlCmdBuff encodeSignalEvent: _mtlEvent value: _mtlEvent.signaledValue + 1];
-	}
+void MVKEventNative::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                  bool status) {
+    if (isSet() != status) {
+        [mtlCmdBuff encodeSignalEvent:_mtlEvent
+                                value:_mtlEvent.signaledValue + 1];
+    }
 }
 
 void MVKEventNative::encodeWait(id<MTLCommandBuffer> mtlCmdBuff) {
-	if ( !isSet() ) {
-		[mtlCmdBuff encodeWaitForEvent: _mtlEvent value: _mtlEvent.signaledValue + 1];
-	}
+    if (!isSet()) {
+        [mtlCmdBuff encodeWaitForEvent:_mtlEvent
+                                 value:_mtlEvent.signaledValue + 1];
+    }
 }
 
-MVKEventNative::MVKEventNative(MVKDevice* device,
-							   const VkEventCreateInfo* pCreateInfo,
-							   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-							   const VkImportMetalSharedEventInfoEXT* pImportInfo) :
-	MVKEvent(device, pCreateInfo, pExportInfo, pImportInfo) {
+MVKEventNative::MVKEventNative(
+    MVKDevice* device, const VkEventCreateInfo* pCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKEvent(device, pCreateInfo, pExportInfo, pImportInfo) {
 
-	// Import or create a Metal event
-	_mtlEvent = (pImportInfo
-				 ? [pImportInfo->mtlSharedEvent retain]
-				 : [getMTLDevice() newSharedEvent]);	//retained
+    // Import or create a Metal event
+    _mtlEvent = (pImportInfo ? [pImportInfo->mtlSharedEvent retain]
+                             : [getMTLDevice() newSharedEvent]); // retained
 }
 
-MVKEventNative::~MVKEventNative() {
-	[_mtlEvent release];
-}
-
+MVKEventNative::~MVKEventNative() { [_mtlEvent release]; }
 
 #pragma mark -
 #pragma mark MVKEventEmulated
@@ -437,244 +494,283 @@ MVKEventNative::~MVKEventNative() {
 bool MVKEventEmulated::isSet() { return !_blocker.isReserved(); }
 
 void MVKEventEmulated::signal(bool status) {
-	if (status) {
-		_blocker.release();
-	} else {
-		_blocker.reserve();
-	}
+    if (status) {
+        _blocker.release();
+    } else {
+        _blocker.reserve();
+    }
 }
 
-void MVKEventEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff, bool status) {
-	if (status) {
-		[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mcb) { _blocker.release(); }];
-	} else {
-		_blocker.reserve();
-	}
+void MVKEventEmulated::encodeSignal(id<MTLCommandBuffer> mtlCmdBuff,
+                                    bool status) {
+    if (status) {
+        [mtlCmdBuff addCompletedHandler:^(id<MTLCommandBuffer> mcb) {
+          _blocker.release();
+        }];
+    } else {
+        _blocker.reserve();
+    }
 
-	// An encoded signal followed by an encoded wait should cause the wait to be skipped.
-	// However, because encoding a signal will not release the blocker until the command buffer
-	// is finished executing (so the CPU can tell when it really is done) it is possible that
-	// the encoded wait will block when it shouldn't. To avoid that, we keep track of whether
-	// the most recent encoded signal was set or reset, so the next encoded wait knows whether
-	// to really wait or not.
-	_inlineSignalStatus = status;
+    // An encoded signal followed by an encoded wait should cause the wait to be
+    // skipped. However, because encoding a signal will not release the blocker
+    // until the command buffer is finished executing (so the CPU can tell when
+    // it really is done) it is possible that the encoded wait will block when
+    // it shouldn't. To avoid that, we keep track of whether the most recent
+    // encoded signal was set or reset, so the next encoded wait knows whether
+    // to really wait or not.
+    _inlineSignalStatus = status;
 }
 
 void MVKEventEmulated::encodeWait(id<MTLCommandBuffer> mtlCmdBuff) {
-	if ( !_inlineSignalStatus ) {
-		_device->addSemaphore(&_blocker);
-		_blocker.wait();
-		_device->removeSemaphore(&_blocker);
-	}
+    if (!_inlineSignalStatus) {
+        _device->addSemaphore(&_blocker);
+        _blocker.wait();
+        _device->removeSemaphore(&_blocker);
+    }
 }
 
-MVKEventEmulated::MVKEventEmulated(MVKDevice* device,
-								   const VkEventCreateInfo* pCreateInfo,
-								   const VkExportMetalObjectCreateInfoEXT* pExportInfo,
-								   const VkImportMetalSharedEventInfoEXT* pImportInfo) :
-	MVKEvent(device, pCreateInfo, pExportInfo, pImportInfo), _blocker(false, 1), _inlineSignalStatus(false) {
+MVKEventEmulated::MVKEventEmulated(
+    MVKDevice* device, const VkEventCreateInfo* pCreateInfo,
+    const VkExportMetalObjectCreateInfoEXT* pExportInfo,
+    const VkImportMetalSharedEventInfoEXT* pImportInfo)
+    : MVKEvent(device, pCreateInfo, pExportInfo, pImportInfo),
+      _blocker(false, 1), _inlineSignalStatus(false) {
 
-	if (pExportInfo && pExportInfo->exportObjectType == VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) {
-		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "vkCreateEvent(): MTLSharedEvent is not available on this platform."));
-	}
+    if (pExportInfo &&
+        pExportInfo->exportObjectType ==
+            VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT) {
+        setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
+                                           "vkCreateEvent(): MTLSharedEvent is "
+                                           "not available on this platform."));
+    }
 }
-
 
 #pragma mark -
 #pragma mark Support functions
 
 VkResult mvkResetFences(uint32_t fenceCount, const VkFence* pFences) {
-	for (uint32_t i = 0; i < fenceCount; i++) {
-		((MVKFence*)pFences[i])->reset();
-	}
-	return VK_SUCCESS;
+    for (uint32_t i = 0; i < fenceCount; i++) {
+        ((MVKFence*)pFences[i])->reset();
+    }
+    return VK_SUCCESS;
 }
 
 // Create a blocking fence sitter, add it to each fence, wait, then remove it.
-VkResult mvkWaitForFences(MVKDevice* device,
-						  uint32_t fenceCount,
-						  const VkFence* pFences,
-						  VkBool32 waitAll,
-						  uint64_t timeout) {
+VkResult mvkWaitForFences(MVKDevice* device, uint32_t fenceCount,
+                          const VkFence* pFences, VkBool32 waitAll,
+                          uint64_t timeout) {
 
-	if (device->getConfigurationResult() != VK_SUCCESS) {
-		return device->getConfigurationResult();
-	}
+    if (device->getConfigurationResult() != VK_SUCCESS) {
+        return device->getConfigurationResult();
+    }
 
-	VkResult rslt = VK_SUCCESS;
-	MVKFenceSitter fenceSitter(waitAll);
+    VkResult rslt = VK_SUCCESS;
+    MVKFenceSitter fenceSitter(waitAll);
 
-	for (uint32_t i = 0; i < fenceCount; i++) {
-		((MVKFence*)pFences[i])->addSitter(&fenceSitter);
-	}
+    for (uint32_t i = 0; i < fenceCount; i++) {
+        ((MVKFence*)pFences[i])->addSitter(&fenceSitter);
+    }
 
-	bool finished = fenceSitter.wait(timeout);
-	if (device->getConfigurationResult() != VK_SUCCESS) {
-		rslt = device->getConfigurationResult();
-	} else if ( !finished ) {
-		rslt = VK_TIMEOUT;
-	}
+    bool finished = fenceSitter.wait(timeout);
+    if (device->getConfigurationResult() != VK_SUCCESS) {
+        rslt = device->getConfigurationResult();
+    } else if (!finished) {
+        rslt = VK_TIMEOUT;
+    }
 
-	for (uint32_t i = 0; i < fenceCount; i++) {
-		((MVKFence*)pFences[i])->removeSitter(&fenceSitter);
-	}
+    for (uint32_t i = 0; i < fenceCount; i++) {
+        ((MVKFence*)pFences[i])->removeSitter(&fenceSitter);
+    }
 
-	return rslt;
+    return rslt;
 }
 
-// Create a blocking fence sitter, add it to each semaphore, wait, then remove it.
+// Create a blocking fence sitter, add it to each semaphore, wait, then remove
+// it.
 VkResult mvkWaitSemaphores(MVKDevice* device,
-						   const VkSemaphoreWaitInfo* pWaitInfo,
-						   uint64_t timeout) {
+                           const VkSemaphoreWaitInfo* pWaitInfo,
+                           uint64_t timeout) {
 
-	if (device->getConfigurationResult() != VK_SUCCESS) {
-		return device->getConfigurationResult();
-	}
+    if (device->getConfigurationResult() != VK_SUCCESS) {
+        return device->getConfigurationResult();
+    }
 
-	VkResult rslt = VK_SUCCESS;
-	bool waitAny = mvkIsAnyFlagEnabled(pWaitInfo->flags, VK_SEMAPHORE_WAIT_ANY_BIT);
-	bool alreadySignaled = false;
-	MVKFenceSitter fenceSitter(!waitAny);
+    VkResult rslt = VK_SUCCESS;
+    bool waitAny =
+        mvkIsAnyFlagEnabled(pWaitInfo->flags, VK_SEMAPHORE_WAIT_ANY_BIT);
+    bool alreadySignaled = false;
+    MVKFenceSitter fenceSitter(!waitAny);
 
-	for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
-		if (((MVKTimelineSemaphore*)pWaitInfo->pSemaphores[i])->registerWait(&fenceSitter, pWaitInfo, i) && waitAny) {
-			// In this case, we don't need to wait.
-			alreadySignaled = true;
-			break;
-		}
-	}
+    for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
+        if (((MVKTimelineSemaphore*)pWaitInfo->pSemaphores[i])
+                ->registerWait(&fenceSitter, pWaitInfo, i) &&
+            waitAny) {
+            // In this case, we don't need to wait.
+            alreadySignaled = true;
+            break;
+        }
+    }
 
-	bool finished = alreadySignaled || fenceSitter.wait(timeout);
-	if (device->getConfigurationResult() != VK_SUCCESS) {
-		rslt = device->getConfigurationResult();
-	} else if ( !finished ) {
-		rslt = VK_TIMEOUT;
-	}
+    bool finished = alreadySignaled || fenceSitter.wait(timeout);
+    if (device->getConfigurationResult() != VK_SUCCESS) {
+        rslt = device->getConfigurationResult();
+    } else if (!finished) {
+        rslt = VK_TIMEOUT;
+    }
 
-	for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
-		((MVKTimelineSemaphore*)pWaitInfo->pSemaphores[i])->unregisterWait(&fenceSitter);
-	}
+    for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
+        ((MVKTimelineSemaphore*)pWaitInfo->pSemaphores[i])
+            ->unregisterWait(&fenceSitter);
+    }
 
-	return rslt;
+    return rslt;
 }
-
 
 #pragma mark -
 #pragma mark MVKMetalCompiler
 
-// Create a compiled object by dispatching the block to the default global dispatch queue, and waiting only as long
-// as the MVKConfiguration::metalCompileTimeout value. If the timeout is triggered, a Vulkan error is created.
-// This approach is used to limit the lengthy time (30+ seconds!) consumed by Metal when it's internal compiler fails.
-// The thread dispatch is needed because even the sync portion of the async Metal compilation methods can take well
-// over a second to return when a compiler failure occurs!
-void MVKMetalCompiler::compile(unique_lock<mutex>& lock, dispatch_block_t block) {
-	MVKAssert( _startTime == 0, "%s compile occurred already in this instance. Instances of %s should only be used for a single compile activity.", _compilerType.c_str(), getClassName().c_str());
+// Create a compiled object by dispatching the block to the default global
+// dispatch queue, and waiting only as long as the
+// MVKConfiguration::metalCompileTimeout value. If the timeout is triggered, a
+// Vulkan error is created. This approach is used to limit the lengthy time (30+
+// seconds!) consumed by Metal when it's internal compiler fails. The thread
+// dispatch is needed because even the sync portion of the async Metal
+// compilation methods can take well over a second to return when a compiler
+// failure occurs!
+void MVKMetalCompiler::compile(unique_lock<mutex>& lock,
+                               dispatch_block_t block) {
+    MVKAssert(_startTime == 0,
+              "%s compile occurred already in this instance. Instances of %s "
+              "should only be used for a single compile "
+              "activity.",
+              _compilerType.c_str(), getClassName().c_str());
 
-	_startTime = getPerformanceTimestamp();
+    _startTime = getPerformanceTimestamp();
 
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{ @autoreleasepool { block(); } });
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT,
+                                             0),
+                   ^{
+                     @autoreleasepool {
+                         block();
+                     }
+                   });
 
-	// Limit timeout to avoid overflow since wait_for() uses wait_until()
-	chrono::nanoseconds nanoTimeout(min(getMVKConfig().metalCompileTimeout, kMVKUndefinedLargeUInt64));
-	_blocker.wait_for(lock, nanoTimeout, [this]{ return _isCompileDone; });
+    // Limit timeout to avoid overflow since wait_for() uses wait_until()
+    chrono::nanoseconds nanoTimeout(
+        min(getMVKConfig().metalCompileTimeout, kMVKUndefinedLargeUInt64));
+    _blocker.wait_for(lock, nanoTimeout, [this] { return _isCompileDone; });
 
-	if ( !_isCompileDone ) {
-		@autoreleasepool {
-			NSString* errDesc = [NSString stringWithFormat: @"Timeout after %.3f milliseconds. Likely internal Metal compiler error", (double)nanoTimeout.count() / 1e6];
-			_compileError = [[NSError alloc] initWithDomain: @(kMVKMoltenVKDriverLayerName) code: 1 userInfo: @{NSLocalizedDescriptionKey : errDesc}];	// retained
-		}
-	}
+    if (!_isCompileDone) {
+        @autoreleasepool {
+            NSString* errDesc = [NSString
+                stringWithFormat:@"Timeout after %.3f milliseconds. Likely "
+                                 @"internal Metal compiler error",
+                                 (double)nanoTimeout.count() / 1e6];
+            _compileError =
+                [[NSError alloc] initWithDomain:@(kMVKMoltenVKDriverLayerName)
+                                           code:1
+                                       userInfo:@{
+                                           NSLocalizedDescriptionKey : errDesc
+                                       }]; // retained
+        }
+    }
 
-	if (_compileError) { handleError(); }
+    if (_compileError) {
+        handleError();
+    }
 
-	addPerformanceInterval(*_pPerformanceTracker, _startTime);
+    addPerformanceInterval(*_pPerformanceTracker, _startTime);
 }
 
 void MVKMetalCompiler::handleError() {
-	_owner->setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED,
-											   "%s compile failed (Error code %li):\n%s.",
-											   _compilerType.c_str(), (long)_compileError.code,
-											   _compileError.localizedDescription.UTF8String));
+    _owner->setConfigurationResult(
+        reportError(VK_ERROR_INITIALIZATION_FAILED,
+                    "%s compile failed (Error code %li):\n%s.",
+                    _compilerType.c_str(), (long)_compileError.code,
+                    _compileError.localizedDescription.UTF8String));
 }
 
-// Returns whether the compilation came in late, after the compiler was destroyed.
+// Returns whether the compilation came in late, after the compiler was
+// destroyed.
 bool MVKMetalCompiler::endCompile(NSError* compileError) {
-	_compileError = [compileError retain];		// retained
-	_isCompileDone = true;
-	_blocker.notify_all();
-	return _isDestroyed;
+    _compileError = [compileError retain]; // retained
+    _isCompileDone = true;
+    _blocker.notify_all();
+    return _isDestroyed;
 }
 
 void MVKMetalCompiler::destroy() {
-	if (markDestroyed()) { MVKBaseObject::destroy(); }
+    if (markDestroyed()) {
+        MVKBaseObject::destroy();
+    }
 }
 
-// Marks this object as destroyed, and returns whether the compilation is complete.
+// Marks this object as destroyed, and returns whether the compilation is
+// complete.
 bool MVKMetalCompiler::markDestroyed() {
-	lock_guard<mutex> lock(_completionLock);
+    lock_guard<mutex> lock(_completionLock);
 
-	_isDestroyed = true;
-	return _isCompileDone;
+    _isDestroyed = true;
+    return _isCompileDone;
 }
-
 
 #pragma mark Construction
 
-MVKMetalCompiler::~MVKMetalCompiler() {
-	[_compileError release];
-}
+MVKMetalCompiler::~MVKMetalCompiler() { [_compileError release]; }
 
 #pragma mark -
 #pragma mark MVKDeferredOperation
 
-// Call appropriate function from MVKDeferredOperationFunctionPointer with parameters.
-// While executing, the function can call setOperationResult() and setMaxConcurrency()
-// to update status of the operation, and should return a VkResult that is returned here.
+// Call appropriate function from MVKDeferredOperationFunctionPointer with
+// parameters. While executing, the function can call setOperationResult() and
+// setMaxConcurrency() to update status of the operation, and should return a
+// VkResult that is returned here.
 VkResult MVKDeferredOperation::join() {
-	switch(_functionType) {
-		// .....
-        default: return VK_SUCCESS;
+    switch (_functionType) {
+        // .....
+    default:
+        return VK_SUCCESS;
     };
 }
 
-void MVKDeferredOperation::deferOperation(const MVKDeferredOperationFunctionPointer& pointer,
-										  MVKDeferredOperationFunctionType type,
-										  void** parameters,
-										  uint32_t paramCount) {
+void MVKDeferredOperation::deferOperation(
+    const MVKDeferredOperationFunctionPointer& pointer,
+    MVKDeferredOperationFunctionType type, void** parameters,
+    uint32_t paramCount) {
     _functionPointer = pointer;
     _functionType = type;
 
-	_functionParameters.reserve(paramCount);
-	for(int i = 0; i < paramCount; i++) {
+    _functionParameters.reserve(paramCount);
+    for (int i = 0; i < paramCount; i++) {
         _functionParameters.push_back(parameters[i]);
     }
 
-	updateResults(VK_SUCCESS, mvkGetAvaliableCPUCores());
+    updateResults(VK_SUCCESS, mvkGetAvaliableCPUCores());
 }
 
 VkResult MVKDeferredOperation::getOperationResult() {
-	lock_guard<mutex> lock(_lock);
-	return _operationResult;
+    lock_guard<mutex> lock(_lock);
+    return _operationResult;
 }
 
 void MVKDeferredOperation::setOperationResult(VkResult opResult) {
-	lock_guard<mutex> lock(_lock);
-	_operationResult = opResult;
+    lock_guard<mutex> lock(_lock);
+    _operationResult = opResult;
 }
 
 uint32_t MVKDeferredOperation::getMaxConcurrency() {
-	lock_guard<mutex> lock(_lock);
-	return _maxConcurrency;
+    lock_guard<mutex> lock(_lock);
+    return _maxConcurrency;
 }
 
 void MVKDeferredOperation::setMaxConcurrency(uint32_t maxConCurr) {
-	lock_guard<mutex> lock(_lock);
-	_maxConcurrency = maxConCurr;
+    lock_guard<mutex> lock(_lock);
+    _maxConcurrency = maxConCurr;
 }
 
-void MVKDeferredOperation::updateResults(VkResult opResult, uint32_t maxConCurr) {
-	lock_guard<mutex> lock(_lock);
-	_operationResult = opResult;
-	_maxConcurrency = maxConCurr;
+void MVKDeferredOperation::updateResults(VkResult opResult,
+                                         uint32_t maxConCurr) {
+    lock_guard<mutex> lock(_lock);
+    _operationResult = opResult;
+    _maxConcurrency = maxConCurr;
 }
-

--- a/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.h
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,67 +25,72 @@
 
 class MVKInstance;
 
-
 #pragma mark -
 #pragma mark MVKVulkanAPIObject
 
 /**
  * Abstract class that represents an opaque Vulkan API handle object.
  *
- * Vulkan API objects can sometimes be destroyed by the client before the GPU is done with them.
- * To support this, this class inherits from MVKReferenceCountingMixin to allow an instance to
- * live past its destruction by the client, until it is no longer referenced by other objects.
+ * Vulkan API objects can sometimes be destroyed by the client before the GPU is
+ * done with them. To support this, this class inherits from
+ * MVKReferenceCountingMixin to allow an instance to live past its destruction
+ * by the client, until it is no longer referenced by other objects.
  */
-class MVKVulkanAPIObject : public MVKReferenceCountingMixin<MVKBaseObject>, public MVKConfigurableMixin {
+class MVKVulkanAPIObject : public MVKReferenceCountingMixin<MVKBaseObject>,
+                           public MVKConfigurableMixin {
 
-public:
+  public:
+    /** Returns the Vulkan API opaque object controlling this object. */
+    MVKVulkanAPIObject* getVulkanAPIObject() override { return this; };
 
-	/** Returns the Vulkan API opaque object controlling this object. */
-	MVKVulkanAPIObject* getVulkanAPIObject() override { return this; };
+    /** Returns a reference to this object suitable for use as a Vulkan API
+     * handle. */
+    virtual void* getVkHandle() { return this; }
 
-	/** Returns a reference to this object suitable for use as a Vulkan API handle. */
-	virtual void* getVkHandle() { return this; }
+    /** Returns the Vulkan type of this object. */
+    virtual VkObjectType getVkObjectType() = 0;
 
-	/** Returns the Vulkan type of this object. */
-	virtual VkObjectType getVkObjectType() = 0;
+    /** Returns the debug report object type of this object. */
+    virtual VkDebugReportObjectTypeEXT getVkDebugReportObjectType() = 0;
 
-	/** Returns the debug report object type of this object. */
-	virtual VkDebugReportObjectTypeEXT getVkDebugReportObjectType() = 0;
+    /** Returns the Vulkan instance. */
+    virtual MVKInstance* getInstance() = 0;
 
-	/** Returns the Vulkan instance. */
-	virtual MVKInstance* getInstance() = 0;
+    /** Gets the debug object name of this instance. */
+    NSString* getDebugName() { return _debugName; }
 
-	/** Gets the debug object name of this instance. */
-	NSString* getDebugName() { return _debugName; }
+    /** Sets the debug object name of this instance. */
+    VkResult setDebugName(const char* pObjectName);
 
-	/** Sets the debug object name of this instance. */
-	VkResult setDebugName(const char* pObjectName);
+    /** Sets the label of the Metal object. */
+    void setMetalObjectLabel(id mtlObj, NSString* label);
 
-	/** Sets the label of the Metal object. */
-	void setMetalObjectLabel(id mtlObj, NSString* label);
+    /** Returns the MVKVulkanAPIObject instance referenced by the object of the
+     * given type. */
+    static MVKVulkanAPIObject*
+    getMVKVulkanAPIObject(VkDebugReportObjectTypeEXT objType, uint64_t object);
 
-	/** Returns the MVKVulkanAPIObject instance referenced by the object of the given type. */
-	static MVKVulkanAPIObject* getMVKVulkanAPIObject(VkDebugReportObjectTypeEXT objType, uint64_t object);
+    /** Returns the MVKVulkanAPIObject instance referenced by the object of the
+     * given type. */
+    static MVKVulkanAPIObject* getMVKVulkanAPIObject(VkObjectType objType,
+                                                     uint64_t objectHandle);
 
-	/** Returns the MVKVulkanAPIObject instance referenced by the object of the given type. */
-	static MVKVulkanAPIObject* getMVKVulkanAPIObject(VkObjectType objType, uint64_t objectHandle);
+    MVKVulkanAPIObject() {}
+    MVKVulkanAPIObject(const MVKVulkanAPIObject& other);
+    MVKVulkanAPIObject& operator=(const MVKVulkanAPIObject& other);
+    ~MVKVulkanAPIObject() override;
 
-	MVKVulkanAPIObject() {}
-	MVKVulkanAPIObject(const MVKVulkanAPIObject& other);
-	MVKVulkanAPIObject& operator=(const MVKVulkanAPIObject& other);
-	~MVKVulkanAPIObject() override;
+  protected:
+    virtual void propagateDebugName() = 0;
 
-protected:
-	virtual void propagateDebugName() = 0;
-
-	NSString* _debugName = nil;
+    NSString* _debugName = nil;
 };
-
 
 #pragma mark -
 #pragma mark MVKDispatchableVulkanAPIObject
 
-/** Abstract class that represents a dispatchable opaque Vulkan API handle object. */
+/** Abstract class that represents a dispatchable opaque Vulkan API handle
+ * object. */
 class MVKDispatchableVulkanAPIObject : public MVKVulkanAPIObject {
 
     typedef struct {
@@ -93,32 +98,34 @@ class MVKDispatchableVulkanAPIObject : public MVKVulkanAPIObject {
         MVKDispatchableVulkanAPIObject* mvkObject;
     } MVKDispatchableObjectICDRef;
 
-public:
-
+  public:
     /**
-     * Returns a reference to this object suitable for use as a dispatchable Vulkan API handle.
-	 *
-	 * Establishes the loader magic number every time, in case the loader
-	 * overwrote it for some reason before passing the object back,
-	 * particularly in pooled objects that the loader might consider freed.
-	 *
-	 * This is the compliment of the getDispatchableObject() function.
+     * Returns a reference to this object suitable for use as a dispatchable
+     * Vulkan API handle.
+     *
+     * Establishes the loader magic number every time, in case the loader
+     * overwrote it for some reason before passing the object back,
+     * particularly in pooled objects that the loader might consider freed.
+     *
+     * This is the compliment of the getDispatchableObject() function.
      */
     void* getVkHandle() override {
-		set_loader_magic_value(&_icdRef);
-		return &_icdRef;
-	}
-
-    /**
-     * Retrieves the MVKDispatchableVulkanAPIObject instance referenced by the dispatchable Vulkan handle.
-	 *
-     * This is the compliment of the getVkHandle() function.
-     */
-    static MVKDispatchableVulkanAPIObject* getDispatchableObject(void* vkHandle) {
-		return vkHandle ? ((MVKDispatchableObjectICDRef*)vkHandle)->mvkObject : nullptr;
+        set_loader_magic_value(&_icdRef);
+        return &_icdRef;
     }
 
-protected:
-    MVKDispatchableObjectICDRef _icdRef = { 0, this };
+    /**
+     * Retrieves the MVKDispatchableVulkanAPIObject instance referenced by the
+     * dispatchable Vulkan handle.
+     *
+     * This is the compliment of the getVkHandle() function.
+     */
+    static MVKDispatchableVulkanAPIObject*
+    getDispatchableObject(void* vkHandle) {
+        return vkHandle ? ((MVKDispatchableObjectICDRef*)vkHandle)->mvkObject
+                        : nullptr;
+    }
 
+  protected:
+    MVKDispatchableObjectICDRef _icdRef = {0, this};
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKVulkanAPIObject.mm
@@ -6,9 +6,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,73 +20,78 @@
 
 using namespace std;
 
-
 #pragma mark -
 #pragma mark MVKVulkanAPIObject
 
 VkResult MVKVulkanAPIObject::setDebugName(const char* pObjectName) {
-	if (pObjectName) {
-		[_debugName release];
-		_debugName = [[NSString alloc] initWithUTF8String: pObjectName];	// retained
-		propagateDebugName();
-	}
-	return VK_SUCCESS;
+    if (pObjectName) {
+        [_debugName release];
+        _debugName =
+            [[NSString alloc] initWithUTF8String:pObjectName]; // retained
+        propagateDebugName();
+    }
+    return VK_SUCCESS;
 }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-method-access"
 void MVKVulkanAPIObject::setMetalObjectLabel(id mtlObj, NSString* label) {
-	if ( !label ) { return; }
+    if (!label) {
+        return;
+    }
 
-	// If debug mode is enabled, append the object address.
-	if (getMVKConfig().debugMode) {
-		[mtlObj setLabel: [label stringByAppendingFormat: @" (%p)", mtlObj]];
-	} else {
-		[mtlObj setLabel: label];
-	}
+    // If debug mode is enabled, append the object address.
+    if (getMVKConfig().debugMode) {
+        [mtlObj setLabel:[label stringByAppendingFormat:@" (%p)", mtlObj]];
+    } else {
+        [mtlObj setLabel:label];
+    }
 }
 #pragma clang diagnostic pop
 
-MVKVulkanAPIObject* MVKVulkanAPIObject::getMVKVulkanAPIObject(VkDebugReportObjectTypeEXT objType, uint64_t object) {
-	void* pVkObj = (void*)object;
-	switch (objType) {
-		case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
-		case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
-		case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
-		case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
-		case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
-			return MVKDispatchableVulkanAPIObject::getDispatchableObject(pVkObj);
-		default:
-			return (MVKVulkanAPIObject*)pVkObj;
-	}
+MVKVulkanAPIObject*
+MVKVulkanAPIObject::getMVKVulkanAPIObject(VkDebugReportObjectTypeEXT objType,
+                                          uint64_t object) {
+    void* pVkObj = (void*)object;
+    switch (objType) {
+    case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
+    case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
+    case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
+    case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
+    case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
+        return MVKDispatchableVulkanAPIObject::getDispatchableObject(pVkObj);
+    default:
+        return (MVKVulkanAPIObject*)pVkObj;
+    }
 }
 
-MVKVulkanAPIObject* MVKVulkanAPIObject::getMVKVulkanAPIObject(VkObjectType objType, uint64_t objectHandle) {
-	void* pVkObj = (void*)objectHandle;
-	switch (objType) {
-		case VK_OBJECT_TYPE_INSTANCE:
-		case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
-		case VK_OBJECT_TYPE_DEVICE:
-		case VK_OBJECT_TYPE_QUEUE:
-		case VK_OBJECT_TYPE_COMMAND_BUFFER:
-			return MVKDispatchableVulkanAPIObject::getDispatchableObject(pVkObj);
-		default:
-			return (MVKVulkanAPIObject*)pVkObj;
-	}
+MVKVulkanAPIObject*
+MVKVulkanAPIObject::getMVKVulkanAPIObject(VkObjectType objType,
+                                          uint64_t objectHandle) {
+    void* pVkObj = (void*)objectHandle;
+    switch (objType) {
+    case VK_OBJECT_TYPE_INSTANCE:
+    case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
+    case VK_OBJECT_TYPE_DEVICE:
+    case VK_OBJECT_TYPE_QUEUE:
+    case VK_OBJECT_TYPE_COMMAND_BUFFER:
+        return MVKDispatchableVulkanAPIObject::getDispatchableObject(pVkObj);
+    default:
+        return (MVKVulkanAPIObject*)pVkObj;
+    }
 }
 
 MVKVulkanAPIObject::MVKVulkanAPIObject(const MVKVulkanAPIObject& other) {
-	_debugName = [other._debugName retain];
+    _debugName = [other._debugName retain];
 }
 
-MVKVulkanAPIObject& MVKVulkanAPIObject::operator=(const MVKVulkanAPIObject& other) {
-	if (_debugName != other._debugName) {
-		[_debugName release];
-		_debugName = [other._debugName retain];
-	}
-	return *this;
+MVKVulkanAPIObject&
+MVKVulkanAPIObject::operator=(const MVKVulkanAPIObject& other) {
+    if (_debugName != other._debugName) {
+        [_debugName release];
+        _debugName = [other._debugName retain];
+    }
+    return *this;
 }
 
-MVKVulkanAPIObject::~MVKVulkanAPIObject() {
-	[_debugName release];
-}
+MVKVulkanAPIObject::~MVKVulkanAPIObject() { [_debugName release]; }


### PR DESCRIPTION
In Android, we're depending on MoltenVK as one of our external dependencies.

We occasionally make small modifications for our purposes that would not make sense to be merged back into the upstream.

However, ensuring consistent formatting seems to be a challenge since we can get merge conflicts from the upstream.  I wanted to propose a simple clang-format (we're not attached to the formatter in any which way - we would just prefer if there were a formatter). 

* First commit presents a simple clang-format.
* In my second commit I present the changes to GPUObjects/ * 

I am happy to remove the formatting example and for one of the main contributors to apply the formatting changes or if desired I am happy to reformat the whole project if we agree on the format. 

I am a bit surprised there isn't a global formatter already - so if I missed that, please just let me know and we will use that.