### PR TITLE
Add support for VK_KHR_maintenance9.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -277,6 +277,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_KHR_maintenance6`
 - `VK_KHR_maintenance7`
 - `VK_KHR_maintenance8`
+- `VK_KHR_maintenance9`
 - `VK_KHR_map_memory2`
 - `VK_KHR_multiview`
 - `VK_KHR_portability_subset`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -32,6 +32,7 @@ Released TBD
 - Raise minimum target to _macOS 11.0 / iOS 14.0 / tvOS 14.0_
 - Add support for `VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT`.
 - Add support for the following extensions:
+  - `VK_KHR_maintenance9`
   - `VK_KHR_shader_fma`
 - Add support for new features and extensions when using `MVK_USE_METAL_PRIVATE_API`:
   - Disabling primitive restart

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -580,6 +580,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				maintenance8Features->maintenance8 = true;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR: {
+				auto* maintenance9Features = (VkPhysicalDeviceMaintenance9FeaturesKHR*)next;
+				maintenance9Features->maintenance9 = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
 				auto* portabilityFeatures = (VkPhysicalDevicePortabilitySubsetFeaturesKHR*)next;
 				portabilityFeatures->constantAlphaColorBlendFactors = true;
@@ -1205,6 +1210,12 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
                 maintenance7Properties->maxDescriptorSetUpdateAfterBindTotalStorageBuffersDynamic = supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
                 maintenance7Properties->maxDescriptorSetUpdateAfterBindTotalBuffersDynamic =
                         supportedProps12.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic + supportedProps12.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
+                break;
+            }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_PROPERTIES_KHR: {
+                auto* maintenance9Properties = (VkPhysicalDeviceMaintenance9PropertiesKHR*)next;
+                maintenance9Properties->image2DViewOf3DSparse = false;
+                maintenance9Properties->defaultVertexAttributeValue = VK_DEFAULT_VERTEX_ATTRIBUTE_VALUE_ZERO_ZERO_ZERO_ZERO_KHR;
                 break;
             }
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES: {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -83,6 +83,7 @@ MVK_DEVICE_FEATURE(ZeroInitializeWorkgroupMemory,         ZERO_INITIALIZE_WORKGR
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderBarycentric,        FRAGMENT_SHADER_BARYCENTRIC,          KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(Maintenance7,                     MAINTENANCE_7,                        KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(Maintenance8,                     MAINTENANCE_8,                        KHR,   1)
+MVK_DEVICE_FEATURE_EXTN(Maintenance9,                     MAINTENANCE_9,                        KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PortabilitySubset,                PORTABILITY_SUBSET,                   KHR,  15)
 MVK_DEVICE_FEATURE_EXTN(PresentId,                        PRESENT_ID,                           KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(PresentId2,                       PRESENT_ID_2,                         KHR,   1)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1959,13 +1959,12 @@ MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
     // and set the _useMTLTextureView variable appropriately.
     if ( _imageView->_image ) {
         _useMTLTextureView = true;
-        bool is3D = _imageView->_image->_mtlTextureType == MTLTextureType3D;
         // If the view is identical to underlying image, don't bother using a Metal view
         if (_mtlPixFmt == _imageView->_image->getMTLPixelFormat(planeIndex) &&
-            (_imageView->_mtlTextureType == _imageView->_image->_mtlTextureType ||
-             ((_imageView->_mtlTextureType == MTLTextureType2D || _imageView->_mtlTextureType == MTLTextureType2DArray) && is3D)) &&
+            _imageView->_mtlTextureType == _imageView->_image->_mtlTextureType &&
             _imageView->_subresourceRange.levelCount == _imageView->_image->_mipLevels &&
-            (is3D || _imageView->_subresourceRange.layerCount == _imageView->_image->_arrayLayers) &&
+            (_imageView->_mtlTextureType == MTLTextureType3D ||
+             _imageView->_subresourceRange.layerCount == _imageView->_image->_arrayLayers) &&
             !_useSwizzle) {
             _useMTLTextureView = false;
         }

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -84,6 +84,7 @@ MVK_EXTENSION(KHR_maintenance5,                         KHR_MAINTENANCE_5,      
 MVK_EXTENSION(KHR_maintenance6,                         KHR_MAINTENANCE_6,                        DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance7,                         KHR_MAINTENANCE_7,                        DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_maintenance8,                         KHR_MAINTENANCE_8,                        DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(KHR_maintenance9,                         KHR_MAINTENANCE_9,                        DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_map_memory2,                          KHR_MAP_MEMORY_2,                         DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_multiview,                            KHR_MULTIVIEW,                            DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(KHR_portability_subset,                   KHR_PORTABILITY_SUBSET,                   DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
Reference: https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_maintenance9.html

Mostly a fairly trivial addition, we already handle all of the new behavior. There was one case with some tests failing related to 2D array compatible 3D images, but it turned out to be an existing bug that went uncaught until now.

CTS results of tests interacting with `maintenance9`:
```
dEQP-VK.pipeline.monolithic.vertex_input.*

Test run totals:
  Passed:        9084/10538 (86.2%)
  Failed:        5/10538 (0.0%)
  Not supported: 1449/10538 (13.8%)
  Warnings:      0/10538 (0.0%)
  Waived:        0/10538 (0.0%)


dEQP-VK.pipeline.monolithic.render_to_image.*

Test run totals:
  Passed:        943/1325 (71.2%)
  Failed:        0/1325 (0.0%)
  Not supported: 382/1325 (28.8%)
  Warnings:      0/1325 (0.0%)
  Waived:        0/1325 (0.0%)


dEQP-VK.pipeline.no_queues.*

Test run totals:
  Passed:        5/36 (13.9%)
  Failed:        0/36 (0.0%)
  Not supported: 31/36 (86.1%)
  Warnings:      0/36 (0.0%)
  Waived:        0/36 (0.0%)


dEQP-VK.pipeline.monolithic.image_2d_view_3d_image.*

Test run totals:
  Passed:        24/48 (50.0%)
  Failed:        0/48 (0.0%)
  Not supported: 24/48 (50.0%)
  Warnings:      0/48 (0.0%)
  Waived:        0/48 (0.0%)


dEQP-VK.synchronization.*

Test run totals:
  Passed:        19891/64823 (30.7%)
  Failed:        0/64823 (0.0%)
  Not supported: 44932/64823 (69.3%)
  Warnings:      0/64823 (0.0%)
  Waived:        0/64823 (0.0%)


dEQP-VK.synchronization2.*

Test run totals:
  Passed:        34082/81435 (41.9%)
  Failed:        0/81435 (0.0%)
  Not supported: 47353/81435 (58.1%)
  Warnings:      0/81435 (0.0%)
  Waived:        0/81435 (0.0%)


dEQP-VK.query_pool.occlusion_query.*

Test run totals:
  Passed:        430/430 (100.0%)
  Failed:        0/430 (0.0%)
  Not supported: 0/430 (0.0%)
  Warnings:      0/430 (0.0%)
  Waived:        0/430 (0.0%)


dEQP-VK.image.2d_array_compatible.*

Test run totals:
  Passed:        6/12 (50.0%)
  Failed:        0/12 (0.0%)
  Not supported: 6/12 (50.0%)
  Warnings:      0/12 (0.0%)
  Waived:        0/12 (0.0%)


dEQP-VK.image.concurrent_copy.*

Test run totals:
  Passed:        144/216 (66.7%)
  Failed:        0/216 (0.0%)
  Not supported: 72/216 (33.3%)
  Warnings:      0/216 (0.0%)
  Waived:        0/216 (0.0%)


dEQP-VK.spirv_assembly.type.*

Test run totals:
  Passed:        15385/18462 (83.3%)
  Failed:        0/18462 (0.0%)
  Not supported: 3077/18462 (16.7%)
  Warnings:      0/18462 (0.0%)
  Waived:        0/18462 (0.0%)


dEQP-VK.spirv_assembly.instruction.maint9_vectorization.*

Test run totals:
  Passed:        3152/3152 (100.0%)
  Failed:        0/3152 (0.0%)
  Not supported: 0/3152 (0.0%)
  Warnings:      0/3152 (0.0%)
  Waived:        0/3152 (0.0%)
```

Failures:
```
New Fails:
  dEQP-VK.pipeline.monolithic.vertex_input.misc.unbound_input

Existing Unrelated Fails:
  dEQP-VK.pipeline.monolithic.vertex_input.multiple_attributes.binding_one_to_one.attributes.vec4.mat3.mat4
  dEQP-VK.pipeline.monolithic.vertex_input.max_attributes.query_max_attributes.binding_one_to_one.interleaved
  dEQP-VK.pipeline.monolithic.vertex_input.max_attributes.query_max_attributes.binding_one_to_many.interleaved
  dEQP-VK.pipeline.monolithic.vertex_input.max_attributes.query_max_attributes.binding_one_to_many.sequential
```

The single new failure seems to be related to us not handling unbound inputs properly in general (`Vertex attribute m_22(1) is missing from the vertex descriptor.`), so I believe it is out of the scope of implementing `maintenance9` specifically. I don't see an indication in the extension description that this capability is provided by`maintenance9`, only the property indicating the result.