### PR TITLE
Update robustness support levels for different GPU types.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -232,7 +232,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 	VkPhysicalDeviceVulkan13Features supportedFeats13 = {
 		.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
 		.pNext = nullptr,
-		.robustImageAccess = true,
+		.robustImageAccess = true, // NOTE: Required by spec, not fully supported by non-Apple GPUs.
 		.inlineUniformBlock = true,
 		.descriptorBindingInlineUniformBlockUpdateAfterBind = true,
 		.pipelineCreationCacheControl = true,
@@ -738,7 +738,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR: {
 				auto* robustness2Features = (VkPhysicalDeviceRobustness2FeaturesKHR*)next;
 				robustness2Features->robustBufferAccess2 = false;
-				robustness2Features->robustImageAccess2 = true;
+				robustness2Features->robustImageAccess2 = _gpuCapabilities.isAppleGPU;
 				robustness2Features->nullDescriptor = false;
 				break;
 			}
@@ -920,6 +920,8 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	supportedProps13.maxBufferSize = _metalFeatures.maxMTLBufferSize;
 
 	// Create a SSOT for these Vulkan 1.4 properties, which can be queried via two mechanisms here.
+	const auto bufferRobustness = _gpuCapabilities.isAppleGPU ? VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS : VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED;
+	const auto imageRobustness = _gpuCapabilities.isAppleGPU ? VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2 : VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED;
 	VkPhysicalDeviceVulkan14Properties supportedProps14;
 	supportedProps14.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_PROPERTIES;
 	supportedProps14.pNext = nullptr;
@@ -938,10 +940,10 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	supportedProps14.blockTexelViewCompatibleMultipleLayers = false;
 	supportedProps14.maxCombinedImageSamplerDescriptorCount = 3;
 	supportedProps14.fragmentShadingRateClampCombinerInputs = false;
-	supportedProps14.defaultRobustnessStorageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED;
-	supportedProps14.defaultRobustnessUniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED;
-	supportedProps14.defaultRobustnessVertexInputs = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED;
-	supportedProps14.defaultRobustnessImages = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2;
+	supportedProps14.defaultRobustnessStorageBuffers = bufferRobustness;
+	supportedProps14.defaultRobustnessUniformBuffers = bufferRobustness;
+	supportedProps14.defaultRobustnessVertexInputs = bufferRobustness;
+	supportedProps14.defaultRobustnessImages = imageRobustness;
 
 	for (auto* next = (VkBaseOutStructure*)properties->pNext; next; next = next->pNext) {
 		switch ((uint32_t)next->sType) {
@@ -2850,7 +2852,7 @@ bool MVKPhysicalDevice::isTier2MetalArgumentBuffers() {
 void MVKPhysicalDevice::initFeatures() {
 	mvkClear(&_features);	// Start with everything cleared
 
-    _features.robustBufferAccess = true;  // XXX Required by Vulkan spec
+    _features.robustBufferAccess = true; // NOTE: Required by spec, not fully supported by non-Apple GPUs.
     _features.fullDrawIndexUint32 = true;
     _features.independentBlend = true;
     _features.sampleRateShading = true;
@@ -5238,8 +5240,9 @@ MVKDevice::MVKDevice(MVKPhysicalDevice* physicalDevice, const VkDeviceCreateInfo
 	reservePrivateData(pCreateInfo);
 	initConfiguration();
 
-	if (_enabledFeatures.robustBufferAccess || _enabledRobustness2Features.robustBufferAccess2) {
-		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Metal does not support buffer robustness.");
+	if (!physicalDevice->_gpuCapabilities.isAppleGPU &&
+	        (_enabledFeatures.robustBufferAccess || _enabledImageRobustnessFeatures.robustImageAccess)) {
+		reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Non-Apple GPUs do not fully support robustness.");
 	}
 
 	// Initialize fences for execution barriers


### PR DESCRIPTION
Re-evaluated this today using the CTS tests with the portability subset check disabled (it causes all of them to report not supported), and it seems that:
* Apple GPUs pass even `robustBufferAccess` tests, so we no longer need to consider `robustBufferAccess` only enabled for spec compliance on those GPUs.
* Intel/AMD GPUs are not even passing all of the `robustImageAccess` tests, so we do need to consider those features as unsupported for non-Apple GPUs.

Based on these I've adjusted the robustness feature flags where possible and updated warning conditions. I've also excluded from the warnings cases where we already advertise a feature as unsupported.

Test results for `dEQP-VK.robustness.*` with the portability subset check disabled:
```
M1/M4:

Test run totals:
  Passed:        9108/64963 (14.0%)
  Failed:        192/64963 (0.3%)
  Not supported: 55663/64963 (85.7%)
  Warnings:      0/64963 (0.0%)
  Waived:        0/64963 (0.0%)

Intel:

Test run totals:
  Passed:        4820/64963 (7.4%)
  Failed:        484/64963 (0.7%)
  Not supported: 59659/64963 (91.8%)
  Warnings:      0/64963 (0.0%)
  Waived:        0/64963 (0.0%)

AMD:

Test run totals:
  Passed:        3604/64963 (5.5%)
  Failed:        1700/64963 (2.6%)
  Not supported: 59659/64963 (91.8%)
  Warnings:      0/64963 (0.0%)
  Waived:        0/64963 (0.0%)
```

The 192 failing tests on M1/M4 are SPIRV-Cross errors due to cube texture atomics being unsupported. On Intel and AMD the failure count is higher because of `robustBufferAccess` and `robustImageAccess` being required.