### PR TITLE
MVKQueue: Remove residency set from MTLCommandQueue on destruction.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -854,6 +854,12 @@ public:
 #endif
 	}
 
+	void removeResidencySet(id<MTLCommandQueue> queue) {
+#if MVK_XCODE_16
+		if (_residencySet) [queue removeResidencySet:_residencySet];
+#endif
+	}
+
 	bool hasResidencySet() {
 #if MVK_XCODE_16
 		return _residencySet != nil;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -353,6 +353,7 @@ void MVKQueue::initMTLCommandQueue() {
 MVKQueue::~MVKQueue() {
 	destroyExecQueue();
 	_submissionCaptureScope->destroy();
+	_device->removeResidencySet(_mtlQueue);
 
 	[_mtlCmdBuffLabelBeginCommandBuffer release];
 	[_mtlCmdBuffLabelQueueSubmit release];


### PR DESCRIPTION
MTLCommandQueues are shared, we need to clean up so that we don't leak and hit the limit of residency sets per queue.

Supersedes #2448 

Fixes issue #2444.