### PR TITLE
Support for KHR_shader_expect_assume

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -270,6 +270,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_sampler_ycbcr_conversion`
 - `VK_KHR_separate_depth_stencil_layouts`
 - `VK_KHR_shader_draw_parameters`
+- `VK_KHR_shader_expect_assume`
 - `VK_KHR_shader_float_controls`
 - `VK_KHR_shader_float16_int8`
 - `VK_KHR_shader_integer_dot_product`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -21,6 +21,7 @@ Released TBD
 - Add support for _Vulkan 1.3_.
 - Add support for extensions:
 	- `VK_KHR_maintenance4`
+	- `VK_KHR_shader_expect_assume`
 	- `VK_KHR_shader_subgroup_rotate`
 	- `VK_KHR_shader_terminate_invocation`
 	- `VK_KHR_vulkan_memory_model`

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -492,6 +492,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				portabilityFeatures->vertexAttributeAccessBeyondStride = true;	// Costs additional buffers. Should make configuration switch.
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES: {
+				auto* shaderExpectAssume = (VkPhysicalDeviceShaderExpectAssumeFeatures*)next;
+				shaderExpectAssume->shaderExpectAssume = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES_KHR: {
 				auto* shaderSGRotateFeatures = (VkPhysicalDeviceShaderSubgroupRotateFeaturesKHR*)next;
 				shaderSGRotateFeatures->shaderSubgroupRotate = _metalFeatures.simdPermute || _metalFeatures.quadPermute;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -69,6 +69,7 @@ MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,      
 MVK_DEVICE_FEATURE(ZeroInitializeWorkgroupMemory,     ZERO_INITIALIZE_WORKGROUP_MEMORY,       1)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
+MVK_DEVICE_FEATURE_EXTN(ShaderExpectAssume,           SHADER_EXPECT_ASSUME,            KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(ShaderSubgroupRotate,         SHADER_SUBGROUP_ROTATE,          KHR,   2)
 MVK_DEVICE_FEATURE_EXTN(4444Formats,                  4444_FORMATS,                    EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(DepthClipControl,             DEPTH_CLIP_CONTROL,              EXT,   1)

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -85,6 +85,7 @@ MVK_EXTENSION(KHR_sampler_ycbcr_conversion,           KHR_SAMPLER_YCBCR_CONVERSI
 MVK_EXTENSION(KHR_separate_depth_stencil_layouts,     KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS,     DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_atomic_int64,                KHR_SHADER_ATOMIC_INT64,                DEVICE,   MVK_NA, MVK_NA, MVK_NA)
 MVK_EXTENSION(KHR_shader_draw_parameters,             KHR_SHADER_DRAW_PARAMETERS,             DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_shader_expect_assume,               KHR_SHADER_EXPECT_ASSUME,               DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_float_controls,              KHR_SHADER_FLOAT_CONTROLS,              DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_float16_int8,                KHR_SHADER_FLOAT16_INT8,                DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_shader_integer_dot_product,         KHR_SHADER_INTEGER_DOT_PRODUCT,         DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
Adds support for the `VK_KHR_shader_expect_assume` extension, which is required for [Vulkan 1.4](https://github.com/KhronosGroup/MoltenVK/issues/2490). Tbh I haven't tested this at runtime yet, but it compiles :sparkles:

See https://github.com/KhronosGroup/SPIRV-Cross/pull/2466