### PR TITLE
Do not attempt to use dynamic depth/stencil attachment for alternate purpose.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.h
@@ -408,9 +408,6 @@ protected:
 	void handleAttachment(const VkRenderingAttachmentInfo* pAttInfo,
 						  VkImageAspectFlagBits aspect,
 						  MVKRenderingAttachmentInfoOperation attOperation);
-	const VkRenderingAttachmentInfo* getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
-													   const VkRenderingAttachmentInfo* pAltAtt,
-													   bool isStencil);
 
 	VkRenderingInfo _renderingInfo;
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -1205,27 +1205,6 @@ void MVKRenderingAttachmentIterator::handleAttachment(const VkRenderingAttachmen
 
 MVKRenderingAttachmentIterator::MVKRenderingAttachmentIterator(const VkRenderingInfo* pRenderingInfo) {
 	_renderingInfo = *pRenderingInfo;
-	_renderingInfo.pDepthAttachment   = getAttachmentInfo(pRenderingInfo->pDepthAttachment, pRenderingInfo->pStencilAttachment, false);
-	_renderingInfo.pStencilAttachment = getAttachmentInfo(pRenderingInfo->pStencilAttachment, pRenderingInfo->pDepthAttachment, true);
-}
-
-// If the depth/stencil attachment is not in use, but the alternate stencil/depth attachment is,
-// and the MTLPixelFormat is usable by both attachments, force the use of the alternate attachment
-// for both attachments, to avoid Metal validation errors when a pipeline expects both depth and
-// stencil, but only one of the attachments has been provided here.
-// Check the MTLPixelFormat of the MVKImage underlying the MVKImageView, to bypass possible
-// substitution of MTLPixelFormat in the MVKImageView due to swizzling, or stencil-only access.
-const VkRenderingAttachmentInfo* MVKRenderingAttachmentIterator::getAttachmentInfo(const VkRenderingAttachmentInfo* pAtt,
-																				   const VkRenderingAttachmentInfo* pAltAtt,
-																				   bool isStencil) {
-	bool useAlt = false;
-	if ( !(pAtt && pAtt->imageView) && (pAltAtt && pAltAtt->imageView) ) {
-		MVKImage* mvkImg = ((MVKImageView*)pAltAtt->imageView)->getImage();
-		useAlt = (isStencil
-				  ? mvkImg->getPixelFormats()->isStencilFormat(mvkImg->getMTLPixelFormat())
-				  : mvkImg->getPixelFormats()->isDepthFormat(mvkImg->getMTLPixelFormat()));
-	}
-	return useAlt ? pAltAtt : pAtt;
 }
 
 


### PR DESCRIPTION
Fixes:
```
dEQP-VK.pipeline.monolithic.stencil.no_stencil_att.dynamic_rendering.static_enable.d32_sfloat_s8_uint
dEQP-VK.pipeline.monolithic.stencil.no_stencil_att.dynamic_rendering.dynamic_enable.d32_sfloat_s8_uint
```

And should fix https://github.com/KhronosGroup/MoltenVK/issues/2412

The depth attachment is not supposed to automatically be used for stencil, and vice-versa. I'm not sure what exactly this logic was intended to handle originally but it is invalid behavior for Vulkan. Plus it was actually causing Metal validation errors; if you have a depth-stencil formatted image for the depth attachment, a null stencil attachment, and the corresponding depth format and `UNDEFINED` stencil format in the pipeline, you would get this:
```
-[MTLDebugRenderCommandEncoder setRenderPipelineState:]:1616: failed assertion `Set Render Pipeline State Validation
For stencil attachment, the render pipeline's pixelFormat (MTLPixelFormatInvalid) does not match the framebuffer's pixelFormat (MTLPixelFormatDepth32Float_Stencil8).
'
```