### PR TITLE
Add support for VK_KHR_maintenance7

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -262,6 +262,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_maintenance3`
 - `VK_KHR_maintenance4`
 - `VK_KHR_maintenance6`
+- `VK_KHR_maintenance7`
 - `VK_KHR_map_memory2`
 - `VK_KHR_multiview`
 - `VK_KHR_portability_subset`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released 2025-04-27
 	- `VK_KHR_load_store_op_none`
 	- `VK_KHR_maintenance4`
 	- `VK_KHR_maintenance6`
+	- `VK_KHR_maintenance7`
 	- `VK_KHR_shader_expect_assume`
 	- `VK_KHR_shader_subgroup_rotate`
 	- `VK_KHR_shader_terminate_invocation`

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -495,6 +495,10 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES_KHR: {
 				auto* maintenance6Features = (VkPhysicalDeviceMaintenance6FeaturesKHR*)next;
 				maintenance6Features->maintenance6 = true;
+			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR: {
+				auto* maintenance7Features = (VkPhysicalDeviceMaintenance7FeaturesKHR*)next;
+				maintenance7Features->maintenance7 = true;
 				break;
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
@@ -978,11 +982,43 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
                 barycentricProperties->triStripVertexOrderIndependentOfProvokingVertex = false;
                 break;
             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_API_PROPERTIES_LIST_KHR: {
+                auto* layeredApiPropertiesList = (VkPhysicalDeviceLayeredApiPropertiesListKHR*)next;
+                if (layeredApiPropertiesList->pLayeredApis == nullptr) {
+                    // Populate with the total number of layered APIs.
+                    layeredApiPropertiesList->layeredApiCount = 1;
+                } else {
+                    // Populate with all layered APIs that will fit.
+                    layeredApiPropertiesList->layeredApiCount = std::min(layeredApiPropertiesList->layeredApiCount, 1u);
+                    if (layeredApiPropertiesList->layeredApiCount >= 1) {
+                        auto& layeredApiProperties = layeredApiPropertiesList->pLayeredApis[0];
+                        layeredApiProperties.vendorID = _properties.vendorID;
+                        layeredApiProperties.deviceID = _properties.deviceID;
+                        layeredApiProperties.layeredAPI = VK_PHYSICAL_DEVICE_LAYERED_API_METAL_KHR;
+                        strlcpy(layeredApiProperties.deviceName, _properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
+                    }
+                }
+                break;
+            }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES_KHR: {
                 auto* maintenance6Properties = (VkPhysicalDeviceMaintenance6PropertiesKHR*)next;
                 maintenance6Properties->blockTexelViewCompatibleMultipleLayers = false;
                 maintenance6Properties->maxCombinedImageSamplerDescriptorCount = 3;
                 maintenance6Properties->fragmentShadingRateClampCombinerInputs = false;
+                break;
+            }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR: {
+                auto* maintenance7Properties = (VkPhysicalDeviceMaintenance7PropertiesKHR*)next;
+                maintenance7Properties->robustFragmentShadingRateAttachmentAccess = false;
+                maintenance7Properties->separateDepthStencilAttachmentAccess = true;
+                maintenance7Properties->maxDescriptorSetTotalUniformBuffersDynamic = _properties.limits.maxDescriptorSetUniformBuffersDynamic;
+                maintenance7Properties->maxDescriptorSetTotalStorageBuffersDynamic = _properties.limits.maxDescriptorSetStorageBuffersDynamic;
+                maintenance7Properties->maxDescriptorSetTotalBuffersDynamic =
+                        _properties.limits.maxDescriptorSetUniformBuffersDynamic + _properties.limits.maxDescriptorSetStorageBuffersDynamic;
+                maintenance7Properties->maxDescriptorSetUpdateAfterBindTotalUniformBuffersDynamic = supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
+                maintenance7Properties->maxDescriptorSetUpdateAfterBindTotalStorageBuffersDynamic = supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
+                maintenance7Properties->maxDescriptorSetUpdateAfterBindTotalBuffersDynamic =
+                        supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic + supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
                 break;
             }
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -69,6 +69,7 @@ MVK_DEVICE_FEATURE(VulkanMemoryModel,                 VULKAN_MEMORY_MODEL,      
 MVK_DEVICE_FEATURE(ZeroInitializeWorkgroupMemory,     ZERO_INITIALIZE_WORKGROUP_MEMORY,       1)
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,    FRAGMENT_SHADER_BARYCENTRIC,     KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(Maintenance6,                 MAINTENANCE_6,                   KHR,   1)
+MVK_DEVICE_FEATURE_EXTN(Maintenance7,                 MAINTENANCE_7,                   KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,            PORTABILITY_SUBSET,              KHR,  15)
 MVK_DEVICE_FEATURE_EXTN(ShaderExpectAssume,           SHADER_EXPECT_ASSUME,            KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(ShaderSubgroupRotate,         SHADER_SUBGROUP_ROTATE,          KHR,   2)

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -77,6 +77,7 @@ MVK_EXTENSION(KHR_maintenance2,                       KHR_MAINTENANCE2,         
 MVK_EXTENSION(KHR_maintenance3,                       KHR_MAINTENANCE3,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance4,                       KHR_MAINTENANCE_4,                      DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance6,                       KHR_MAINTENANCE_6,                      DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_maintenance7,                       KHR_MAINTENANCE_7,                      DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_map_memory2,                        KHR_MAP_MEMORY_2,                       DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_multiview,                          KHR_MULTIVIEW,                          DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_portability_subset,                 KHR_PORTABILITY_SUBSET,                 DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
Adds VK_KHR_maintenance7, containing the following:
* Add a property query to determine if a framebuffer writes to depth or stencil aspect does not trigger a write access in the sibling aspect. For example, this allows sampling stencil aspect as a texture while rendering to the sibling depth attachment and vice-versa given appropriate image layouts.
  * `true`, as this seems to be the case and CTS tests reflect that.

* Add a way to query information regarding the underlying devices in environments where the Vulkan implementation is provided through layered implementations. For example, running on Mesa/Venus, driver ID is returned as VK_DRIVER_ID_MESA_VENUS, but it can be necessary to know what the real driver under the hood is. The new [VkPhysicalDeviceLayeredApiPropertiesKHR](https://registry.khronos.org/vulkan/specs/latest/man/html/VkPhysicalDeviceLayeredApiPropertiesKHR.html) structure can be used to gather information regarding layers underneath the top-level physical device.
  * Added the layered properties indicating there is a single layered Metal API.

* Promote VK_RENDERING_CONTENTS_INLINE_BIT_EXT and VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT to KHR
  * Nothing to do here, these aren't even used in MoltenVK.

* Add a limit to report the maximum total count of dynamic uniform buffers and dynamic storage buffers that can be included in a pipeline layout.
  * Added these properties, and they pass CTS validity checks.

* Require that for an unsigned integer query, the 32-bit result value must be equal to the 32 least significant bits of the equivalent 64-bit result value.
  * Verified with CTS tests this is the case.

* Add query for robust access support when using fragment shading rate attachments
  * `false`, as `VK_KHR_fragment_shading_rate` is not supported.

Gathered CTS tests that interact with maintenance7: [tests.txt](https://github.com/user-attachments/files/19919348/tests.txt)
```
Test run totals:
  Passed:        270/1048 (25.8%)
  Failed:        2/1048 (0.2%)
  Not supported: 775/1048 (74.0%)
  Warnings:      1/1048 (0.1%)
  Waived:        0/1048 (0.0%)
```

The two failures are pre-existing failures in `dEQP-VK.pipeline.monolithic.timestamp.misc_tests.fill_buffer_before_copy` and `dEQP-VK.pipeline.monolithic.timestamp.misc_tests.consistent_results`. The actual maintenance7 relevant part seems to be correct, where the 32-bit value and the lower 32 bits of the 64-bit value are equivalent.

The warning is from `dEQP-VK.pipeline.monolithic.timestamp.calibrated.calibration_test`, and seems to be unrelated as well: `Warnings found: Calibrated maximum deviation reported as zero`