### PR TITLE
Allow host-coherent optimal tiling images on macOS with Apple GPU.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -402,7 +402,6 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 
 	// "Dedicated" means this memory can only be used for this image or buffer.
 	if (dedicatedImage) {
-#if MVK_MACOS
 		if (!isAppleGPU() && isMemoryHostCoherent()) {
 			if (!dedicatedImage->_isLinear) {
 				setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Host-coherent VkDeviceMemory objects cannot be associated with optimal-tiling images."));
@@ -411,7 +410,6 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 				setConfigurationResult(reportError(VK_ERROR_OUT_OF_DEVICE_MEMORY, "vkAllocateMemory(): Could not allocate a host-coherent VkDeviceMemory of size %llu bytes. The maximum memory-aligned size of a host-coherent VkDeviceMemory is %llu bytes.", _allocationSize, getMetalFeatures().maxMTLBufferSize));
 			}
 		}
-#endif
         for (auto& memoryBinding : dedicatedImage->_memoryBindings) {
             _imageMemoryBindings.push_back(memoryBinding);
         }


### PR DESCRIPTION
This should fix https://github.com/KhronosGroup/MoltenVK/issues/2618.

Updates the check when creating a dedicated allocation for a host-coherent, optimally-tiled image, to allow macOS with Apple GPUs.

I'll probably do a pass over all of the macOS checks later to see if there's anything else left... just this for now though, to get the issue fixed.