### PR TITLE
Remove atomic usage for RG32Uint.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -296,7 +296,7 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
         if ( mvkIsAnyFlagEnabled(_buffer->getUsage(), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) ) {
 			usage |= MTLTextureUsageShaderWrite;
 #if MVK_XCODE_15
-			if (getMetalFeatures().nativeTextureAtomics && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint || _mtlPixelFormat == MTLPixelFormatRG32Uint))
+			if (getMetalFeatures().nativeTextureAtomics && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint))
 				usage |= MTLTextureUsageShaderAtomic;
 #endif
         }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -748,7 +748,7 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 	}
 
 #if MVK_XCODE_15
-	if (supportAtomics && (mtlFormat == MTLPixelFormatR32Uint || mtlFormat == MTLPixelFormatR32Sint || mtlFormat == MTLPixelFormatRG32Uint)) {
+	if (supportAtomics && (mtlFormat == MTLPixelFormatR32Uint || mtlFormat == MTLPixelFormatR32Sint)) {
 		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderAtomic);
 	}
 #endif
@@ -1542,7 +1542,6 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities
 	// Including this here so we remember to update this if support is added to Vulkan in the future.
 	bool atomic64 = noVulkanSupport && (gpuCaps.supportsApple9 || (gpuCaps.supportsApple8 && gpuCaps.supportsMac2));
 	enableMTLPixFmtCapsIf( atomic64, RG32Uint, Atomic );
-	enableMTLPixFmtCapsIf( atomic64, RG32Sint, Atomic );
 
 	setMTLPixFmtCapsIf( iosOnly8, RG32Float, RWCMB );
 	setMTLPixFmtCapsIf( iosOnly6, RG32Float, RWCB );


### PR DESCRIPTION
Looking into https://github.com/KhronosGroup/MoltenVK/issues/2414, it appears that 64-bit atomics for RG32 texture is not supported by Vulkan at this time, and code for it was only added to prepare for if it is in the future.

However, marking every texture with this format as atomic not only could have performance implications, it is also causing issues on devices like M1 family GPUs that support native texture atomics but not 64-bit atomics. Thus it is better to remove it and revisit if Vulkan ever does decide to support this.

I left the part enabling MTLPixFmtCaps as it already has a flag to force-disable it since it isn't supported by Vulkan along with a comment explaining, and thus it seems pretty harmless. Although I removed enabling it on `RG32Sint` as according to the spec Metal only supports it for `RG32Uint`.