### PR TITLE
MVKPhysicalDevice: Fix fencepost error.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -4291,7 +4291,7 @@ void MVKDevice::getDescriptorVariableDescriptorCountLayoutSupport(const VkDescri
 
 	// If there is enough room for the requested size, indicate the amount available,
 	// otherwise indicate that the requested size cannot be supported.
-	if (requestedCount < maxVarDescCount) {
+	if (requestedCount <= maxVarDescCount) {
 		pVarDescSetCountSupport->maxVariableDescriptorCount = maxVarDescCount;
 	} else {
 		pSupport->supported = false;


### PR DESCRIPTION
If the client requests exactly as many variable descriptors as would fit, the check would return "not supported." The CTS explicitly tests this case.

Fixes 10 tests under
`dEQP-VK.api.maintenance3_check.support_count_*_extra_bindings`.