### PR TITLE
Avoid calling useResource on resources in argument buffers

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -338,7 +338,8 @@ typedef enum {
 	kMVKBarrierStageFragment,
 	kMVKBarrierStageCompute,
 	kMVKBarrierStageCopy,
-	kMVKBarrierStageCount
+	kMVKBarrierStageNone,
+	kMVKBarrierStageCount = kMVKBarrierStageNone
 } MVKBarrierStage;
 
 /** Returns the Metal MTLColorWriteMask corresponding to the specified Vulkan VkColorComponentFlags. */

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -333,6 +333,14 @@ typedef enum {
 	kMVKShaderStageMax = kMVKShaderStageCount	// Public API legacy value
 } MVKShaderStage;
 
+typedef enum {
+	kMVKBarrierStageVertex = 0,
+	kMVKBarrierStageFragment,
+	kMVKBarrierStageCompute,
+	kMVKBarrierStageCopy,
+	kMVKBarrierStageCount
+} MVKBarrierStage;
+
 /** Returns the Metal MTLColorWriteMask corresponding to the specified Vulkan VkColorComponentFlags. */
 MTLColorWriteMask mvkMTLColorWriteMaskFromVkChannelFlags(VkColorComponentFlags vkWriteFlags);
 

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -358,6 +358,7 @@ typedef struct {
 	VkBool32 needsCubeGradWorkaround;				/**< If true, sampling from cube textures with explicit gradients is broken and needs a workaround. */
 	VkBool32 nativeTextureAtomics;                  /**< If true, atomic operations on textures are supported natively. */
 	VkBool32 needsArgumentBufferEncoders;			/**< If true, Metal argument buffer encoders are needed to populate argument buffer content. */
+    VkBool32 residencySets;                         /**< If true, the device supports creating residency sets. */
 } MVKPhysicalDeviceMetalFeatures;
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -186,7 +186,7 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 	}
 #endif
 
-	if (!cmdEncoder->_mtlRenderEncoder && cmdEncoder->isUsingMetalArgumentBuffers()) {
+	if (!cmdEncoder->_mtlRenderEncoder && cmdEncoder->isUsingMetalArgumentBuffers() && cmdEncoder->getDevice()->hasResidencySet()) {
 		cmdEncoder->endCurrentMetalEncoding();
 
 		for (auto& b : _barriers) {

--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -79,6 +79,35 @@ VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
 	return VK_SUCCESS;
 }
 
+static uint64_t mvkPipelineStageFlagsToBarrierStages(VkPipelineStageFlags2 flags) {
+	uint64_t result = 0;
+
+	if (mvkIsAnyFlagEnabled(flags, VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT |
+							VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT | VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT |
+							VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT | VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT | VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT |
+							VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT | VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT | VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT |
+							VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT))
+		result |= 1 << kMVKBarrierStageVertex;
+
+	if (mvkIsAnyFlagEnabled(flags, VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT |
+							VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT |
+							VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR | VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT |
+							VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT | VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT))
+		result |= 1 << kMVKBarrierStageFragment;
+
+	if (mvkIsAnyFlagEnabled(flags, VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT |
+							VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT))
+		result |= 1 << kMVKBarrierStageCompute;
+
+	if (mvkIsAnyFlagEnabled(flags, VK_PIPELINE_STAGE_2_BLIT_BIT | VK_PIPELINE_STAGE_2_COPY_BIT | VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT |
+							VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT | VK_PIPELINE_STAGE_2_TRANSFER_BIT | VK_PIPELINE_STAGE_2_RESOLVE_BIT |
+							VK_PIPELINE_STAGE_2_CLEAR_BIT | VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR | VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT |
+							VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT))
+		result |= 1 << kMVKBarrierStageCopy;
+
+	return result;
+}
+
 template <size_t N>
 VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
 											  VkPipelineStageFlags srcStageMask,
@@ -156,6 +185,15 @@ void MVKCmdPipelineBarrier<N>::encode(MVKCommandEncoder* cmdEncoder) {
 		}
 	}
 #endif
+
+	if (!cmdEncoder->_mtlRenderEncoder && cmdEncoder->isUsingMetalArgumentBuffers()) {
+		cmdEncoder->endCurrentMetalEncoding();
+
+		for (auto& b : _barriers) {
+			uint64_t sourceStageMask = mvkPipelineStageFlagsToBarrierStages(b.srcStageMask), destStageMask = mvkPipelineStageFlagsToBarrierStages(b.dstStageMask);
+			cmdEncoder->setBarrier(sourceStageMask, destStageMask);
+		}
+	}
 
 	// Apple GPUs do not support renderpass barriers, and do not support rendering/writing
 	// to an attachment and then reading from that attachment within a single renderpass.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -410,6 +410,27 @@ public:
     /** Returns the command encoding pool. */
     MVKCommandEncodingPool* getCommandEncodingPool();
 
+	#pragma mark Barriers
+
+	/** Encode waits in the current command encoder for the stage that corresponds to given use. */
+	void encodeBarrierWaits(MVKCommandUse use);
+
+	/** Update fences for the currently executing pipeline stage. */
+	void encodeBarrierUpdates();
+
+	/** Insert a new execution barrier */
+	void setBarrier(uint64_t sourceStageMask, uint64_t destStageMask);
+
+	/** Encode waits for a specific stage in given encoder. */
+	void barrierWait(MVKBarrierStage stage, id<MTLRenderCommandEncoder> mtlEncoder, MTLRenderStages beforeStages);
+	void barrierWait(MVKBarrierStage stage, id<MTLBlitCommandEncoder> mtlEncoder);
+	void barrierWait(MVKBarrierStage stage, id<MTLComputeCommandEncoder> mtlEncoder);
+
+	/** Encode update for a specific stage in given encoder. */
+	void barrierUpdate(MVKBarrierStage stage, id<MTLRenderCommandEncoder> mtlEncoder, MTLRenderStages afterStages);
+	void barrierUpdate(MVKBarrierStage stage, id<MTLBlitCommandEncoder> mtlEncoder);
+	void barrierUpdate(MVKBarrierStage stage, id<MTLComputeCommandEncoder> mtlEncoder);
+
 #pragma mark Queries
 
     /** Begins an occlusion query. */
@@ -492,6 +513,7 @@ protected:
 	NSString* getMTLRenderCommandEncoderName(MVKCommandUse cmdUse);
 	template<typename T> void retainIfImmediatelyEncoding(T& mtlEnc);
 	template<typename T> void endMetalEncoding(T& mtlEnc);
+	id<MTLFence> getBarrierStageFence(MVKBarrierStage stage);
 
 	typedef struct GPUCounterQuery {
 		MVKGPUCounterQueryPool* queryPool = nullptr;
@@ -519,6 +541,9 @@ protected:
     uint32_t _flushCount;
 	MVKCommandUse _mtlComputeEncoderUse;
 	MVKCommandUse _mtlBlitEncoderUse;
+	uint32_t _updateFenceSlotDirtyBits = ~0;
+	int _updateFenceSlots[kMVKBarrierStageCount] = {};
+	int _waitFenceSlots[kMVKBarrierStageCount][kMVKBarrierStageCount] = {};
 	bool _isRenderingEntireAttachment;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -48,11 +48,19 @@ typedef uint64_t MVKMTLCommandBufferID;
 #pragma mark -
 #pragma mark MVKCommandEncodingContext
 
+struct BarrierFenceSlots {
+	uint32_t updateDirtyBits = ~0;
+	int update[kMVKBarrierStageCount] = {};
+	int wait[kMVKBarrierStageCount][kMVKBarrierStageCount] = {};
+};
+
 /** Context for tracking information across multiple encodings. */
 typedef struct MVKCommandEncodingContext {
 	NSUInteger mtlVisibilityResultOffset = 0;
 	const MVKMTLBufferAllocation* visibilityResultBuffer = nullptr;
+	BarrierFenceSlots fenceSlots;
 
+	void syncFences(MVKDevice *device, id<MTLCommandBuffer> mtlCommandBuffer);
 	MVKRenderPass* getRenderPass() { return _renderPass; }
 	MVKFramebuffer* getFramebuffer() { return _framebuffer; }
 	void setRenderingContext(MVKRenderPass* renderPass, MVKFramebuffer* framebuffer);
@@ -541,9 +549,6 @@ protected:
     uint32_t _flushCount;
 	MVKCommandUse _mtlComputeEncoderUse;
 	MVKCommandUse _mtlBlitEncoderUse;
-	uint32_t _updateFenceSlotDirtyBits = ~0;
-	int _updateFenceSlots[kMVKBarrierStageCount] = {};
-	int _waitFenceSlots[kMVKBarrierStageCount][kMVKBarrierStageCount] = {};
 	bool _isRenderingEntireAttachment;
 };
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -537,19 +537,19 @@ void MVKCommandEncoder::endMetalEncoding(T& mtlEnc) {
 
 static MVKBarrierStage commandUseToBarrierStage(MVKCommandUse use) {
 	switch (use) {
-	case kMVKCommandUseNone:                         return kMVKBarrierStageCount; /**< No use defined. */
-	case kMVKCommandUseBeginCommandBuffer:           return kMVKBarrierStageCount; /**< vkBeginCommandBuffer (prefilled VkCommandBuffer). */
-	case kMVKCommandUseQueueSubmit:                  return kMVKBarrierStageCount; /**< vkQueueSubmit. */
-	case kMVKCommandUseAcquireNextImage:             return kMVKBarrierStageCount; /**< vkAcquireNextImageKHR. */
-	case kMVKCommandUseQueuePresent:                 return kMVKBarrierStageCount; /**< vkQueuePresentKHR. */
-	case kMVKCommandUseQueueWaitIdle:                return kMVKBarrierStageCount; /**< vkQueueWaitIdle. */
-	case kMVKCommandUseDeviceWaitIdle:               return kMVKBarrierStageCount; /**< vkDeviceWaitIdle. */
-	case kMVKCommandUseInvalidateMappedMemoryRanges: return kMVKBarrierStageCount; /**< vkInvalidateMappedMemoryRanges. */
-	case kMVKCommandUseBeginRendering:               return kMVKBarrierStageCount; /**< vkCmdBeginRendering. */
-	case kMVKCommandUseBeginRenderPass:              return kMVKBarrierStageCount; /**< vkCmdBeginRenderPass. */
-	case kMVKCommandUseNextSubpass:                  return kMVKBarrierStageCount; /**< vkCmdNextSubpass. */
-	case kMVKCommandUseRestartSubpass:               return kMVKBarrierStageCount; /**< Create a new Metal renderpass due to Metal requirements. */
-	case kMVKCommandUsePipelineBarrier:              return kMVKBarrierStageCount; /**< vkCmdPipelineBarrier. */
+	case kMVKCommandUseNone:                         return kMVKBarrierStageNone; /**< No use defined. */
+	case kMVKCommandUseBeginCommandBuffer:           return kMVKBarrierStageNone; /**< vkBeginCommandBuffer (prefilled VkCommandBuffer). */
+	case kMVKCommandUseQueueSubmit:                  return kMVKBarrierStageNone; /**< vkQueueSubmit. */
+	case kMVKCommandUseAcquireNextImage:             return kMVKBarrierStageNone; /**< vkAcquireNextImageKHR. */
+	case kMVKCommandUseQueuePresent:                 return kMVKBarrierStageNone; /**< vkQueuePresentKHR. */
+	case kMVKCommandUseQueueWaitIdle:                return kMVKBarrierStageNone; /**< vkQueueWaitIdle. */
+	case kMVKCommandUseDeviceWaitIdle:               return kMVKBarrierStageNone; /**< vkDeviceWaitIdle. */
+	case kMVKCommandUseInvalidateMappedMemoryRanges: return kMVKBarrierStageNone; /**< vkInvalidateMappedMemoryRanges. */
+	case kMVKCommandUseBeginRendering:               return kMVKBarrierStageNone; /**< vkCmdBeginRendering. */
+	case kMVKCommandUseBeginRenderPass:              return kMVKBarrierStageNone; /**< vkCmdBeginRenderPass. */
+	case kMVKCommandUseNextSubpass:                  return kMVKBarrierStageNone; /**< vkCmdNextSubpass. */
+	case kMVKCommandUseRestartSubpass:               return kMVKBarrierStageNone; /**< Create a new Metal renderpass due to Metal requirements. */
+	case kMVKCommandUsePipelineBarrier:              return kMVKBarrierStageNone; /**< vkCmdPipelineBarrier. */
 	case kMVKCommandUseBlitImage:                    return kMVKBarrierStageCopy; /**< vkCmdBlitImage. */
 	case kMVKCommandUseCopyImage:                    return kMVKBarrierStageCopy; /**< vkCmdCopyImage. */
 	case kMVKCommandUseResolveImage:                 return kMVKBarrierStageCopy; /**< vkCmdResolveImage - resolve stage. */
@@ -561,7 +561,7 @@ static MVKBarrierStage commandUseToBarrierStage(MVKCommandUse use) {
 	case kMVKCommandUseCopyImageToBuffer:            return kMVKBarrierStageCopy; /**< vkCmdCopyImageToBuffer. */
 	case kMVKCommandUseFillBuffer:                   return kMVKBarrierStageCopy; /**< vkCmdFillBuffer. */
 	case kMVKCommandUseUpdateBuffer:                 return kMVKBarrierStageCopy; /**< vkCmdUpdateBuffer. */
-	case kMVKCommandUseClearAttachments:             return kMVKBarrierStageCount; /**< vkCmdClearAttachments. */
+	case kMVKCommandUseClearAttachments:             return kMVKBarrierStageNone; /**< vkCmdClearAttachments. */
 	case kMVKCommandUseClearColorImage:              return kMVKBarrierStageCopy; /**< vkCmdClearColorImage. */
 	case kMVKCommandUseClearDepthStencilImage:       return kMVKBarrierStageCopy; /**< vkCmdClearDepthStencilImage. */
 	case kMVKCommandUseResetQueryPool:               return kMVKBarrierStageCopy; /**< vkCmdResetQueryPool. */
@@ -569,8 +569,8 @@ static MVKBarrierStage commandUseToBarrierStage(MVKCommandUse use) {
 	case kMVKCommandUseTessellationVertexTessCtl:    return kMVKBarrierStageVertex; /**< vkCmdDraw* - vertex and tessellation control stages. */
 	case kMVKCommandUseDrawIndirectConvertBuffers:   return kMVKBarrierStageVertex; /**< vkCmdDrawIndirect* convert indirect buffers. */
 	case kMVKCommandUseCopyQueryPoolResults:         return kMVKBarrierStageCopy; /**< vkCmdCopyQueryPoolResults. */
-	case kMVKCommandUseAccumOcclusionQuery:          return kMVKBarrierStageCount; /**< Any command terminating a Metal render pass with active visibility buffer. */
-	case kMVKCommandUseRecordGPUCounterSample:       return kMVKBarrierStageCount; /**< Any command triggering the recording of a GPU counter sample. */
+	case kMVKCommandUseAccumOcclusionQuery:          return kMVKBarrierStageNone; /**< Any command terminating a Metal render pass with active visibility buffer. */
+	case kMVKCommandUseRecordGPUCounterSample:       return kMVKBarrierStageNone; /**< Any command triggering the recording of a GPU counter sample. */
 	}
 }
 
@@ -656,13 +656,13 @@ void MVKCommandEncoder::encodeBarrierWaits(MVKCommandUse use) {
 	}
 	if (_mtlComputeEncoder) {
 		auto stage = commandUseToBarrierStage(use);
-		if (stage != kMVKBarrierStageCount) {
+		if (stage != kMVKBarrierStageNone) {
 			barrierWait(stage, _mtlComputeEncoder);
 		}
 	}
 	if (_mtlBlitEncoder) {
 		auto stage = commandUseToBarrierStage(use);
-		if (stage != kMVKBarrierStageCount) {
+		if (stage != kMVKBarrierStageNone) {
 			barrierWait(stage, _mtlBlitEncoder);
 		}
 	}
@@ -676,14 +676,14 @@ void MVKCommandEncoder::encodeBarrierUpdates() {
 
 	if (_mtlComputeEncoder) {
 		MVKBarrierStage stage = commandUseToBarrierStage(_mtlComputeEncoderUse);
-		if (stage != kMVKBarrierStageCount) {
+		if (stage != kMVKBarrierStageNone) {
 			barrierUpdate(stage, _mtlComputeEncoder);
 		}
 	}
 
 	if (_mtlBlitEncoder) {
 		MVKBarrierStage stage = commandUseToBarrierStage(_mtlBlitEncoderUse);
-		if (stage != kMVKBarrierStageCount) {
+		if (stage != kMVKBarrierStageNone) {
 			barrierUpdate(stage, _mtlBlitEncoder);
 		}
 	}

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -577,7 +577,7 @@ static MVKBarrierStage commandUseToBarrierStage(MVKCommandUse use) {
 
 
 void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLRenderCommandEncoder> mtlEncoder, MTLRenderStages beforeStages) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	for (int i = 0; i < kMVKBarrierStageCount; ++i) {
 		auto fenceIndex = _waitFenceSlots[stage][i];
 		auto fence = _device->getFence((MVKBarrierStage)i, fenceIndex);
@@ -586,7 +586,7 @@ void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLRenderCommandEn
 }
 
 void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLBlitCommandEncoder> mtlEncoder) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	for (int i = 0; i < kMVKBarrierStageCount; ++i) {
 		auto fenceIndex = _waitFenceSlots[stage][i];
 		auto fence = _device->getFence((MVKBarrierStage)i, fenceIndex);
@@ -595,7 +595,7 @@ void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLBlitCommandEnco
 }
 
 void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLComputeCommandEncoder> mtlEncoder) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	for (int i = 0; i < kMVKBarrierStageCount; ++i) {
 		auto fenceIndex = _waitFenceSlots[stage][i];
 		auto fence = _device->getFence((MVKBarrierStage)i, fenceIndex);
@@ -604,19 +604,19 @@ void MVKCommandEncoder::barrierWait(MVKBarrierStage stage, id<MTLComputeCommandE
 }
 
 void MVKCommandEncoder::barrierUpdate(MVKBarrierStage stage, id<MTLRenderCommandEncoder> mtlEncoder, MTLRenderStages afterStages) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	auto fence = getBarrierStageFence(stage);
 	[mtlEncoder updateFence:fence afterStages:afterStages];
 }
 
 void MVKCommandEncoder::barrierUpdate(MVKBarrierStage stage, id<MTLBlitCommandEncoder> mtlEncoder) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	auto fence = getBarrierStageFence(stage);
 	[mtlEncoder updateFence:fence];
 }
 
 void MVKCommandEncoder::barrierUpdate(MVKBarrierStage stage, id<MTLComputeCommandEncoder> mtlEncoder) {
-	if (!isUsingMetalArgumentBuffers()) return;
+	if (!isUsingMetalArgumentBuffers() || !getDevice()->hasResidencySet()) return;
 	auto fence = getBarrierStageFence(stage);
 	[mtlEncoder updateFence:fence];
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -681,6 +681,7 @@ void MVKResourcesCommandEncoderState::encodeMetalArgumentBuffer(MVKShaderStage s
 			auto* dslBind = dsLayout->getBindingAt(dslBindIdx);
 			if (dslBind->getApplyToStage(stage) && shaderBindingUsage.getBit(dslBindIdx)) {
 				shouldBindArgBuffToStage = true;
+				if (getDevice()->hasResidencySet()) continue;
 				uint32_t elemCnt = dslBind->getDescriptorCount(descSet->getVariableDescriptorCount());
 				for (uint32_t elemIdx = 0; elemIdx < elemCnt; elemIdx++) {
 					uint32_t descIdx = dslBind->getDescriptorIndex(elemIdx);

--- a/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKMTLBufferAllocation.mm
@@ -46,6 +46,7 @@ MVKMTLBufferAllocation* MVKMTLBufferAllocationPool::newObject() {
 void MVKMTLBufferAllocationPool::addMTLBuffer() {
     MTLResourceOptions mbOpts = (_mtlStorageMode << MTLResourceStorageModeShift) | MTLResourceCPUCacheModeDefaultCache;
     _mtlBuffers.push_back({ [getMTLDevice() newBufferWithLength: _mtlBufferLength options: mbOpts], 0 });
+	getDevice()->makeResident(_mtlBuffers.back().mtlBuffer);
     _nextOffset = 0;
 }
 
@@ -106,6 +107,7 @@ uint32_t MVKMTLBufferAllocationPool::calcMTLBufferAllocationCount() {
 
 MVKMTLBufferAllocationPool::~MVKMTLBufferAllocationPool() {
     for (uint32_t bufferIndex = 0; bufferIndex < _mtlBuffers.size(); ++bufferIndex) {
+		getDevice()->removeResidency(_mtlBuffers[bufferIndex].mtlBuffer);
         [_mtlBuffers[bufferIndex].mtlBuffer release];
     }
     _mtlBuffers.clear();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -824,9 +824,9 @@ public:
 	void getMetalObjects(VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);
 
 #if !MVK_XCODE_16
-	inline void makeResident(id allocation) {}
+	void makeResident(id allocation) {}
 #else
-	inline void makeResident(id<MTLAllocation> allocation) {
+	void makeResident(id<MTLAllocation> allocation) {
 		@synchronized(_residencySet) {
 			[_residencySet addAllocation: allocation];
 			[_residencySet commit];
@@ -835,9 +835,9 @@ public:
 #endif
 
 #if !MVK_XCODE_16
-	inline void removeResidency(id allocation) {}
+	void removeResidency(id allocation) {}
 #else
-	inline void removeResidency(id<MTLAllocation> allocation) {
+	void removeResidency(id<MTLAllocation> allocation) {
 		@synchronized(_residencySet) {
 			[_residencySet removeAllocation:allocation];
 			[_residencySet commit];
@@ -845,13 +845,13 @@ public:
 	}
 #endif
 
-	inline void addResidencySet(id<MTLCommandQueue> queue) {
+	void addResidencySet(id<MTLCommandQueue> queue) {
 #if MVK_XCODE_16
 		if (_residencySet) [queue addResidencySet:_residencySet];
 #endif
 	}
 
-	inline bool hasResidencySet() {
+	bool hasResidencySet() {
 #if MVK_XCODE_16
 		return _residencySet != nil;
 #else
@@ -885,7 +885,8 @@ public:
 	/** Returns a Metal fence to update for the given barrier stage. */
 	id<MTLFence> getBarrierStageFence(id<MTLCommandBuffer> mtlCommandBuffer, MVKBarrierStage stage);
 
-	inline id<MTLFence> getFence(MVKBarrierStage stage, int index) {
+	/** Returns a Metal fence by its stage and slot index. */
+	id<MTLFence> getFence(MVKBarrierStage stage, int index) {
 		return _barrierFences[stage][index];
 	}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4813,6 +4813,9 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 	initQueues(pCreateInfo);
 	reservePrivateData(pCreateInfo);
 
+	// Initialize fences for execution barriers
+	for (auto &stage: _barrierFences) for (auto &fence: stage) fence = [_physicalDevice->getMTLDevice() newFence];
+
 #if MVK_MACOS
 	// After enableExtensions
 	// If the VK_KHR_swapchain extension is enabled, we expect to render to the screen.
@@ -5177,6 +5180,8 @@ MVKDevice::~MVKDevice() {
 	}
 
 	if (_commandResourceFactory) { _commandResourceFactory->destroy(); }
+
+	for (auto &fences: _barrierFences) for (auto fence: fences) [fence release];
 
     [_globalVisibilityResultMTLBuffer release];
 	[_defaultMTLSamplerState release];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -246,7 +246,7 @@ bool MVKDeviceMemory::ensureMTLBuffer() {
 	}
 	if (!_mtlBuffer) { return false; }
 	_pMemory = isMemoryHostAccessible() ? _mtlBuffer.contents : nullptr;
-
+	getDevice()->makeResident(_mtlBuffer);
 	propagateDebugName();
 
 	return true;
@@ -425,6 +425,7 @@ MVKDeviceMemory::~MVKDeviceMemory() {
 	auto imgCopies = _imageMemoryBindings;
 	for (auto& img : imgCopies) { img->bindDeviceMemory(nullptr, 0); }
 
+	if (_mtlBuffer) getDevice()->removeResidency(_mtlBuffer);
 	[_mtlBuffer release];
 	_mtlBuffer = nil;
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -533,6 +533,12 @@ VkResult MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool sign
 	// to ensure a fresh one will be used by commands executing on any subsequent MTLCommandBuffers.
 	_encodingContext.visibilityResultBuffer = nullptr;
 
+	// If this is the last command buffer in the submission, we're losing the context and need synchronize
+	// current barrier fences to the ones at index 0, which will be what the next submision starts with.
+	if (isUsingMetalArgumentBuffers() && signalCompletion) {
+		_encodingContext.syncFences(getDevice(), _activeMTLCommandBuffer);
+	}
+
 	// If we need to signal completion, use getActiveMTLCommandBuffer() to ensure at least
 	// one MTLCommandBuffer is used, otherwise if this instance has no content, it will not
 	// finish(), signal the fence and semaphores, and be destroyed.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -339,6 +339,7 @@ void MVKQueue::initExecQueue() {
 // Retrieves and initializes the Metal command queue and Xcode GPU capture scopes
 void MVKQueue::initMTLCommandQueue() {
 	_mtlQueue = _queueFamily->getMTLCommandQueue(_index);	// not retained (cached in queue family)
+	_device->addResidencySet(_mtlQueue);
 
 	_submissionCaptureScope = new MVKGPUCaptureScope(this);
 	if (_queueFamily->getIndex() == getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&


### PR DESCRIPTION
This PR implements execution barriers with Metal fences and puts all resources in a residency set to avoid having to useResource all resources in bound argument buffers. That makes it possible to run programs that use descriptor indexing with large descriptor tables efficiently.

Consider a pipeline executing some render passes with a couple vertex to fragment barriers:
```
1 2   3 4   5 6
v v B v v B v v
f f B f f B f f
```
Here `v` and `f` symbolize the vertex and fragment stages of a render pass, and `B` stands for the barrier.
In this example, stages `v1` and `v2` need to run before `f3..6`, and `v1..4` before `f5` and `f6`.

To implement this I maintain a set of fences that will be waited on before each stage, and updated after it. Here's a diagram with the fences `a` and `b` placed before the stage symbol when waited on, and after when updated:
```
1  2     3   4     5  6
va va B avb avb B av av
f  f  B af  af  B bf bf
```
Here `v1` updates fence `a`, `v4` waits for `a` and updates `b`, `f4` waits for `a`, etc.

Note that the synchronization is a little stronger than the original - `v3..6` are forced to execute after `v1` and `v2`. This is for practical reasons - I want to keep a constant, limited set of fences active, only wait for one fence per stage pair, and only update one fence per stage.

There's some things that could be improved here:
- Keep the number of fences in flight more limited, reuse, at the potential cost of incurring extra synchronization.
- Don't add so many release handlers. I am quite defensive with retain/release here, but doing any less caused use after free errors. I think it should be possible to do better though, or at least maybe batch the releases in a single handler.
- I think the fences should be assigned per queue, not device, and I'm a bit worried about using fences across queues. I don't think we want to rely on which queue we'll be be executing on to encode though.