### PR TITLE
GHActions: Update legacy build to macOS 13 / Xcode 14

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,8 @@ jobs:
 
         # Legacy build. Up to 3 versions behind latest (or beta).
         include:
-          - os: "macos-12"
-            xcode: "13.4.1"
+          - os: "macos-13"
+            xcode: "14.3.1"
             platform: "macos"
             upload_artifacts: false
             select_xcode: true


### PR DESCRIPTION
macOS 12 runners are gone: https://github.com/actions/runner-images/issues/10721