### PR TITLE
Revert to fixed number of argument buffer binding reservations.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -161,7 +161,7 @@ MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
 
 	// For pipeline layout compatibility (“compatible for set N”),
 	// consume the Metal resource indexes in this order:
-	//   - An argument buffer for each descriptor set (if using Metal argument buffers).
+	//   - Fixed count of argument buffers for descriptor sets (if using Metal argument buffers).
 	//   - Push constants
 	//   - Descriptor set content
 
@@ -169,7 +169,7 @@ MVKPipelineLayout::MVKPipelineLayout(MVKDevice* device,
 	// buffer indexes covering all descriptor sets for the Metal
 	// argument buffers themselves.
 	if (isUsingMetalArgumentBuffers()) {
-		_mtlResourceCounts.addArgumentBuffers(dslCnt);
+		_mtlResourceCounts.addArgumentBuffers(kMVKMaxDescriptorSetCount);
 	}
 
 	// Add push constants from config


### PR DESCRIPTION
Partially reverts https://github.com/KhronosGroup/MoltenVK/pull/2417, restoring fixed argument buffer reservation count but only when argument buffers are used by any descriptor set.

I've found that this seems to break the "compatible for set N" rule when push constants are used and the application relies on not having to re-push them after changing pipelines. I got in a situation where, when a pipeline with N + 1 descriptor sets is followed later by pipelines with N descriptor sets, something with the way buffer bindings dirty state works for layout compatibility may end up re-binding that N + 1 argument buffer into the push constants slot that is now at N + 1. Then, since the push constants are not re-pushed, they are not updated by MoltenVK back into that slot. I think that reserving no slots in the case of no argument buffers should be fine, since redefining descriptor sets as push descriptors for example would break the compatibility rule and re-bind properly.

Maybe this could be investigated deeper and some changes figured out to allow optimizing the binding usage this way, but I wasn't able to figure something out that I was satisfied with. Most of what I was thinking of was either kind of intrusive with the push constant checks or would add extra push constant rebinds that could impact performance. So at least for now, I've opted to just revert this part of the change.