### PR TITLE
MVKDevice: Also apply zombie counter set workaround to AMD RDNA devices.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -437,6 +437,7 @@ protected:
 	void initProperties();
 	void initLimits();
 	void initGPUInfoProperties();
+	bool isAMDRDNAGPU();
 	void initMemoryProperties();
 	void initVkSemaphoreStyle();
 	void setMemoryHeap(uint32_t heapIndex, VkDeviceSize heapSize, VkMemoryHeapFlags heapFlags);


### PR DESCRIPTION
Luckily, I know this one was actually fixed; this doesn't happen after 10.15.

While I'm at it, put all the known RDNA device IDs into a single function, and call it from both the subgroup size code and the zombie counter set hack. This should also correct the minimum subgroup size for those GPUs.