### PR TITLE
Update minimum CI to macOS 14 and minimum build to Xcode 15.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,8 @@ jobs:
             select_xcode: false
             private_api: true
           # Legacy build. Up to 3 versions behind latest (or beta).
-          - os: "macos-13"
-            xcode: "14.3.1"
+          - os: "macos-14"
+            xcode: "15.0.1"
             platform: "macos"
             upload_artifacts: false
             select_xcode: true

--- a/Common/MVKCommonEnvironment.h
+++ b/Common/MVKCommonEnvironment.h
@@ -99,11 +99,6 @@ extern "C" {
                                     (__VISION_OS_VERSION_MAX_ALLOWED >= 20000) || \
                                         (__TV_OS_VERSION_MAX_ALLOWED >= 180000))
 #endif
-#ifndef MVK_XCODE_15
-#   define MVK_XCODE_15             ((__MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) || \
-                                    (__IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) || \
-                                        (__TV_OS_VERSION_MAX_ALLOWED >= 170000))
-#endif
 
 /**
  * Enable use of private Metal APIs.

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -86,16 +86,10 @@ struct MVKResourceBinder {
 struct MVKVertexBufferBinder {
 	SEL _setBuffer;
 	SEL _setOffset;
-#if MVK_XCODE_15
 	SEL _setBufferDynamic;
 	SEL _setOffsetDynamic;
-#endif
 	template <typename T> static MVKVertexBufferBinder Create() {
-#if MVK_XCODE_15
 		return { T::selSetBuffer(), T::selSetOffset(), T::selSetBufferDynamic(), T::selSetOffsetDynamic() };
-#else
-		return { T::selSetBuffer(), T::selSetOffset() };
-#endif
 	}
 	void setBuffer(id<MTLCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger index) const {
 		reinterpret_cast<void(*)(id, SEL, id<MTLBuffer>, NSUInteger, NSUInteger)>(objc_msgSend)(encoder, _setBuffer, buffer, offset, index);
@@ -104,18 +98,10 @@ struct MVKVertexBufferBinder {
 		reinterpret_cast<void(*)(id, SEL, NSUInteger, NSUInteger)>(objc_msgSend)(encoder, _setOffset, offset, index);
 	}
 	void setBufferDynamic(id<MTLCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger stride, NSUInteger index) const {
-#if MVK_XCODE_15
 		reinterpret_cast<void(*)(id, SEL, id<MTLBuffer>, NSUInteger, NSUInteger, NSUInteger)>(objc_msgSend)(encoder, _setBufferDynamic, buffer, offset, stride, index);
-#else
-		assert(0);
-#endif
 	}
 	void setBufferOffsetDynamic(id<MTLCommandEncoder> encoder, NSUInteger offset, NSUInteger stride, NSUInteger index) const {
-#if MVK_XCODE_15
 		reinterpret_cast<void(*)(id, SEL, NSUInteger, NSUInteger, NSUInteger)>(objc_msgSend)(encoder, _setOffsetDynamic, offset, stride, index);
-#else
-		assert(0);
-#endif
 	}
 	enum class Stage {
 		Vertex,

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -88,10 +88,8 @@ struct MVKVertexBinder {
 	static SEL selSetTexture() { return @selector(setVertexTexture:atIndex:); }
 	static SEL selSetSampler() { return @selector(setVertexSamplerState:atIndex:); }
 	static MVKResourceBinder::UseResource useResource() { return useResourceGraphics; }
-#if MVK_XCODE_15
 	static SEL selSetBufferDynamic() { return @selector(setVertexBuffer:offset:attributeStride:atIndex:); }
 	static SEL selSetOffsetDynamic() { return @selector(setVertexBufferOffset:attributeStride:atIndex:); }
-#endif
 	static void setBuffer(id<MTLRenderCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger index) {
 		[encoder setVertexBuffer:buffer offset:offset atIndex:index];
 	}
@@ -99,18 +97,10 @@ struct MVKVertexBinder {
 		[encoder setVertexBufferOffset:offset atIndex:index];
 	}
 	static void setBufferDynamic(id<MTLRenderCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger stride, NSUInteger index) {
-#if MVK_XCODE_15
 		[encoder setVertexBuffer:buffer offset:offset attributeStride:stride atIndex:index];
-#else
-		assert(0);
-#endif
 	}
 	static void setBufferOffsetDynamic(id<MTLRenderCommandEncoder> encoder, NSUInteger offset, NSUInteger stride, NSUInteger index) {
-#if MVK_XCODE_15
 		[encoder setVertexBufferOffset:offset attributeStride:stride atIndex:index];
-#else
-		assert(0);
-#endif
 	}
 	static void setBytes(id<MTLRenderCommandEncoder> encoder, const void* bytes, NSUInteger length, NSUInteger index) {
 		[encoder setVertexBytes:bytes length:length atIndex:index];
@@ -130,10 +120,8 @@ struct MVKComputeBinder {
 	static SEL selSetTexture() { return @selector(setTexture:atIndex:); }
 	static SEL selSetSampler() { return @selector(setSamplerState:atIndex:); }
 	static MVKResourceBinder::UseResource useResource() { return useResourceCompute; }
-#if MVK_XCODE_15
 	static SEL selSetBufferDynamic() { return @selector(setBuffer:offset:attributeStride:atIndex:); }
 	static SEL selSetOffsetDynamic() { return @selector(setBufferOffset:attributeStride:atIndex:); }
-#endif
 	static void setBuffer(id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger index) {
 		[encoder setBuffer:buffer offset:offset atIndex:index];
 	}
@@ -141,18 +129,10 @@ struct MVKComputeBinder {
 		[encoder setBufferOffset:offset atIndex:index];
 	}
 	static void setBufferDynamic(id<MTLComputeCommandEncoder> encoder, id<MTLBuffer> buffer, NSUInteger offset, NSUInteger stride, NSUInteger index) {
-#if MVK_XCODE_15
 		[encoder setBuffer:buffer offset:offset attributeStride:stride atIndex:index];
-#else
-		assert(0);
-#endif
 	}
 	static void setBufferOffsetDynamic(id<MTLComputeCommandEncoder> encoder, NSUInteger offset, NSUInteger stride, NSUInteger index) {
-#if MVK_XCODE_15
 		[encoder setBufferOffset:offset attributeStride:stride atIndex:index];
-#else
-		assert(0);
-#endif
 	}
 	static void setBytes(id<MTLComputeCommandEncoder> encoder, const void* bytes, NSUInteger length, NSUInteger index) {
 		[encoder setBytes:bytes length:length atIndex:index];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKBuffer.mm
@@ -266,10 +266,8 @@ id<MTLTexture> MVKBufferView::getMTLTexture() {
 		MTLTextureUsage usage = MTLTextureUsageShaderRead;
 		if ( mvkIsAnyFlagEnabled(_usage, VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT) ) {
 			usage |= MTLTextureUsageShaderWrite;
-#if MVK_XCODE_15
 			if (getMetalFeatures().nativeTextureAtomics && (_mtlPixelFormat == MTLPixelFormatR32Sint || _mtlPixelFormat == MTLPixelFormatR32Uint))
 				usage |= MTLTextureUsageShaderAtomic;
-#endif
 		}
 		id<MTLBuffer> mtlBuff = _buffer->getMTLBuffer();
 		VkDeviceSize mtlBuffOffset = _buffer->getMTLBufferOffset() + _offset;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -106,9 +106,7 @@ MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
 	supportsApple6 = supportsGPUFam(Apple6, mtlDev);
 	supportsApple7 = supportsGPUFam(Apple7, mtlDev);
 	supportsApple8 = supportsGPUFam(Apple8, mtlDev);
-#if MVK_XCODE_15 && !MVK_TVOS && !MVK_VISIONOS
 	supportsApple9 = supportsGPUFam(Apple9, mtlDev);
-#endif
 #if MVK_XCODE_26
 	supportsApple10 = supportsGPUFam(Apple10, mtlDev);
 #endif
@@ -2446,11 +2444,9 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.multisampleArrayTextures = !MVK_TVOS || mvkOSVersionIsAtLeast(16.0);
 	_metalFeatures.nativeTextureSwizzle = true;
 
-#if MVK_XCODE_15
 	// Dynamic vertex stride needs to have everything aligned - compiled with support for vertex stride calls, and supported by both runtime OS and GPU.
 	_metalFeatures.dynamicVertexStride = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2));
 	_metalFeatures.nativeTextureAtomics = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Metal3) || supportsMTLGPUFamily(Apple6) || supportsMTLGPUFamily(Mac2));
-#endif
 
 	if (supportsMTLGPUFamily(Mac2)) {
 		_metalFeatures.mtlBufferAlignment = 256;
@@ -2581,13 +2577,10 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		setMSLVersion(3, 2);
 	} else
 #endif
-#if MVK_XCODE_15
 	if ( mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_1;
 		setMSLVersion(3, 1);
-	} else
-#endif
-	if ( mvkOSVersionIsAtLeast(13.0, 16.0, 1.0) ) {
+	} else if ( mvkOSVersionIsAtLeast(13.0, 16.0, 1.0) ) {
 		_metalFeatures.mslVersionEnum = MTLLanguageVersion3_0;
 		setMSLVersion(3, 0);
 	} else if ( mvkOSVersionIsAtLeast(12.0, 15.0, 1.0) ) {
@@ -3397,11 +3390,9 @@ uint64_t MVKPhysicalDevice::getVRAMSize() {
 
 // If possible, retrieve from the MTLDevice, otherwise from available memory size, or a fixed conservative estimate.
 uint64_t MVKPhysicalDevice::getRecommendedMaxWorkingSetSize() {
-#if MVK_XCODE_15 || MVK_MACOS
 	if ( [_mtlDevice respondsToSelector: @selector(recommendedMaxWorkingSetSize)]) {
 		return _mtlDevice.recommendedMaxWorkingSetSize;
 	}
-#endif
 	uint64_t freeMem = mvkGetAvailableMemorySize();
 	return freeMem ? freeMem : 256 * MEBI;
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1666,10 +1666,6 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 	return verifyImplicitBuffers(kMVKShaderStageFragment);
 }
 
-#if !MVK_XCODE_15
-static const NSUInteger MTLBufferLayoutStrideDynamic = NSUIntegerMax;
-#endif
-
 template<class T>
 bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
 												   const VkPipelineVertexInputStateCreateInfo* pVI,

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -54,11 +54,6 @@ using namespace std;
 #   define MTLPixelFormatBGRG422                    MTLPixelFormatInvalid
 #endif
 
-#if !MVK_XCODE_15
-#   define MTLVertexFormatFloatRG11B10              MTLVertexFormatInvalid
-#   define MTLVertexFormatFloatRGB9E5               MTLVertexFormatInvalid
-#endif
-
 
 #pragma mark -
 #pragma mark MVKPixelFormats
@@ -627,11 +622,9 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderWrite);
 	}
 
-#if MVK_XCODE_15
 	if (supportAtomics && (mtlFormat == MTLPixelFormatR32Uint || mtlFormat == MTLPixelFormatR32Sint)) {
 		mvkEnableFlags(mtlUsage, MTLTextureUsageShaderAtomic);
 	}
-#endif
 
     // Clearing a linear image may use shader writes.
     if (mvkIsAnyFlagEnabled(vkImageUsageFlags, (VK_IMAGE_USAGE_TRANSFER_DST_BIT)) &&

--- a/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverterTool/OSSupport.mm
@@ -81,12 +81,9 @@ bool mvk::compile(const string& mslSourceCode,
 		mslVerEnum = MTLLanguageVersion3_2;
 	} else
 #endif
-#if MVK_XCODE_15
 	if (mslVer(3, 1, 0)) {
 		mslVerEnum = MTLLanguageVersion3_1;
-	} else
-#endif
-	if (mslVer(3, 0, 0)) {
+	} else if (mslVer(3, 0, 0)) {
 		mslVerEnum = MTLLanguageVersion3_0;
 	} else if (mslVer(2, 4, 0)) {
 		mslVerEnum = MTLLanguageVersion2_4;

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Building **MoltenVK**
 During building, **MoltenVK** references the latest *Apple SDK* frameworks. To access these frameworks,
 and to avoid build errors, be sure to use the latest publicly available version of *Xcode*.
 
-MoltenVK currently supports being built with *Xcode 14.3* or later. Support is based on the
+MoltenVK currently supports being built with *Xcode 15.0.1* or later. Support is based on the
 earliest version of Xcode that can be verified in CI workflows.
 
 Once built, the **MoltenVK** libraries can be run on *macOS*, *iOS*, *tvOS*, or *visionOS* devices


### PR DESCRIPTION
Didn't quite expect to be updating this again already, but GitHub sent out an email that starting in November, they will be doing `macos-13` CI brown-outs, followed by full removal in December. The new minimum is `macos-14`.

Thus, we need to switch the minimum CI build over to macOS 14. Consequently, the minimum Xcode becomes 15.0.1. The minimum OS target remains macOS 11.