### PR TITLE
Fix crash on vkGetDeviceImageMemoryRequirements().

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.h
@@ -43,7 +43,7 @@ public:
 	VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements);
 
 	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+	VkResult getMemoryRequirements(VkMemoryRequirements2* pMemoryRequirements);
 
 	/** Binds this resource to the specified offset within the specified memory allocation. */
 	VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -57,7 +57,7 @@ VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements* pMemoryRequireme
 	return VK_SUCCESS;
 }
 
-VkResult MVKBuffer::getMemoryRequirements(const void*, VkMemoryRequirements2* pMemoryRequirements) {
+VkResult MVKBuffer::getMemoryRequirements(VkMemoryRequirements2* pMemoryRequirements) {
 	pMemoryRequirements->sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
 	getMemoryRequirements(&pMemoryRequirements->memoryRequirements);
 	for (auto* next = (VkBaseOutStructure*)pMemoryRequirements->pNext; next; next = next->pNext) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -112,7 +112,7 @@ public:
     VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements);
 
     /** Returns the memory requirements of this resource by populating the specified structure. */
-    VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+    VkResult getMemoryRequirements(VkMemoryRequirements2* pMemoryRequirements);
 
     /** Binds this resource to the specified offset within the specified memory allocation. */
     VkResult bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOffset) override;
@@ -242,8 +242,8 @@ public:
 	VkResult getMemoryRequirements(VkMemoryRequirements* pMemoryRequirements, uint8_t planeIndex);
 
 	/** Returns the memory requirements of this resource by populating the specified structure. */
-	VkResult getMemoryRequirements(const void* pInfo, VkMemoryRequirements2* pMemoryRequirements);
-	
+	VkResult getMemoryRequirements(const VkImageMemoryRequirementsInfo2* pInfo, VkMemoryRequirements2* pMemoryRequirements);
+
 	VkResult getMemoryRequirements(VkMemoryRequirements2* pMemoryRequirements, uint8_t planeIndex);
 
 	/** Binds this resource to the specified offset within the specified memory allocation. */

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2208,7 +2208,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetBufferMemoryRequirements2(
 
 	MVKTraceVulkanCallStart();
     MVKBuffer* mvkBuff = (MVKBuffer*)pInfo->buffer;
-    mvkBuff->getMemoryRequirements(pInfo, pMemoryRequirements);
+    mvkBuff->getMemoryRequirements(pMemoryRequirements);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -2830,9 +2830,8 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetDeviceBufferMemoryRequirements(
 	
 	MVKTraceVulkanCallStart();
 	auto* mvkDev = MVKDevice::getMVKDevice(device);
-	auto* buffer = new MVKBuffer(mvkDev, pInfo->pCreateInfo);
-	buffer->getMemoryRequirements(nullptr, pMemoryRequirements);
-	buffer->destroy();
+	MVKBuffer mvkBuff(mvkDev, pInfo->pCreateInfo);
+	mvkBuff.getMemoryRequirements(pMemoryRequirements);
 	MVKTraceVulkanCallEnd();
 }
 
@@ -2843,9 +2842,8 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetDeviceImageMemoryRequirements(
 	
 	MVKTraceVulkanCallStart();
 	auto* mvkDev = MVKDevice::getMVKDevice(device);
-	auto* image = new MVKImage(mvkDev, pInfo->pCreateInfo);
-	image->getMemoryRequirements(pMemoryRequirements, MVKImage::getPlaneFromVkImageAspectFlags(pInfo->planeAspect));
-	image->destroy();
+	MVKImage mvkImg(mvkDev, pInfo->pCreateInfo);
+	mvkImg.getMemoryRequirements(pMemoryRequirements, MVKImage::getPlaneFromVkImageAspectFlags(pInfo->planeAspect));
 	MVKTraceVulkanCallEnd();
 }
 
@@ -2856,7 +2854,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkGetDeviceImageSparseMemoryRequirements(
 	VkSparseImageMemoryRequirements2*           pSparseMemoryRequirements) {
 	
 	MVKTraceVulkanCallStart();
-	// Metal does not support sparse images
+	// Sparse images are not currently supported
 	*pSparseMemoryRequirementCount = 0;
 	MVKTraceVulkanCallEnd();
 }


### PR DESCRIPTION
- `MVKImage::getMemoryRequirements()` fix access to memory bindings.
- Fix parameter declarations of `getMemoryRequirements()` on `MVKImageMemoryBinding`, `MVKImage`, and `MVKBuffer`.
- Use inline allocation for temp `MVKImage` in `vkGetDeviceImageMemoryRequirements()` and temp `MVKBuffer` in `vkGetDeviceBufferMemoryRequirements()`.