### PR TITLE
Fix vertexStrideAlignment value without Apple5

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2423,7 +2423,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
     _metalFeatures.maxPerStageSamplerCount = 16;
     _metalFeatures.maxQueryBufferSize = (64 * KIBI);
 
-	_metalFeatures.vertexStrideAlignment = 1;
+	_metalFeatures.vertexStrideAlignment = 4;
 	_metalFeatures.pushConstantSizeAlignment = 16;     // Min float4 alignment for typical uniform structs.
 
 	_metalFeatures.maxTextureLayers = (2 * KIBI);


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/MoltenVK/issues/2660. `vertexStrideAlignment` is set to 1 below in the `Apple5` block, and needs to be defaulted to 4 here.