### PR TITLE
WIP: MVKDescriptor: Prevent batched write combined image-sampler from overwriting each other in argument buffer

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.h
@@ -449,6 +449,14 @@ public:
 			   size_t srcStride,
 			   const void* pData) override;
 
+	void writeCombined(MVKDescriptorSetLayoutBinding* mvkDSLBind,
+					   MVKDescriptorSet* mvkDescSet,
+					   uint32_t dstIdx,
+					   uint32_t srcIdx,
+					   size_t srcStride,
+					   const void* pData,
+					   uint32_t argStride);
+
 	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  MVKDescriptorSet* mvkDescSet,
 			  uint32_t dstIndex,
@@ -524,7 +532,8 @@ protected:
 			   uint32_t dstIdx,
 			   uint32_t srcIdx,
 			   size_t srcStride,
-			   const void* pData);
+			   const void* pData,
+			   uint32_t argStride = 1);
 
 	void read(MVKDescriptorSetLayoutBinding* mvkDSLBind,
 			  MVKDescriptorSet* mvkDescSet,


### PR DESCRIPTION
Currently samplerXXArray is translated to one textureXX_array and a single sampler in MSL, consuming 2 bindings in Metal regardless of the array size. This is already not an accurate translation. In the meantime, the descriptor set update does not consider the difference in numbers between the approaches. Despite the inaccuracy, the current solution "works" in some cases when not using argument buffers. They are broken when argument buffer is enabled.

The underlying reason is that image (texture) and sampler are in the same index space when used in argument buffers, and when updated in a batch (as sampler array) using combined image-sampler descriptor type, the sampler is overwritten by the next texture. This change avoids this kind of overwriting.

The ultimate solution would be properly implement texture/sampler arrays and account for the semantic differences between Vulkan and Metal in descriptor sets. But let's make it less broken first as the appropriate solution would require considerable effort.

Not a full fix, but addresses the symptom of #2403 .