### PR TITLE
Allow the proc address of vkGetMoltenVKConfigurationMVK() to be retrieved before a VkInstance has been created.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -59,6 +59,7 @@ Released TBD
 - Fix a crash when searching the first enabled bit in a completely disabled bit array.
 - When logging a pipeline layout, log contained descriptor set layouts.
 - Add debug labels to barrier fences.
+- Allow the proc address of `vkGetMoltenVKConfigurationMVK()` to be retrieved before a `VkInstance` has been created.
 - GitHub CI update legacy build to _macOS 13 / Xcode 14_.
 - Fix compile with `MVK_USE_CEREAL=0`.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -495,7 +495,6 @@ void MVKInstance::initProcAddrs() {
 #endif
 
 	// MoltenVK-specific instannce functions, not tied to a Vulkan API version or an extension.
-	ADD_INST_OPEN_ENTRY_POINT(vkGetMoltenVKConfigurationMVK);
 	ADD_INST_OPEN_ENTRY_POINT(vkGetPhysicalDeviceMetalFeaturesMVK);
 	ADD_INST_OPEN_ENTRY_POINT(vkGetPerformanceStatisticsMVK);
 

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
@@ -167,7 +167,7 @@ VkResult MVKExtensionList::enable(uint32_t count, const char* const* names, cons
 			enable(extnName);
 			if (mvkStringsAreEqual(extnName, VK_MVK_MOLTENVK_EXTENSION_NAME)) {
 				reportMessage(MVK_CONFIG_LOG_LEVEL_WARNING, "Extension %s is deprecated. For access to Metal objects, use extension %s. "
-							  "For MoltenVK configuration, use the global vkGetMoltenVKConfigurationMVK() and vkSetMoltenVKConfigurationMVK() functions.",
+							  "For MoltenVK configuration, use the VK_EXT_layer_settings extension or environment variables.",
 							  VK_MVK_MOLTENVK_EXTENSION_NAME, VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
 			}
 		}

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -321,6 +321,8 @@ MVK_PUBLIC_SYMBOL PFN_vkVoidFunction vkGetInstanceProcAddr(
 		func = (PFN_vkVoidFunction)vkEnumerateInstanceLayerProperties;
 	} else if (mvkStringsAreEqual(pName, "vkEnumerateInstanceVersion")) {
 		func = (PFN_vkVoidFunction)vkEnumerateInstanceVersion;
+	} else if (mvkStringsAreEqual(pName, "vkGetMoltenVKConfigurationMVK")) {
+		func = (PFN_vkVoidFunction)vkGetMoltenVKConfigurationMVK;
 	} else if (instance) {
 		MVKInstance* mvkInst = MVKInstance::getMVKInstance(instance);
 		func = mvkInst->getProcAddr(pName);


### PR DESCRIPTION
Completes #2479.