### PR TITLE
Enable sampler lod bias for Xcode 26.

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -160,6 +160,7 @@ typedef struct {
     VkBool32 subgroupUniformControlFlow;            /**< If true, subgroup invocations will reconverge if they were uniform upon entry to a block and exit via the corresponding merge block. */
     VkBool32 maximalReconvergence;                  /**< If true, shader invocations that diverge will reconverge as soon as possible. */
     VkBool32 quadControlFlow;                       /**< If true, derivatives are calculated on a per-quad basis, and full quads are spawned for fragment shaders using helper invocations. */
+    VkBool32 samplerMipLodBias;                     /**< If true, a mip lod bias can be set on a sampler. */
 } MVKPhysicalDeviceMetalFeatures;
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -2535,11 +2535,9 @@ MTLSamplerDescriptor* MVKSampler::newMTLSamplerDescriptor(const VkSamplerCreateI
     mtlSampDesc.mipFilter = (pCreateInfo->unnormalizedCoordinates
                              ? MTLSamplerMipFilterNotMipmapped
                              : mvkMTLSamplerMipFilterFromVkSamplerMipmapMode(pCreateInfo->mipmapMode));
-#if MVK_USE_METAL_PRIVATE_API
-	if (getMVKConfig().useMetalPrivateAPI) {
+	if (getMetalFeatures().samplerMipLodBias) {
 		mtlSampDesc.lodBiasMVK = pCreateInfo->mipLodBias;
 	}
-#endif
 	mtlSampDesc.lodMinClamp = pCreateInfo->minLod;
 	mtlSampDesc.lodMaxClamp = pCreateInfo->maxLod;
 	mtlSampDesc.maxAnisotropy = (pCreateInfo->anisotropyEnable

--- a/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
@@ -21,7 +21,7 @@
 #include "MVKCommonEnvironment.h"
 
 
-#if MVK_USE_METAL_PRIVATE_API
+#if MVK_USE_METAL_PRIVATE_API && !MVK_XCODE_26
 /** Additional methods not necessarily declared in <Metal/MTLSampler.h>. */
 @interface MTLSamplerDescriptor ()
 
@@ -55,14 +55,14 @@
 }
 
 -(float) lodBiasMVK {
-#if MVK_USE_METAL_PRIVATE_API
+#if MVK_USE_METAL_PRIVATE_API || MVK_XCODE_26
 	if ( [self respondsToSelector: @selector(lodBias)] ) { return self.lodBias; }
 #endif
 	return 0.0f;
 }
 
 -(void) setLodBiasMVK: (float) bias {
-#if MVK_USE_METAL_PRIVATE_API
+#if MVK_USE_METAL_PRIVATE_API || MVK_XCODE_26
 	if ( [self respondsToSelector: @selector(setLodBias:)] ) { self.lodBias = bias; }
 #endif
 }


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/MoltenVK/issues/2611

Enables sampler lod bias regardless of private API availability and removes the custom definition of the descriptor field when using Xcode 26, as this is now a public API. This fixes a build failure as the definitions were conflicting.

I also adjusted the max sampler lod bias limit to reflect the new Metal docs here: https://developer.apple.com/documentation/metal/mtlsamplerdescriptor/lodbias

This will likely break building with Xcode 26 betas and require using the RC, but I don't see a way to detect the betas (and it might not even be worth supporting them).