### PR TITLE
Add base GPU family for samplerMipLodBias support.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2437,8 +2437,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 
 #if MVK_XCODE_26
-	// NOTE: The Metal feature set table claims this requires Apple10, but it seems to work fine on older GPUs as well.
-	_metalFeatures.samplerMipLodBias = mvkOSVersionIsAtLeast(26.0);
+	// NOTE: The Metal feature set table claims this requires Apple10, but it seems to work fine on at least Apple9 as well.
+	// TODO: Test on Apple8 (M2).
+	_metalFeatures.samplerMipLodBias = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple9);
 	_metalFeatures.depthBoundsTest = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple10);
 #endif
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2437,9 +2437,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #endif
 
 #if MVK_XCODE_26
-	// NOTE: The Metal feature set table claims this requires Apple10, but it seems to work fine on at least Apple9 as well.
-	// TODO: Test on Apple8 (M2).
-	_metalFeatures.samplerMipLodBias = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple9);
+	_metalFeatures.samplerMipLodBias = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple10);
 	_metalFeatures.depthBoundsTest = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple10);
 #endif
 


### PR DESCRIPTION
Adds a base GPU family of `Apple9` for `samplerMipLodBias` support.

Testing has revealed that it does not function correctly on `Apple7` (e.g. M1) GPUs. I have confirmed it works on `Apple9`, but do not have an `Apple8` device to test, so I have left that as a TODO item. If anyone can test CTS for this on `Apple8`, I can update the support requirement.

On M4:
```
./deqp-vk --deqp-case="dEQP-VK.pipeline.monolithic.sampler.*.lod.*"

Test run totals:
  Passed:        4865/6244 (77.9%)
  Failed:        0/6244 (0.0%)
  Not supported: 1379/6244 (22.1%)
  Warnings:      0/6244 (0.0%)
  Waived:        0/6244 (0.0%)
```