### PR TITLE
[WIP] An attempt to allow Vulkan secondary command buffers to be encoded as Metal IndirectCommandBuffers

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
@@ -46,6 +46,10 @@ public:
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
 
+    MVKSmallVector<MVKMTLBufferBinding, N> getBufferBindings() {
+        return _bindings;
+    }
+
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
 
@@ -70,6 +74,10 @@ public:
 						VkIndexType indexType);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
+
+    MVKIndexMTLBufferBinding getBufferBinding() {
+        return _binding;
+    }
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
@@ -117,6 +125,7 @@ public:
 						uint32_t firstInstance);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
+    void encodeToICB(id<MTLIndirectRenderCommand> command, MVKIndexMTLBufferBinding ibb);
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -558,6 +558,17 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
     }
 }
 
+void MVKCmdDrawIndexed::encodeToICB(id<MTLIndirectRenderCommand> command, MVKIndexMTLBufferBinding ibb) {
+    [command drawIndexedPrimitives:MTLPrimitiveTypeTriangle
+                       indexCount:_indexCount
+                         indexType:(MTLIndexType)ibb.mtlIndexType
+                       indexBuffer:ibb.mtlBuffer
+                 indexBufferOffset:ibb.offset
+                     instanceCount:_instanceCount
+                        baseVertex:_vertexOffset
+                      baseInstance:_firstInstance];
+
+}
 
 // This is totally arbitrary, but we're forced to do this because we don't know how many vertices
 // there are at encoding time. And this will probably be inadequate for large instanced draws.

--- a/MoltenVK/MoltenVK/Commands/MVKCommand.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommand.h
@@ -67,6 +67,10 @@ public:
 	/** Encodes this command on the specified command encoder. */
 	virtual void encode(MVKCommandEncoder* cmdEncoder) = 0;
 
+    virtual void encodeToICB(id<MTLIndirectCommandBuffer> icb) {
+        throw "Kablooie!";
+    }
+
 protected:
 	friend MVKCommandBuffer;
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -217,6 +217,10 @@ protected:
 	bool _supportsConcurrentExecution;
 	bool _wasExecuted;
 	bool _hasStageCounterTimestampCommand;
+    id<MTLIndirectCommandBuffer> _icbIfSecondary = nil;
+                             MVKIndexMTLBufferBinding _icbIBB;
+                             MVKSmallVector<MVKMTLBufferBinding, 8> _icbVBB;
+
 };
 
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -658,6 +658,7 @@ id<MTLFunction> MVKCommandResourceFactory::newMTLFunction(NSString* mslSrcCode, 
 id<MTLRenderPipelineState> MVKCommandResourceFactory::newMTLRenderPipelineState(MTLRenderPipelineDescriptor* plDesc,
 																				MVKVulkanAPIDeviceObject* owner) {
 	MVKRenderPipelineCompiler* plc = new MVKRenderPipelineCompiler(owner);
+    plDesc.supportIndirectCommandBuffers = YES;
 	id<MTLRenderPipelineState> rps = plc->newMTLRenderPipelineState(plDesc);	// retained
 	plc->destroy();
     return rps;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -666,6 +666,7 @@ id<MTLRenderPipelineState> MVKGraphicsPipeline::getOrCompilePipeline(MTLRenderPi
 																	 id<MTLRenderPipelineState>& plState) {
 	if ( !plState ) {
 		MVKRenderPipelineCompiler* plc = new MVKRenderPipelineCompiler(this);
+        plDesc.supportIndirectCommandBuffers = YES;
 		plState = plc->newMTLRenderPipelineState(plDesc);	// retained
 		plc->destroy();
 		if ( !plState ) { _hasValidMTLPipelineStates = false; }
@@ -764,6 +765,7 @@ void MVKGraphicsPipeline::initMTLRenderPipelineState(const VkGraphicsPipelineCre
 	if (!isTessellationPipeline()) {
 		MTLRenderPipelineDescriptor* plDesc = newMTLRenderPipelineDescriptor(pCreateInfo, reflectData, pVertexSS, pVertexFB, pFragmentSS, pFragmentFB);	// temp retain
 		if (plDesc) {
+            plDesc.supportIndirectCommandBuffers = YES;
 			const VkPipelineRenderingCreateInfo* pRendInfo = getRenderingCreateInfo(pCreateInfo);
 			if (pRendInfo && mvkIsMultiview(pRendInfo->viewMask)) {
 				// We need to adjust the step rate for per-instance attributes to account for the
@@ -841,8 +843,9 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLRenderPipelineDescriptor
 	initShaderConversionConfig(shaderConfig, pCreateInfo, reflectData);
 
 	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// retained
+    plDesc.supportIndirectCommandBuffers = YES;
 
-	SPIRVShaderOutputs vtxOutputs;
+    SPIRVShaderOutputs vtxOutputs;
 	std::string errorLog;
 	if (!getShaderOutputs(((MVKShaderModule*)pVertexSS->module)->getSPIRV(), spv::ExecutionModelVertex, pVertexSS->pName, vtxOutputs, errorLog) ) {
 		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get vertex outputs: %s", errorLog.c_str()));
@@ -2836,6 +2839,8 @@ id<MTLRenderPipelineState> MVKRenderPipelineCompiler::newMTLRenderPipelineState(
 	compile(lock, ^{
 		auto mtlDev = getMTLDevice();
 		@synchronized (mtlDev) {
+            mtlRPLDesc.fr
+            mtlRPLDesc.supportIndirectCommandBuffers = YES;
 			[mtlDev newRenderPipelineStateWithDescriptor: mtlRPLDesc
 									   completionHandler: ^(id<MTLRenderPipelineState> ps, NSError* error) {
 										   bool isLate = compileComplete(ps, error);

--- a/MoltenVK/icd/MoltenVK_icd.json
+++ b/MoltenVK/icd/MoltenVK_icd.json
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.0.0",
     "ICD": {
-        "library_path": "./libMoltenVK.dylib",
+        "library_path": "/Users/oconnee/Library/Developer/Xcode/DerivedData/MoltenVKPackaging-eyiryupfgmhbbobgdgoqnimnvryt/Build/Products/Debug/libMoltenVK.dylib",
         "api_version" : "1.2.0",
         "is_portability_driver" : true
     }


### PR DESCRIPTION
Following on from #2247 I finally took a very naive stab at this. Things appear to be more or less working up until the point where I have a fragment shader that takes an array of textures (or perhaps even a single texture) as input, which fails with this log under Metal API Validation:

```
[mvk-error] VK_ERROR_INITIALIZATION_FAILED: Render pipeline compile failed (Error code 3):
Fragment shader cannot be used with indirect command buffers.
-[MTLDebugRenderCommandEncoder setRenderPipelineState:]:1604: failed assertion `Set Render Pipeline State Validation
renderPipelineState must not be nil.
```

There are several deficiencies with the code I'm submitting here -- my eyes are wide open, I assure you -- and that's discounting all the problems I don't even know that I have yet ;) 

I'm opening this mostly as a plea for help, since I would love to get to a point where I could selectively enable ICBs for specific pipelines, so that any of the incompatible shaders would not be opted in to `supportIndirectCommandBuffers`. My use case is very specific, which should in theory mostly work by means of `inheritBuffers`, but a true implementation would need to be much more robust -- in theory if I could avoid requesting `supportIndirectCommandBuffers` except for one pipeline I believe this would actually be sufficient for me (but not anyone else :)

What else should I be aware of? Obviously there are some definite code-quality improvements to be made here :) 