### PR TITLE
Fix #2342: Incorrect image format with depth stencil render passes

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -239,6 +239,7 @@ public:
 
 	MVKAttachmentDescription(MVKRenderPass* renderPass,
 							const VkRenderingAttachmentInfo* pAttInfo,
+							VkImageAspectFlagBits aspect,
 							bool isResolveAttachment);
 
 protected:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -890,10 +890,11 @@ MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
 
 MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
 												   const VkRenderingAttachmentInfo* pAttInfo,
+												   VkImageAspectFlagBits aspect,
 												   bool isResolveAttachment) {
 	if (isResolveAttachment) {
 		_info.flags = 0;
-		_info.format = ((MVKImageView*)pAttInfo->resolveImageView)->getVkFormat();
+		_info.format = ((MVKImageView*)pAttInfo->resolveImageView)->getVkFormat(MVKImage::getPlaneFromVkImageAspectFlags(aspect));
 		_info.samples = VK_SAMPLE_COUNT_1_BIT;
 		_info.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		_info.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
@@ -903,7 +904,7 @@ MVKAttachmentDescription::MVKAttachmentDescription(MVKRenderPass* renderPass,
 		_info.finalLayout = pAttInfo->resolveImageLayout;
 	} else {
 		_info.flags = 0;
-		_info.format = ((MVKImageView*)pAttInfo->imageView)->getVkFormat();
+		_info.format = ((MVKImageView*)pAttInfo->imageView)->getVkFormat(MVKImage::getPlaneFromVkImageAspectFlags(aspect));
 		_info.samples = ((MVKImageView*)pAttInfo->imageView)->getSampleCount();
 		_info.loadOp = pAttInfo->loadOp;
 		_info.storeOp = pAttInfo->storeOp;
@@ -1046,7 +1047,7 @@ MVKRenderPass::MVKRenderPass(MVKDevice* device, const VkRenderingInfo* pRenderin
 	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void { attCnt++; });
 	_attachments.reserve(attCnt);
 	attIter.iterate([&](const VkRenderingAttachmentInfo* pAttInfo, VkImageAspectFlagBits aspect, bool isResolveAttachment)->void {
-		_attachments.emplace_back(this, pAttInfo, isResolveAttachment);
+		_attachments.emplace_back(this, pAttInfo, aspect, isResolveAttachment);
 	});
 
 	// Add subpass


### PR DESCRIPTION
This is still work in progress and this implementation isn't working.
Even with the correct aspect, the image format is still undefined.

the previous hack (if undefined, use the actual image format) is working.
However I find it ugly as incorrect data can still be stored in the image view.

The idea I have (not yet implemented) is to have a separate lookup table based
on the aspect you're requesting.

Any direction is welcome.

**TODO**:

- [ ] Store all MTL formats <-> Vk formats including aspect