### PR TITLE
PoC: MVKShaderLibrary: Handle specializtion with macros

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKShaderModule.h
@@ -86,7 +86,8 @@ public:
 
 	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
 					 const mvk::SPIRVToMSLConversionResultInfo& resultInfo,
-					 const MVKCompressor<std::string> compressedMSL);
+					 const MVKCompressor<std::string> compressedMSL,
+					 const std::vector<std::pair<uint32_t, uint32_t> >* spec_list = nullptr);
 
 	MVKShaderLibrary(MVKVulkanAPIDeviceObject* owner,
 					 const void* mslCompiledCodeData,
@@ -108,7 +109,8 @@ protected:
 								  MVKShaderModule* shaderModule);
 	void handleCompilationError(NSError* err, const char* opDesc);
     MTLFunctionConstant* getFunctionConstant(NSArray<MTLFunctionConstant*>* mtlFCs, NSUInteger mtlFCID);
-	void compileLibrary(const std::string& msl);
+	void compileLibrary(const std::string& msl,
+						const std::vector<std::pair<uint32_t, uint32_t> >* spec_list = nullptr);
 	void compressMSL(const std::string& msl);
 	void decompressMSL(std::string& msl);
 	MVKCompressor<std::string>& getCompressedMSL() { return _compressedMSL; }
@@ -117,6 +119,9 @@ protected:
 	id<MTLLibrary> _mtlLibrary;
 	MVKCompressor<std::string> _compressedMSL;
   mvk::SPIRVToMSLConversionResultInfo _shaderConversionResultInfo;
+
+	bool _specialized;
+	std::map<std::vector<std::pair<uint32_t, uint32_t> >, MVKShaderLibrary *> _spec_variants;
 };
 
 
@@ -260,7 +265,8 @@ public:
 	 * nanoseconds, an error will be generated and logged, and nil will be returned.
 	 */
 	id<MTLLibrary> newMTLLibrary(NSString* mslSourceCode,
-								 const mvk::SPIRVToMSLConversionResultInfo& shaderConversionResults);
+								 const mvk::SPIRVToMSLConversionResultInfo& shaderConversionResults,
+								 const std::vector<std::pair<uint32_t, uint32_t> >* spec_list = nullptr);
 
 
 #pragma mark Construction


### PR DESCRIPTION
The converted MSL may use macro instead of function constants to realize spirv specialization constant for various reasons (e.g. when the constant is used as array size).

In this case, we should define the macros at shader compilation stage and generate different variants of the metal shader library depending on macro-value mapping to make specializtion work properly when we cannot rely on metal's specialization.

The current version is hacky as it scans the shader for macro each time we create the function, and guesses the macro based on spirv-cross's habit. Ideally, we should obtain the information from spirv-cross instead.

Although the current form is not ready to merge but I would like to throw it in to see how people think about the approach. I would appreciate insights and suggestions on API design and coding as I'm not an objc guru or equipped with a good knowledge of how the internal API should be.

Fixes: #2423 