### PR TITLE
Advertise VK_KHR_shader_terminate_invocation.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -273,6 +273,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_shader_non_semantic_info`
 - `VK_KHR_shader_subgroup_extended_types`
   - *Requires Metal 2.1 on Mac or Metal 2.2 and Apple family 4 on iOS.*
+- `VK_KHR_shader_terminate_invocation`
 - `VK_KHR_spirv_1_4`
 - `VK_KHR_storage_buffer_storage_class`
 - `VK_KHR_surface`

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -473,6 +473,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				formatFeatures->formatA4B4G4R4 = canSupport4444;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT: {
+				auto* depthFeatures = (VkPhysicalDeviceDepthClipControlFeaturesEXT*)next;
+				depthFeatures->depthClipControl = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
 				auto* extDynState = (VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*)next;
 				extDynState->extendedDynamicState = true;
@@ -580,11 +585,6 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				auto* divisorFeatures = (VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*)next;
 				divisorFeatures->vertexAttributeInstanceRateDivisor = true;
 				divisorFeatures->vertexAttributeInstanceRateZeroDivisor = true;
-				break;
-			}
-			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT: {
-				auto* depthFeatures = (VkPhysicalDeviceDepthClipControlFeaturesEXT*)next;
-				depthFeatures->depthClipControl = true;
 				break;
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -459,6 +459,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				shaderIntDotFeatures->shaderIntegerDotProduct = true;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR: {
+				auto* terminateFeatures = (VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR*)next;
+				terminateFeatures->shaderTerminateInvocation = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
 				auto* formatFeatures = (VkPhysicalDevice4444FormatsFeaturesEXT*)next;
 				bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering &&

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -64,6 +64,7 @@ MVK_DEVICE_FEATURE(VariablePointer,                   VARIABLE_POINTER,         
 MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,                    3)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
+MVK_DEVICE_FEATURE_EXTN(ShaderTerminateInvocation,    SHADER_TERMINATE_INVOCATION,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(4444Formats,                  4444_FORMATS,                    EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState,         EXTENDED_DYNAMIC_STATE,          EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState2,        EXTENDED_DYNAMIC_STATE_2,        EXT,   3)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -66,6 +66,7 @@ MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRI
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
 MVK_DEVICE_FEATURE_EXTN(ShaderTerminateInvocation,    SHADER_TERMINATE_INVOCATION,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(4444Formats,                  4444_FORMATS,                    EXT,   2)
+MVK_DEVICE_FEATURE_EXTN(DepthClipControl,             DEPTH_CLIP_CONTROL,              EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState,         EXTENDED_DYNAMIC_STATE,          EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState2,        EXTENDED_DYNAMIC_STATE_2,        EXT,   3)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState3,        EXTENDED_DYNAMIC_STATE_3,        EXT,  31)

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -89,6 +89,7 @@ MVK_EXTENSION(KHR_shader_float16_int8,                KHR_SHADER_FLOAT16_INT8,  
 MVK_EXTENSION(KHR_shader_integer_dot_product,         KHR_SHADER_INTEGER_DOT_PRODUCT,         DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_non_semantic_info,           KHR_SHADER_NON_SEMANTIC_INFO,           DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_subgroup_extended_types,     KHR_SHADER_SUBGROUP_EXTENDED_TYPES,     DEVICE,   10.14, 13.0,  1.0)
+MVK_EXTENSION(KHR_shader_terminate_invocation,        KHR_SHADER_TERMINATE_INVOCATION,        DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_spirv_1_4,                          KHR_SPIRV_1_4,                          DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_storage_buffer_storage_class,       KHR_STORAGE_BUFFER_STORAGE_CLASS,       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_surface,                            KHR_SURFACE,                            INSTANCE, 10.11,  8.0,  1.0)


### PR DESCRIPTION
`OpTerminateInvocation` is already handled in SPIRV-Cross identically to `OpKill`. Advertise support for the extension.