### PR TITLE
MVKDescriptorPool: Return `VK_ERROR_OUT_OF_POOL_MEMORY` when running …

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -328,6 +328,7 @@ protected:
 
 	VkDescriptorPoolCreateFlags _flags = 0;
 	size_t _allocatedDescSetCount = 0;
+	size_t _freeArgBuffSpace = 0;
 };
 
 


### PR DESCRIPTION
…out of sets.

As required by `VK_KHR_maintenance1`.

Also keep track of available argument buffer space, and return `VK_ERROR_OUT_OF_POOL_MEMORY` if there is not enough total space left to accommodate the encoded argument buffer for a descriptor set.

Fixes the `dEQP-VK.api.descriptor_pool.out_of_pool_memory` test.