### PR TITLE
Fix buffer and heap out-of-sync in initExternalMemory()

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.h
@@ -160,7 +160,7 @@ protected:
 	bool ensureHostMemory();
 	void freeHostMemory();
 	MVKResource* getDedicatedResource();
-	void initExternalMemory(MVKImage* dedicatedImage);
+	void initExternalMemory(MVKImage* dedicatedImage, bool wantsHeap);
 
 	MVKSmallVector<MVKBuffer*, 4> _buffers;
 	MVKSmallVector<MVKImageMemoryBinding*, 4> _imageMemoryBindings;


### PR DESCRIPTION
If a buffer is created before a heap in MVKDeviceMemory, the buffer would
be used in some places (for example `MVKDeviceMemory::map` and the heap
would be used in other places (for example `MVKBuffer::getMTLBuffer()`).
This leads to inconsistent memory mappings.

Specifically, there are two cases when this happens:
1. When `vkAllocateMemory` is called with an imported buffer.
2. When `vkAllocateMemory` expects `HANDLE_TYPE_MTLBUFFER` to be exported.

In either case, `ensureMTLBuffer()` gets called before `ensureMTLHeap()`
which sets `_mtlBuffer` to a buffer not allocated from the placement heap.

This change fixes this by making sure that if a placement heap is needed,
we will always create it prior to allocating the buffer. In cases where
the heap is not used at all (imported buffer), we will return error if the
user tries to specify a `HANDLE_TYPE_MTLHEAP` for export.