### PR TITLE
Fix high latency on present wait.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1629,8 +1629,9 @@ VkResult MVKPresentableSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffe
 	// Ensure this image, the drawable, and the present fence are not destroyed while
 	// awaiting MTLCommandBuffer completion. We retain the drawable separately because
 	// a new drawable might be acquired by this image by then.
-	// Signal the fence from this callback, because the last one or two presentation
-	// completion callbacks can occasionally stall.
+	// Signal the fence and notify the swapchain that the present has completed
+	// from this callback, because the last one or two presentation completion
+	// callbacks can occasionally stall.
 	retain();
 	[mtlDrwbl retain];
 	auto* fence = presentInfo.fence;
@@ -1640,6 +1641,7 @@ VkResult MVKPresentableSwapchainImage::presentCAMetalDrawable(id<MTLCommandBuffe
 		if (fence) { fence->release(); }
 		[mtlDrwbl release];
 		release();
+		if (_swapchain) { _swapchain->notifyPresentComplete(presentInfo); }
 	}];
 
 	signal(signaler.semaphore, signaler.semaphoreSignalToken, mtlCmdBuff);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.h
@@ -123,6 +123,7 @@ protected:
     void markFrameInterval();
 	void beginPresentation(const MVKImagePresentInfo& presentInfo);
 	void endPresentation(const MVKImagePresentInfo& presentInfo, uint64_t beginPresentTime, uint64_t actualPresentTime = 0);
+	void notifyPresentComplete(const MVKImagePresentInfo& presentInfo);
 	void forceUnpresentedImageCompletion();
 
 	MVKSurface* _surface = nullptr;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -277,7 +277,9 @@ void MVKSwapchain::endPresentation(const MVKImagePresentInfo& presentInfo, uint6
 	_presentTimingHistory[_presentHistoryIndex].earliestPresentTime = actualPresentTime;
 	_presentTimingHistory[_presentHistoryIndex].presentMargin = actualPresentTime > beginPresentTime ? actualPresentTime - beginPresentTime : 0;
 	_presentHistoryIndex = (_presentHistoryIndex + 1) % kMaxPresentationHistory;
+}
 
+void MVKSwapchain::notifyPresentComplete(const MVKImagePresentInfo& presentInfo) {
 	if (presentInfo.presentId != 0) {
 		std::unique_lock pidLock(_currentPresentIdMutex);
 		_currentPresentId = std::max(_currentPresentId, presentInfo.presentId);


### PR DESCRIPTION
Encountered an issue using present wait in practice in [Unleashed Recompiled](https://github.com/hedge-dev/UnleashedRecomp), where when v-sync is enabled the present wait would take too long and severely disrupt frame pacing.

While looking into it I noticed a section near the present handler logic where we signal the present fence in a separate completed handler, because the present handler callbacks can possibly stall. Indeed, moving the logic to notify the swapchain to update the present ID seems to have solved my issues; I went from having wild fluctuations around 9ms for present waits for `currentPresentId - 1` to around a microsecond. I also verified with timestamps that the completed handler is paced correctly, rather than just seeing the results I expect due to it calling very quickly or something.

So, in this PR I've split out the present ID update to a separate swapchain function `notifyPresentComplete`, and call that from the end of the completed handler.