### PR TITLE
Fix out-of-bound access when using multiview with multiple subpasses.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm
@@ -953,8 +953,8 @@ void MVKAttachmentDescription::linkToSubpasses() {
 	_firstUseSubpassIdx = kMVKUndefinedLargeUInt32;
 	_lastUseSubpassIdx = 0;
 	if (_renderPass->_subpasses[0].isMultiview()) {
-		_firstUseViewMasks.reserve(_renderPass->_subpasses.size());
-		_lastUseViewMasks.reserve(_renderPass->_subpasses.size());
+		_firstUseViewMasks.resize(_renderPass->_subpasses.size());
+		_lastUseViewMasks.resize(_renderPass->_subpasses.size());
 	}
 	for (auto& subPass : _renderPass->_subpasses) {
 		// If it uses this attachment, the subpass will identify required format capabilities.
@@ -965,10 +965,10 @@ void MVKAttachmentDescription::linkToSubpasses() {
 			_lastUseSubpassIdx = max(spIdx, _lastUseSubpassIdx);
 			if ( subPass.isMultiview() ) {
 				uint32_t viewMask = subPass._pipelineRenderingCreateInfo.viewMask;
-				std::for_each(_lastUseViewMasks.begin(), _lastUseViewMasks.end(), [viewMask](uint32_t& mask) { mask &= ~viewMask; });
-				_lastUseViewMasks.push_back(viewMask);
-				std::for_each(_firstUseViewMasks.begin(), _firstUseViewMasks.end(), [&viewMask](uint32_t mask) { viewMask &= ~mask; });
-				_firstUseViewMasks.push_back(viewMask);
+				std::for_each(_lastUseViewMasks.begin(), _lastUseViewMasks.begin() + spIdx, [viewMask](uint32_t& mask) { mask &= ~viewMask; });
+				_lastUseViewMasks[spIdx] = viewMask;
+				std::for_each(_firstUseViewMasks.begin(), _firstUseViewMasks.begin() + spIdx, [&viewMask](uint32_t mask) { viewMask &= ~mask; });
+				_firstUseViewMasks[spIdx] = viewMask;
 			}
 
 			// Validate that the attachment pixel format supports the capabilities required by the subpass.


### PR DESCRIPTION
https://github.com/KhronosGroup/MoltenVK/blob/48d5cfbf25c0d98e6337522b9a17472351731b2a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm#L795-L801

Attachment will be always loaded regardless of its specified loadOp, if it is not the first use at the subpass.

https://github.com/KhronosGroup/MoltenVK/blob/48d5cfbf25c0d98e6337522b9a17472351731b2a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm#L882-L888

If the render pass is using multiview, whether the attachment image is first used or not is determined by `MVKAttachmentDescription::_firstUseViewMasks`, by accessing the `subpass->_subpassIndex`-th element.

https://github.com/KhronosGroup/MoltenVK/blob/48d5cfbf25c0d98e6337522b9a17472351731b2a/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm#L945-L984

`MVKAttachmentDescription::_firstUseViewMasks` is calculated at the `VkRenderPass` initialization. For every subpass of the render pass, if it is used in the subpass (line 962) (=`reqCaps` is evaluated to `true` in the `if` statement) and if the subpass uses multiview, the calculated view mask is pushed to `_firstUseViewMasks`.

**Therefore, if the attachment image is not used in the any prior subpass,  size of `MVKAttachmentDescription::_firstUseViewMasks` will be less than the subpass count, and accessing the `subpass->_subpassIndex`-th element will be out-of-bound access.** So does `MVKAttachmentDescription::_lastUseViewMasks`.

I added bound checking code to the subscript operator of `MVKSmallVector` and verified OOB access is happened.

Usually it returns 0 and `_firstUseViewMasks[subpass->_subpassIndex] == subpass->_pipelineRenderingCreateInfo.viewMask` is evaluated as `false`. Eventually, loadOp of all attachments used from the 2nd subpasses will be set to `MTLLoadActionLoad`, cause a bad behavior.

If I understand correctly, `MVKAttachmentDescription::{_firstUseViewMasks,_lastUseViewMasks}` must have the equal count of the subpasses.