### PR TITLE
Include Metal constant buffer alignment in argument buffer gpuAlign calc

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -100,7 +100,6 @@ typedef struct {
     VkDeviceSize maxMTLBufferSize;              	/**< The max size of a MTLBuffer (in bytes). */
     VkDeviceSize mtlBufferAlignment;            	/**< The alignment used when allocating memory for MTLBuffers. Must be PoT. */
     VkDeviceSize maxQueryBufferSize;            	/**< The maximum size of an occlusion query buffer (in bytes). */
-	VkDeviceSize mtlConstantBufferAlignment;		/**< The alignment required for Metal constant buffers (in bytes). */
 	VkDeviceSize mtlCopyBufferAlignment;        	/**< The alignment required during buffer copy operations (in bytes). */
     VkSampleCountFlags supportedSampleCounts;   	/**< A bitmask identifying the sample counts supported by the device. */
 	uint32_t minSwapchainImageCount;	 	  		/**< The minimum number of swapchain images that can be supported by a surface. */
@@ -164,6 +163,7 @@ typedef struct {
     VkBool32 samplerMipLodBias;                     /**< If true, a mip lod bias can be set on a sampler. */
     VkSampleCountFlags supportedSamplePosCounts;    /**< A bitmask identifying the sample counts for which the device supports sample positions. */
     VkBool32 depthBoundsTest;                       /**< If true, depth bounds test is supported. */
+	VkDeviceSize mtlConstantBufferAlignment;		/**< Minimum Metal constant buffer offset alignment (in bytes). */
 } MVKPhysicalDeviceMetalFeatures;
 
 

--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -100,6 +100,7 @@ typedef struct {
     VkDeviceSize maxMTLBufferSize;              	/**< The max size of a MTLBuffer (in bytes). */
     VkDeviceSize mtlBufferAlignment;            	/**< The alignment used when allocating memory for MTLBuffers. Must be PoT. */
     VkDeviceSize maxQueryBufferSize;            	/**< The maximum size of an occlusion query buffer (in bytes). */
+	VkDeviceSize mtlConstantBufferAlignment;		/**< The alignment required for Metal constant buffers (in bytes). */
 	VkDeviceSize mtlCopyBufferAlignment;        	/**< The alignment required during buffer copy operations (in bytes). */
     VkSampleCountFlags supportedSampleCounts;   	/**< A bitmask identifying the sample counts supported by the device. */
 	uint32_t minSwapchainImageCount;	 	  		/**< The minimum number of swapchain images that can be supported by a surface. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1900,6 +1900,7 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
 	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
 	uint32_t cbufAlign = std::max<uint32_t>(gpuAlign, sizes.cbuffer.align);
+	uint32_t dataAlign = gpuAlign;
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;
 	uint32_t cpuSize = 0;
@@ -1907,7 +1908,6 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	uint32_t numAuxOffset = 0;
 	uint32_t inlineUniformSize = 0;
 	bool usesAuxBuffer = false;
-	bool usesTexCombined = false;
 
 	for (const auto& pool : pools) {
 		if (pool.type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
@@ -1918,14 +1918,7 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		MVKDescriptorCPULayout cpu = pickCPULayout(pool.type, 1, argBufMode, device);
 		numElem += descriptorGPUBindingCount(gpu) * pool.descriptorCount;
 		cpuSize += alignDescriptorOffset(descriptorCPUSize(cpu), cpuAlign) * pool.descriptorCount;
-		if (gpu == MVKDescriptorGPULayout::TexBufSoA || gpu == MVKDescriptorGPULayout::TexSampSoA ||
-			gpu == MVKDescriptorGPULayout::Tex2SampSoA || gpu == MVKDescriptorGPULayout::Tex3SampSoA) {
-			// Combined textures use Metal Constant Buffer alignment
-			gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), cbufAlign) * pool.descriptorCount;
-			usesTexCombined = true;
-		}
-		else
-			gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), gpuAlign) * pool.descriptorCount;
+		gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), gpuAlign) * pool.descriptorCount;
 		numAuxOffset += needsAuxOffset(gpu) ? pool.descriptorCount : 0;
 		usesAuxBuffer |= gpu == MVKDescriptorGPULayout::BufferAuxSize;
 	}
@@ -1945,10 +1938,10 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 				// Add space for the pointers
 				gpuSize += alignDescriptorOffset(sizes.pointer.size, gpuAlign) * info->maxInlineUniformBlockBindings;
 				// Outlined data is 16-byte aligned
-				gpuAlign = std::max(gpuAlign, 16u);
+				dataAlign = std::max(gpuAlign, 16u);
 			}
 			if (gpuLayout != MVKDescriptorGPULayout::None)
-				gpuSize += calcGroupSizeWithPadding(inlineUniformSize, info->maxInlineUniformBlockBindings, 4, gpuAlign);
+				gpuSize += calcGroupSizeWithPadding(inlineUniformSize, info->maxInlineUniformBlockBindings, 4, dataAlign);
 		}
 	}
 
@@ -1958,14 +1951,12 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		gpuSize += alignDescriptorOffset(maxGPUSize(MVKDescriptorGPULayout::Buffer, sizes), gpuAlign) * pCreateInfo->maxSets;
 		// The aux buffer is sized relative to the number of total elements in a descriptor, rather than the number of bindings with aux buffers
 		uint32_t size = numElem * sizeof(uint32_t);
-		// Aux buffers use Metal Constant Buffer alignment
-		gpuAlign = cbufAlign;
-		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), gpuAlign);
+		// Aux buffers require Metal constant buffer alignment padding between descriptor sets
+		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), cbufAlign);
 	}
-	else if (usesTexCombined) {
-		// Combined textures use Metal Constant Buffer alignment
-		gpuAlign = cbufAlign;
-	}
+
+	// Set overall gpu alignment incorporating Metal constant buffer and inline uniform data alignment
+	gpuAlign = std::max(cbufAlign, dataAlign);
 
 	bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;
 	void* cpuBuffer;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1923,6 +1923,9 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		usesAuxBuffer |= gpu == MVKDescriptorGPULayout::BufferAuxSize;
 	}
 
+	// Apply Metal constant buffer alignment padding for each descriptor set
+	gpuSize = calcGroupSizeWithPadding(gpuSize, pCreateInfo->maxSets, gpuAlign, cbufAlign);
+
 	if (numAuxOffset) {
 		// Aux offsets are allocated on the CPU buffer
 		cpuSize += calcGroupSizeWithPadding(numAuxOffset * sizeof(uint32_t), pCreateInfo->maxSets, alignof(uint32_t), cpuAlign);
@@ -1951,7 +1954,7 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		gpuSize += alignDescriptorOffset(maxGPUSize(MVKDescriptorGPULayout::Buffer, sizes), gpuAlign) * pCreateInfo->maxSets;
 		// The aux buffer is sized relative to the number of total elements in a descriptor, rather than the number of bindings with aux buffers
 		uint32_t size = numElem * sizeof(uint32_t);
-		// Aux buffers require Metal constant buffer alignment padding between descriptor sets
+		// Apply Metal constant buffer alignment padding for each descriptor set
 		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), cbufAlign);
 	}
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1898,7 +1898,7 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	MVKArrayRef pools(pCreateInfo->pPoolSizes, pCreateInfo->poolSizeCount);
 	MVKArgumentBufferMode argBufMode = pickArgumentBufferMode(device);
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
-	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
+	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, sizes.uniform.align));
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;
 	uint32_t cpuSize = 0;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1898,7 +1898,8 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	MVKArrayRef pools(pCreateInfo->pPoolSizes, pCreateInfo->poolSizeCount);
 	MVKArgumentBufferMode argBufMode = pickArgumentBufferMode(device);
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
-	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, sizes.uniform.align));
+	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
+	uint32_t cbufAlign = std::max<uint32_t>(gpuAlign, sizes.cbuffer.align);
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;
 	uint32_t cpuSize = 0;
@@ -1906,6 +1907,7 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	uint32_t numAuxOffset = 0;
 	uint32_t inlineUniformSize = 0;
 	bool usesAuxBuffer = false;
+	bool usesTexCombined = false;
 
 	for (const auto& pool : pools) {
 		if (pool.type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
@@ -1916,7 +1918,14 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		MVKDescriptorCPULayout cpu = pickCPULayout(pool.type, 1, argBufMode, device);
 		numElem += descriptorGPUBindingCount(gpu) * pool.descriptorCount;
 		cpuSize += alignDescriptorOffset(descriptorCPUSize(cpu), cpuAlign) * pool.descriptorCount;
-		gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), gpuAlign) * pool.descriptorCount;
+		if (gpu == MVKDescriptorGPULayout::TexBufSoA || gpu == MVKDescriptorGPULayout::TexSampSoA ||
+			gpu == MVKDescriptorGPULayout::Tex2SampSoA || gpu == MVKDescriptorGPULayout::Tex3SampSoA) {
+			// Combined textures use Metal Constant Buffer alignment
+			gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), cbufAlign) * pool.descriptorCount;
+			usesTexCombined = true;
+		}
+		else
+			gpuSize += alignDescriptorOffset(maxGPUSize(gpu, sizes), gpuAlign) * pool.descriptorCount;
 		numAuxOffset += needsAuxOffset(gpu) ? pool.descriptorCount : 0;
 		usesAuxBuffer |= gpu == MVKDescriptorGPULayout::BufferAuxSize;
 	}
@@ -1949,7 +1958,13 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		gpuSize += alignDescriptorOffset(maxGPUSize(MVKDescriptorGPULayout::Buffer, sizes), gpuAlign) * pCreateInfo->maxSets;
 		// The aux buffer is sized relative to the number of total elements in a descriptor, rather than the number of bindings with aux buffers
 		uint32_t size = numElem * sizeof(uint32_t);
+		// Aux buffers use Metal Constant Buffer alignment
+		gpuAlign = cbufAlign;
 		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), gpuAlign);
+	}
+	else if (usesTexCombined) {
+		// Combined textures use Metal Constant Buffer alignment
+		gpuAlign = cbufAlign;
 	}
 
 	bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1899,7 +1899,8 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	MVKArgumentBufferMode argBufMode = pickArgumentBufferMode(device);
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
 	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
-	uint32_t cbufAlign = std::max<uint32_t>(gpuAlign, sizes.cbuffer.align);
+	const uint32_t mtlCbufAlign = (uint32_t)device->getPhysicalDevice()->getMetalFeatures()->mtlConstantBufferAlignment;
+	uint32_t cbufAlign = std::max(gpuAlign, argBufMode != MVKArgumentBufferMode::Off ? mtlCbufAlign : 1u);
 	uint32_t dataAlign = gpuAlign;
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1887,6 +1887,7 @@ static uint32_t maxGPUSize(MVKDescriptorGPULayout layout, const MVKPhysicalDevic
  * where each group is aligned to `groupAlign`, calculates the amount of space required to do that
  */
 static uint32_t calcGroupSizeWithPadding(uint32_t size, uint32_t groups, uint32_t elemAlign, uint32_t groupAlign) {
+	groups = std::min(groups, size / elemAlign); // Each group needs at least one element
 	size += groups * (std::max(elemAlign, groupAlign) - elemAlign);
 	return size & ~(groupAlign - 1);
 }
@@ -1900,7 +1901,8 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
 	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
 	const uint32_t mtlCbufAlign = (uint32_t)device->getPhysicalDevice()->getMetalFeatures()->mtlConstantBufferAlignment;
-	uint32_t cbufAlign = std::max(gpuAlign, argBufMode != MVKArgumentBufferMode::Off ? mtlCbufAlign : 1u);
+	const bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;
+	uint32_t cbufAlign = std::max(gpuAlign, hostOnly ? 1u : mtlCbufAlign);
 	uint32_t dataAlign = gpuAlign;
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;
@@ -1924,8 +1926,6 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		usesAuxBuffer |= gpu == MVKDescriptorGPULayout::BufferAuxSize;
 	}
 
-	// Apply Metal constant buffer alignment padding for each descriptor set
-	gpuSize = calcGroupSizeWithPadding(gpuSize, pCreateInfo->maxSets, gpuAlign, cbufAlign);
 
 	if (numAuxOffset) {
 		// Aux offsets are allocated on the CPU buffer
@@ -1949,6 +1949,9 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		}
 	}
 
+	// Apply Metal constant buffer alignment padding for each descriptor set
+	gpuSize = calcGroupSizeWithPadding(gpuSize, pCreateInfo->maxSets, gpuAlign, cbufAlign);
+
 	if (usesAuxBuffer) {
 		// One entry is also used at the beginning of each set for the pointer to the aux buffer
 		numElem += pCreateInfo->maxSets;
@@ -1962,7 +1965,6 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	// Set overall gpu alignment incorporating Metal constant buffer and inline uniform data alignment
 	gpuAlign = std::max(cbufAlign, dataAlign);
 
-	bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;
 	void* cpuBuffer;
 	void* hostOnlyGPUBuffer;
 	// Pad ourselves to reduce the amount of space wasted in driver padding

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -1887,7 +1887,7 @@ static uint32_t maxGPUSize(MVKDescriptorGPULayout layout, const MVKPhysicalDevic
  * where each group is aligned to `groupAlign`, calculates the amount of space required to do that
  */
 static uint32_t calcGroupSizeWithPadding(uint32_t size, uint32_t groups, uint32_t elemAlign, uint32_t groupAlign) {
-	groups = std::min(groups, size / elemAlign); // Each group needs at least one element
+	groups = std::min(groups, size / elemAlign);	// Each group needs at least one element
 	size += groups * (std::max(elemAlign, groupAlign) - elemAlign);
 	return size & ~(groupAlign - 1);
 }
@@ -1900,10 +1900,6 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 	MVKArgumentBufferMode argBufMode = pickArgumentBufferMode(device);
 	const MVKPhysicalDeviceArgumentBufferSizes& sizes = device->getPhysicalDevice()->getArgumentBufferSizes();
 	uint32_t gpuAlign = std::max(std::max<uint32_t>(sizes.texture.align, sizes.sampler.align), std::max<uint32_t>(sizes.pointer.align, 1));
-	const uint32_t mtlCbufAlign = (uint32_t)device->getPhysicalDevice()->getMetalFeatures()->mtlConstantBufferAlignment;
-	const bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;
-	uint32_t cbufAlign = std::max(gpuAlign, hostOnly ? 1u : mtlCbufAlign);
-	uint32_t dataAlign = gpuAlign;
 	uint32_t cpuAlign = alignof(id);
 	uint32_t gpuSize = 0;
 	uint32_t cpuSize = 0;
@@ -1926,7 +1922,6 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		usesAuxBuffer |= gpu == MVKDescriptorGPULayout::BufferAuxSize;
 	}
 
-
 	if (numAuxOffset) {
 		// Aux offsets are allocated on the CPU buffer
 		cpuSize += calcGroupSizeWithPadding(numAuxOffset * sizeof(uint32_t), pCreateInfo->maxSets, alignof(uint32_t), cpuAlign);
@@ -1938,19 +1933,17 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 			if (argBufMode == MVKArgumentBufferMode::Off || mayDisableArgumentBuffers(device))
 				cpuSize += calcGroupSizeWithPadding(inlineUniformSize, info->maxInlineUniformBlockBindings, 4, cpuAlign);
 			MVKDescriptorGPULayout gpuLayout = pickGPULayout(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK, 1, argBufMode, device);
+			uint32_t dataAlign = gpuAlign;
 			if (gpuLayout == MVKDescriptorGPULayout::OutlinedData) {
 				// Add space for the pointers
 				gpuSize += alignDescriptorOffset(sizes.pointer.size, gpuAlign) * info->maxInlineUniformBlockBindings;
 				// Outlined data is 16-byte aligned
-				dataAlign = std::max(gpuAlign, 16u);
+				dataAlign = std::max(dataAlign, 16u);
 			}
 			if (gpuLayout != MVKDescriptorGPULayout::None)
 				gpuSize += calcGroupSizeWithPadding(inlineUniformSize, info->maxInlineUniformBlockBindings, 4, dataAlign);
 		}
 	}
-
-	// Apply Metal constant buffer alignment padding for each descriptor set
-	gpuSize = calcGroupSizeWithPadding(gpuSize, pCreateInfo->maxSets, gpuAlign, cbufAlign);
 
 	if (usesAuxBuffer) {
 		// One entry is also used at the beginning of each set for the pointer to the aux buffer
@@ -1958,12 +1951,16 @@ MVKDescriptorPool* MVKDescriptorPool::Create(MVKDevice* device, const VkDescript
 		gpuSize += alignDescriptorOffset(maxGPUSize(MVKDescriptorGPULayout::Buffer, sizes), gpuAlign) * pCreateInfo->maxSets;
 		// The aux buffer is sized relative to the number of total elements in a descriptor, rather than the number of bindings with aux buffers
 		uint32_t size = numElem * sizeof(uint32_t);
-		// Apply Metal constant buffer alignment padding for each descriptor set
-		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), cbufAlign);
+		gpuSize += calcGroupSizeWithPadding(size, pCreateInfo->maxSets, alignof(uint32_t), gpuAlign);
 	}
 
-	// Set overall gpu alignment incorporating Metal constant buffer and inline uniform data alignment
-	gpuAlign = std::max(cbufAlign, dataAlign);
+	bool hostOnly = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) && argBufMode != MVKArgumentBufferMode::ArgEncoder;
+
+	// Apply Metal constant buffer offset alignment padding for descriptor sets
+	const uint32_t mtlCbufAlign = (uint32_t)device->getPhysicalDevice()->getMetalFeatures()->mtlConstantBufferAlignment;
+	const uint32_t cbufAlign = std::max(gpuAlign, hostOnly || argBufMode == MVKArgumentBufferMode::Off ? 1u : mtlCbufAlign);
+	gpuSize = calcGroupSizeWithPadding(gpuSize, pCreateInfo->maxSets, gpuAlign, cbufAlign);
+	gpuAlign = cbufAlign;
 
 	void* cpuBuffer;
 	void* hostOnlyGPUBuffer;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -168,6 +168,7 @@ struct MVKPhysicalDeviceArgumentBufferSizes {
 	Entry texture;
 	Entry sampler;
 	Entry pointer;
+	Entry uniform;
 };
 
 /** Represents a Vulkan physical GPU device. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -168,7 +168,7 @@ struct MVKPhysicalDeviceArgumentBufferSizes {
 	Entry texture;
 	Entry sampler;
 	Entry pointer;
-	Entry uniform;
+	Entry cbuffer;
 };
 
 /** Represents a Vulkan physical GPU device. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -168,7 +168,6 @@ struct MVKPhysicalDeviceArgumentBufferSizes {
 	Entry texture;
 	Entry sampler;
 	Entry pointer;
-	Entry cbuffer;
 };
 
 /** Represents a Vulkan physical GPU device. */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2705,8 +2705,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_argumentBufferSizes.texture = getArgumentBufferSize(_mtlDevice, MTLDataTypeTexture);
 		_argumentBufferSizes.sampler = getArgumentBufferSize(_mtlDevice, MTLDataTypeSampler);
 		_argumentBufferSizes.pointer = getArgumentBufferSize(_mtlDevice, MTLDataTypePointer);
-		_argumentBufferSizes.cbuffer.size  = _argumentBufferSizes.pointer.size;
-		_argumentBufferSizes.cbuffer.align = std::max<uint16_t>(_argumentBufferSizes.pointer.align, _metalFeatures.mtlConstantBufferAlignment);
 	} else {
 		_argumentBufferSizes = {};
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2705,8 +2705,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_argumentBufferSizes.texture = getArgumentBufferSize(_mtlDevice, MTLDataTypeTexture);
 		_argumentBufferSizes.sampler = getArgumentBufferSize(_mtlDevice, MTLDataTypeSampler);
 		_argumentBufferSizes.pointer = getArgumentBufferSize(_mtlDevice, MTLDataTypePointer);
-		_argumentBufferSizes.uniform.size  = _argumentBufferSizes.pointer.size;
-		_argumentBufferSizes.uniform.align = max(_argumentBufferSizes.pointer.align, static_cast<uint16_t>(_metalFeatures.mtlConstantBufferAlignment));
+		_argumentBufferSizes.cbuffer.size  = _argumentBufferSizes.pointer.size;
+		_argumentBufferSizes.cbuffer.align = max(_argumentBufferSizes.pointer.align, static_cast<uint16_t>(_metalFeatures.mtlConstantBufferAlignment));
 	} else {
 		_argumentBufferSizes = {};
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2706,7 +2706,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_argumentBufferSizes.sampler = getArgumentBufferSize(_mtlDevice, MTLDataTypeSampler);
 		_argumentBufferSizes.pointer = getArgumentBufferSize(_mtlDevice, MTLDataTypePointer);
 		_argumentBufferSizes.cbuffer.size  = _argumentBufferSizes.pointer.size;
-		_argumentBufferSizes.cbuffer.align = max(_argumentBufferSizes.pointer.align, static_cast<uint16_t>(_metalFeatures.mtlConstantBufferAlignment));
+		_argumentBufferSizes.cbuffer.align = std::max<uint16_t>(_argumentBufferSizes.pointer.align, _metalFeatures.mtlConstantBufferAlignment);
 	} else {
 		_argumentBufferSizes = {};
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2468,6 +2468,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 	if (supportsMTLGPUFamily(Mac2)) {
 		_metalFeatures.mtlBufferAlignment = 256;
+		_metalFeatures.mtlConstantBufferAlignment = 32;
 		_metalFeatures.mtlCopyBufferAlignment = 4;
 		_metalFeatures.maxPerStageTextureCount = 128;
 		_metalFeatures.maxTextureDimension = (16 * KIBI);
@@ -2499,6 +2500,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
     if (supportsMTLGPUFamily(Apple1)) {
 		_metalFeatures.mtlBufferAlignment = 64;
+		_metalFeatures.mtlConstantBufferAlignment = 4;
 		_metalFeatures.mtlCopyBufferAlignment = 1;
 		_metalFeatures.maxPerStageTextureCount = 31;
 		_metalFeatures.maxTextureDimension = (8 * KIBI);
@@ -2577,6 +2579,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 // iOS, tvOS and visionOS adjustments necessary when running on the simulator.
 #if MVK_OS_SIMULATOR
 	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
+	_metalFeatures.mtlConstantBufferAlignment = 256;
 	_metalFeatures.renderLinearTextures = false;
 #endif
 
@@ -2702,6 +2705,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_argumentBufferSizes.texture = getArgumentBufferSize(_mtlDevice, MTLDataTypeTexture);
 		_argumentBufferSizes.sampler = getArgumentBufferSize(_mtlDevice, MTLDataTypeSampler);
 		_argumentBufferSizes.pointer = getArgumentBufferSize(_mtlDevice, MTLDataTypePointer);
+		_argumentBufferSizes.uniform.size  = _argumentBufferSizes.pointer.size;
+		_argumentBufferSizes.uniform.align = _metalFeatures.mtlConstantBufferAlignment;
 	} else {
 		_argumentBufferSizes = {};
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2706,7 +2706,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_argumentBufferSizes.sampler = getArgumentBufferSize(_mtlDevice, MTLDataTypeSampler);
 		_argumentBufferSizes.pointer = getArgumentBufferSize(_mtlDevice, MTLDataTypePointer);
 		_argumentBufferSizes.uniform.size  = _argumentBufferSizes.pointer.size;
-		_argumentBufferSizes.uniform.align = _metalFeatures.mtlConstantBufferAlignment;
+		_argumentBufferSizes.uniform.align = max(_argumentBufferSizes.pointer.align, static_cast<uint16_t>(_metalFeatures.mtlConstantBufferAlignment));
 	} else {
 		_argumentBufferSizes = {};
 	}


### PR DESCRIPTION
Provisionally fixes #2699.

This is a ~~draft~~ fix to avoid Xcode's Metal API Validation failures for non-arm64 targets, more specifically when running on the _iOS Simulator_, or on an _x86_64_ machine.

As stated in the associated PR above,  while this fix works I am not sure if this is the correct way to fix the problem.  In particular I am not sure if taking the worst case alignment for constant buffers (256 bytes on iOS Simulator, or 32 bytes on x86_64 vs. 4 bytes for arm64) vs arg buffer alignments for other types (e.g. textures, samplers, and regular buffers which are all typically 8 bytes) will lead to inefficient memory use within Argument Buffers.

I have decided to post this ~~draft~~ fix anyways, if only to spark conversation about the issue and how to fix correctly.