### PR TITLE
Fix not saving shouldFixupClipSpace when serializing a pipeline.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2729,7 +2729,8 @@ namespace mvk {
 				opt.entryPointStage,
 				opt.tessPatchKind,
 				opt.numTessControlPoints,
-				opt.shouldFlipVertexY);
+				opt.shouldFlipVertexY,
+				opt.shouldFixupClipSpace);
 	}
 
 	template<class Archive>


### PR DESCRIPTION
Small fix pointed out in https://github.com/KhronosGroup/MoltenVK/pull/2430#issuecomment-2621122639; need to add `shouldFixupClipSpace` option to pipeline serialization.