### PR TITLE
Support triangle fans without breaking render pass where possible.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.h
@@ -92,7 +92,7 @@ public:
 						uint32_t firstInstance);
 
     void encode(MVKCommandEncoder* cmdEncoder) override;
-	void encodeIndexedIndirect(MVKCommandEncoder* cmdEncoder);
+	void encodeIndexed(MVKCommandEncoder* cmdEncoder);
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;
@@ -118,6 +118,7 @@ public:
 						uint32_t firstInstance);
 
 	void encode(MVKCommandEncoder* cmdEncoder) override;
+	void encode(MVKCommandEncoder* cmdEncoder, const MVKIndexMTLBufferBinding& ibb);
 
 protected:
 	MVKCommandTypePool<MVKCommand>* getTypePool(MVKCommandPool* cmdPool) override;


### PR DESCRIPTION
* Support reindexing triangle fans on the CPU for direct draws, avoiding breaking render pass for compute. Exception is that when the index buffer is in GPU-private memory, we need to do it in compute anyway as CPU does not have access.
* Fix some mistakes with the recent temporary index buffer related changes, where the offset of the temporary buffer was not propagated.

Fixes https://github.com/KhronosGroup/MoltenVK/issues/2471