### PR TITLE
Lift minimum build Xcode to 14.3 and document minimum support policies.

### DIFF
--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -114,21 +114,6 @@ extern "C" {
                                     (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) || \
                                         (__TV_OS_VERSION_MAX_ALLOWED >= 170000))
 #endif
-#ifndef MVK_XCODE_14_3
-#	define MVK_XCODE_14_3			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130300) || \
-									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160400) || \
-                                        (__TV_OS_VERSION_MAX_ALLOWED >= 160400))
-#endif
-#ifndef MVK_XCODE_14
-#	define MVK_XCODE_14				((__MAC_OS_X_VERSION_MAX_ALLOWED >= 130000) || \
-									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 160000) || \
-                                        (__TV_OS_VERSION_MAX_ALLOWED >= 160000))
-#endif
-#ifndef MVK_XCODE_13
-#	define MVK_XCODE_13 			((__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000) || \
-									(__IPHONE_OS_VERSION_MAX_ALLOWED >= 150000 || \
-                                        (__TV_OS_VERSION_MAX_ALLOWED >= 150000)))
-#endif
 
 /**
  * Enable use of private Metal APIs.

--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -69,8 +69,8 @@ to their *MSL* equivalents.
 
 To provide *Vulkan* capability to the *macOS*, *iOS*, and *tvOS* platforms, **MoltenVK** uses
 *Apple's* publicly available API's, including *Metal*. **MoltenVK** does **_not_** use any
-private or undocumented API calls or features, so your app will be compatible with all
-standard distribution channels, including *Apple's App Store*.
+private or undocumented API calls or features unless configured to do so at build time, so your
+app will be compatible with all standard distribution channels, including *Apple's App Store*.
 
 
 <a name="install"></a>
@@ -191,6 +191,8 @@ Once built, your app integrating the **MoltenVK** libraries can be run on *macOS
 devices that support *Metal*, or on the *Xcode* *iOS Simulator* or *tvOS Simulator*.
 
 - At runtime, **MoltenVK** requires at least *macOS 11.0*, *iOS 14*, or *tvOS 14.5*.
+  - This support policy is based on the earliest deployment target [officially supported](https://developer.apple.com/support/xcode/)
+    by the latest version of Xcode.
 - Information on *macOS* devices that are compatible with *Metal* can be found in
   [this article](http://www.idownloadblog.com/2015/06/22/how-to-find-mac-el-capitan-metal-compatible).
 - Information on *iOS* devices that are compatible with *Metal* can be found in

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -1320,9 +1320,7 @@ bool MVKCmdBufferImageCopy<N>::isArrayTexture() {
 	MTLTextureType mtlTexType = _image->getMTLTextureType();
 	return (mtlTexType == MTLTextureType3D ||
 			mtlTexType == MTLTextureType2DArray ||
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 			mtlTexType == MTLTextureType2DMultisampleArray ||
-#endif
 			mtlTexType == MTLTextureType1DArray);
 }
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -76,9 +76,7 @@ typedef struct MVKRPSKeyBlitImg {
 
 	inline bool isSrcArrayType() {
 		return (srcMTLTextureType == MTLTextureType2DArray ||
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 				srcMTLTextureType == MTLTextureType2DMultisampleArray ||
-#endif
 				srcMTLTextureType == MTLTextureType1DArray);
 	}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -170,10 +170,7 @@ id<MTLBuffer> MVKBuffer::getMTLBuffer() {
 }
 
 uint64_t MVKBuffer::getMTLBufferGPUAddress() {
-#if MVK_XCODE_14
 	return [getMTLBuffer() gpuAddress] + getMTLBufferOffset();
-#endif
-	return 0;
 }
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -97,19 +97,15 @@ uint8_t MVKMTLDeviceCapabilities::getHighestMacGPU() const {
 
 MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
 	mvkClear(this);
+	supportsMetal3 = supportsGPUFam(Metal3, mtlDev);
 	supportsApple1 = supportsGPUFam(Apple1, mtlDev);
 	supportsApple2 = supportsGPUFam(Apple2, mtlDev);
 	supportsApple3 = supportsGPUFam(Apple3, mtlDev);
 	supportsApple4 = supportsGPUFam(Apple4, mtlDev);
 	supportsApple5 = supportsGPUFam(Apple5, mtlDev);
 	supportsApple6 = supportsGPUFam(Apple6, mtlDev);
-#if MVK_XCODE_13
 	supportsApple7 = supportsGPUFam(Apple7, mtlDev);
-#endif
-#if MVK_XCODE_14
 	supportsApple8 = supportsGPUFam(Apple8, mtlDev);
-	supportsMetal3 = supportsGPUFam(Metal3, mtlDev);
-#endif
 #if MVK_XCODE_15 && !MVK_TVOS && !MVK_VISIONOS
 	supportsApple9 = supportsGPUFam(Apple9, mtlDev);
 #endif
@@ -121,23 +117,17 @@ MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
 
 	isAppleGPU = supportsApple1;
 
-#if MVK_XCODE_14_3 || (MVK_MACOS && !MVK_MACCAT)
 	if ([mtlDev respondsToSelector: @selector(supportsBCTextureCompression)]) {
 		supportsBCTextureCompression = mtlDev.supportsBCTextureCompression;
 	}
-#else
-	supportsBCTextureCompression = supportsMac1;
-#endif
-#if MVK_MACOS
-	supportsDepth24Stencil8 = mtlDev.isDepth24Stencil8PixelFormatSupported;
-#endif
-#if MVK_XCODE_14 || !MVK_TVOS
 	if ([mtlDev respondsToSelector: @selector(supports32BitFloatFiltering)]) {
 		supports32BitFloatFiltering = mtlDev.supports32BitFloatFiltering;
 	}
 	if ([mtlDev respondsToSelector: @selector(supports32BitMSAA)]) {
 		supports32BitMSAA = mtlDev.supports32BitMSAA;
 	}
+#if MVK_MACOS
+	supportsDepth24Stencil8 = mtlDev.isDepth24Stencil8PixelFormatSupported;
 #endif
 }
 
@@ -2374,7 +2364,7 @@ void MVKPhysicalDevice::initMTLDevice() {
 	// Apple Silicon will respond false to isLowPower, but never hits it.
 	_hasUnifiedMemory = _mtlDevice.hasUnifiedMemory;
 
-#if MVK_XCODE_14_3 && !MVK_MACCAT
+#if !MVK_MACCAT
 	if ([_mtlDevice respondsToSelector: @selector(setShouldMaximizeConcurrentCompilation:)]) {
 		[_mtlDevice setShouldMaximizeConcurrentCompilation: getMVKConfig().shouldMaximizeConcurrentCompilation];
 		MVKLogInfoIf(getMVKConfig().debugMode, "maximumConcurrentCompilationTaskCount %lu", _mtlDevice.maximumConcurrentCompilationTaskCount);
@@ -2530,16 +2520,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	} else {
 		_metalFeatures.maxPerStageTextureCount = 31;
 	}
-#if MVK_XCODE_13
 	if ( mvkOSVersionIsAtLeast(15.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
 	}
-#endif
-#if MVK_XCODE_14
 	if ( mvkOSVersionIsAtLeast(16.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
 	}
-#endif
 #if MVK_XCODE_15
 	if ( mvkOSVersionIsAtLeast(17.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
@@ -2600,16 +2586,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.placementHeaps = useMTLHeap;
 		_metalFeatures.renderWithoutAttachments = true;
 	}
-#if MVK_XCODE_13
 	if ( mvkOSVersionIsAtLeast(12.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion2_4;
 	}
-#endif
-#if MVK_XCODE_14
 	if ( mvkOSVersionIsAtLeast(13.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
 	}
-#endif
 #if MVK_XCODE_15
 	if ( mvkOSVersionIsAtLeast(14.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
@@ -2655,7 +2637,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.rasterOrderGroups = _mtlDevice.areRasterOrderGroupsSupported;
 	_metalFeatures.pullModelInterpolation = _mtlDevice.supportsPullModelInterpolation;
 
-#if (MVK_MACOS && !MVK_MACCAT) || (MVK_MACCAT && MVK_XCODE_14) || MVK_IOS
 	// Both current and deprecated properties are retrieved and OR'd together, due to a
 	// Metal bug that, in some environments, returned true for one and false for the other.
 	bool bcProp1 = false;
@@ -2667,7 +2648,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		bcProp2 = _mtlDevice.areBarycentricCoordsSupported;
 	}
 	_metalFeatures.shaderBarycentricCoordinates = bcProp1 || bcProp2;
-#endif
 
     _metalFeatures.maxMTLBufferSize = _mtlDevice.maxBufferLength;
 
@@ -2733,16 +2713,12 @@ void MVKPhysicalDevice::initMetalFeatures() {
 			setMSLVersion(3, 1);
 			break;
 #endif
-#if MVK_XCODE_14
 		case MTLLanguageVersion3_0:
 			setMSLVersion(3, 0);
 			break;
-#endif
-#if MVK_XCODE_13
 		case MTLLanguageVersion2_4:
 			setMSLVersion(2, 4);
 			break;
-#endif
 		case MTLLanguageVersion2_3:
 			setMSLVersion(2, 3);
 			break;
@@ -2784,13 +2760,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 													_properties.vendorID == kIntelVendorId);
 
 	// Argument encoders are not needed if Metal 3 plus Tier 2 argument buffers.
-#if MVK_XCODE_14
 	_metalFeatures.needsArgumentBufferEncoders = !(mvkOSVersionIsAtLeast(13.0, 16.0, 1.0) &&
 													supportsMTLGPUFamily(Metal3) &&
 													_metalFeatures.argumentBuffersTier >= MTLArgumentBuffersTier2);
-#else
-	_metalFeatures.needsArgumentBufferEncoders = true;
-#endif
 
 	_isUsingMetalArgumentBuffers = _metalFeatures.descriptorSetArgumentBuffers && getMVKConfig().useMetalArgumentBuffers;
 
@@ -3660,17 +3632,11 @@ void MVKPhysicalDevice::initExtensions() {
 		pWritableExtns->vk_EXT_image_2d_view_of_3d.enabled = false;
 	}
 
-    // The relevant functions are not available if not built with Xcode 14.
-#if MVK_XCODE_14
     // gpuAddress requires Tier2 argument buffer support (per feedback from Apple engineers).
     if (_metalFeatures.argumentBuffersTier < MTLArgumentBuffersTier2) {
 		pWritableExtns->vk_KHR_buffer_device_address.enabled = false;
 		pWritableExtns->vk_EXT_buffer_device_address.enabled = false;
 	}
-#else
-    pWritableExtns->vk_KHR_buffer_device_address.enabled = false;
-    pWritableExtns->vk_EXT_buffer_device_address.enabled = false;
-#endif
 
 #if MVK_MACOS
 	if (!supportsMTLGPUFamily(Apple5)) {
@@ -3785,18 +3751,12 @@ void MVKPhysicalDevice::logGPUInfo() {
 	logMsg += "\n\tMetal Shading Language %s";
 	logMsg += "\n\tsupports the following GPU Features:";
 
-#if MVK_XCODE_14
 	if (supportsMTLGPUFamily(Metal3)) { logMsg += "\n\t\tGPU Family Metal 3"; }
-#endif
 #if MVK_XCODE_15 && (MVK_IOS || MVK_MACOS)
 	if (supportsMTLGPUFamily(Apple9)) { logMsg += "\n\t\tGPU Family Apple 9"; } else
 #endif
-#if MVK_XCODE_14 || (MVK_IOS && MVK_XCODE_13)
 	if (supportsMTLGPUFamily(Apple8)) { logMsg += "\n\t\tGPU Family Apple 8"; } else
-#endif
-#if MVK_IOS || MVK_MACOS
 	if (supportsMTLGPUFamily(Apple7)) { logMsg += "\n\t\tGPU Family Apple 7"; } else
-#endif
 	if (supportsMTLGPUFamily(Apple6)) { logMsg += "\n\t\tGPU Family Apple 6"; } else
 	if (supportsMTLGPUFamily(Apple5)) { logMsg += "\n\t\tGPU Family Apple 5"; } else
 	if (supportsMTLGPUFamily(Apple4)) { logMsg += "\n\t\tGPU Family Apple 4"; } else
@@ -5051,11 +5011,9 @@ MTLCompileOptions* MVKDevice::getMTLCompileOptions(uint32_t fpFastMathFlags,
 		mtlCompOpt.fastMathEnabled = mvkAreAllFlagsEnabled(fpFastMathFlags, mvk::kSPIRVFPFastMathModesSupported);
 	}
 
-#if MVK_XCODE_14
 	if ([mtlCompOpt respondsToSelector: @selector(optimizationLevel)]) {
 		mtlCompOpt.optimizationLevel = MTLLibraryOptimizationLevelDefault;
 	}
-#endif
 
 	mtlCompOpt.preserveInvariance = preserveInvariance;
 	return [mtlCompOpt autorelease];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKFramebuffer.mm
@@ -36,16 +36,12 @@ id<MTLTexture> MVKFramebuffer::getDummyAttachmentMTLTexture(MVKRenderSubpass* su
 	uint32_t sampleCount = mvkSampleCountFromVkSampleCountFlagBits(subpass->getDefaultSampleCount());
 	MTLTextureDescriptor* mtlTexDesc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat: MTLPixelFormatR8Unorm width: fbExtent.width height: fbExtent.height mipmapped: NO];
 	if (subpass->isMultiview()) {
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 		if (sampleCount > 1 && getMetalFeatures().multisampleLayeredRendering) {
 			mtlTexDesc.textureType = MTLTextureType2DMultisampleArray;
 			mtlTexDesc.sampleCount = sampleCount;
 		} else {
 			mtlTexDesc.textureType = MTLTextureType2DArray;
 		}
-#else
-		mtlTexDesc.textureType = MTLTextureType2DArray;
-#endif
 		mtlTexDesc.arrayLength = subpass->getViewCountInMetalPass(passIdx);
 	} else if (fbLayerCount > 1) {
 #if MVK_MACOS

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -2426,10 +2426,8 @@ MVKImageView::MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCrea
 										 VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT))) {
 		if (_mtlTextureType == MTLTextureType2DArray && _image->_mtlTextureType == MTLTextureType2D) {
 			_mtlTextureType = MTLTextureType2D;
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 		} else if (_mtlTextureType == MTLTextureType2DMultisampleArray && _image->_mtlTextureType == MTLTextureType2DMultisample) {
 			_mtlTextureType = MTLTextureType2DMultisample;
-#endif
 		}
 	}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -32,40 +32,6 @@ using namespace std;
 #endif
 
 #if MVK_IOS_OR_TVOS
-#   if !MVK_XCODE_14_3   // iOS/tvOS 16.4
-#       define MTLPixelFormatBC1_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC1_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC2_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC2_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC3_RGBA               MTLPixelFormatInvalid
-#       define MTLPixelFormatBC3_RGBA_sRGB          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC4_RUnorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatBC4_RSnorm             MTLPixelFormatInvalid
-#       define MTLPixelFormatBC5_RGUnorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatBC5_RGSnorm            MTLPixelFormatInvalid
-#       define MTLPixelFormatBC6H_RGBUfloat         MTLPixelFormatInvalid
-#       define MTLPixelFormatBC6H_RGBFloat          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC7_RGBAUnorm          MTLPixelFormatInvalid
-#       define MTLPixelFormatBC7_RGBAUnorm_sRGB     MTLPixelFormatInvalid
-#   endif
-
-#   if MVK_TVOS && !MVK_XCODE_14
-#       define MTLPixelFormatASTC_4x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x4_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_5x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_6x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x5_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x6_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_8x8_HDR           MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x5_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x6_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x8_HDR          MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_10x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x10_HDR         MTLPixelFormatInvalid
-#       define MTLPixelFormatASTC_12x12_HDR         MTLPixelFormatInvalid
-#   endif
-
 #   define MTLPixelFormatDepth16Unorm_Stencil8      MTLPixelFormatDepth32Float_Stencil8
 #   define MTLPixelFormatDepth24Unorm_Stencil8      MTLPixelFormatInvalid
 #   define MTLPixelFormatX24_Stencil8               MTLPixelFormatInvalid

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -240,9 +240,7 @@ void MVKQueue::handleMTLCommandBufferError(id<MTLCommandBuffer> mtlCmdBuff) {
 		case MTLCommandBufferErrorTimeout:
 			vkErr = VK_TIMEOUT;
 			break;
-#if MVK_XCODE_13
 		case MTLCommandBufferErrorStackOverflow:
-#endif
 		case MTLCommandBufferErrorPageFault:
 		case MTLCommandBufferErrorOutOfMemory:
 		default:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -196,10 +196,8 @@ VkResult MVKSwapchain::getRefreshCycleDuration(VkRefreshCycleDurationGOOGLE *pRe
 		CGDisplayModeRef mode = CGDisplayCopyDisplayMode(displayId);
 		framesPerSecond = CGDisplayModeGetRefreshRate(mode);
 		CGDisplayModeRelease(mode);
-#if MVK_XCODE_13
 		if (framesPerSecond == 0 && [screen respondsToSelector: @selector(maximumFramesPerSecond)])
 			framesPerSecond = [screen maximumFramesPerSecond];
-#endif
 		// Builtin panels, e.g., on MacBook, report a zero refresh rate.
 		if (framesPerSecond == 0)
 			framesPerSecond = 60.0;

--- a/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
+++ b/MoltenVK/MoltenVK/OS/MTLSamplerDescriptor+MoltenVK.m
@@ -24,16 +24,12 @@
 @implementation MTLSamplerDescriptor (MoltenVK)
 
 -(NSUInteger) borderColorMVK {
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 	if ( [self respondsToSelector: @selector(borderColor)] ) { return self.borderColor; }
-#endif
 	return /*MTLSamplerBorderColorTransparentBlack*/ 0;
 }
 
 -(void) setBorderColorMVK: (NSUInteger) color {
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 	if ( [self respondsToSelector: @selector(setBorderColor:)] ) { self.borderColor = (MTLSamplerBorderColor) color; }
-#endif
 }
 
 -(float) lodBiasMVK {

--- a/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
+++ b/MoltenVK/MoltenVK/Vulkan/mvk_datatypes.mm
@@ -163,9 +163,7 @@ MTLTextureType mvkMTLTextureTypeFromVkImageTypeObj(VkImageType vkImageType,
 									   : (arraySize > 1 ? MTLTextureType1DArray : MTLTextureType1D));
 		case VK_IMAGE_TYPE_2D:
 		default: {
-#if MVK_MACOS_OR_IOS || MVK_XCODE_14
 			if (arraySize > 1 && isMultisample) { return MTLTextureType2DMultisampleArray; }
-#endif
 			if (arraySize > 1) { return MTLTextureType2DArray; }
 			if (isMultisample) { return MTLTextureType2DMultisample; }
 			return MTLTextureType2D;

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -86,17 +86,11 @@ bool mvk::compile(const string& mslSourceCode,
 		mslVerEnum = MTLLanguageVersion3_1;
 	} else
 #endif
-#if MVK_XCODE_14
 	if (mslVer(3, 0, 0)) {
 		mslVerEnum = MTLLanguageVersion3_0;
-	} else
-#endif
-#if MVK_XCODE_13
-	if (mslVer(2, 4, 0)) {
+	} else if (mslVer(2, 4, 0)) {
 		mslVerEnum = MTLLanguageVersion2_4;
-	} else
-#endif
-	if (mslVer(2, 3, 0)) {
+	} else if (mslVer(2, 3, 0)) {
 		mslVerEnum = MTLLanguageVersion2_3;
 	} else if (mslVer(2, 2, 0)) {
 		mslVerEnum = MTLLanguageVersion2_2;

--- a/README.md
+++ b/README.md
@@ -175,19 +175,8 @@ Building **MoltenVK**
 During building, **MoltenVK** references the latest *Apple SDK* frameworks. To access these frameworks,
 and to avoid build errors, be sure to use the latest publicly available version of *Xcode*.
 
-> ***Note:*** *Xcode 14* introduced a new static linkage model that is not compatible with previous
-versions of *Xcode*. If you link to a `MoltenVK.xcframework` that was built with *Xcode 14* or later,
-also use *Xcode 14* or later to link it to your app or game.
->
-> If you need to use *Xcode 13* or earlier to link `MoltenVK.xcframework` to your app or game,
-first build **MoltenVK** with *Xcode 13* or earlier.
->
-> Or, if you want to use *Xcode 14* or later to build **MoltenVK**, in order to be able to use the
-latest *Metal* capabilities, but need to use *Xcode 13* or earlier to link `MoltenVK.xcframework`
-to your app or game, first add the value `-fno-objc-msgsend-selector-stubs` to the `OTHER_CFLAGS`
-*Xcode* build setting in the `MoltenVK.xcodeproj` and `MoltenVKShaderConverter.xcodeproj` *Xcode*
-projects, build **MoltenVK** with *Xcode 14* or later, and then link `MoltenVK.xcframework`
-to your app or game using *Xcode 13* or earlier.
+MoltenVK currently supports being built with *Xcode 14.3* or later. Support is based on the
+earliest version of Xcode that can be verified in CI workflows.
 
 Once built, the **MoltenVK** libraries can be run on *macOS*, *iOS*, *tvOS*, or *visionOS* devices
 that support *Metal*,or on the *Xcode* *iOS Simulator*, *tvOS Simulator*, or *visionOS Simulator*.


### PR DESCRIPTION
Resolves https://github.com/KhronosGroup/MoltenVK/issues/2629

* Documents the policy for minimum OS deployment target and Xcode version.
* Lifts the minimum Xcode build to 14.3 based on the minimum we test on in CI.