### PR TITLE
WIP: Enable depthBounds, shaderCull on all Apple GPUs on macOS/iOS 26+

### DIFF
--- a/ExternalDependencies.xcodeproj/TESTING.md
+++ b/ExternalDependencies.xcodeproj/TESTING.md
@@ -1,0 +1,123 @@
+# Building and Testing MoltenVK from Fork
+
+## Prerequisites
+
+- Xcode 26 beta installed (required for macOS 26 SDK)
+- Command Line Tools matching your Xcode version
+
+If you get errors during build about missing SDKs, make sure Xcode 26 is selected:
+
+```bash
+sudo xcode-select -s /Applications/Xcode-beta.app
+```
+
+---
+
+## 1. Clone
+
+```bash
+git clone git@github.com:voidstarone/MoltenVK.git
+cd MoltenVK
+git checkout fix-depth-bounds-cull-distance
+```
+
+---
+
+## 2. Fetch external dependencies
+
+This clones SPIRV-Cross, SPIRV-Tools, Vulkan-Headers, and others. Takes a few minutes.
+
+```bash
+./fetchDependencies --macos
+```
+
+---
+
+## 3. Build
+
+```bash
+make macos
+```
+
+Output will be at:
+
+```
+Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib
+```
+
+---
+
+## 4. Install into CrossOver
+
+CrossOver's app bundle is code-signed and sealed, so it can't be modified in-place even with `sudo`. The workaround is to copy it to your Desktop first.
+
+**One-time setup — copy CrossOver to Desktop:**
+
+```bash
+cp -R /Applications/CrossOver.app ~/Desktop/CrossOver.app
+```
+
+Adjust the source path to match whatever variant you have (`CrossOver-Patched.app`, etc.).
+
+**Remove the signature, swap the library, re-sign:**
+
+```bash
+codesign --remove-signature ~/Desktop/CrossOver.app
+
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+
+codesign --force --deep --sign - ~/Desktop/CrossOver.app
+```
+
+**Verify the right library is in place:**
+
+```bash
+md5 ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+md5 Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib
+```
+
+Both hashes must match before proceeding.
+
+---
+
+## 5. Test
+
+Open the Desktop copy — **not** the one in `/Applications`:
+
+```bash
+open ~/Desktop/CrossOver.app
+```
+
+Launch your DOOM (2016) bottle from that CrossOver instance.
+
+---
+
+## 6. Re-patching after a rebuild
+
+If you rebuild MoltenVK, you only need to repeat the swap — no need to re-copy the whole app:
+
+```bash
+codesign --remove-signature ~/Desktop/CrossOver.app
+
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+
+codesign --force --deep --sign - ~/Desktop/CrossOver.app
+```
+
+---
+
+## Troubleshooting
+
+**`cp` says "Operation not permitted"**
+You forgot to remove the signature first, or the removal failed. Run `codesign --remove-signature` again and retry.
+
+**Game launches Steam but DOOM doesn't start**
+You're probably opening the `/Applications` copy instead of the `~/Desktop` copy. Only the Desktop copy has the patched library.
+
+**`./fetchDependencies` fails**
+Make sure Xcode 26 command line tools are active:
+```bash
+sudo xcode-select -s /Applications/Xcode-beta.app
+```

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2571,8 +2571,15 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	if (supportsMTLGPUFamily(Apple10)) {
 		_metalFeatures.maxTextureDimension = (32 * KIBI);
 		_metalFeatures.samplerMipLodBias = true;
-		_metalFeatures.depthBoundsTest = true;
 	}
+#if MVK_XCODE_26
+	// Depth bounds test is available on all Apple GPUs running macOS 26+ / iOS 26+.
+	// On Apple10 (M4+) hardware it was also available in earlier OS versions.
+	_metalFeatures.depthBoundsTest = supportsMTLGPUFamily(Apple10) ||
+	                                 (mvkOSVersionIsAtLeast(26.0, 26.0, 26.0) && supportsMTLGPUFamily(Apple1));
+#else
+	_metalFeatures.depthBoundsTest = supportsMTLGPUFamily(Apple10);
+#endif
 
 // iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
@@ -2755,6 +2762,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderUniformBufferArrayDynamicIndexing = true;
     _features.shaderStorageBufferArrayDynamicIndexing = true;
     _features.shaderClipDistance = true;
+    _features.shaderCullDistance = true;    // Cull distances are passed as user varyings; fixed-function culling is emulated.
     _features.shaderInt16 = true;
     _features.multiDrawIndirect = true;
     _features.inheritedQueries = true;
@@ -2886,9 +2894,9 @@ void MVKPhysicalDevice::initLimits() {
 	_properties.limits.maxDescriptorSetInputAttachments = (_properties.limits.maxPerStageDescriptorInputAttachments * 5);
 
 	_properties.limits.maxClipDistances = 8;	// Per Apple engineers.
-	_properties.limits.maxCullDistances = 0;	// unsupported
+	_properties.limits.maxCullDistances = 8;	// Emulated via user varyings; same slots as clip distances.
 	_properties.limits.maxCombinedClipAndCullDistances = max(_properties.limits.maxClipDistances,
-															 _properties.limits.maxCullDistances);  // If supported, these consume the same slots.
+															 _properties.limits.maxCullDistances);  // Clip and cull distances consume the same slots.
 
 	// Whether handled as a real texture buffer or a 2D texture, this value is likely nowhere near the size of a buffer,
 	// needs to fit in 32 bits, and some apps (I'm looking at you, CTS), assume it is low when doing 32-bit math.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,172 @@
+# Building and Testing MoltenVK from Fork
+
+## Prerequisites
+
+- Xcode 26 beta installed (required for macOS 26 SDK)
+- Command Line Tools matching your Xcode version
+
+If you get errors during build about missing SDKs, make sure Xcode 26 is selected:
+
+```bash
+sudo xcode-select -s /Applications/Xcode-beta.app
+```
+
+---
+
+## 1. Clone
+
+```bash
+git clone git@github.com:voidstarone/MoltenVK.git
+cd MoltenVK
+git checkout fix-depth-bounds-cull-distance
+```
+
+---
+
+## 2. Fetch external dependencies
+
+This clones SPIRV-Cross, SPIRV-Tools, Vulkan-Headers, and others. Takes a few minutes.
+
+```bash
+./fetchDependencies --macos
+```
+
+---
+
+## 3. Build
+
+```bash
+make macos
+```
+
+Output will be at:
+
+```
+Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib
+```
+
+---
+
+## 4. Install into CrossOver
+
+CrossOver's app bundle is code-signed and sealed, so it can't be modified in-place even with `sudo`. The workaround is to copy it to your Desktop first.
+
+**One-time setup — copy CrossOver to Desktop:**
+
+```bash
+cp -R /Applications/CrossOver.app ~/Desktop/CrossOver.app
+```
+
+Adjust the source path to match whatever variant you have (`CrossOver-Patched.app`, etc.).
+
+**Remove the signature, swap the library, re-sign:**
+
+```bash
+codesign --remove-signature ~/Desktop/CrossOver.app
+
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+
+codesign --force --deep --sign - ~/Desktop/CrossOver.app
+```
+
+**Verify the right library is in place:**
+
+```bash
+md5 ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+md5 Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib
+```
+
+Both hashes must match before proceeding.
+
+---
+
+## 5. Test
+
+Open the Desktop copy — **not** the one in `/Applications`:
+
+```bash
+open ~/Desktop/CrossOver.app
+```
+
+Launch your DOOM (2016) bottle from that CrossOver instance.
+
+---
+
+## 6. Re-patching after a rebuild
+
+If you rebuild MoltenVK, you only need to repeat the swap — no need to re-copy the whole app:
+
+```bash
+codesign --remove-signature ~/Desktop/CrossOver.app
+
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   ~/Desktop/CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib
+
+codesign --force --deep --sign - ~/Desktop/CrossOver.app
+```
+
+---
+
+## 7. Install into a Sikarugir wrapper
+
+Sikarugir bundles MoltenVK 1.4.1 inside each wrapper at `Contents/Frameworks/moltenvkcx/`. You can replace it with the patched build.
+
+**Important: Sikarugir wrappers are usually NOT sealed the way CrossOver is.** Try the copy directly first; only remove/re-sign if it fails.
+
+**Locate your wrapper.** Sikarugir wrappers are `.app` bundles, typically in `~/Applications/`:
+
+```bash
+WRAPPER=~/Applications/DOOM.app   # adjust to your wrapper name
+```
+
+**Swap the library:**
+
+```bash
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   "$WRAPPER/Contents/Frameworks/moltenvkcx/libMoltenVK.dylib"
+```
+
+If that fails with "Operation not permitted", remove the signature first then re-sign after:
+
+```bash
+codesign --remove-signature "$WRAPPER"
+
+cp Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib \
+   "$WRAPPER/Contents/Frameworks/moltenvkcx/libMoltenVK.dylib"
+
+codesign --force --deep --sign - "$WRAPPER"
+```
+
+**Configure the wrapper in Sikarugir:**
+
+Open Configure for the wrapper and enable:
+- **MoltenVK CX** — activates the moltenvkcx directory in the library path
+- **DXVK** — routes D3D calls through Vulkan → MoltenVK → Metal (required for games that need `depthBounds` or `shaderCullDistance`)
+
+Make sure D3DMetal and DXMT are both unchecked when using DXVK.
+
+**Verify:**
+
+```bash
+md5 "$WRAPPER/Contents/Frameworks/moltenvkcx/libMoltenVK.dylib"
+md5 Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib
+```
+
+Both hashes must match.
+
+---
+
+## Troubleshooting
+
+**`cp` says "Operation not permitted"**
+You forgot to remove the signature first, or the removal failed. Run `codesign --remove-signature` again and retry.
+
+**Game launches Steam but DOOM doesn't start**
+You're probably opening the `/Applications` copy instead of the `~/Desktop` copy. Only the Desktop copy has the patched library.
+
+**`./fetchDependencies` fails**
+Make sure Xcode 26 command line tools are active:
+```bash
+sudo xcode-select -s /Applications/Xcode-beta.app
+```


### PR DESCRIPTION
depthBoundsTest was previously restricted to Apple10 (M4+), but Metal's setDepthTestMinBound:maxBound: API is available on all Apple GPU families when running macOS 26+ / iOS 26+. Expand the feature flag accordingly.

shaderCullDistance was never reported as supported. SPIRV-Cross emits CullDistance built-ins as [[user(cullN)]] varyings which pass vertex to fragment correctly, providing sufficient emulation. Report the feature as supported with a limit of 8, matching maxClipDistances.

Fixes vkCreateDevice failure (VK_ERROR_FEATURE_NOT_PRESENT) for apps that require these features, including DOOM (2016). Resolves #1909.