### PR TITLE
Fix a warning with subgroup size control

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -826,7 +826,7 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 				subgroupSizeProps->minSubgroupSize = _metalFeatures.minSubgroupSize;
 				subgroupSizeProps->maxSubgroupSize = _metalFeatures.maxSubgroupSize;
 				subgroupSizeProps->maxComputeWorkgroupSubgroups = _properties.limits.maxComputeWorkGroupInvocations / _metalFeatures.minSubgroupSize;
-				subgroupSizeProps->requiredSubgroupSizeStages = 0;
+				subgroupSizeProps->requiredSubgroupSizeStages = VK_SHADER_STAGE_COMPUTE_BIT;
 				break;
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES: {


### PR DESCRIPTION
Hello there ☺️ 

This PR is fixing a warning when trying to use `VK_EXT_subgroup_size_control` (even If I keep the default 32 size). Today, if this feature is enabled (while supported), it will generate the following warning:

```
[Error] Validation - vkCreateShaderModule(): SPIR-V Capability VulkanMemoryModel was declared, but one of the following requirements is required (VkPhysicalDeviceVulkan12Features::vulkanMemoryModel).
The Vulkan spec states: If pCode is a pointer to SPIR-V code, and pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.4.309.0/mac/antora/spec/latest/chapters/shaders.html#VUID-VkShaderModuleCreateInfo-pCode-08740)
[Error] Validation - (VK_OBJECT_TYPE_SHADER_MODULE) vkCreateComputePipelines(): pCreateInfos[0].stage SPIR-V (VK_SHADER_STAGE_COMPUTE_BIT) is not in requiredSubgroupSizeStages (VkShaderStageFlags(0)).
The Vulkan spec states: If a VkPipelineShaderStageRequiredSubgroupSizeCreateInfo structure is included in the pNext chain, the subgroupSizeControl feature must be enabled, and stage must be a valid bit specified in requiredSubgroupSizeStages (https://vulkan.lunarg.com/doc/view/1.4.309.0/mac/antora/spec/latest/chapters/pipelines.html#VUID-VkPipelineShaderStageCreateInfo-pNext-02755)
```

I'm not entirely sure, but I would thought that it is only relevant for compute shaders. So that's what this PR is adding (instead of 0).

Thanks!