### PR TITLE
MVKDevice: Apple, AMD, and Intel devices really do use parallelograms…

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -911,8 +911,8 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	supportedProps14.earlyFragmentSampleMaskTestBeforeSampleCounting = false;
 	supportedProps14.depthStencilSwizzleOneSupport = true;
 	supportedProps14.polygonModePointSize = true;
-	supportedProps14.nonStrictSinglePixelWideLinesUseParallelogram = false;
-	supportedProps14.nonStrictWideLinesUseParallelogram = false;
+	supportedProps14.nonStrictSinglePixelWideLinesUseParallelogram = !_properties.limits.strictLines;
+	supportedProps14.nonStrictWideLinesUseParallelogram = !_properties.limits.strictLines;
 	supportedProps14.blockTexelViewCompatibleMultipleLayers = false;
 	supportedProps14.maxCombinedImageSamplerDescriptorCount = 3;
 	supportedProps14.fragmentShadingRateClampCombinerInputs = false;
@@ -3373,7 +3373,7 @@ void MVKPhysicalDevice::initLimits() {
     _properties.limits.lineWidthGranularity = _features.wideLines ? 0.125f : 0;
 
     _properties.limits.standardSampleLocations = VK_TRUE;
-    _properties.limits.strictLines = _properties.vendorID == kIntelVendorId || _properties.vendorID == kNVVendorId;
+    _properties.limits.strictLines = _properties.vendorID == kNVVendorId;
 
 	VkExtent3D wgSize = mvkVkExtent3DFromMTLSize(_mtlDevice.maxThreadsPerThreadgroup);
 	_properties.limits.maxComputeWorkGroupSize[0] = wgSize.width;


### PR DESCRIPTION
… for lines.

I know this is so because the lines are antialiased with multisampled rendering. This means these devices render wide lines with polygons. In the Bresenham rendering tests, the reference image does not have antialiasing, even when the sample count is greater than 1.

I've also learned that Intel devices now draw non-strict lines. On the Mac, this has been so since at least macOS 10.15. This is not unique to Metal: Sascha's GPUInfo database shows that only the earliest versions of Intel's Vulkan drivers draw strict lines; later drivers, around 2017 and implementing Vulkan 1.1, draw non-strict lines. I suspect the change has to do with the `VK_EXT_line_rasterization` extension; it provides rectangular (i.e. strict) lines as an option. Intel thus changed to non-strict lines to allow clients to select between parallelograms and rectangles.

Other than correcting Intel's capabilities for macOS 10.15+, this doesn't make any difference in passing the tests, which suggests they're inadequate.