### PR TITLE
Re-expose proc addr for VK_MVK_moltenvk extension functions.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -29,6 +29,9 @@ Released TBD
 	- `VK_KHR_shader_relaxed_extended_instruction`
 	- `VK_KHR_shader_subgroup_uniform_control_flow`
 	- `VK_KHR_surface_protected_capabilities`
+- For behaviouraly consistency, require deprecated unofficial extension `VK_MVK_moltenvk` be enabled to access 
+  the proc addrs for functions `vkSetMoltenVKConfigurationMVK()` and `vkGetPhysicalDeviceMetalFeaturesMVK()`. 
+- Move `vkGetPhysicalDeviceMetalFeaturesMVK()` from `mvk_private_api.h` to `mvk_deprecated_api.h`.
 - Update to latest SPIRV-Cross:
   - MSL: Add support for `DebugPrintf`.
   - MSL: Fix crash due to regression caused by recent changes to location calculations.

--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -46,11 +46,128 @@ extern "C" {
  * The VK_EXT_metal_objects extension is supported by the Vulkan Loader and Layers.
  */
 
+#pragma mark -
+#pragma mark VkPhysicalDevice Metal capabilities
+
+/** Identifies the type of rounding Metal uses for float to integer conversions in particular calculatons. */
+typedef enum MVKFloatRounding {
+	MVK_FLOAT_ROUNDING_NEAREST     = 0,	 /**< Metal rounds to nearest. */
+	MVK_FLOAT_ROUNDING_UP          = 1,	 /**< Metal rounds towards positive infinity. */
+	MVK_FLOAT_ROUNDING_DOWN        = 2,	 /**< Metal rounds towards negative infinity. */
+	MVK_FLOAT_ROUNDING_UP_MAX_ENUM = 0x7FFFFFFF
+} MVKFloatRounding;
+
+/** Identifies the pipeline points where GPU counter sampling can occur. Maps to MTLCounterSamplingPoint. */
+typedef enum MVKCounterSamplingBits {
+	MVK_COUNTER_SAMPLING_AT_DRAW           = 0x00000001,
+	MVK_COUNTER_SAMPLING_AT_DISPATCH       = 0x00000002,
+	MVK_COUNTER_SAMPLING_AT_BLIT           = 0x00000004,
+	MVK_COUNTER_SAMPLING_AT_PIPELINE_STAGE = 0x00000008,
+	MVK_COUNTER_SAMPLING_MAX_ENUM          = 0X7FFFFFFF
+} MVKCounterSamplingBits;
+typedef VkFlags MVKCounterSamplingFlags;
+
+/**
+ * Features provided by the current implementation of Metal on the current device. You can retrieve
+ * a copy of this structure using the deprecated vkGetPhysicalDeviceMetalFeaturesMVK() function.
+ *
+ * This structure may be extended as new features are added to MoltenVK. If you are linking to
+ * an implementation of MoltenVK that was compiled from a different MVK_PRIVATE_API_VERSION
+ * than your app was, the size of this structure in your app may be larger or smaller than the
+ * struct in MoltenVK. See the description of the vkGetPhysicalDeviceMetalFeaturesMVK() function
+ * for information about how to handle this.
+ *
+ * TO SUPPORT DYNAMIC LINKING TO THIS STRUCTURE AS DESCRIBED ABOVE, THIS STRUCTURE SHOULD NOT BE CHANGED
+ * EXCEPT TO ADD ADDITIONAL MEMBERS ON THE END. THE ORDER AND SIZE OF EXISTING MEMBERS SHOULD NOT BE CHANGED.
+ */
+typedef struct {
+    uint32_t mslVersion;                        	/**< The version of the Metal Shading Language available on this device. The format of the integer is MMmmpp, with two decimal digts each for Major, minor, and patch version values (eg. MSL 1.3 would appear as 010300). */
+	VkBool32 indirectDrawing;                   	/**< If true, draw calls support parameters held in a GPU buffer. */
+	VkBool32 baseVertexInstanceDrawing;         	/**< If true, draw calls support specifiying the base vertex and instance. */
+    uint32_t dynamicMTLBufferSize;              	/**< If greater than zero, dynamic MTLBuffers for setting vertex, fragment, and compute bytes are supported, and their content must be below this value. */
+    VkBool32 shaderSpecialization;              	/**< If true, shader specialization (aka Metal function constants) is supported. */
+    VkBool32 ioSurfaces;                        	/**< If true, VkImages can be underlaid by IOSurfaces via the vkUseIOSurfaceMVK() function, to support inter-process image transfers. */
+    VkBool32 texelBuffers;                      	/**< If true, texel buffers are supported, allowing the contents of a buffer to be interpreted as an image via a VkBufferView. */
+	VkBool32 layeredRendering;                  	/**< If true, layered rendering to multiple cube or texture array layers is supported. */
+	VkBool32 presentModeImmediate;              	/**< If true, immediate surface present mode (VK_PRESENT_MODE_IMMEDIATE_KHR), allowing a swapchain image to be presented immediately, without waiting for the vertical sync period of the display, is supported. */
+	VkBool32 stencilViews;                      	/**< If true, stencil aspect views are supported through the MTLPixelFormatX24_Stencil8 and MTLPixelFormatX32_Stencil8 formats. */
+	VkBool32 multisampleArrayTextures;          	/**< If true, MTLTextureType2DMultisampleArray is supported. */
+	VkBool32 samplerClampToBorder;              	/**< If true, the border color set when creating a sampler will be respected. */
+	uint32_t maxTextureDimension; 	     	  		/**< The maximum size of each texture dimension (width, height, or depth). */
+	uint32_t maxPerStageBufferCount;            	/**< The total number of per-stage Metal buffers available for shader uniform content and attributes. */
+    uint32_t maxPerStageTextureCount;           	/**< The total number of per-stage Metal textures available for shader uniform content. */
+    uint32_t maxPerStageSamplerCount;           	/**< The total number of per-stage Metal samplers available for shader uniform content. */
+    VkDeviceSize maxMTLBufferSize;              	/**< The max size of a MTLBuffer (in bytes). */
+    VkDeviceSize mtlBufferAlignment;            	/**< The alignment used when allocating memory for MTLBuffers. Must be PoT. */
+    VkDeviceSize maxQueryBufferSize;            	/**< The maximum size of an occlusion query buffer (in bytes). */
+	VkDeviceSize mtlCopyBufferAlignment;        	/**< The alignment required during buffer copy operations (in bytes). */
+    VkSampleCountFlags supportedSampleCounts;   	/**< A bitmask identifying the sample counts supported by the device. */
+	uint32_t minSwapchainImageCount;	 	  		/**< The minimum number of swapchain images that can be supported by a surface. */
+	uint32_t maxSwapchainImageCount;	 	  		/**< The maximum number of swapchain images that can be supported by a surface. */
+	VkBool32 combinedStoreResolveAction;			/**< If true, the device supports VK_ATTACHMENT_STORE_OP_STORE with a simultaneous resolve attachment. */
+	VkBool32 arrayOfTextures;			 	  		/**< If true, arrays of textures is supported. */
+	VkBool32 arrayOfSamplers;			 	  		/**< If true, arrays of texture samplers is supported. */
+	MTLLanguageVersion mslVersionEnum;				/**< The version of the Metal Shading Language available on this device, as a Metal enumeration. */
+	VkBool32 depthSampleCompare;					/**< If true, depth texture samplers support the comparison of the pixel value against a reference value. */
+	VkBool32 events;								/**< If true, Metal synchronization events (MTLEvent) are supported. */
+	VkBool32 memoryBarriers;						/**< If true, full memory barriers within Metal render passes are supported. */
+	VkBool32 multisampleLayeredRendering;       	/**< If true, layered rendering to multiple multi-sampled cube or texture array layers is supported. */
+	VkBool32 stencilFeedback;						/**< If true, fragment shaders that write to [[stencil]] outputs are supported. */
+	VkBool32 textureBuffers;						/**< If true, textures of type MTLTextureTypeBuffer are supported. */
+	VkBool32 postDepthCoverage;						/**< If true, coverage masks in fragment shaders post-depth-test are supported. */
+	VkBool32 fences;								/**< If true, Metal synchronization fences (MTLFence) are supported. */
+	VkBool32 rasterOrderGroups;						/**< If true, Raster order groups in fragment shaders are supported. */
+	VkBool32 native3DCompressedTextures;			/**< If true, 3D compressed images are supported natively, without manual decompression. */
+	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
+	VkBool32 placementHeaps;						/**< If true, MTLHeap objects support placement of resources. */
+	VkDeviceSize pushConstantSizeAlignment;			/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
+	uint32_t maxTextureLayers;						/**< The maximum number of layers in an array texture. */
+    uint32_t maxSubgroupSize;			        	/**< The maximum number of threads in a SIMD-group. */
+	VkDeviceSize vertexStrideAlignment;         	/**< The alignment used for the stride of vertex attribute bindings. */
+	VkBool32 indirectTessellationDrawing;			/**< If true, tessellation draw calls support parameters held in a GPU buffer. */
+	VkBool32 nonUniformThreadgroups;				/**< If true, the device supports arbitrary-sized grids in compute workloads. */
+	VkBool32 renderWithoutAttachments;          	/**< If true, we don't have to create a dummy attachment for a render pass if there isn't one. */
+	VkBool32 deferredStoreActions;					/**< If true, render pass store actions can be specified after the render encoder is created. */
+	VkBool32 sharedLinearTextures;					/**< If true, linear textures and texture buffers can be created from buffers in Shared storage. */
+	VkBool32 depthResolve;							/**< If true, resolving depth textures with filters other than Sample0 is supported. */
+	VkBool32 stencilResolve;						/**< If true, resolving stencil textures with filters other than Sample0 is supported. */
+	uint32_t maxPerStageDynamicMTLBufferCount;		/**< The maximum number of inline buffers that can be set on a command buffer. */
+	uint32_t maxPerStageStorageTextureCount;    	/**< The total number of per-stage Metal textures with read-write access available for writing to from a shader. */
+	VkBool32 astcHDRTextures;						/**< If true, ASTC HDR pixel formats are supported. */
+	VkBool32 renderLinearTextures;					/**< If true, linear textures are renderable. */
+	VkBool32 pullModelInterpolation;				/**< If true, explicit interpolation functions are supported. */
+	VkBool32 samplerMirrorClampToEdge;				/**< If true, the mirrored clamp to edge address mode is supported in samplers. */
+	VkBool32 quadPermute;							/**< If true, quadgroup permutation functions (vote, ballot, shuffle) are supported in shaders. */
+	VkBool32 simdPermute;							/**< If true, SIMD-group permutation functions (vote, ballot, shuffle) are supported in shaders. */
+	VkBool32 simdReduction;							/**< If true, SIMD-group reduction functions (arithmetic) are supported in shaders. */
+    uint32_t minSubgroupSize;			        	/**< The minimum number of threads in a SIMD-group. */
+    VkBool32 textureBarriers;                   	/**< If true, texture barriers are supported within Metal render passes. Deprecated. Will always be false on all platforms. */
+    VkBool32 tileBasedDeferredRendering;        	/**< If true, this device uses tile-based deferred rendering. */
+	VkBool32 argumentBuffers;						/**< If true, Metal argument buffers are supported on the platform. */
+	VkBool32 descriptorSetArgumentBuffers;			/**< If true, Metal argument buffers can be used for descriptor sets. */
+	MVKFloatRounding clearColorFloatRounding;		/**< Identifies the type of rounding Metal uses for MTLClearColor float to integer conversions. */
+	MVKCounterSamplingFlags counterSamplingPoints;	/**< Identifies the points where pipeline GPU counter sampling may occur. */
+	VkBool32 programmableSamplePositions;			/**< If true, programmable MSAA sample positions are supported. */
+	VkBool32 shaderBarycentricCoordinates;			/**< If true, fragment shader barycentric coordinates are supported. */
+	MTLArgumentBuffersTier argumentBuffersTier;		/**< The argument buffer tier available on this device, as a Metal enumeration. */
+	VkBool32 needsSampleDrefLodArrayWorkaround;		/**< If true, sampling from arrayed depth images with explicit LoD is broken and needs a workaround. */
+	VkDeviceSize hostMemoryPageSize;				/**< The size of a page of host memory on this platform. */
+	VkBool32 dynamicVertexStride;					/**< If true, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE is supported. */
+	VkBool32 needsCubeGradWorkaround;				/**< If true, sampling from cube textures with explicit gradients is broken and needs a workaround. */
+	VkBool32 nativeTextureAtomics;                  /**< If true, atomic operations on textures are supported natively. */
+	VkBool32 needsArgumentBufferEncoders;			/**< If true, Metal argument buffer encoders are needed to populate argument buffer content. */
+    VkBool32 residencySets;                         /**< If true, the device supports creating residency sets. */
+    VkBool32 subgroupUniformControlFlow;            /**< If true, subgroup invocations will reconverge if they were uniform upon entry to a block and exit via the corresponding merge block. */
+    VkBool32 maximalReconvergence;                  /**< If true, shader invocations that diverge will reconverge as soon as possible. */
+    VkBool32 quadControlFlow;                       /**< If true, derivatives are calculated on a per-quad basis, and full quads are spawned for fragment shaders using helper invocations. */
+} MVKPhysicalDeviceMetalFeatures;
+
 
 #pragma mark -
 #pragma mark Function types
 
 typedef VkResult (VKAPI_PTR *PFN_vkSetMoltenVKConfigurationMVK)(VkInstance ignored, const MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
+typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceMetalFeaturesMVK)(VkPhysicalDevice physicalDevice, MVKPhysicalDeviceMetalFeatures* pMetalFeatures, size_t* pMetalFeaturesSize);
 typedef void (VKAPI_PTR *PFN_vkGetVersionStringsMVK)(char* pMoltenVersionStringBuffer, uint32_t moltenVersionStringBufferLength, char* pVulkanVersionStringBuffer, uint32_t vulkanVersionStringBufferLength);
 typedef void (VKAPI_PTR *PFN_vkSetWorkgroupSizeMVK)(VkShaderModule shaderModule, uint32_t x, uint32_t y, uint32_t z);
 typedef VkResult (VKAPI_PTR *PFN_vkUseIOSurfaceMVK)(VkImage image, IOSurfaceRef ioSurface);
@@ -87,6 +204,39 @@ VkResult VKAPI_CALL vkSetMoltenVKConfigurationMVK(
     VkInstance                                  instance,
     const MVKConfiguration*                     pConfiguration,
     size_t*                                     pConfigurationSize);
+
+/**
+ * DEPRECATED.
+ * Populates the pMetalFeatures structure with the Metal-specific features
+ * supported by the specified physical device.
+ *
+ * If you are linking to an implementation of MoltenVK that was compiled from a different
+ * MVK_PRIVATE_API_VERSION than your app was, the size of the MVKPhysicalDeviceMetalFeatures
+ * structure in your app may be larger or smaller than the same struct as expected by MoltenVK.
+ *
+ * When calling this function, set the value of *pMetalFeaturesSize to sizeof(MVKPhysicalDeviceMetalFeatures),
+ * to tell MoltenVK the limit of the size of your MVKPhysicalDeviceMetalFeatures structure. Upon return from
+ * this function, the value of *pMetalFeaturesSize will hold the actual number of bytes copied into your
+ * passed MVKPhysicalDeviceMetalFeatures structure, which will be the smaller of what your app thinks is the
+ * size of MVKPhysicalDeviceMetalFeatures, and what MoltenVK thinks it is. This represents the safe access
+ * area within the structure for both MoltenVK and your app.
+ *
+ * If the size that MoltenVK expects for MVKPhysicalDeviceMetalFeatures is different than the value passed in
+ * *pMetalFeaturesSize, this function will return VK_INCOMPLETE, otherwise it will return VK_SUCCESS.
+ *
+ * Although it is not necessary, you can use this function to determine in advance the value that MoltenVK
+ * expects the size of MVKPhysicalDeviceMetalFeatures to be by setting the value of pMetalFeatures to NULL.
+ * In that case, this function will set *pMetalFeaturesSize to the size that MoltenVK expects
+ * MVKPhysicalDeviceMetalFeatures to be.
+ *
+ * This function is not supported by the Vulkan SDK Loader and Layers framework
+ * and is unavailable when using the Vulkan SDK Loader and Layers framework.
+ */
+MVK_DEPRECATED
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceMetalFeaturesMVK(
+	VkPhysicalDevice                            physicalDevice,
+	MVKPhysicalDeviceMetalFeatures*             pMetalFeatures,
+	size_t*                                     pMetalFeaturesSize);
 
 /**
  * DEPRECATED.

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -202,9 +202,8 @@ typedef enum MVKConfigUseMTLHeap {
  * may be larger or smaller than the struct in MoltenVK. See the description of the
  * vkGetMoltenVKConfigurationMVK() function for information about how to handle this.
  *
- * TO SUPPORT DYNAMIC LINKING TO THIS STRUCTURE AS DESCRIBED ABOVE, THIS STRUCTURE SHOULD NOT
- * BE CHANGED EXCEPT TO ADD ADDITIONAL MEMBERS ON THE END. EXISTING MEMBERS, AND THEIR ORDER,
- * SHOULD NOT BE CHANGED.
+ * TO SUPPORT DYNAMIC LINKING TO THIS STRUCTURE AS DESCRIBED ABOVE, THIS STRUCTURE SHOULD NOT BE CHANGED
+ * EXCEPT TO ADD ADDITIONAL MEMBERS ON THE END. THE ORDER AND SIZE OF EXISTING MEMBERS SHOULD NOT BE CHANGED.
  */
 typedef struct {
     VkBool32 debugMode;                                                        /**< MVK_CONFIG_DEBUG */
@@ -253,124 +252,6 @@ typedef struct {
 #define swapchainMagFilterUseNearest swapchainMinMagFilterUseNearest
 #define semaphoreUseMTLEvent semaphoreSupportStyle
 #define logActivityPerformanceInline activityPerformanceLoggingStyle
-
-
-#pragma mark -
-#pragma mark VkPhysicalDevice Metal capabilities
-
-/** Identifies the type of rounding Metal uses for float to integer conversions in particular calculatons. */
-typedef enum MVKFloatRounding {
-	MVK_FLOAT_ROUNDING_NEAREST     = 0,	 /**< Metal rounds to nearest. */
-	MVK_FLOAT_ROUNDING_UP          = 1,	 /**< Metal rounds towards positive infinity. */
-	MVK_FLOAT_ROUNDING_DOWN        = 2,	 /**< Metal rounds towards negative infinity. */
-	MVK_FLOAT_ROUNDING_UP_MAX_ENUM = 0x7FFFFFFF
-} MVKFloatRounding;
-
-/** Identifies the pipeline points where GPU counter sampling can occur. Maps to MTLCounterSamplingPoint. */
-typedef enum MVKCounterSamplingBits {
-	MVK_COUNTER_SAMPLING_AT_DRAW           = 0x00000001,
-	MVK_COUNTER_SAMPLING_AT_DISPATCH       = 0x00000002,
-	MVK_COUNTER_SAMPLING_AT_BLIT           = 0x00000004,
-	MVK_COUNTER_SAMPLING_AT_PIPELINE_STAGE = 0x00000008,
-	MVK_COUNTER_SAMPLING_MAX_ENUM          = 0X7FFFFFFF
-} MVKCounterSamplingBits;
-typedef VkFlags MVKCounterSamplingFlags;
-
-/**
- * Features provided by the current implementation of Metal on the current device. You can
- * retrieve a copy of this structure using the vkGetPhysicalDeviceMetalFeaturesMVK() function.
- *
- * This structure may be extended as new features are added to MoltenVK. If you are linking to
- * an implementation of MoltenVK that was compiled from a different MVK_PRIVATE_API_VERSION
- * than your app was, the size of this structure in your app may be larger or smaller than the
- * struct in MoltenVK. See the description of the vkGetPhysicalDeviceMetalFeaturesMVK() function
- * for information about how to handle this.
- *
- * TO SUPPORT DYNAMIC LINKING TO THIS STRUCTURE AS DESCRIBED ABOVE, THIS STRUCTURE SHOULD NOT
- * BE CHANGED EXCEPT TO ADD ADDITIONAL MEMBERS ON THE END. EXISTING MEMBERS, AND THEIR ORDER,
- * SHOULD NOT BE CHANGED.
- */
-typedef struct {
-    uint32_t mslVersion;                        	/**< The version of the Metal Shading Language available on this device. The format of the integer is MMmmpp, with two decimal digts each for Major, minor, and patch version values (eg. MSL 1.3 would appear as 010300). */
-	VkBool32 indirectDrawing;                   	/**< If true, draw calls support parameters held in a GPU buffer. */
-	VkBool32 baseVertexInstanceDrawing;         	/**< If true, draw calls support specifiying the base vertex and instance. */
-    uint32_t dynamicMTLBufferSize;              	/**< If greater than zero, dynamic MTLBuffers for setting vertex, fragment, and compute bytes are supported, and their content must be below this value. */
-    VkBool32 shaderSpecialization;              	/**< If true, shader specialization (aka Metal function constants) is supported. */
-    VkBool32 ioSurfaces;                        	/**< If true, VkImages can be underlaid by IOSurfaces via the vkUseIOSurfaceMVK() function, to support inter-process image transfers. */
-    VkBool32 texelBuffers;                      	/**< If true, texel buffers are supported, allowing the contents of a buffer to be interpreted as an image via a VkBufferView. */
-	VkBool32 layeredRendering;                  	/**< If true, layered rendering to multiple cube or texture array layers is supported. */
-	VkBool32 presentModeImmediate;              	/**< If true, immediate surface present mode (VK_PRESENT_MODE_IMMEDIATE_KHR), allowing a swapchain image to be presented immediately, without waiting for the vertical sync period of the display, is supported. */
-	VkBool32 stencilViews;                      	/**< If true, stencil aspect views are supported through the MTLPixelFormatX24_Stencil8 and MTLPixelFormatX32_Stencil8 formats. */
-	VkBool32 multisampleArrayTextures;          	/**< If true, MTLTextureType2DMultisampleArray is supported. */
-	VkBool32 samplerClampToBorder;              	/**< If true, the border color set when creating a sampler will be respected. */
-	uint32_t maxTextureDimension; 	     	  		/**< The maximum size of each texture dimension (width, height, or depth). */
-	uint32_t maxPerStageBufferCount;            	/**< The total number of per-stage Metal buffers available for shader uniform content and attributes. */
-    uint32_t maxPerStageTextureCount;           	/**< The total number of per-stage Metal textures available for shader uniform content. */
-    uint32_t maxPerStageSamplerCount;           	/**< The total number of per-stage Metal samplers available for shader uniform content. */
-    VkDeviceSize maxMTLBufferSize;              	/**< The max size of a MTLBuffer (in bytes). */
-    VkDeviceSize mtlBufferAlignment;            	/**< The alignment used when allocating memory for MTLBuffers. Must be PoT. */
-    VkDeviceSize maxQueryBufferSize;            	/**< The maximum size of an occlusion query buffer (in bytes). */
-	VkDeviceSize mtlCopyBufferAlignment;        	/**< The alignment required during buffer copy operations (in bytes). */
-    VkSampleCountFlags supportedSampleCounts;   	/**< A bitmask identifying the sample counts supported by the device. */
-	uint32_t minSwapchainImageCount;	 	  		/**< The minimum number of swapchain images that can be supported by a surface. */
-	uint32_t maxSwapchainImageCount;	 	  		/**< The maximum number of swapchain images that can be supported by a surface. */
-	VkBool32 combinedStoreResolveAction;			/**< If true, the device supports VK_ATTACHMENT_STORE_OP_STORE with a simultaneous resolve attachment. */
-	VkBool32 arrayOfTextures;			 	  		/**< If true, arrays of textures is supported. */
-	VkBool32 arrayOfSamplers;			 	  		/**< If true, arrays of texture samplers is supported. */
-	MTLLanguageVersion mslVersionEnum;				/**< The version of the Metal Shading Language available on this device, as a Metal enumeration. */
-	VkBool32 depthSampleCompare;					/**< If true, depth texture samplers support the comparison of the pixel value against a reference value. */
-	VkBool32 events;								/**< If true, Metal synchronization events (MTLEvent) are supported. */
-	VkBool32 memoryBarriers;						/**< If true, full memory barriers within Metal render passes are supported. */
-	VkBool32 multisampleLayeredRendering;       	/**< If true, layered rendering to multiple multi-sampled cube or texture array layers is supported. */
-	VkBool32 stencilFeedback;						/**< If true, fragment shaders that write to [[stencil]] outputs are supported. */
-	VkBool32 textureBuffers;						/**< If true, textures of type MTLTextureTypeBuffer are supported. */
-	VkBool32 postDepthCoverage;						/**< If true, coverage masks in fragment shaders post-depth-test are supported. */
-	VkBool32 fences;								/**< If true, Metal synchronization fences (MTLFence) are supported. */
-	VkBool32 rasterOrderGroups;						/**< If true, Raster order groups in fragment shaders are supported. */
-	VkBool32 native3DCompressedTextures;			/**< If true, 3D compressed images are supported natively, without manual decompression. */
-	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
-	VkBool32 placementHeaps;						/**< If true, MTLHeap objects support placement of resources. */
-	VkDeviceSize pushConstantSizeAlignment;			/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
-	uint32_t maxTextureLayers;						/**< The maximum number of layers in an array texture. */
-    uint32_t maxSubgroupSize;			        	/**< The maximum number of threads in a SIMD-group. */
-	VkDeviceSize vertexStrideAlignment;         	/**< The alignment used for the stride of vertex attribute bindings. */
-	VkBool32 indirectTessellationDrawing;			/**< If true, tessellation draw calls support parameters held in a GPU buffer. */
-	VkBool32 nonUniformThreadgroups;				/**< If true, the device supports arbitrary-sized grids in compute workloads. */
-	VkBool32 renderWithoutAttachments;          	/**< If true, we don't have to create a dummy attachment for a render pass if there isn't one. */
-	VkBool32 deferredStoreActions;					/**< If true, render pass store actions can be specified after the render encoder is created. */
-	VkBool32 sharedLinearTextures;					/**< If true, linear textures and texture buffers can be created from buffers in Shared storage. */
-	VkBool32 depthResolve;							/**< If true, resolving depth textures with filters other than Sample0 is supported. */
-	VkBool32 stencilResolve;						/**< If true, resolving stencil textures with filters other than Sample0 is supported. */
-	uint32_t maxPerStageDynamicMTLBufferCount;		/**< The maximum number of inline buffers that can be set on a command buffer. */
-	uint32_t maxPerStageStorageTextureCount;    	/**< The total number of per-stage Metal textures with read-write access available for writing to from a shader. */
-	VkBool32 astcHDRTextures;						/**< If true, ASTC HDR pixel formats are supported. */
-	VkBool32 renderLinearTextures;					/**< If true, linear textures are renderable. */
-	VkBool32 pullModelInterpolation;				/**< If true, explicit interpolation functions are supported. */
-	VkBool32 samplerMirrorClampToEdge;				/**< If true, the mirrored clamp to edge address mode is supported in samplers. */
-	VkBool32 quadPermute;							/**< If true, quadgroup permutation functions (vote, ballot, shuffle) are supported in shaders. */
-	VkBool32 simdPermute;							/**< If true, SIMD-group permutation functions (vote, ballot, shuffle) are supported in shaders. */
-	VkBool32 simdReduction;							/**< If true, SIMD-group reduction functions (arithmetic) are supported in shaders. */
-    uint32_t minSubgroupSize;			        	/**< The minimum number of threads in a SIMD-group. */
-    VkBool32 textureBarriers;                   	/**< If true, texture barriers are supported within Metal render passes. Deprecated. Will always be false on all platforms. */
-    VkBool32 tileBasedDeferredRendering;        	/**< If true, this device uses tile-based deferred rendering. */
-	VkBool32 argumentBuffers;						/**< If true, Metal argument buffers are supported on the platform. */
-	VkBool32 descriptorSetArgumentBuffers;			/**< If true, Metal argument buffers can be used for descriptor sets. */
-	MVKFloatRounding clearColorFloatRounding;		/**< Identifies the type of rounding Metal uses for MTLClearColor float to integer conversions. */
-	MVKCounterSamplingFlags counterSamplingPoints;	/**< Identifies the points where pipeline GPU counter sampling may occur. */
-	VkBool32 programmableSamplePositions;			/**< If true, programmable MSAA sample positions are supported. */
-	VkBool32 shaderBarycentricCoordinates;			/**< If true, fragment shader barycentric coordinates are supported. */
-	MTLArgumentBuffersTier argumentBuffersTier;		/**< The argument buffer tier available on this device, as a Metal enumeration. */
-	VkBool32 needsSampleDrefLodArrayWorkaround;		/**< If true, sampling from arrayed depth images with explicit LoD is broken and needs a workaround. */
-	VkDeviceSize hostMemoryPageSize;				/**< The size of a page of host memory on this platform. */
-	VkBool32 dynamicVertexStride;					/**< If true, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE is supported. */
-	VkBool32 needsCubeGradWorkaround;				/**< If true, sampling from cube textures with explicit gradients is broken and needs a workaround. */
-	VkBool32 nativeTextureAtomics;                  /**< If true, atomic operations on textures are supported natively. */
-	VkBool32 needsArgumentBufferEncoders;			/**< If true, Metal argument buffer encoders are needed to populate argument buffer content. */
-    VkBool32 residencySets;                         /**< If true, the device supports creating residency sets. */
-    VkBool32 subgroupUniformControlFlow;            /**< If true, subgroup invocations will reconverge if they were uniform upon entry to a block and exit via the corresponding merge block. */
-    VkBool32 maximalReconvergence;                  /**< If true, shader invocations that diverge will reconverge as soon as possible. */
-    VkBool32 quadControlFlow;                       /**< If true, derivatives are calculated on a per-quad basis, and full quads are spawned for fragment shaders using helper invocations. */
-} MVKPhysicalDeviceMetalFeatures;
 
 
 #pragma mark -
@@ -450,7 +331,6 @@ typedef struct {
 #pragma mark Function types
 
 typedef VkResult (VKAPI_PTR *PFN_vkGetMoltenVKConfigurationMVK)(VkInstance ignored, MVKConfiguration* pConfiguration, size_t* pConfigurationSize);
-typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceMetalFeaturesMVK)(VkPhysicalDevice physicalDevice, MVKPhysicalDeviceMetalFeatures* pMetalFeatures, size_t* pMetalFeaturesSize);
 typedef VkResult (VKAPI_PTR *PFN_vkGetPerformanceStatisticsMVK)(VkDevice device, MVKPerformanceStatistics* pPerf, size_t* pPerfSize);
 
 
@@ -489,37 +369,6 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetMoltenVKConfigurationMVK(
 	VkInstance                                  ignored,
 	MVKConfiguration*                           pConfiguration,
 	size_t*                                     pConfigurationSize);
-
-/** 
- * Populates the pMetalFeatures structure with the Metal-specific features
- * supported by the specified physical device. 
- *
- * If you are linking to an implementation of MoltenVK that was compiled from a different
- * MVK_PRIVATE_API_VERSION than your app was, the size of the MVKPhysicalDeviceMetalFeatures
- * structure in your app may be larger or smaller than the same struct as expected by MoltenVK.
- *
- * When calling this function, set the value of *pMetalFeaturesSize to sizeof(MVKPhysicalDeviceMetalFeatures),
- * to tell MoltenVK the limit of the size of your MVKPhysicalDeviceMetalFeatures structure. Upon return from
- * this function, the value of *pMetalFeaturesSize will hold the actual number of bytes copied into your
- * passed MVKPhysicalDeviceMetalFeatures structure, which will be the smaller of what your app thinks is the
- * size of MVKPhysicalDeviceMetalFeatures, and what MoltenVK thinks it is. This represents the safe access
- * area within the structure for both MoltenVK and your app.
- *
- * If the size that MoltenVK expects for MVKPhysicalDeviceMetalFeatures is different than the value passed in
- * *pMetalFeaturesSize, this function will return VK_INCOMPLETE, otherwise it will return VK_SUCCESS.
- *
- * Although it is not necessary, you can use this function to determine in advance the value that MoltenVK
- * expects the size of MVKPhysicalDeviceMetalFeatures to be by setting the value of pMetalFeatures to NULL.
- * In that case, this function will set *pMetalFeaturesSize to the size that MoltenVK expects
- * MVKPhysicalDeviceMetalFeatures to be.
- *
- * This function is not supported by the Vulkan SDK Loader and Layers framework
- * and is unavailable when using the Vulkan SDK Loader and Layers framework.
- */
-VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceMetalFeaturesMVK(
-	VkPhysicalDevice                            physicalDevice,
-	MVKPhysicalDeviceMetalFeatures*             pMetalFeatures,
-	size_t*                                     pMetalFeaturesSize);
 
 /**
  * Populates the pPerf structure with the current performance statistics for the device.

--- a/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
+++ b/MoltenVK/MoltenVK/API/vk_mvk_moltenvk.h
@@ -33,8 +33,7 @@
  *   - Build settings at MoltenVK build time.
  *
  * If you require access to private structures and functions to query MoltenVK about MoltenVK
- * version and configuration, runtime performance information, and available Metal capabilities,
- * use the following header file:
+ * version, configuration, or runtime performance information, use the following header file:
  *
  *     #include <MoltenVK/mvk_private_api.h>
  *

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.mm
@@ -166,9 +166,13 @@ VkResult MVKExtensionList::enable(uint32_t count, const char* const* names, cons
 		} else {
 			enable(extnName);
 			if (mvkStringsAreEqual(extnName, VK_MVK_MOLTENVK_EXTENSION_NAME)) {
-				reportMessage(MVK_CONFIG_LOG_LEVEL_WARNING, "Extension %s is deprecated. For access to Metal objects, use extension %s. "
-							  "For MoltenVK configuration, use the VK_EXT_layer_settings extension or environment variables.",
-							  VK_MVK_MOLTENVK_EXTENSION_NAME, VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
+				reportMessage(MVK_CONFIG_LOG_LEVEL_WARNING, "Extension %s is deprecated."
+							  " For access to Metal objects, use extension %s."
+							  " For MoltenVK configuration, use extension %s,  or environment variables."
+							  " For other %s functions, use with extreme caution. Calling these functions with"
+							  " handles and objects retrieved from other Vulkan layers will cause crashes.",
+							  VK_MVK_MOLTENVK_EXTENSION_NAME, VK_EXT_METAL_OBJECTS_EXTENSION_NAME,
+							  VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_MVK_MOLTENVK_EXTENSION_NAME);
 			}
 		}
 	}

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -21,7 +21,7 @@
 
 #include "MVKCommonEnvironment.h"
 #include "mvk_vulkan.h"
-#include "mvk_private_api.h"
+#include "mvk_deprecated_api.h"
 #include "MVKLogging.h"
 #ifdef __cplusplus
 #include <string>


### PR DESCRIPTION
Several proc addr for `VK_MVK_moltenvk` extension functions were erroneously hidden by commit 70db7651.

- Handle the proc addrs for functions `vkGetPhysicalDeviceMetalFeaturesMVK()`, `vkGetPerformanceStatisticsMVK()`, and `vkSetMoltenVKConfigurationMVK()` consistently with all other functions, by replacing these functions under the `VK_MVK_moltenvk` extension, and requiring that extension to be enabled to use the functions.
- Remove `ADD_INST_OPEN_ENTRY_POINT()` and `ADD_DVC_OPEN_ENTRY_POINT()` macros.
- Improve warning message output when extension `VK_MVK_moltenvk` is enabled.

Completes #2532.

@SRSaunders  I put the previously un-categorized functions under `VK_MVK_moltenvk`, where they started out. This makes them like any other extension functions, to avoid the special-case situation that caused them to fall through the cracks in #2532.

It does mean that someone using these functions now needs to enable the `VK_MVK_moltenvk`, which again is consistent with all other Vulkan behaviour. But if this will cause legacy issues, what we can do is simply enable `VK_MVK_moltenvk` by default in MoltenVK, so the user doesn't need to take that step.