### PR TITLE
MVKInstance: Make vkGetPhysicalDeviceToolProperties() instance again.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKInstance.mm
@@ -428,9 +428,9 @@ void MVKInstance::initMVKConfig(const VkInstanceCreateInfo* pCreateInfo) {
 	ADD_DVC_1_2_ENTRY_POINT(func); \
 	ADD_ENTRY_POINT_MAP(func##extSuffix, func, 0, VK_##EXT##_EXTENSION_NAME, true)
 
-#define ADD_INST_1_3_PROMOTED_ENTRY_POINT(func, EXT)	\
+#define ADD_INST_1_3_PROMOTED_ENTRY_POINT(func, extSuffix, EXT)	\
 	ADD_INST_1_3_ENTRY_POINT(func);	\
-	ADD_ENTRY_POINT_MAP(func##KHR, func, 0, VK_##EXT##_EXTENSION_NAME, false)
+	ADD_ENTRY_POINT_MAP(func##extSuffix, func, 0, VK_##EXT##_EXTENSION_NAME, false)
 
 #define ADD_DVC_1_3_PROMOTED_ENTRY_POINT(func, extSuffix, EXT) \
 	ADD_DVC_1_3_ENTRY_POINT(func); \
@@ -480,6 +480,8 @@ void MVKInstance::initProcAddrs() {
 	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalFenceProperties, KHR_EXTERNAL_FENCE_CAPABILITIES);
 	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalBufferProperties, KHR_EXTERNAL_MEMORY_CAPABILITIES);
 	ADD_INST_1_1_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceExternalSemaphoreProperties, KHR_EXTERNAL_SEMAPHORE_CAPABILITIES);
+
+	ADD_INST_1_3_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceToolProperties, EXT, EXT_TOOLING_INFO);
 
 	// Instance extension functions.
 	ADD_INST_EXT_ENTRY_POINT(vkDestroySurfaceKHR, KHR_SURFACE);
@@ -725,7 +727,6 @@ void MVKInstance::initProcAddrs() {
 	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetPrivateData, EXT, EXT_PRIVATE_DATA);
 	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkQueueSubmit2, KHR, KHR_SYNCHRONIZATION_2);
 	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkSetPrivateData, EXT, EXT_PRIVATE_DATA);
-	ADD_DVC_1_3_PROMOTED_ENTRY_POINT(vkGetPhysicalDeviceToolProperties, EXT, EXT_TOOLING_INFO);
 
 	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCmdSetRenderingAttachmentLocations, KHR, KHR_DYNAMIC_RENDERING_LOCAL_READ);
 	ADD_DVC_1_4_PROMOTED_ENTRY_POINT(vkCmdSetRenderingInputAttachmentIndices, KHR, KHR_DYNAMIC_RENDERING_LOCAL_READ);


### PR DESCRIPTION
The Vulkan spec [states][1] that `vkGetInstanceProcAddr()` returns all dispatchable functions of a `VkInstance` or its direct children. It further [states][2] that `vkGetDeviceProcAddr()` does _not_ return any dispatchable function of a `VkPhysicalDevice`. This means that, despite that `VK_EXT_tooling_info` is a device extension, the `vkGetPhysicalDeviceToolProperties()` function is an _instance_ function. This case falls under the "available device extension dispatchable command for `instance`" case in Table 1, and footnote 3 in Table 2.

Fixes the `dEQP-VK.api.version_check.entry_points` test.

[1]: https://docs.vulkan.org/spec/latest/chapters/initialization.html#vkGetInstanceProcAddr-behavior
[2]: https://docs.vulkan.org/spec/latest/chapters/initialization.html#vkGetDeviceProcAddr-behavior