### PR TITLE
Enable MVK_CONFIG_USE_MTLHEAP by default to support VK_EXT_image_2d_view_of_3d

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -652,16 +652,15 @@ This option is not available unless **MoltenVK** was built with `MVK_USE_METAL_P
 #### MVK_CONFIG_USE_MTLHEAP
 
 ##### Type: Boolean
-##### Default: `0`
+##### Default: `1`
 
 Controls whether **MoltenVK** should use `MTLHeaps` for allocating textures and buffers from device memory.
 If this setting is enabled, and placement `MTLHeaps` are available on the platform, **MoltenVK** will allocate a
 placement `MTLHeap` for each `VkDeviceMemory` instance, and allocate textures and buffers from that placement heap.
 If this parameter is disabled, **MoltenVK** will allocate textures and buffers from general device memory.
 
-Apple recommends that `MTLHeaps` should only be used for specific requirements such as aliasing or hazard tracking,
-and **MoltenVK** testing has shown that allocating multiple textures of different types or usages from one `MTLHeap`
-can occassionally cause corruption issues under certain circumstances.
+Vulkan extension `VK_EXT_image_2d_view_of_3d` requires this parameter to be enabled, 
+to allow aliasing of texture memory between the 3D image and the 2D view.
 
 
 ---------------------------------------
@@ -680,7 +679,6 @@ can occassionally cause corruption issues under certain circumstances.
 ##### Default: `1`
 
 Determines the style used to implement _Vulkan_ semaphore (`VkSemaphore`) functionality in _Metal_.
-
 
 In the special case of `VK_SEMAPHORE_TYPE_TIMELINE` semaphores, **MoltenVK** will always use
 `MTLSharedEvent` if it is available on the platform, regardless of the value of this parameter.

--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -308,6 +308,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_EXT_extended_dynamic_state3`
   - *Metal does not support `VK_POLYGON_MODE_POINT`*
 - `VK_EXT_external_memory_host`
+- `VK_EXT_external_memory_metal`
 - `VK_EXT_fragment_shader_interlock`
   - *Requires Metal 2.0 and Raster Order Groups.*
 - `VK_EXT_hdr_metadata`
@@ -368,7 +369,6 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_INTEL_shader_integer_functions2`
 - `VK_NV_fragment_shader_barycentric`
   - *Requires Metal 2.2 on Mac or Metal 2.3 on iOS.*
-- `VK_EXT_external_memory_metal`
 
 In order to visibly display your content on *macOS*, *iOS*, or *tvOS*, you must enable the
 `VK_EXT_metal_surface` extension, and use the function defined in that extension to create a

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -303,9 +303,9 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #  	define MVK_CONFIG_USE_COMMAND_POOLING    1
 #endif
 
-/** Use MTLHeaps where possible when allocating MTLBuffers and MTLTextures. Disabled by default. */
+/** Use MTLHeaps where possible when allocating MTLBuffers and MTLTextures. Enabled by default. */
 #ifndef MVK_CONFIG_USE_MTLHEAP
-#  	define MVK_CONFIG_USE_MTLHEAP    0
+#  	define MVK_CONFIG_USE_MTLHEAP    1
 #endif
 
 /** The Vulkan API version to advertise. Defaults to MVK_VULKAN_API_VERSION. */


### PR DESCRIPTION
- Enable `MVK_CONFIG_USE_MTLHEAP` by default to support `VK_EXT_image_2d_view_of_3d`.
- Alphabetize position of `VK_EXT_external_memory_metal` in `MoltenVK_Runtime_UserGuide.md` (unrelated).