### PR TITLE
MVKCmdWaitEvents: end current encoder before encodeWait

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -588,6 +588,7 @@ VkResult MVKCmdWaitEvents<N>::setContent(MVKCommandBuffer* cmdBuff,
 
 template <size_t N>
 void MVKCmdWaitEvents<N>::encode(MVKCommandEncoder* cmdEncoder) {
+	cmdEncoder->endCurrentMetalEncoding();
 	for (MVKEvent* mvkEvt : _mvkEvents) {
 		mvkEvt->encodeWait(cmdEncoder->_mtlCmdBuffer);
 	}


### PR DESCRIPTION
The Metal documentation for encodeWaitForEvent method says:

A command buffer can instruct the GPU to wait for an event only between passes, not within a pass. If a command buffer has an active encoder, finish using the encoder, call its endEncoding() method, and then call this method before creating another encoder.

We should obey this rule and call endEncoding when there can be active encoder around.

This should fix #2078.