### PR TITLE
MVKCmdDraw: Fix indirect index for triangle fan topology

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -112,19 +112,20 @@ void MVKCmdDraw::encodeIndexedIndirect(MVKCommandEncoder* cmdEncoder) {
 	auto* indirectIdxBuff = cmdEncoder->getTempMTLBuffer(indirectIdxBuffStride);
 	auto* pIndArg = (MTLDrawIndexedPrimitivesIndirectArguments*)indirectIdxBuff->getContents();
 	pIndArg->indexCount = _vertexCount;
-	pIndArg->indexStart = _firstVertex;
+	// let the indirect index point to the beginning of vertex index buffer below
+	pIndArg->indexStart = 0;
 	pIndArg->baseVertex = 0;
 	pIndArg->instanceCount = _instanceCount;
 	pIndArg->baseInstance = _firstInstance;
 
 	// Create an index buffer populated with synthetic indexes.
-	// Start populating indexes below _firstVertex so that indexes align with their corresponding vertexes
+	// Start populating indexes directly from the beginning and align with corresponding vertexes by adding _firstVertex
 	MTLIndexType mtlIdxType = MTLIndexTypeUInt32;
 	auto* vtxIdxBuff = cmdEncoder->getTempMTLBuffer(mvkMTLIndexTypeSizeInBytes(mtlIdxType) * _vertexCount);
 	auto* pIdxBuff = (uint32_t*)vtxIdxBuff->getContents();
-	uint32_t idxCnt = _firstVertex + _vertexCount;
-	for (uint32_t idx = 0; idx < idxCnt; idx++) {
-		pIdxBuff[idx] = idx;
+
+	for (uint32_t idx = 0; idx < _vertexCount; idx++) {
+		pIdxBuff[idx] = _firstVertex + idx;
 	}
 
 	MVKIndexMTLBufferBinding ibb;


### PR DESCRIPTION
When we call vkCmdDraw with vertexCount=N and firstVertex=X, we only need an array with N element, X, X+1, ..., X+N-1, to generate the indirect indices. However, the current logic generates all the way from 0 to X+N-1 (which is X+N elements) while only reserving N spaces. This causes issue when the unreserved part is overwritten, for example, when issuing consecutive draw calls with triangle fan primitives.

Fixes #2418 