### PR TITLE
Support compiling using Xcode 26

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -107,6 +107,11 @@ extern "C" {
 #endif
 
 /** Building with Xcode versions. */
+#ifndef MVK_XCODE_26
+#   define MVK_XCODE_26             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 260000) || \
+                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 260000) || \
+                                        (__TV_OS_VERSION_MAX_ALLOWED >= 260000))
+#endif
 #ifndef MVK_XCODE_16
 #   define MVK_XCODE_16             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) || \
                                     (__IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2485,14 +2485,20 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(17.0) ) {
-        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
-    }
+	if ( mvkOSVersionIsAtLeast(17.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
 #endif
 
 #if MVK_XCODE_16
 	if ( mvkOSVersionIsAtLeast(18.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
+	}
+#endif
+
+#if MVK_XCODE_26
+	if ( mvkOSVersionIsAtLeast(26.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion4_0;
 	}
 #endif
 
@@ -2599,13 +2605,18 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	}
 #endif
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(17.0) ) {
-        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
-    }
+	if ( mvkOSVersionIsAtLeast(17.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
 #endif
 #if MVK_XCODE_16
 	if ( mvkOSVersionIsAtLeast(18.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
+	}
+#endif
+#if MVK_XCODE_26
+	if ( mvkOSVersionIsAtLeast(26.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion4_0;
 	}
 #endif
 
@@ -2686,14 +2697,19 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	}
 #endif
 #if MVK_XCODE_15
-    if ( mvkOSVersionIsAtLeast(14.0) ) {
-        _metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
-    }
+	if ( mvkOSVersionIsAtLeast(14.0) ) {
+		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
+	}
 #endif
 #if MVK_XCODE_16
 	if ( mvkOSVersionIsAtLeast(15.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_2;
 	}
+#endif
+#if MVK_XCODE_26
+        if ( mvkOSVersionIsAtLeast(26.0) ) {
+                _metalFeatures.mslVersionEnum = MTLLanguageVersion4_0;
+        }
 #endif
 
 	// This is an Apple GPU--treat it accordingly.
@@ -2808,15 +2824,20 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(maj, min);
 
 	switch (_metalFeatures.mslVersionEnum) {
+#if MVK_XCODE_26
+		case MTLLanguageVersion4_0:
+			setMSLVersion(4, 0);
+			break;
+#endif
 #if MVK_XCODE_16
 		case MTLLanguageVersion3_2:
 			setMSLVersion(3, 2);
 			break;
 #endif
 #if MVK_XCODE_15
-        case MTLLanguageVersion3_1:
-            setMSLVersion(3, 1);
-            break;
+		case MTLLanguageVersion3_1:
+			setMSLVersion(3, 1);
+			break;
 #endif
 #if MVK_XCODE_14
 		case MTLLanguageVersion3_0:

--- a/MoltenVK/MoltenVK/Utility/MVKCodec.h
+++ b/MoltenVK/MoltenVK/Utility/MVKCodec.h
@@ -22,6 +22,7 @@
 #include "MVKEnvironment.h"
 #include <vector>
 #include <string>
+#include <memory>
 
 
 #pragma mark -

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -71,15 +71,20 @@ bool mvk::compile(const string& mslSourceCode,
 #define mslVer(MJ, MN, PT)	mslVersionMajor == MJ && mslVersionMinor == MN && mslVersionPoint == PT
 
 	MTLLanguageVersion mslVerEnum = (MTLLanguageVersion)0;
+#if MVK_XCODE_26
+	if (mslVer(4, 0, 0)) {
+		mslVerEnum = MTLLanguageVersion4_0;
+	} else
+#endif
 #if MVK_XCODE_16
 	if (mslVer(3, 2, 0)) {
 		mslVerEnum = MTLLanguageVersion3_2;
 	} else
-		#endif
+#endif
 #if MVK_XCODE_15
-    if (mslVer(3, 1, 0)) {
-        mslVerEnum = MTLLanguageVersion3_1;
-    } else
+	if (mslVer(3, 1, 0)) {
+		mslVerEnum = MTLLanguageVersion3_1;
+	} else
 #endif
 #if MVK_XCODE_14
 	if (mslVer(3, 0, 0)) {


### PR DESCRIPTION
* Adds `MVK_XCODE_26` for Xcode 26.
* Adds necessary code to use `MTLLanguageVersion4_0` when supported.
* Fixes a missing include in `MVKCodec.h` for using `std::unique_ptr`.
* Minor fixes to whitespace consistency around these changes.