### PR TITLE
Remove native swizzle and depth clamp simulator limitations.

### DIFF
--- a/Docs/MoltenVK_Configuration_Parameters.md
+++ b/Docs/MoltenVK_Configuration_Parameters.md
@@ -233,46 +233,6 @@ Forces **MoltenVK** to only advertise the low-power GPUs, if availble on the dev
 
 
 ---------------------------------------
-#### MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE
-
-##### Type: Boolean
-##### Default: `0`
-
-If _Metal_ supports native per-texture swizzling (_Mac2 or Apple GPU_),
-this parameter is ignored.
-
-When running on an older version of _Metal_ that does not support native per-texture swizzling,
-if this parameter is enabled, `VkImageView` swizzling is automatically performed in the converted
-_Metal_ shader code during all texture sampling and reading operations. This occurs regardless
-of whether a swizzle is required for the `VkImageView` associated with the _Metal_ texture,
-which may result in reduced performance.
-
-If disabled, and native _Metal_ per-texture swizzling is not available on the platform, the
-following very limited set of `VkImageView` component swizzles is supported via format substitutions:
-
-```
-Texture format			            Swizzle
---------------                  -------
-VK_FORMAT_R8_UNORM              ZERO, ANY, ANY, RED
-VK_FORMAT_A8_UNORM              ALPHA, ANY, ANY, ZERO
-VK_FORMAT_R8G8B8A8_UNORM        BLUE, GREEN, RED, ALPHA
-VK_FORMAT_R8G8B8A8_SRGB         BLUE, GREEN, RED, ALPHA
-VK_FORMAT_B8G8R8A8_UNORM        BLUE, GREEN, RED, ALPHA
-VK_FORMAT_B8G8R8A8_SRGB         BLUE, GREEN, RED, ALPHA
-VK_FORMAT_D32_SFLOAT_S8_UINT    RED, ANY, ANY, ANY (stencil only)
-VK_FORMAT_D24_UNORM_S8_UINT     RED, ANY, ANY, ANY (stencil only)
-```
-
-If native per-texture swizzling is not available, and this feature is not enabled,
-an error is logged and returned in the following situations:
-
-- `VkImageView` creation if that `VkImageView` requires full image view swizzling.
-- A pipeline that was not compiled with full image view swizzling uses a `VkImageView` that is expecting a swizzle.
-- `VkPhysicalDeviceImageFormatInfo2KHR` is passed in a call to `vkGetPhysicalDeviceImageFormatProperties2KHR()`
-  to query for an `VkImageView` format that will require full swizzling.
-
-
----------------------------------------
 #### MVK_CONFIG_LOG_LEVEL
 
 ##### Type: Enumeration

--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -118,7 +118,7 @@ typedef struct {
 	VkBool32 fences;								/**< If true, Metal synchronization fences (MTLFence) are supported. Deprecated. Will always be true on all platforms. */
 	VkBool32 rasterOrderGroups;						/**< If true, Raster order groups in fragment shaders are supported. */
 	VkBool32 native3DCompressedTextures;			/**< If true, 3D compressed images are supported natively, without manual decompression. */
-	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
+	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. Deprecated. Will always be true on all platforms. */
 	VkBool32 placementHeaps;						/**< If true, MTLHeap objects support placement of resources. */
 	VkDeviceSize pushConstantSizeAlignment;			/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
 	uint32_t maxTextureLayers;						/**< The maximum number of layers in an array texture. */

--- a/MoltenVK/MoltenVK/API/mvk_private_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_private_api.h
@@ -220,7 +220,7 @@ typedef struct {
 	VkBool32 displayWatermark;                                                 /**< MVK_CONFIG_DISPLAY_WATERMARK */
 	VkBool32 specializedQueueFamilies;                                         /**< MVK_CONFIG_SPECIALIZED_QUEUE_FAMILIES */
 	VkBool32 switchSystemGPU;                                                  /**< MVK_CONFIG_SWITCH_SYSTEM_GPU */
-	VkBool32 fullImageViewSwizzle;                                             /**< MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE */
+	VkBool32 fullImageViewSwizzle;                                             /**< Obsolete, deprecated, and ignored. */
 	uint32_t defaultGPUCaptureScopeQueueFamilyIndex;                           /**< MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_FAMILY_INDEX */
 	uint32_t defaultGPUCaptureScopeQueueIndex;                                 /**< MVK_CONFIG_DEFAULT_GPU_CAPTURE_SCOPE_QUEUE_INDEX */
 	MVKConfigFastMath fastMathEnabled;                                         /**< MVK_CONFIG_FAST_MATH_ENABLED */

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -532,8 +532,7 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
         id<MTLTexture> srcMTLTex = _srcImage->getMTLTexture(srcPlaneIndex);
         id<MTLTexture> dstMTLTex = _dstImage->getMTLTexture(dstPlaneIndex);
         if (blitCnt && srcMTLTex && dstMTLTex) {
-			if (mtlFeats.nativeTextureSwizzle &&
-				_srcImage->needsSwizzle()) {
+			if (_srcImage->needsSwizzle()) {
 				// Use a view that has a swizzle on it.
 				srcMTLTex = [srcMTLTex newTextureViewWithPixelFormat:srcMTLTex.pixelFormat
 														 textureType:srcMTLTex.textureType
@@ -589,14 +588,6 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
             blitKey.srcFilter = mvkMTLSamplerMinMagFilterFromVkFilter(_filter);
             blitKey.srcAspect = mvkIBR.region.srcSubresource.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
             blitKey.dstSampleCount = mvkSampleCountFromVkSampleCountFlagBits(_dstImage->getSampleCount());
-			if (!mtlFeats.nativeTextureSwizzle &&
-				_srcImage->needsSwizzle()) {
-				VkComponentMapping vkMapping = _srcImage->getPixelFormats()->getVkComponentMapping(_srcImage->getVkFormat());
-				blitKey.srcSwizzleR = vkMapping.r;
-				blitKey.srcSwizzleG = vkMapping.g;
-				blitKey.srcSwizzleB = vkMapping.b;
-				blitKey.srcSwizzleA = vkMapping.a;
-			}
             id<MTLRenderPipelineState> mtlRPS = cmdEncoder->getCommandEncodingPool()->getCmdBlitImageMTLRenderPipelineState(blitKey);
             bool isBlittingDepth = mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT));
             bool isBlittingStencil = mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_STENCIL_BIT));

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -135,7 +135,6 @@ struct MVKVulkanSharedCommandEncoderState {
 };
 
 struct MVKImplicitBufferData {
-	MVKSmallVector<uint32_t, 8> textureSwizzles;
 	MVKSmallVector<uint32_t, 8> bufferSizes;
 	MVKSmallVector<uint32_t, 8> dynamicOffsets;
 };

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -44,13 +44,8 @@ typedef struct MVKRPSKeyBlitImg {
 	uint8_t srcFilter : 4;					/**< as MTLSamplerMinMagFilter */
 	uint8_t srcAspect = 0;					/**< as VkImageAspectFlags */
 	uint8_t dstSampleCount = 0;
-	uint8_t srcSwizzleR : 4;				/**< as VkComponentSwizzle */
-	uint8_t srcSwizzleG : 4;				/**< as VkComponentSwizzle */
-	uint8_t srcSwizzleB : 4;				/**< as VkComponentSwizzle */
-	uint8_t srcSwizzleA : 4;				/**< as VkComponentSwizzle */
 
-	MVKRPSKeyBlitImg() : srcMTLPixelFormat(0), dstMTLPixelFormat(0), srcMTLTextureType(0), srcFilter(0),
-		srcSwizzleR(0), srcSwizzleG(0), srcSwizzleB(0), srcSwizzleA(0) {}
+	MVKRPSKeyBlitImg() : srcMTLPixelFormat(0), dstMTLPixelFormat(0), srcMTLTextureType(0), srcFilter(0) {}
 
 	bool operator==(const MVKRPSKeyBlitImg& rhs) const {
 		if (srcMTLPixelFormat != rhs.srcMTLPixelFormat) { return false; }
@@ -59,10 +54,6 @@ typedef struct MVKRPSKeyBlitImg {
 		if (srcFilter != rhs.srcFilter) { return false; }
 		if (srcAspect != rhs.srcAspect) { return false; }
 		if (dstSampleCount != rhs.dstSampleCount) { return false; }
-		if (srcSwizzleR != rhs.srcSwizzleR) { return false; }
-		if (srcSwizzleG != rhs.srcSwizzleG) { return false; }
-		if (srcSwizzleB != rhs.srcSwizzleB) { return false; }
-		if (srcSwizzleA != rhs.srcSwizzleA) { return false; }
 		return true;
 	}
 
@@ -78,11 +69,6 @@ typedef struct MVKRPSKeyBlitImg {
 		return (srcMTLTextureType == MTLTextureType2DArray ||
 				srcMTLTextureType == MTLTextureType2DMultisampleArray ||
 				srcMTLTextureType == MTLTextureType1DArray);
-	}
-
-	VkComponentMapping getSrcSwizzle() {
-		return { (VkComponentSwizzle)srcSwizzleR, (VkComponentSwizzle)srcSwizzleG,
-			 (VkComponentSwizzle)srcSwizzleB, (VkComponentSwizzle)srcSwizzleA };
 	}
 
 	std::size_t hash() const {
@@ -102,18 +88,6 @@ typedef struct MVKRPSKeyBlitImg {
 
 		hash <<= 8;
 		hash |= dstSampleCount;
-
-		hash <<= 4;
-		hash |= srcSwizzleR;
-
-		hash <<= 4;
-		hash |= srcSwizzleG;
-
-		hash <<= 4;
-		hash |= srcSwizzleB;
-
-		hash <<= 4;
-		hash |= srcSwizzleA;
 		return hash;
 	}
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -168,25 +168,6 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	return rps;
 }
 
-static char getSwizzleChar(char defaultChar, VkComponentSwizzle vkSwizzle) {
-	switch (vkSwizzle) {
-		case VK_COMPONENT_SWIZZLE_IDENTITY: return defaultChar;
-		// FIXME: 0 and 1 (currently not used in any default swizzles)
-		case VK_COMPONENT_SWIZZLE_R:		return 'x';
-		case VK_COMPONENT_SWIZZLE_G:		return 'y';
-		case VK_COMPONENT_SWIZZLE_B:		return 'z';
-		case VK_COMPONENT_SWIZZLE_A:		return 'w';
-		default:							return defaultChar;
-	}
-}
-
-static void getSwizzleString(char swizzleStr[4], VkComponentMapping vkMapping) {
-	swizzleStr[0] = getSwizzleChar('x', vkMapping.r);
-	swizzleStr[1] = getSwizzleChar('y', vkMapping.g);
-	swizzleStr[2] = getSwizzleChar('z', vkMapping.b);
-	swizzleStr[3] = getSwizzleChar('w', vkMapping.a);
-}
-
 id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg& blitKey) {
 	@autoreleasepool {
 		bool isLayeredBlit = blitKey.dstSampleCount > 1 ? getMetalFeatures().multisampleLayeredRendering : getMetalFeatures().layeredRendering;
@@ -197,7 +178,6 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		NSString* typePrefix = @"texture";
 		NSString* typeSuffix;
 		NSString* coordArg;
-		char swizzleArg[4] = { 'x', 'y', 'z', 'w' };
 		if (mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT))) {
 			typePrefix = @"depth";
 		}
@@ -229,9 +209,6 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 		}
 		NSString* sliceArg = isArrayType ? (isLayeredBlit ? @", subRez.slice + varyings.v_layer" : @", subRez.slice") : @"";
 		NSString* srcFilter = isLinearFilter ? @"linear" : @"nearest";
-		if (!getMetalFeatures().nativeTextureSwizzle) {
-			getSwizzleString(swizzleArg, blitKey.getSrcSwizzle());
-		}
 
 		NSMutableString* msl = [NSMutableString stringWithCapacity: (2 * KIBI) ];
 		[msl appendLineMVK: @"#include <metal_stdlib>"];
@@ -291,11 +268,11 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 			[msl appendLineMVK];
 		}
 		if (mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_STENCIL_BIT))) {
-			[msl appendFormat: @"    out.stencil = stencilTex.sample(ce_stencil_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).%c;", coordArg, sliceArg, swizzleArg[0]];
+			[msl appendFormat: @"    out.stencil = stencilTex.sample(ce_stencil_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).x;", coordArg, sliceArg];
 			[msl appendLineMVK];
 		}
 		if (!mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-			[msl appendFormat: @"    out.color = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod)).%.4s;", coordArg, sliceArg, swizzleArg];
+			[msl appendFormat: @"    out.color = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod));", coordArg, sliceArg];
 			[msl appendLineMVK];
 		}
 		[msl appendLineMVK: @"    return out;"];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -137,9 +137,9 @@ struct MVKDescriptorResourceCount {
 /** Descriptor metadata for images. */
 struct MVKDescriptorMetaImage {
 	uint32_t size;
-	uint32_t swizzle;
+	uint32_t pad;
 	MVKDescriptorMetaImage() = default;
-	constexpr MVKDescriptorMetaImage(uint32_t size_, uint32_t swizzle_): size(size_), swizzle(swizzle_) {}
+	constexpr MVKDescriptorMetaImage(uint32_t size_): size(size_), pad(0) {}
 };
 static_assert(sizeof(MVKDescriptorMetaImage) == sizeof(uint64_t));
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -587,8 +587,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				portabilityFeatures->constantAlphaColorBlendFactors = true;
 				portabilityFeatures->events = true;
 				portabilityFeatures->imageViewFormatReinterpretation = true;
-				portabilityFeatures->imageViewFormatSwizzle = (_metalFeatures.nativeTextureSwizzle ||
-															   getMVKConfig().fullImageViewSwizzle);
+				portabilityFeatures->imageViewFormatSwizzle = true;
 				portabilityFeatures->imageView2DOn3DImage = _metalFeatures.placementHeaps;
 				portabilityFeatures->multisampleArrayImage = _metalFeatures.multisampleArrayTextures;
 				portabilityFeatures->mutableComparisonSamplers = _metalFeatures.depthSampleCompare;
@@ -644,9 +643,7 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
 				auto* formatFeatures = (VkPhysicalDevice4444FormatsFeaturesEXT*)next;
-				bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering &&
-									  (_metalFeatures.nativeTextureSwizzle ||
-									   getMVKConfig().fullImageViewSwizzle);
+				bool canSupport4444 = _metalFeatures.tileBasedDeferredRendering;
 				formatFeatures->formatA4R4G4B4 = canSupport4444;
 				formatFeatures->formatA4B4G4R4 = canSupport4444;
 				break;
@@ -2444,7 +2441,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	                                 ? cfgUseMTLHeap == MVK_CONFIG_USE_MTLHEAP_ALWAYS
 	                                 : cfgUseMTLHeap != MVK_CONFIG_USE_MTLHEAP_NEVER);
 	_metalFeatures.multisampleArrayTextures = !MVK_TVOS || mvkOSVersionIsAtLeast(16.0);
-	_metalFeatures.nativeTextureSwizzle = true;
 
 #if MVK_XCODE_15
 	// Dynamic vertex stride needs to have everything aligned - compiled with support for vertex stride calls, and supported by both runtime OS and GPU.
@@ -2562,7 +2558,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 // iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
 	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
-	_metalFeatures.nativeTextureSwizzle = false;
 	_metalFeatures.renderLinearTextures = false;
 #endif
 
@@ -2715,6 +2710,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.events = true;
 	_metalFeatures.ioSurfaces = true;
 	_metalFeatures.renderWithoutAttachments = true;
+	_metalFeatures.nativeTextureSwizzle = true;
 }
 
 bool MVKPhysicalDevice::isTier2MetalArgumentBuffers() {
@@ -2793,11 +2789,6 @@ void MVKPhysicalDevice::initFeatures() {
 		_features.shaderResourceMinLod = true;
 		_features.shaderInt64 = true;
     }
-
-// iOS, tvOS and visionOS adjustments necessary when running on the simulator.
-#if MVK_OS_SIMULATOR
-	_features.depthClamp = false;
-#endif
 
 	// Additional non-extension Vulkan 1.2 features.
 	mvkClear(&_vulkan12NoExtFeatures);		// Start with everything cleared

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -553,16 +553,12 @@ public:
 
     void releaseMTLTexture();
 
-	/** Returns the packed component swizzle of this image view. */
-	uint32_t getPackedSwizzle() { return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
-
     ~MVKImageViewPlane();
 
 protected:
     void propagateDebugName();
     id<MTLTexture> newMTLTexture();
 	VkResult initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo);
-	bool enableSwizzling();
     MVKImageViewPlane(MVKImageView* imageView, uint8_t planeIndex, MTLPixelFormat mtlPixFmt, const VkImageViewCreateInfo* pCreateInfo);
 
     friend MVKImageView;
@@ -572,8 +568,7 @@ protected:
     MTLPixelFormat _mtlPixFmt;
 	uint8_t _planeIndex;
     bool _useMTLTextureView;
-	bool _useNativeSwizzle;
-	bool _useShaderSwizzle;
+    bool _useSwizzle;
 };
 
 
@@ -611,9 +606,6 @@ public:
 	/** Returns the number of samples for each pixel of this image view. */
 	VkSampleCountFlagBits getSampleCount() { return _image->getSampleCount(); }
 
-    /** Returns the packed component swizzle of this image view. */
-    uint32_t getPackedSwizzle() { return _planes.empty() ? 0 : _planes[0]->getPackedSwizzle(); }	// Guard against destroyed instance retained in a descriptor.
-    
     /** Returns the number of planes of this image view. */
     uint8_t getPlaneCount() { return _planes.size(); }
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -157,9 +157,6 @@ public:
 	/** Returns the debug report object type of this object. */
 	VkDebugReportObjectTypeEXT getVkDebugReportObjectType() override { return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT; }
 
-	/** Returns whether or not full image view swizzling is enabled for this pipeline. */
-	bool fullImageViewSwizzle() const { return _fullImageViewSwizzle; }
-
 	/** Returns whether all internal Metal pipeline states are valid. */
 	bool hasValidMTLPipelineStates() { return _hasValidMTLPipelineStates; }
 
@@ -209,7 +206,6 @@ protected:
 	VkPipelineCreateFlags2 _flags;
 	uint32_t _descriptorSetCount;
 	bool _stageUsesPushConstants[kMVKShaderStageCount];
-	bool _fullImageViewSwizzle;
 	bool _hasValidMTLPipelineStates = true;
 
 };

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -661,9 +661,6 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 
 	bool pfv = false;
 
-	// Swizzle emulation may need to reinterpret
-	needsReinterpretation |= !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle;
-
 	pfv |= isColorFormat && needsReinterpretation &&
 	       mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_SAMPLED_BIT |
 	                                               VK_IMAGE_USAGE_STORAGE_BIT |
@@ -1490,10 +1487,6 @@ void MVKPixelFormats::modifyMTLFormatCapabilities(const MVKMTLDeviceCapabilities
 // Connects Vulkan and Metal pixel formats to one-another.
 void MVKPixelFormats::buildVkFormatMaps(const MVKMTLDeviceCapabilities& gpuCaps) {
 	for (auto& vkDesc : _vkFormatDescriptions) {
-		if (vkDesc.needsSwizzle() && !_physicalDevice->getMetalFeatures()->nativeTextureSwizzle && !getMVKConfig().fullImageViewSwizzle) {
-			vkDesc.mtlPixelFormat = vkDesc.mtlPixelFormatSubstitute = MTLPixelFormatInvalid;
-		}
-
 		// Populate the back reference from the Metal formats to the Vulkan format.
 		// Validate the corresponding Metal formats for the platform, and clear them
 		// if the Vulkan format if not supported.

--- a/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
+++ b/MoltenVK/MoltenVK/Utility/MVKEnvironment.h
@@ -174,7 +174,7 @@ void mvkSetConfig(MVKConfiguration& dstMVKConfig, const MVKConfiguration& srcMVK
 #   define MVK_CONFIG_SWITCH_SYSTEM_GPU    1
 #endif
 
-/** Support full ImageView swizzles. Disabled by default. */
+/** Obsolete, deprecated, and ignored. */
 #ifndef MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE
 #   define MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE    0
 #endif

--- a/MoltenVK/MoltenVK/Utility/MVKStateTracking.h
+++ b/MoltenVK/MoltenVK/Utility/MVKStateTracking.h
@@ -168,7 +168,6 @@ struct std::hash<MVKMTLDepthStencilDescriptorData> {
 /** These buffers are dirty-tracked across draw calls, and need code to make sure they're invalidated if they ever change binding indices. */
 enum class MVKNonVolatileImplicitBuffer : uint32_t {
 	PushConstant,
-	Swizzle,
 	BufferSize,
 	DynamicOffset,
 	ViewRange,
@@ -177,7 +176,6 @@ enum class MVKNonVolatileImplicitBuffer : uint32_t {
 
 enum class MVKImplicitBuffer : uint32_t {
 	PushConstant  = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::PushConstant),
-	Swizzle       = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::Swizzle),
 	BufferSize    = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::BufferSize),
 	DynamicOffset = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::DynamicOffset),
 	ViewRange     = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::ViewRange),

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
@@ -358,7 +358,6 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverter::convert(SPIRVToMSLConversionConfigur
 	populateEntryPoint(pMSLCompiler, shaderConfig.options, conversionResult.resultInfo.entryPoint);
 	conversionResult.resultInfo.isRasterizationDisabled = pMSLCompiler && pMSLCompiler->get_is_rasterization_disabled();
 	conversionResult.resultInfo.isPositionInvariant = pMSLCompiler && pMSLCompiler->is_position_invariant();
-	conversionResult.resultInfo.needsSwizzleBuffer = pMSLCompiler && pMSLCompiler->needs_swizzle_buffer();
 	conversionResult.resultInfo.needsOutputBuffer = pMSLCompiler && pMSLCompiler->needs_output_buffer();
 	conversionResult.resultInfo.needsPatchOutputBuffer = pMSLCompiler && pMSLCompiler->needs_patch_output_buffer();
 	conversionResult.resultInfo.needsBufferSizeBuffer = pMSLCompiler && pMSLCompiler->needs_buffer_size_buffer();

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
@@ -252,7 +252,6 @@ namespace mvk {
 		SPIRVEntryPoint entryPoint;
 		bool isRasterizationDisabled = false;
 		bool isPositionInvariant = false;
-		bool needsSwizzleBuffer = false;
 		bool needsOutputBuffer = false;
 		bool needsPatchOutputBuffer = false;
 		bool needsBufferSizeBuffer = false;


### PR DESCRIPTION
From the previous PR, `nativeTextureSwizzle` became true always except for simulators. I went and tested on simulator and it seems that at least nowadays both `nativeTextureSwizzle` and `depthClamp` work fine.

So:
* Deprecate `nativeTextureSwizzle` as always true and remove swizzle emulation code.
* Remove logic to set `depthClamp` feature to false on simulator.

It's possible some of the other simulator limitations no longer exist but these are the ones I was able to verify easily.