### PR TITLE
Fix Metal API violation when using VK_KHR_swapchain_mutable_format.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -483,17 +483,8 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 	mtlLayer.framebufferOnly = !mvkIsAnyFlagEnabled(pCreateInfo->imageUsage, (VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
 																			  VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 																			  VK_IMAGE_USAGE_SAMPLED_BIT |
-																			  VK_IMAGE_USAGE_STORAGE_BIT));
-
-	// Texture view creation is not allowed from framebufferOnly textures.
-	if (mtlLayer.framebufferOnly) {
-		for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
-			if (next->sType == VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO) {
-				mtlLayer.framebufferOnly = false;
-				break;
-			}
-		}
-	}
+																			  VK_IMAGE_USAGE_STORAGE_BIT)) &&
+								!mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR);
 
 	// Because of a regression in Metal, the most recent one or two presentations may not
 	// complete and call back. Changing the CAMetalLayer drawableSize will force any incomplete

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -485,6 +485,16 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 																			  VK_IMAGE_USAGE_SAMPLED_BIT |
 																			  VK_IMAGE_USAGE_STORAGE_BIT));
 
+	// Texture view creation is not allowed from framebufferOnly textures.
+	if (mtlLayer.framebufferOnly) {
+		for (const auto* next = (const VkBaseInStructure*)pCreateInfo->pNext; next; next = next->pNext) {
+			if (next->sType == VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO) {
+				mtlLayer.framebufferOnly = false;
+				break;
+			}
+		}
+	}
+
 	// Because of a regression in Metal, the most recent one or two presentations may not
 	// complete and call back. Changing the CAMetalLayer drawableSize will force any incomplete
 	// presentations on the oldSwapchain to complete and call back, but if the drawableSize


### PR DESCRIPTION
Texture view creation is not allowed from `framebufferOnly` textures. The flag should be disabled if texture view will be created from it.

Related: https://github.com/KhronosGroup/MoltenVK/issues/2261