### PR TITLE
Fix crash when shader validation is enabled.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -666,9 +666,14 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newMTLRenderPipelineState(
 id<MTLComputePipelineState> MVKCommandResourceFactory::newMTLComputePipelineState(const char* funcName,
 																				  MVKVulkanAPIDeviceObject* owner) {
 	id<MTLFunction> mtlFunc = newFunctionNamed(funcName);							// temp retain
+	// Providing a function directly may cause issues with Metal shader validation layer object
+	// management for some reason, so create a temporary pipeline descriptor to provide instead.
+	MTLComputePipelineDescriptor* plDesc = [MTLComputePipelineDescriptor new];		// temp retain
+	plDesc.computeFunction = mtlFunc;
 	MVKComputePipelineCompiler* plc = new MVKComputePipelineCompiler(owner);
-	id<MTLComputePipelineState> cps = plc->newMTLComputePipelineState(mtlFunc);		// retained
+	id<MTLComputePipelineState> cps = plc->newMTLComputePipelineState(plDesc);		// retained
 	plc->destroy();
+	[plDesc release];																// temp release
 	[mtlFunc release];																// temp release
     return cps;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -595,14 +595,6 @@ class MVKComputePipelineCompiler : public MVKMetalCompiler {
 public:
 
 	/**
-	 * Returns a new (retained) MTLComputePipelineState object compiled from the MTLFunction.
-	 *
-	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout
-	 * nanoseconds, an error will be generated and logged, and nil will be returned.
-	 */
-	id<MTLComputePipelineState> newMTLComputePipelineState(id<MTLFunction> mtlFunction);
-
-	/**
 	 * Returns a new (retained) MTLComputePipelineState object compiled from the MTLComputePipelineDescriptor.
 	 *
 	 * If the Metal pipeline compiler does not return within MVKConfiguration::metalCompileTimeout

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2823,23 +2823,6 @@ MVKRenderPipelineCompiler::~MVKRenderPipelineCompiler() {
 #pragma mark -
 #pragma mark MVKComputePipelineCompiler
 
-id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineState(id<MTLFunction> mtlFunction) {
-	unique_lock<mutex> lock(_completionLock);
-
-	compile(lock, ^{
-		auto mtlDev = getMTLDevice();
-		@synchronized (mtlDev) {
-			[mtlDev newComputePipelineStateWithFunction: mtlFunction
-									  completionHandler: ^(id<MTLComputePipelineState> ps, NSError* error) {
-										  bool isLate = compileComplete(ps, error);
-										  if (isLate) { destroy(); }
-									  }];
-		}
-	});
-
-	return [_mtlComputePipelineState retain];
-}
-
 id<MTLComputePipelineState> MVKComputePipelineCompiler::newMTLComputePipelineState(MTLComputePipelineDescriptor* plDesc) {
 	unique_lock<mutex> lock(_completionLock);
 


### PR DESCRIPTION
I didn't get any feedback on https://github.com/KhronosGroup/MoltenVK/issues/2416 whether this would be an acceptable fix, so I'm opening it as a PR in case it's wanted.

Basically it seems that for some reason when Metal shader validation is enabled, there may be a crash due to auto-release pool double-release on an `MTLComputePipelineDescriptorInternal`, but only when using `newComputePipelineStateWithFunction`. I'm not sure why this is happening or whether it's an internal Metal bug with the validation layer or MoltenVK's fault, but changing it to create a temporary `MTLComputePipelineDescriptor` and call `newComputePipelineStateWithDescriptor` resolves the issue for me.