### PR TITLE
Reduce number of unused pipeline bindings reserved for argument buffers.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -82,6 +82,9 @@ public:
 	/** Returns a text description of this layout. */
 	std::string getLogDescription(std::string indent = "");
 
+	/** Overridden because pipeline descriptor sets may be marked as discrete and not use an argument buffer. */
+	bool isUsingMetalArgumentBuffers() override;
+
 	/** Constructs an instance for the specified device. */
 	MVKPipelineLayout(MVKDevice* device, const VkPipelineLayoutCreateInfo* pCreateInfo);
 
@@ -98,6 +101,7 @@ protected:
 	MVKSmallVector<VkPushConstantRange> _pushConstants;
 	MVKShaderResourceBinding _mtlResourceCounts;
 	MVKShaderResourceBinding _pushConstantsMTLResourceIndexes;
+	bool _canUseMetalArgumentBuffers;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -160,7 +160,7 @@ MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
 
 	// For pipeline layout compatibility (“compatible for set N”),
 	// consume the Metal resource indexes in this order:
-	//   - Fixed count of argument buffers for descriptor sets (if using Metal argument buffers).
+	//   - An argument buffer for each descriptor set (if using Metal argument buffers).
 	//   - Push constants
 	//   - Descriptor set content
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -141,8 +141,22 @@ std::string MVKPipelineLayout::getLogDescription(std::string indent) {
 	return descStr.str();
 }
 
+bool MVKPipelineLayout::isUsingMetalArgumentBuffers() {
+	return MVKDeviceTrackingMixin::isUsingMetalArgumentBuffers() && _canUseMetalArgumentBuffers;
+}
+
 MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
                                      const VkPipelineLayoutCreateInfo* pCreateInfo) : MVKVulkanAPIDeviceObject(device) {
+
+	_canUseMetalArgumentBuffers = false;
+	uint32_t dslCnt = pCreateInfo->setLayoutCount;
+	_descriptorSetLayouts.reserve(dslCnt);
+	for (uint32_t i = 0; i < dslCnt; i++) {
+		MVKDescriptorSetLayout* pDescSetLayout = (MVKDescriptorSetLayout*)pCreateInfo->pSetLayouts[i];
+		pDescSetLayout->retain();
+		_descriptorSetLayouts.push_back(pDescSetLayout);
+		_canUseMetalArgumentBuffers = _canUseMetalArgumentBuffers || pDescSetLayout->isUsingMetalArgumentBuffers();
+	}
 
 	// For pipeline layout compatibility (“compatible for set N”),
 	// consume the Metal resource indexes in this order:
@@ -150,10 +164,11 @@ MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
 	//   - Push constants
 	//   - Descriptor set content
 
-	// If we are using Metal argument buffers, consume a fixed number
-	// of buffer indexes for the Metal argument buffers themselves.
+	// If we are using Metal argument buffers, consume a number of
+	// buffer indexes covering all descriptor sets for the Metal
+	// argument buffers themselves.
 	if (isUsingMetalArgumentBuffers()) {
-		_mtlResourceCounts.addArgumentBuffers(kMVKMaxDescriptorSetCount);
+		_mtlResourceCounts.addArgumentBuffers(dslCnt);
 	}
 
 	// Add push constants from config
@@ -172,13 +187,8 @@ MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
 
 	// Add descriptor set layouts, accumulating the resource index offsets used by the corresponding DSL,
 	// and associating the current accumulated resource index offsets with each DSL as it is added.
-	uint32_t dslCnt = pCreateInfo->setLayoutCount;
-	_descriptorSetLayouts.reserve(dslCnt);
 	for (uint32_t i = 0; i < dslCnt; i++) {
-		MVKDescriptorSetLayout* pDescSetLayout = (MVKDescriptorSetLayout*)pCreateInfo->pSetLayouts[i];
-		pDescSetLayout->retain();
-		_descriptorSetLayouts.push_back(pDescSetLayout);
-
+		MVKDescriptorSetLayout* pDescSetLayout = _descriptorSetLayouts[i];
 		MVKShaderResourceBinding adjstdDSLRezOfsts = _mtlResourceCounts;
 		MVKShaderResourceBinding adjstdDSLRezCnts = pDescSetLayout->_mtlResourceCounts;
 		if (pDescSetLayout->isUsingMetalArgumentBuffers()) {


### PR DESCRIPTION
* Checks if any descriptor set layouts bound to a pipeline layout are actually using argument buffers before reserving any indices to bind them.
* Reduces the number of reserved indices for argument buffers to only the number of descriptor sets.

I was hitting limits on number of bind indices available because a fixed 8 are always reserved for argument buffers, even with only a single descriptor set using push descriptors (which do not use argument buffers). Mainly when tessellation is involved, it was unable to reserve indices for the output buffer.

Please let me know if there's anything I'm missing with this approach, I tested it in my application both as-is and with push descriptors disabled, and it seems to work fine.

Side note: It may be worth modifying the `maxPushDescriptors` property based on the number of potential reserved bindings needed, as it's what I use to determine whether to use push descriptors or not for a pipeline descriptor set layout. Advertising with the max possible number when in reality some may be taken away for argument buffers and other internal bindings can cause problems that could be avoided if the application knew to avoid using as many push descriptors. But I didn't delve into that in this PR.