### PR TITLE
Remove samplerMipLodBias private API.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2429,10 +2429,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.depthBoundsTest = mvkOSVersionIsAtLeast(26.0) && supportsMTLGPUFamily(Apple10);
 #endif
 
-#if MVK_USE_METAL_PRIVATE_API
-	_metalFeatures.samplerMipLodBias = _metalFeatures.samplerMipLodBias || getMVKConfig().useMetalPrivateAPI;
-#endif
-
 	// GPU-specific features
 	switch (_properties.vendorID) {
 		case kAMDVendorId:

--- a/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
@@ -21,15 +21,6 @@
 #include "MVKCommonEnvironment.h"
 
 
-#if MVK_USE_METAL_PRIVATE_API && !MVK_XCODE_26
-/** Additional methods not necessarily declared in <Metal/MTLSampler.h>. */
-@interface MTLSamplerDescriptor ()
-
-@property(nonatomic, readwrite) float lodBias;
-
-@end
-#endif
-
 @implementation MTLSamplerDescriptor (MoltenVK)
 
 -(MTLCompareFunction) compareFunctionMVK {
@@ -55,14 +46,14 @@
 }
 
 -(float) lodBiasMVK {
-#if MVK_USE_METAL_PRIVATE_API || MVK_XCODE_26
+#if MVK_XCODE_26
 	if ( [self respondsToSelector: @selector(lodBias)] ) { return self.lodBias; }
 #endif
 	return 0.0f;
 }
 
 -(void) setLodBiasMVK: (float) bias {
-#if MVK_USE_METAL_PRIVATE_API || MVK_XCODE_26
+#if MVK_XCODE_26
 	if ( [self respondsToSelector: @selector(setLodBias:)] ) { self.lodBias = bias; }
 #endif
 }

--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ included in any of the `make` command-line build commands [mentioned above](#com
 Functionality added with `MVK_USE_METAL_PRIVATE_API` enabled includes:
 - `VkPhysicalDeviceFeatures::wideLines`
 - `VkPhysicalDeviceFeatures::logicOp`
-- `VkPhysicalDevicePortabilitySubsetFeaturesKHR::samplerMipLodBias` (before macOS/iOS 26)
 - `VkGraphicsPipelineRasterizationCreateInfo::sampleMask`, using `MTLRenderPipelineDescriptor.sampleMask` instead of emulating it in the fragment shader
 
 


### PR DESCRIPTION
As established in https://github.com/KhronosGroup/MoltenVK/pull/2631, this does not generally work, and is replaced by proper support on Apple10 GPUs.