### PR TITLE
Fix attempting to add memoryless images to residency sets.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -88,7 +88,9 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
         }
 
         [mtlTexDesc release];                                            // temp release
-		_image->getDevice()->makeResident(_mtlTexture);
+        if (_mtlTexture.storageMode != MTLStorageModeMemoryless) {
+            _image->getDevice()->makeResident(_mtlTexture);
+        }
         propagateDebugName();
     }
     return _mtlTexture;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -785,7 +785,7 @@ bool MVKAttachmentDescription::populateMTLRenderPassAttachmentDescriptor(MTLRend
 
 	bool isMemorylessAttachment = false;
 #if MVK_APPLE_SILICON
-	isMemorylessAttachment = attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
+	isMemorylessAttachment = attachment->getImage()->getMTLStorageMode() == MTLStorageModeMemoryless;
 #endif
 	bool isResuming = mvkIsAnyFlagEnabled(_renderPass->getRenderingFlags(), VK_RENDERING_RESUMING_BIT);
 
@@ -853,7 +853,7 @@ void MVKAttachmentDescription::encodeStoreAction(MVKCommandEncoder* cmdEncoder,
 
 	bool isMemorylessAttachment = false;
 #if MVK_APPLE_SILICON
-	isMemorylessAttachment = attachment->getMTLTexture().storageMode == MTLStorageModeMemoryless;
+	isMemorylessAttachment = attachment->getImage()->getMTLStorageMode() == MTLStorageModeMemoryless;
 #endif
 	MTLStoreAction storeAction = getMTLStoreAction(subpass, isRenderingEntireAttachment, isMemorylessAttachment,
 												   hasResolveAttachment, canResolveFormat, isStencil, storeOverride);


### PR DESCRIPTION
* Do not attempt to make memoryless images resident.
* Switch two cases in render pass code to directly check the storage mode from `MVKImage` instead of needing to create the `MTLTexture`.

Should fix https://github.com/KhronosGroup/MoltenVK/issues/2592