### PR TITLE
Miscellaneous build and documentation updates.

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -492,21 +492,6 @@ apps to select a queue family with the appropriate requirements.
 
 
 ---------------------------------------
-#### MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS
-
-##### Type: Boolean
-##### Default: `1`
-
-Depending on the GPU, _Metal_ allows 8,192 or 32,768 occlusion queries per `MTLBuffer`.
-If enabled, **MoltenVK** allocates a `MTLBuffer` for each query pool, allowing each query
-pool to support that permitted number of queries. This may slow performance or cause
-unexpected behaviour if the query pool is not established prior to a _Metal_ renderpass,
-or if the query pool is changed within a renderpass. If disabled, one `MTLBuffer` will
-be shared by all query pools, which improves performance, but limits the total device
-queries to the permitted number.
-
-
----------------------------------------
 #### MVK_CONFIG_SWAPCHAIN_MIN_MAG_FILTER_USE_NEAREST
 
 ##### Type: Boolean

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,13 +18,31 @@ MoltenVK 1.4.1
 
 Released TBD
 
-- .
-- New state tracker implementation.
-- New descriptor set/pool implementation.
-	- The new implementation is less forgiving of applications that don't properly manage the lifetime of their descriptors
-	  (and bind them after the objects they point to have been destroyed).
-	  Use `MVK_CONFIG_LIVE_CHECK_ALL_RESOURCES=1` to revert any crashes this might cause, or mark potentially-destroyed descriptors
-	  with `VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT`.
+- Improved occlusion query support:
+  - Add support for occlusion queries across multiple renderpasses.
+  - Improve performance by accumulating occlusion quieries in parallel, 
+    and using untracked buffers to avoid encoder serialization.
+- New descriptor state tracker implementation to improve performance.
+- New descriptor set/pool implementation:
+  - The new implementation is less forgiving of applications that don't properly manage the lifetime 
+    of their descriptors (and bind them after the objects they point to have been destroyed).
+	Use `MVK_CONFIG_LIVE_CHECK_ALL_RESOURCES=1` to revert any crashes this might cause, 
+	or mark potentially-destroyed descriptors with `VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT`.
+- Added working demo target for VisionOS in Cube Demo.
+- Raise minimum target to _macOS 11.0 / iOS 14.0 / tvOS 14.0_
+- Add support for `VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT`.
+- Reject image usages whose format features are not supported.
+- Return `VK_ERROR_OUT_OF_POOL_MEMORY` when running out of descriptor sets.
+- Make vkGetPhysicalDeviceToolProperties() an instance function.
+- Enable sample LOD bias for Xcode 26.
+- Fix VkExternalMemory*CreateInfo not allowing host memory handle types.
+- Fix improper boundary error when requesting exactly the number of variable descriptors allocated.
+- Fix regression on functions used by multiple extensions.
+- Fix improper use of dynamic depth/stencil attachment.
+- Fix out-of-bound access when using multiview with multiple subpasses.
+- Deprecate configuration parameter `MVKConfiguration::supportLargeQueryPools` and corresponding environment variable 
+  `MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS`, as obsolete and ignored. Large query pools are now supported always.
+- Disable Mac Catalyst builds from `all` and `all-debug` in `Makefile`, due to unresolved issues with Mac Catalyst builds. 
 - Update to latest SPIRV-Cross:
 
 

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ MAKEARGS := $(strip \
       $(v)=$(value $(v)) ,)))
 
 # Specify individually (not as dependencies) so the sub-targets don't run in parallel
+# maccat is currently excluded from `all` because of unresolved build issues on Mac Catalyst platform.
 .PHONY: all
 all:
 	@$(MAKE) macos
 	@$(MAKE) ios
 	@$(MAKE) iossim
-	@$(MAKE) maccat
+#	@$(MAKE) maccat
 	@$(MAKE) tvos
 	@$(MAKE) tvossim
 	@$(MAKE) visionos       # Requires Xcode 15+
@@ -37,7 +38,7 @@ all-debug:
 	@$(MAKE) macos-debug
 	@$(MAKE) ios-debug
 	@$(MAKE) iossim-debug
-	@$(MAKE) maccat-debug
+#	@$(MAKE) maccat-debug
 	@$(MAKE) tvos-debug
 	@$(MAKE) tvossim-debug
 	@$(MAKE) visionos-debug       # Requires Xcode 15+

--- a/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
+++ b/MoltenVK/MoltenVK.xcodeproj/project.pbxproj
@@ -2591,6 +2591,10 @@
 					"-w",
 				);
 				SDKROOT = xros;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-deprecated-declarations",
+				);
 			};
 			name = Debug;
 		};
@@ -2604,6 +2608,10 @@
 					"-w",
 				);
 				SDKROOT = xros;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-deprecated-declarations",
+				);
 			};
 			name = Release;
 		};
@@ -2792,6 +2800,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				SDKROOT = xros;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-deprecated-declarations",
+				);
 			};
 			name = Debug;
 		};
@@ -2799,6 +2811,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				SDKROOT = xros;
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-deprecated-declarations",
+				);
 			};
 			name = Release;
 		};

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -211,7 +211,7 @@ typedef struct {
 	VkBool32 synchronousQueueSubmits;                                          /**< MVK_CONFIG_SYNCHRONOUS_QUEUE_SUBMITS */
 	MVKPrefillMetalCommandBuffersStyle prefillMetalCommandBuffers;             /**< MVK_CONFIG_PREFILL_METAL_COMMAND_BUFFERS */
 	uint32_t maxActiveMetalCommandBuffersPerQueue;                             /**< MVK_CONFIG_MAX_ACTIVE_METAL_COMMAND_BUFFERS_PER_QUEUE */
-	VkBool32 supportLargeQueryPools;                                           /**< MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS */
+	VkBool32 supportLargeQueryPools;                                           /**< Obsolete, deprecated, and ignored. */
 	VkBool32 presentWithCommandBuffer;                                         /**< Obsolete, deprecated, and ignored. */
 	VkBool32 swapchainMinMagFilterUseNearest;                                  /**< MVK_CONFIG_SWAPCHAIN_MIN_MAG_FILTER_USE_NEAREST */
 	uint64_t metalCompileTimeout;                                              /**< MVK_CONFIG_METAL_COMPILE_TIMEOUT */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -457,7 +457,6 @@ protected:
 	friend class MVKDeviceTrackingMixin;
 
 	void propagateDebugName() override {}
-	MTLFeatureSet getMaximalMTLFeatureSet();
     void initMetalFeatures();
 	void initFeatures();
 	void initMTLDevice();

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -73,18 +73,6 @@ static const uint32_t kMaxTimeDomains = 2;
 
 #define supportsGPUFam(gpuFam, mtlDev)  ([mtlDev respondsToSelector: @selector(supportsFamily:)] && [mtlDev supportsFamily: MTLGPUFamily ##gpuFam])
 
-#if MVK_IOS
-#define supportsIOSGPU(gpuIdx, mtlDev)  [mtlDev supportsFeatureSet: MTLFeatureSet_iOS_GPUFamily ##gpuIdx ##_v1]
-#else
-#define supportsIOSGPU(gpuIdx, mtlDev)  false
-#endif
-
-#if MVK_TVOS
-#define supportsTVOSGPU(gpuIdx, mtlDev)  [mtlDev supportsFeatureSet: MTLFeatureSet_tvOS_GPUFamily ##gpuIdx ##_v1]
-#else
-#define supportsTVOSGPU(gpuIdx, mtlDev)  false
-#endif
-
 #define returnGPUValIf(gpuType, gpuIdx)  if (supports ##gpuType ##gpuIdx) { return gpuIdx; }
 
 uint8_t MVKMTLDeviceCapabilities::getHighestAppleGPU() const {
@@ -108,11 +96,11 @@ uint8_t MVKMTLDeviceCapabilities::getHighestMacGPU() const {
 
 MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
 	mvkClear(this);
-	supportsApple1 = supportsGPUFam(Apple1, mtlDev) || supportsIOSGPU(1, mtlDev) || supportsTVOSGPU(1, mtlDev);
-	supportsApple2 = supportsGPUFam(Apple2, mtlDev) || supportsIOSGPU(2, mtlDev) || supportsTVOSGPU(1, mtlDev);
-	supportsApple3 = supportsGPUFam(Apple3, mtlDev) || supportsIOSGPU(3, mtlDev) || supportsTVOSGPU(2, mtlDev);
-	supportsApple4 = supportsGPUFam(Apple4, mtlDev) || supportsIOSGPU(4, mtlDev);
-	supportsApple5 = supportsGPUFam(Apple5, mtlDev) || supportsIOSGPU(5, mtlDev);
+	supportsApple1 = supportsGPUFam(Apple1, mtlDev);
+	supportsApple2 = supportsGPUFam(Apple2, mtlDev);
+	supportsApple3 = supportsGPUFam(Apple3, mtlDev);
+	supportsApple4 = supportsGPUFam(Apple4, mtlDev);
+	supportsApple5 = supportsGPUFam(Apple5, mtlDev);
 	supportsApple6 = supportsGPUFam(Apple6, mtlDev);
 #if MVK_XCODE_13
 	supportsApple7 = supportsGPUFam(Apple7, mtlDev);

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ graphics and compute functionality, that is built on Apple's [*Metal*](https://d
 graphics and compute framework on *macOS*, *iOS*, *tvOS*, and *visionOS*. **MoltenVK** allows
 you to use *Vulkan* graphics and compute functionality to develop modern, cross-platform,
 high-performance graphical games and applications, and to run them across many platforms,
-including *macOS*, *iOS*, *tvOS*, *visionOS*, *Simulators*, and *Mac Catalyst* on *macOS 11.0+*,
+including *macOS*, *iOS*, *tvOS*, *visionOS*, *Simulators*, and *Mac Catalyst*,
 and all *Apple* architectures, including *Apple Silicon*.
 
 *Metal* uses a different shading language, the *Metal Shading Language (MSL)*, than


### PR DESCRIPTION
- ~Update to latest SPIRV-Cross version.~
- Disable Mac Catalyst builds from all and all-debug in Makefile, due to unresolved issues with Mac Catalyst builds (see issue #2626).
- Disable numerous deprecation warnings in visionos builds.
- Remove references to deprecated `MTLFeatureSet`.
- Remove `MVK_CONFIG_SUPPORT_LARGE_QUERY_POOLS` from `MoltenVK_Configuration_Parameters.md` document.
- Update `Whats_New.md` document.