### PR TITLE
Add support for VK_KHR_maintenance6

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -261,6 +261,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_maintenance2`
 - `VK_KHR_maintenance3`
 - `VK_KHR_maintenance4`
+- `VK_KHR_maintenance6`
 - `VK_KHR_map_memory2`
 - `VK_KHR_multiview`
 - `VK_KHR_portability_subset`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
 - Add support for extensions:
 	- `VK_KHR_load_store_op_none`
 	- `VK_KHR_maintenance4`
+	- `VK_KHR_maintenance6`
 	- `VK_KHR_shader_expect_assume`
 	- `VK_KHR_shader_subgroup_rotate`
 	- `VK_KHR_shader_terminate_invocation`

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -96,7 +96,19 @@ VkResult MVKBuffer::bindDeviceMemory(MVKDeviceMemory* mvkMem, VkDeviceSize memOf
 }
 
 VkResult MVKBuffer::bindDeviceMemory2(const VkBindBufferMemoryInfo* pBindInfo) {
-	return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset);
+	VkResult res = bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset);
+	for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next; next = next->pNext) {
+		switch (next->sType) {
+			case VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS: {
+				auto* pBindMemoryStatus = (const VkBindMemoryStatus*)next;
+				*(pBindMemoryStatus->pResult) = res;
+				break;
+			}
+			default:
+				break;
+		}
+	}
+	return res;
 }
 
 void MVKBuffer::applyMemoryBarrier(MVKPipelineBarrier& barrier,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -492,6 +492,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				barycentricFeatures->fragmentShaderBarycentric = true;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR: {
+				auto* maintenance6Features = (VkPhysicalDeviceMaintenance6FeaturesKHR*)next;
+				maintenance6Features->maintenance6 = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
 				auto* portabilityFeatures = (VkPhysicalDevicePortabilitySubsetFeaturesKHR*)next;
 				portabilityFeatures->constantAlphaColorBlendFactors = true;
@@ -971,6 +976,13 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR: {
                 auto* barycentricProperties = (VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*)next;
                 barycentricProperties->triStripVertexOrderIndependentOfProvokingVertex = false;
+                break;
+            }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR: {
+                auto* maintenance6Properties = (VkPhysicalDeviceMaintenance6PropertiesKHR*)next;
+                maintenance6Properties->blockTexelViewCompatibleMultipleLayers = false;
+                maintenance6Properties->maxCombinedImageSamplerDescriptorCount = 3;
+                maintenance6Properties->fragmentShadingRateClampCombinerInputs = false;
                 break;
             }
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -68,6 +68,7 @@ MVK_DEVICE_FEATURE(VariablePointer,                   VARIABLE_POINTER,         
 MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,                    3)
 MVK_DEVICE_FEATURE(ZeroInitializeWorkgroupMemory,     ZERO_INITIALIZE_WORKGROUP_MEMORY,       1)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
+MVK_DEVICE_FEATURE_EXTN(Maintenance6,                 MAINTENANCE_6,                   KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
 MVK_DEVICE_FEATURE_EXTN(ShaderExpectAssume,           SHADER_EXPECT_ASSUME,            KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(ShaderSubgroupRotate,         SHADER_SUBGROUP_ROTATE,          KHR,   2)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -942,7 +942,19 @@ VkResult MVKImage::bindDeviceMemory2(const VkBindImageMemoryInfo* pBindInfo) {
                 break;
         }
     }
-    return bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset, planeIndex);
+    VkResult res = bindDeviceMemory((MVKDeviceMemory*)pBindInfo->memory, pBindInfo->memoryOffset, planeIndex);
+    for (const auto* next = (const VkBaseInStructure*)pBindInfo->pNext; next; next = next->pNext) {
+        switch (next->sType) {
+            case VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS: {
+                auto* pBindMemoryStatus = (const VkBindMemoryStatus*)next;
+                *(pBindMemoryStatus->pResult) = res;
+                break;
+            }
+            default:
+                break;
+        }
+    }
+    return res;
 }
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.h
@@ -38,13 +38,15 @@ typedef struct MVKEntryPoint {
 	uint32_t apiVersion;
 	const char* ext1Name;
 	const char* ext2Name;
+	const char* ext3Name;
 	bool isDevice;
 
-	bool isCore() { return !ext1Name && !ext2Name; }
+	bool isCore() { return !ext1Name && !ext2Name && !ext3Name; }
 	bool isEnabled(uint32_t enabledVersion, const MVKExtensionList& extList, const MVKExtensionList* instExtList = nullptr) {
 		bool isAPISupported = MVK_VULKAN_API_VERSION_CONFORM(enabledVersion) >= apiVersion;
 		auto isExtnSupported = [this, isAPISupported](const MVKExtensionList& extList) {
-			return extList.isEnabled(this->ext1Name) && (isAPISupported || !this->ext2Name || extList.isEnabled(this->ext2Name));
+			return extList.isEnabled(this->ext1Name) && (isAPISupported ||
+					((!this->ext2Name || extList.isEnabled(this->ext2Name)) && (!this->ext3Name || extList.isEnabled(this->ext3Name))));
 		};
 		return ((isCore() && isAPISupported) ||
 				isExtnSupported(extList) ||

--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -394,55 +394,68 @@ void MVKInstance::initMVKConfig(const VkInstanceCreateInfo* pCreateInfo) {
 	mvkSetConfig(_mvkConfig, _mvkConfig, _mvkConfigStringHolders);
 }
 
-#define ADD_ENTRY_POINT_MAP(name, func, api, ext1, ext2, isDev)	\
-	_entryPoints[""#name] = { (PFN_vkVoidFunction)&func, api, ext1,  ext2,  isDev }
+#define ADD_ENTRY_POINT_MAP(name, func, api, ext1, ext2, ext3, isDev)	\
+	_entryPoints[""#name] = { (PFN_vkVoidFunction)&func, api, ext1,  ext2,  ext3,  isDev }
 
-#define ADD_ENTRY_POINT(func, api, ext1, ext2, isDev)	ADD_ENTRY_POINT_MAP(func, func, api, ext1, ext2, isDev)
+#define ADD_ENTRY_POINT(func, api, ext1, ext2, ext3, isDev)	ADD_ENTRY_POINT_MAP(func, func, api, ext1, ext2, ext3, isDev)
 
-#define ADD_INST_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, false)
-#define ADD_DVC_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, true)
+#define ADD_INST_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, nullptr, false)
+#define ADD_DVC_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, VK_API_VERSION_1_0, nullptr, nullptr, nullptr, true)
 
 // Add a core function.
-#define ADD_INST_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, false)
-#define ADD_INST_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, false)
-#define ADD_DVC_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, true)
-#define ADD_DVC_1_2_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_2, nullptr, nullptr, true)
-#define ADD_DVC_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, true)
+#define ADD_INST_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, nullptr, false)
+#define ADD_INST_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, nullptr, false)
+#define ADD_DVC_1_1_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_1, nullptr, nullptr, nullptr, true)
+#define ADD_DVC_1_2_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_2, nullptr, nullptr, nullptr, true)
+#define ADD_DVC_1_3_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_3, nullptr, nullptr, nullptr, true)
+#define ADD_DVC_1_4_ENTRY_POINT(func)					ADD_ENTRY_POINT(func, VK_API_VERSION_1_4, nullptr, nullptr, nullptr, true)
 
 // Add both the promoted core function and the extension function.
 #define ADD_INST_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
 	ADD_INST_1_1_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, false)
 
 #define ADD_DVC_1_1_PROMOTED_ENTRY_POINT(func, EXT)	\
 	ADD_DVC_1_1_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
 
 #define ADD_DVC_1_2_PROMOTED_ENTRY_POINT(func, suffix, EXT) \
 	ADD_DVC_1_2_ENTRY_POINT(func); \
-	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
 
 #define ADD_INST_1_3_PROMOTED_ENTRY_POINT(func, EXT)	\
 	ADD_INST_1_3_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
+	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, false)
 
 #define ADD_DVC_1_3_PROMOTED_ENTRY_POINT(func, suffix, EXT) \
 	ADD_DVC_1_3_ENTRY_POINT(func); \
-	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
+
+#define ADD_DVC_1_4_PROMOTED_ENTRY_POINT(func, suffix, EXT) \
+	ADD_DVC_1_4_ENTRY_POINT(func); \
+	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
+
+#define ADD_DVC_1_4_PROMOTED2_ENTRY_POINT(func, suffix, EXT1, EXT2) \
+	ADD_DVC_1_4_ENTRY_POINT(func); \
+	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, nullptr, true)
+
+#define ADD_DVC_1_4_PROMOTED3_ENTRY_POINT(func, suffix, EXT1, EXT2, EXT3) \
+	ADD_DVC_1_4_ENTRY_POINT(func); \
+	ADD_ENTRY_POINT_MAP(func##suffix, func, 0, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, VK_##EXT3##_EXTENSION_NAME, true)
 
 // Add an extension function.
-#define ADD_INST_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
-#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_INST_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, false)
+#define ADD_DVC_EXT_ENTRY_POINT(func, EXT)					ADD_ENTRY_POINT(func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
 
-#define ADD_INST_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)	ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, false)
-#define ADD_DVC_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)		ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, true)
+#define ADD_INST_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)	ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, nullptr, false)
+#define ADD_DVC_EXT2_ENTRY_POINT(func, API, EXT1, EXT2)		ADD_ENTRY_POINT(func, VK_API_VERSION_##API, VK_##EXT1##_EXTENSION_NAME, VK_##EXT2##_EXTENSION_NAME, nullptr, true)
 
-#define ADD_INST_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)	ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, false)
-#define ADD_DVC_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)		ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, true)
+#define ADD_INST_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)	ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, false)
+#define ADD_DVC_EXT_ENTRY_POINT_ALIAS(alias, func, EXT)		ADD_ENTRY_POINT_MAP(alias, func, 0, VK_##EXT##_EXTENSION_NAME, nullptr, nullptr, true)
 
 // Add an open function, not tied to core or an extension.
-#define ADD_INST_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, false)
-#define ADD_DVC_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, true)
+#define ADD_INST_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, nullptr, false)
+#define ADD_DVC_OPEN_ENTRY_POINT(func)						ADD_ENTRY_POINT(func, 0, nullptr, nullptr, nullptr, true)
 
 // Initializes the function pointer map.
 void MVKInstance::initProcAddrs() {
@@ -717,6 +730,20 @@ void MVKInstance::initProcAddrs() {
 	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkSetPrivateData, EXT, EXT_PRIVATE_DATA);
 	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceToolProperties, EXT, EXT_TOOLING_INFO);
 
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkMapMemory2, KHR, KHR_MAP_MEMORY_2);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkUnmapMemory2, KHR, KHR_MAP_MEMORY_2);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCmdBindDescriptorSets2, KHR, KHR_MAINTENANCE_6);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCmdPushConstants2, KHR, KHR_MAINTENANCE_6);
+	ADD_DVC_1_4_PROMOTED2_ENTRY_POINT(vkCmdPushDescriptorSet2, KHR, KHR_MAINTENANCE_6, KHR_PUSH_DESCRIPTOR);
+	ADD_DVC_1_4_PROMOTED3_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplate2, KHR, KHR_MAINTENANCE_6, KHR_PUSH_DESCRIPTOR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCmdPushDescriptorSet, KHR, KHR_PUSH_DESCRIPTOR);
+	ADD_DVC_1_4_PROMOTED2_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplate, KHR, KHR_PUSH_DESCRIPTOR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCopyImageToImage, EXT, EXT_HOST_IMAGE_COPY);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCopyImageToMemory, EXT, EXT_HOST_IMAGE_COPY);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCopyMemoryToImage, EXT, EXT_HOST_IMAGE_COPY);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkGetImageSubresourceLayout2, EXT, EXT_HOST_IMAGE_COPY);
+	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkTransitionImageLayout, EXT, EXT_HOST_IMAGE_COPY);
+
 	// Device extension functions.
 	ADD_DVC_EXT_ENTRY_POINT(vkGetCalibratedTimestampsKHR, KHR_CALIBRATED_TIMESTAMPS);
 	ADD_DVC_EXT_ENTRY_POINT(vkGetPhysicalDeviceCalibrateableTimeDomainsKHR, KHR_CALIBRATED_TIMESTAMPS);
@@ -725,10 +752,6 @@ void MVKInstance::initProcAddrs() {
     ADD_DVC_EXT_ENTRY_POINT(vkDestroyDeferredOperationKHR, KHR_DEFERRED_HOST_OPERATIONS);
     ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationMaxConcurrencyKHR, KHR_DEFERRED_HOST_OPERATIONS);
     ADD_DVC_EXT_ENTRY_POINT(vkGetDeferredOperationResultKHR, KHR_DEFERRED_HOST_OPERATIONS);
-	ADD_DVC_EXT_ENTRY_POINT(vkMapMemory2KHR, KHR_MAP_MEMORY_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkUnmapMemory2KHR, KHR_MAP_MEMORY_2);
-	ADD_DVC_EXT_ENTRY_POINT(vkCmdPushDescriptorSetKHR, KHR_PUSH_DESCRIPTOR);
-	ADD_DVC_EXT2_ENTRY_POINT(vkCmdPushDescriptorSetWithTemplateKHR, 1_1, KHR_PUSH_DESCRIPTOR, KHR_DESCRIPTOR_UPDATE_TEMPLATE);
 	ADD_DVC_EXT_ENTRY_POINT(vkCreateSwapchainKHR, KHR_SWAPCHAIN);
 	ADD_DVC_EXT_ENTRY_POINT(vkDestroySwapchainKHR, KHR_SWAPCHAIN);
 	ADD_DVC_EXT_ENTRY_POINT(vkGetSwapchainImagesKHR, KHR_SWAPCHAIN);
@@ -776,11 +799,6 @@ void MVKInstance::initProcAddrs() {
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleLocationsEnableEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetSampleMaskEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
 	ADD_DVC_EXT_ENTRY_POINT(vkCmdSetTessellationDomainOriginEXT, EXT_EXTENDED_DYNAMIC_STATE_3);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToImageEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyImageToMemoryEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkCopyMemoryToImageEXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkGetImageSubresourceLayout2EXT, EXT_HOST_IMAGE_COPY);
-	ADD_DVC_EXT_ENTRY_POINT(vkTransitionImageLayoutEXT, EXT_HOST_IMAGE_COPY);
 	ADD_DVC_EXT_ENTRY_POINT(vkGetMemoryMetalHandleEXT, EXT_EXTERNAL_MEMORY_METAL);
 	ADD_DVC_EXT_ENTRY_POINT(vkGetMemoryMetalHandlePropertiesEXT, EXT_EXTERNAL_MEMORY_METAL);
 }

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -76,6 +76,7 @@ MVK_EXTENSION(KHR_maintenance1,                       KHR_MAINTENANCE1,         
 MVK_EXTENSION(KHR_maintenance2,                       KHR_MAINTENANCE2,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance3,                       KHR_MAINTENANCE3,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance4,                       KHR_MAINTENANCE_4,                      DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_maintenance6,                       KHR_MAINTENANCE_6,                      DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_map_memory2,                        KHR_MAP_MEMORY_2,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_multiview,                          KHR_MULTIVIEW,                          DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_portability_subset,                 KHR_PORTABILITY_SUBSET,                 DEVICE,   10.11,  8.0,  1.0)

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2917,6 +2917,187 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetPrivateData(
 
 
 #pragma mark -
+#pragma mark Vulkan 1.4 calls
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkMapMemory2(
+    VkDevice device,
+    const VkMemoryMapInfoKHR* pMemoryMapInfo,
+    void** ppData) {
+
+    MVKTraceVulkanCallStart();
+    MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMemoryMapInfo->memory;
+    VkResult rslt = mvkMem->map(pMemoryMapInfo, ppData);
+    MVKTraceVulkanCallEnd();
+    return rslt;
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkUnmapMemory2(
+    VkDevice device,
+    const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo) {
+
+    MVKTraceVulkanCallStart();
+    MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMemoryUnmapInfo->memory;
+    VkResult rslt = mvkMem->unmap(pMemoryUnmapInfo);
+    MVKTraceVulkanCallEnd();
+    return rslt;
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdBindDescriptorSets2(
+    VkCommandBuffer                             commandBuffer,
+    const VkBindDescriptorSetsInfo*             pBindDescriptorSetsInfo) {
+
+	MVKTraceVulkanCallStart();
+	// If stageFlags specifies a subset of all stages corresponding to one or more pipeline bind points,
+	// the binding operation still affects all stages corresponding to the given pipeline bind point(s)
+	// as if the equivalent original version of this command had been called with the same parameters.
+	if (pBindDescriptorSetsInfo->stageFlags & VK_SHADER_STAGE_ALL_GRAPHICS) {
+		if (pBindDescriptorSetsInfo->dynamicOffsetCount) {
+			MVKAddCmdFromThreshold(BindDescriptorSetsDynamic, pBindDescriptorSetsInfo->descriptorSetCount, 4, commandBuffer,
+					VK_PIPELINE_BIND_POINT_GRAPHICS, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+					pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets, pBindDescriptorSetsInfo->dynamicOffsetCount,
+					pBindDescriptorSetsInfo->pDynamicOffsets);
+		} else {
+			MVKAddCmdFrom2Thresholds(BindDescriptorSetsStatic, pBindDescriptorSetsInfo->descriptorSetCount, 1, 4, commandBuffer,
+					VK_PIPELINE_BIND_POINT_GRAPHICS, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+					pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets);
+		}
+	}
+	if (pBindDescriptorSetsInfo->stageFlags & VK_SHADER_STAGE_COMPUTE_BIT) {
+		if (pBindDescriptorSetsInfo->dynamicOffsetCount) {
+			MVKAddCmdFromThreshold(BindDescriptorSetsDynamic, pBindDescriptorSetsInfo->descriptorSetCount, 4, commandBuffer,
+					VK_PIPELINE_BIND_POINT_COMPUTE, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+					pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets, pBindDescriptorSetsInfo->dynamicOffsetCount,
+					pBindDescriptorSetsInfo->pDynamicOffsets);
+		} else {
+			MVKAddCmdFrom2Thresholds(BindDescriptorSetsStatic, pBindDescriptorSetsInfo->descriptorSetCount, 1, 4, commandBuffer,
+					VK_PIPELINE_BIND_POINT_COMPUTE, pBindDescriptorSetsInfo->layout, pBindDescriptorSetsInfo->firstSet,
+					pBindDescriptorSetsInfo->descriptorSetCount, pBindDescriptorSetsInfo->pDescriptorSets);
+		}
+	}
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushConstants2(
+    VkCommandBuffer                             commandBuffer,
+    const VkPushConstantsInfo*                  pPushConstantsInfo) {
+
+	MVKTraceVulkanCallStart();
+	MVKAddCmdFrom2Thresholds(PushConstants, pPushConstantsInfo->size, 64, 128, commandBuffer, pPushConstantsInfo->layout,
+				  pPushConstantsInfo->stageFlags, pPushConstantsInfo->offset, pPushConstantsInfo->size, pPushConstantsInfo->pValues);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSet2(
+    VkCommandBuffer                             commandBuffer,
+    const VkPushDescriptorSetInfo*              pPushDescriptorSetInfo) {
+
+	MVKTraceVulkanCallStart();
+	// If stageFlags specifies a subset of all stages corresponding to one or more pipeline bind points,
+	// the binding operation still affects all stages corresponding to the given pipeline bind point(s)
+	// as if the equivalent original version of this command had been called with the same parameters.
+	if (pPushDescriptorSetInfo->stageFlags & VK_SHADER_STAGE_ALL_GRAPHICS) {
+		MVKAddCmd(PushDescriptorSet, commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pPushDescriptorSetInfo->layout,
+				pPushDescriptorSetInfo->set, pPushDescriptorSetInfo->descriptorWriteCount, pPushDescriptorSetInfo->pDescriptorWrites);
+	}
+	if (pPushDescriptorSetInfo->stageFlags & VK_SHADER_STAGE_COMPUTE_BIT) {
+		MVKAddCmd(PushDescriptorSet, commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, pPushDescriptorSetInfo->layout,
+				pPushDescriptorSetInfo->set, pPushDescriptorSetInfo->descriptorWriteCount, pPushDescriptorSetInfo->pDescriptorWrites);
+	}
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplate2(
+    VkCommandBuffer                             commandBuffer,
+    const VkPushDescriptorSetWithTemplateInfo*  pPushDescriptorSetWithTemplateInfo) {
+
+	MVKTraceVulkanCallStart();
+    MVKAddCmd(PushDescriptorSetWithTemplate, commandBuffer, pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate,
+				  pPushDescriptorSetWithTemplateInfo->layout, pPushDescriptorSetWithTemplateInfo->set, pPushDescriptorSetWithTemplateInfo->pData);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSet(
+    VkCommandBuffer                             commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    VkPipelineLayout                            layout,
+    uint32_t                                    set,
+    uint32_t                                    descriptorWriteCount,
+    const VkWriteDescriptorSet*                 pDescriptorWrites) {
+
+	MVKTraceVulkanCallStart();
+    MVKAddCmd(PushDescriptorSet, commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplate(
+    VkCommandBuffer                            commandBuffer,
+    VkDescriptorUpdateTemplate                 descriptorUpdateTemplate,
+    VkPipelineLayout                           layout,
+    uint32_t                                   set,
+    const void*                                pData) {
+
+	MVKTraceVulkanCallStart();
+    MVKAddCmd(PushDescriptorSetWithTemplate, commandBuffer, descriptorUpdateTemplate, layout, set, pData);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToImage(
+    VkDevice                                    device,
+    const VkCopyImageToImageInfoEXT*            pCopyImageToImageInfo) {
+
+	MVKTraceVulkanCallStart();
+	VkResult rslt = MVKImage::copyImageToImage(pCopyImageToImageInfo);
+	MVKTraceVulkanCallEnd();
+	return rslt;
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToMemory(
+    VkDevice                                    device,
+    const VkCopyImageToMemoryInfoEXT*           pCopyImageToMemoryInfo) {
+
+	MVKTraceVulkanCallStart();
+	MVKImage* srcImg = (MVKImage*)pCopyImageToMemoryInfo->srcImage;
+	VkResult rslt = srcImg->copyImageToMemory(pCopyImageToMemoryInfo);
+	MVKTraceVulkanCallEnd();
+	return rslt;
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyMemoryToImage(
+    VkDevice                                    device,
+	const VkCopyMemoryToImageInfoEXT*           pCopyMemoryToImageInfo) {
+
+	MVKTraceVulkanCallStart();
+	MVKImage* dstImg = (MVKImage*)pCopyMemoryToImageInfo->dstImage;
+	VkResult rslt = dstImg->copyMemoryToImage(pCopyMemoryToImageInfo);
+	MVKTraceVulkanCallEnd();
+	return rslt;
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL void  vkGetImageSubresourceLayout2(
+    VkDevice                                    device,
+    VkImage                                     image,
+    const VkImageSubresource2KHR*               pSubresource,
+    VkSubresourceLayout2KHR*                    pLayout) {
+
+	MVKTraceVulkanCallStart();
+	MVKImage* mvkImg = (MVKImage*)image;
+	mvkImg->getSubresourceLayout(pSubresource, pLayout);
+	MVKTraceVulkanCallEnd();
+}
+
+MVK_PUBLIC_VULKAN_SYMBOL VkResult vkTransitionImageLayout(
+    VkDevice                                    device,
+    uint32_t                                    transitionCount,
+    const VkHostImageLayoutTransitionInfoEXT*   pTransitions) {
+
+	MVKTraceVulkanCallStart();
+	// Metal lacks the concept of image layouts, so nothing to do.
+	MVKTraceVulkanCallEnd();
+	return VK_SUCCESS;
+}
+
+
+#pragma mark -
 #pragma mark VK_KHR_bind_memory2 extension
 
 MVK_PUBLIC_VULKAN_CORE_ALIAS(vkBindBufferMemory2, KHR);
@@ -3161,59 +3342,26 @@ MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetDeviceImageSparseMemoryRequirements, KHR);
 
 
 #pragma mark -
+#pragma mark VK_KHR_maintenance6 extension
+
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdBindDescriptorSets2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPushConstants2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPushDescriptorSet2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPushDescriptorSetWithTemplate2, KHR);
+
+
+#pragma mark -
 #pragma mark VK_KHR_map_memory2 extension
 
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkMapMemory2KHR(
-    VkDevice device,
-    const VkMemoryMapInfoKHR* pMemoryMapInfo,
-    void** ppData) {
-	
-    MVKTraceVulkanCallStart();
-    MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMemoryMapInfo->memory;
-    VkResult rslt = mvkMem->map(pMemoryMapInfo, ppData);
-    MVKTraceVulkanCallEnd();
-    return rslt;
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkUnmapMemory2KHR(
-    VkDevice device,
-    const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo) {
-
-    MVKTraceVulkanCallStart();
-    MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMemoryUnmapInfo->memory;
-    VkResult rslt = mvkMem->unmap(pMemoryUnmapInfo);
-    MVKTraceVulkanCallEnd();
-    return rslt;
-}
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkMapMemory2, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkUnmapMemory2, KHR);
 
 
 #pragma mark -
 #pragma mark VK_KHR_push_descriptor extension
 
-MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetKHR(
-    VkCommandBuffer                             commandBuffer,
-    VkPipelineBindPoint                         pipelineBindPoint,
-    VkPipelineLayout                            layout,
-    uint32_t                                    set,
-    uint32_t                                    descriptorWriteCount,
-    const VkWriteDescriptorSet*                 pDescriptorWrites) {
-
-	MVKTraceVulkanCallStart();
-    MVKAddCmd(PushDescriptorSet, commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
-	MVKTraceVulkanCallEnd();
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplateKHR(
-    VkCommandBuffer                            commandBuffer,
-    VkDescriptorUpdateTemplate                 descriptorUpdateTemplate,
-    VkPipelineLayout                           layout,
-    uint32_t                                   set,
-    const void*                                pData) {
-
-	MVKTraceVulkanCallStart();
-    MVKAddCmd(PushDescriptorSetWithTemplate, commandBuffer, descriptorUpdateTemplate, layout, set, pData);
-	MVKTraceVulkanCallEnd();
-}
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPushDescriptorSet, KHR);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCmdPushDescriptorSetWithTemplate, KHR);
 
 
 #pragma mark -
@@ -3996,60 +4144,11 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCreateHeadlessSurfaceEXT(
 #pragma mark -
 #pragma mark VK_EXT_host_image_copy extension
 
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToImageEXT(
-    VkDevice                                    device,
-    const VkCopyImageToImageInfoEXT*            pCopyImageToImageInfo) {
-
-	MVKTraceVulkanCallStart();
-	VkResult rslt = MVKImage::copyImageToImage(pCopyImageToImageInfo);
-	MVKTraceVulkanCallEnd();
-	return rslt;
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToMemoryEXT(
-    VkDevice                                    device,
-    const VkCopyImageToMemoryInfoEXT*           pCopyImageToMemoryInfo) {
-
-	MVKTraceVulkanCallStart();
-	MVKImage* srcImg = (MVKImage*)pCopyImageToMemoryInfo->srcImage;
-	VkResult rslt = srcImg->copyImageToMemory(pCopyImageToMemoryInfo);
-	MVKTraceVulkanCallEnd();
-	return rslt;
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyMemoryToImageEXT(
-    VkDevice                                    device,
-	const VkCopyMemoryToImageInfoEXT*           pCopyMemoryToImageInfo) {
-
-	MVKTraceVulkanCallStart();
-	MVKImage* dstImg = (MVKImage*)pCopyMemoryToImageInfo->dstImage;
-	VkResult rslt = dstImg->copyMemoryToImage(pCopyMemoryToImageInfo);
-	MVKTraceVulkanCallEnd();
-	return rslt;
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL void  vkGetImageSubresourceLayout2EXT(
-    VkDevice                                    device,
-    VkImage                                     image,
-    const VkImageSubresource2KHR*               pSubresource,
-    VkSubresourceLayout2KHR*                    pLayout) {
-
-	MVKTraceVulkanCallStart();
-	MVKImage* mvkImg = (MVKImage*)image;
-	mvkImg->getSubresourceLayout(pSubresource, pLayout);
-	MVKTraceVulkanCallEnd();
-}
-
-MVK_PUBLIC_VULKAN_SYMBOL VkResult vkTransitionImageLayoutEXT(
-    VkDevice                                    device,
-    uint32_t                                    transitionCount,
-    const VkHostImageLayoutTransitionInfoEXT*   pTransitions) {
-
-	MVKTraceVulkanCallStart();
-	// Metal lacks the concept of image layouts, so nothing to do.
-	MVKTraceVulkanCallEnd();
-	return VK_SUCCESS;
-}
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCopyImageToImage, EXT);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCopyImageToMemory, EXT);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkCopyMemoryToImage, EXT);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkGetImageSubresourceLayout2, EXT);
+MVK_PUBLIC_VULKAN_CORE_ALIAS(vkTransitionImageLayout, EXT);
 
 
 #pragma mark -

--- a/MoltenVK/MoltenVK/Vulkan/vulkan.mm
+++ b/MoltenVK/MoltenVK/Vulkan/vulkan.mm
@@ -2921,7 +2921,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkSetPrivateData(
 
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkMapMemory2(
     VkDevice device,
-    const VkMemoryMapInfoKHR* pMemoryMapInfo,
+    const VkMemoryMapInfo* pMemoryMapInfo,
     void** ppData) {
 
     MVKTraceVulkanCallStart();
@@ -2933,7 +2933,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkMapMemory2(
 
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkUnmapMemory2(
     VkDevice device,
-    const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo) {
+    const VkMemoryUnmapInfo* pMemoryUnmapInfo) {
 
     MVKTraceVulkanCallStart();
     MVKDeviceMemory* mvkMem = (MVKDeviceMemory*)pMemoryUnmapInfo->memory;
@@ -3043,7 +3043,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void vkCmdPushDescriptorSetWithTemplate(
 
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToImage(
     VkDevice                                    device,
-    const VkCopyImageToImageInfoEXT*            pCopyImageToImageInfo) {
+    const VkCopyImageToImageInfo*               pCopyImageToImageInfo) {
 
 	MVKTraceVulkanCallStart();
 	VkResult rslt = MVKImage::copyImageToImage(pCopyImageToImageInfo);
@@ -3053,7 +3053,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToImage(
 
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToMemory(
     VkDevice                                    device,
-    const VkCopyImageToMemoryInfoEXT*           pCopyImageToMemoryInfo) {
+    const VkCopyImageToMemoryInfo*              pCopyImageToMemoryInfo) {
 
 	MVKTraceVulkanCallStart();
 	MVKImage* srcImg = (MVKImage*)pCopyImageToMemoryInfo->srcImage;
@@ -3064,7 +3064,7 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyImageToMemory(
 
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyMemoryToImage(
     VkDevice                                    device,
-	const VkCopyMemoryToImageInfoEXT*           pCopyMemoryToImageInfo) {
+	const VkCopyMemoryToImageInfo*              pCopyMemoryToImageInfo) {
 
 	MVKTraceVulkanCallStart();
 	MVKImage* dstImg = (MVKImage*)pCopyMemoryToImageInfo->dstImage;
@@ -3076,8 +3076,8 @@ MVK_PUBLIC_VULKAN_SYMBOL VkResult vkCopyMemoryToImage(
 MVK_PUBLIC_VULKAN_SYMBOL void  vkGetImageSubresourceLayout2(
     VkDevice                                    device,
     VkImage                                     image,
-    const VkImageSubresource2KHR*               pSubresource,
-    VkSubresourceLayout2KHR*                    pLayout) {
+    const VkImageSubresource2*                  pSubresource,
+    VkSubresourceLayout2*                       pLayout) {
 
 	MVKTraceVulkanCallStart();
 	MVKImage* mvkImg = (MVKImage*)image;
@@ -3088,7 +3088,7 @@ MVK_PUBLIC_VULKAN_SYMBOL void  vkGetImageSubresourceLayout2(
 MVK_PUBLIC_VULKAN_SYMBOL VkResult vkTransitionImageLayout(
     VkDevice                                    device,
     uint32_t                                    transitionCount,
-    const VkHostImageLayoutTransitionInfoEXT*   pTransitions) {
+    const VkHostImageLayoutTransitionInfo*      pTransitions) {
 
 	MVKTraceVulkanCallStart();
 	// Metal lacks the concept of image layouts, so nothing to do.


### PR DESCRIPTION
Adds `VK_KHR_maintenance6`, required for Vulkan 1.4 (https://github.com/KhronosGroup/MoltenVK/issues/2490).

List of changes:
* [VkBindMemoryStatusKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkBindMemoryStatusKHR.html) may be included in the pNext chain of [VkBindBufferMemoryInfo](https://registry.khronos.org/vulkan/specs/latest/man/html/VkBindBufferMemoryInfo.html) and [VkBindImageMemoryInfo](https://registry.khronos.org/vulkan/specs/latest/man/html/VkBindImageMemoryInfo.html), allowing applications to identify individual resources for which memory binding failed during calls to [vkBindBufferMemory2](https://registry.khronos.org/vulkan/specs/latest/man/html/vkBindBufferMemory2.html) and [vkBindImageMemory2](https://registry.khronos.org/vulkan/specs/latest/man/html/vkBindImageMemory2.html).
  * Added populating for these structures if present.

* A new property fragmentShadingRateClampCombinerInputs to indicate if an implementation clamps the inputs to fragment shading rate combiner operations.
  * `false`, since `VK_KHR_fragment_shading_rate` is not supported at all.

* [VK_NULL_HANDLE](https://registry.khronos.org/vulkan/specs/latest/man/html/VK_NULL_HANDLE.html) is allowed to be used when binding an index buffer, instead of a valid [VkBuffer](https://registry.khronos.org/vulkan/specs/latest/man/html/VkBuffer.html) handle. When the [nullDescriptor](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#features-nullDescriptor) feature is enabled, every index fetched results in a value of zero.
  * Since `nullDescriptor` is not supported, we do not have to worry about defined behavior for this, only not crashing when a null index buffer is bound. Thus, I added handling for null inputs, and if the buffer is null when an indexed draw occurs, we create a temporary stand-in buffer with space for one index to satisfy Metal, and anything beyond there the app does with it is undefined behavior.

* A new property maxCombinedImageSamplerDescriptorCount to indicate the maximum number of descriptors needed for any of the [formats that require a sampler Y′CBCR conversion](https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#formats-requiring-sampler-ycbcr-conversion) supported by the implementation.
  * `3`, which is the maximum required by the `VkSamplerYcbcrConversionImageFormatProperties` of any applicable format.

* A new property blockTexelViewCompatibleMultipleLayers indicating whether VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT is allowed to be used with layerCount > 1
  * `false`, as `VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT` is not supported at all.

* pNext extensible *2 versions of all descriptor binding commands.
  * Added the commands for these.

Additionally, this extension required me to add the plumbing for setting up Vulkan 1.4 promoted commands, so I also moved all of the existing Vulkan 1.4 promoted commands from other implemented extensions over to have both their extension and promoted aliases.

Ran the following set of CTS commands, basically anything with `maintenance6` in the name: [tests.txt](https://github.com/user-attachments/files/19918429/tests.txt)
```
Test run totals:
  Passed:        70/812 (8.6%)
  Failed:        0/812 (0.0%)
  Not supported: 742/812 (91.4%)
  Warnings:      0/812 (0.0%)
  Waived:        0/812 (0.0%)
```

Unsupported tests range are typically from no `VK_KHR_fragment_shading_rate`, no `nullDescriptor`, no `VK_KHR_draw_indirect_count`, no `VK_EXT_multi_draw`, no `VK_EXT_memory_priority`, or no `VK_KHR_maintenance5`.