### PR TITLE
Fix compile with MVK_USE_CEREAL=0

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -28,6 +28,7 @@
 #endif
 #include "mvk_datatypes.hpp"
 #include <sys/stat.h>
+#include <sstream>
 
 #ifndef MVK_USE_CEREAL
 #define MVK_USE_CEREAL (1)


### PR DESCRIPTION
Ran into this while testing with a local compile. In `MVKPipeline.mm`, it seems that with `MVK_USE_CEREAL=0`, `sstream` is not included, but `stringstream` is used.