### PR TITLE
Revert use of size 1 for variable length arrays in shader.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptor.mm
@@ -531,9 +531,10 @@ void MVKDescriptorSetLayoutBinding::encodeImmutableSamplersToMetalArgumentBuffer
 void MVKDescriptorSetLayoutBinding::populateShaderConversionConfig(mvk::SPIRVToMSLConversionConfiguration& shaderConfig,
                                                                    MVKShaderResourceBinding& dslMTLRezIdxOffsets,
                                                                    uint32_t dslIndex) {
-	// For argument buffers, set variable length arrays to length 1 in shader.
 	bool isUsingMtlArgBuff = _layout->isUsingMetalArgumentBuffers();
-	uint32_t descCnt = isUsingMtlArgBuff ? getDescriptorCount(1) : getDescriptorCount();
+	// Previously this would set variable length array sizes to 1 for argument buffers.
+	// However, this no longer works on M1 and M2 GPUs, so use the full length.
+	uint32_t descCnt = getDescriptorCount();
 
 	// Establish the resource indices to use, by combining the offsets of the DSL and this DSL binding.
     MVKShaderResourceBinding mtlIdxs = _mtlResourceIndexOffsets + dslMTLRezIdxOffsets;


### PR DESCRIPTION
Reverts part of https://github.com/KhronosGroup/MoltenVK/pull/2273 that set variable length arrays in argument buffers to size 1 in shaders.

This seems to be the cause behind various recent issues with argument buffers (https://github.com/KhronosGroup/MoltenVK/issues/2480, https://github.com/KhronosGroup/MoltenVK/issues/2453, probably https://github.com/KhronosGroup/MoltenVK/issues/2300). It seems that using an array of size 1 for variable length arrays may have been partially broken before, and is now completely broken as of macOS 15.4 on M1 and M2 systems. I verified on M1 myself that with this partial revert in place, my application works perfectly instead of immediately hitting a GPU page fault, and that it still works fine on M4.

As I understand, this may trigger some Metal validation errors from the shader size being larger than the contents, but does actually work across GPU families, unlike the current solution. I'm open to more discussion on this but felt that it makes sense to fix the issue the easy way first to get things actually functioning again, and then it can be further improved and optimized down the line in a way that continues to work everywhere.