### PR TITLE
Store the residency set in MVKPhysicalDevice.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -41,6 +41,7 @@ id<MTLCommandQueue> MVKQueueFamily::getMTLCommandQueue(uint32_t queueIndex) {
 		@autoreleasepool {		// Catch any autoreleased objects created during MTLCommandQueue creation
 			uint32_t maxCmdBuffs = getMVKConfig().maxActiveMetalCommandBuffersPerQueue;
 			mtlQ = [_physicalDevice->getMTLDevice() newCommandQueueWithMaxCommandBufferCount: maxCmdBuffs];		// retained
+			_physicalDevice->addResidencySet(mtlQ);
 			_mtlQueues[queueIndex] = mtlQ;
 		}
 	}
@@ -339,7 +340,6 @@ void MVKQueue::initExecQueue() {
 // Retrieves and initializes the Metal command queue and Xcode GPU capture scopes
 void MVKQueue::initMTLCommandQueue() {
 	_mtlQueue = _queueFamily->getMTLCommandQueue(_index);	// not retained (cached in queue family)
-	_device->addResidencySet(_mtlQueue);
 
 	_submissionCaptureScope = new MVKGPUCaptureScope(this);
 	if (_queueFamily->getIndex() == getMVKConfig().defaultGPUCaptureScopeQueueFamilyIndex &&


### PR DESCRIPTION
@billhollings Attaching once to the MTLQueue seems like the more efficient thing to do, but on the other hand Metal presumably caches things and does not do big intersections repeatedly when the same set is attached to all command buffers. If we care about having separate sets for each device that's something to consider.

Fixes #2444 