### PR TITLE
Fix incorrect variable usage in `MVKImagePlane::getMTLTexture()`

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -89,7 +89,7 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
         } else {
             tex = [_image->getMTLDevice() newTextureWithDescriptor: mtlTexDesc];
         }
-        if (_mtlTexture.storageMode != MTLStorageModeMemoryless) {
+        if (tex.storageMode != MTLStorageModeMemoryless) {
             _image->_device->makeResident(tex);
             _image->_device->getLiveResources().add(tex);
         }


### PR DESCRIPTION
`_mtlTexture` can still be nil at this point which means that we may have a memoryless texture attempt to get added to the residency set.