### PR TITLE
WIP: Strip sRGB from storage image Metal textures for Vulkan spec compliance

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -851,11 +851,14 @@ static bool canUseFastPathUpdate(MVKDescriptorGPULayout layout, MVKArgumentBuffe
 }
 
 /** Get the MTLTexture stored at the given image-representing source Vulkan update pointer. */
-static id<MTLTexture> getTexture(const void* src, MVKDescriptorUpdateSourceType type) {
+static id<MTLTexture> getTexture(const void* src, MVKDescriptorUpdateSourceType type,
+								 VkDescriptorType descType = VK_DESCRIPTOR_TYPE_MAX_ENUM) {
 	switch (type) {
 		case MVKDescriptorUpdateSourceType::Image: {
 			auto* img = reinterpret_cast<MVKImageView*>(static_cast<const VkDescriptorImageInfo*>(src)->imageView);
-			return img ? img->getMTLTexture() : nullptr;
+			if (!img) return nullptr;
+			return (descType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+				? img->getMTLTextureForStorage() : img->getMTLTexture();
 		}
 		case MVKDescriptorUpdateSourceType::TexelBuffer: {
 			auto* img = *reinterpret_cast<MVKBufferView*const*>(src);
@@ -970,7 +973,7 @@ static void writeDescriptorSetGPUBuffer(
 	for (uint32_t i = 0; i < count; i++) {
 		switch (Layout) {
 			case MVKDescriptorGPULayout::Texture:
-				enc.setTexture(getTexture(src, srcType));
+				enc.setTexture(getTexture(src, srcType, binding.descriptorType));
 				break;
 
 			case MVKDescriptorGPULayout::Sampler:
@@ -985,7 +988,7 @@ static void writeDescriptorSetGPUBuffer(
 				break;
 
 			case MVKDescriptorGPULayout::TexBufSoA:
-				if (id<MTLTexture> tex = getTexture(src, srcType)) {
+				if (id<MTLTexture> tex = getTexture(src, srcType, binding.descriptorType)) {
 					enc.setTexture(tex);
 					enc.setBuffer([tex buffer], [tex bufferOffset], binding.descriptorCount);
 				} else {
@@ -1161,7 +1164,13 @@ static void writeDescriptorSetCPUBuffer(
 					case MVKDescriptorUpdateSourceType::ImageSampler: {
 						// OneID ImageSampler is image + constexpr sampler
 						auto* img = reinterpret_cast<MVKImageView*>(static_cast<const VkDescriptorImageInfo*>(src)->imageView);
-						*desc = img ? img->getMTLTexture() : nil;
+						if (!img) {
+							*desc = nil;
+						} else if (binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+							*desc = img->getMTLTextureForStorage();
+						} else {
+							*desc = img->getMTLTexture();
+						}
 						break;
 					}
 					case MVKDescriptorUpdateSourceType::Sampler: {
@@ -1277,7 +1286,8 @@ static void writeDescriptorSetCPUBuffer(
 					case MVKDescriptorUpdateSourceType::Image: {
 						auto* img = reinterpret_cast<MVKImageView*>(static_cast<const VkDescriptorImageInfo*>(src)->imageView);
 						if (img) {
-							id<MTLTexture> tex = img->getMTLTexture();
+							id<MTLTexture> tex = (binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
+								? img->getMTLTextureForStorage() : img->getMTLTexture();
 							desc->a = tex;
 							desc->b = [tex buffer];
 							desc->offset = [tex bufferOffset];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -551,6 +551,15 @@ public:
     /** Returns the Metal texture underlying this image view. */
     id<MTLTexture> getMTLTexture();
 
+    /**
+     * Returns a Metal texture for use as a storage image (imageStore).
+     * If the view format is sRGB, returns a non-sRGB texture view to prevent
+     * Metal from applying automatic linear-to-sRGB conversion on compute writes.
+     * This matches the Vulkan spec behavior where imageStore does not apply
+     * sRGB conversion, unlike color attachment writes in render passes.
+     */
+    id<MTLTexture> getMTLTextureForStorage();
+
     void releaseMTLTexture();
 
     ~MVKImageViewPlane();
@@ -564,6 +573,7 @@ protected:
     friend MVKImageView;
     MVKImageView* _imageView;
 	id<MTLTexture> _mtlTexture;
+	id<MTLTexture> _mtlTextureLinear;  // Non-sRGB view for storage image writes
 	VkComponentMapping _componentSwizzle;
     MTLPixelFormat _mtlPixFmt;
 	uint8_t _planeIndex;
@@ -596,6 +606,9 @@ public:
 
 	/** Returns the Metal texture underlying this image view.  */
 	id<MTLTexture> getMTLTexture(uint8_t planeIndex = 0) { return planeIndex < _planes.size() ? _planes[planeIndex]->getMTLTexture() : nil; }	// Guard against destroyed instance retained in a descriptor.
+
+	/** Returns a Metal texture for use as a storage image, with sRGB stripped to prevent automatic conversion on compute writes. */
+	id<MTLTexture> getMTLTextureForStorage(uint8_t planeIndex = 0) { return planeIndex < _planes.size() ? _planes[planeIndex]->getMTLTextureForStorage() : nil; }
 
 	/** Returns the Metal pixel format of this image view. */
 	MTLPixelFormat getMTLPixelFormat(uint8_t planeIndex = 0) { return planeIndex < _planes.size() ? _planes[planeIndex]->_mtlPixFmt : MTLPixelFormatInvalid; }	// Guard against destroyed instance retained in a descriptor.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1866,6 +1866,68 @@ id<MTLTexture> MVKImageViewPlane::getMTLTexture() {
     }
 }
 
+// Returns the linear (non-sRGB) equivalent of an sRGB MTLPixelFormat, or MTLPixelFormatInvalid if not sRGB.
+static MTLPixelFormat getLinearMTLPixelFormat(MTLPixelFormat fmt) {
+    switch (fmt) {
+        case MTLPixelFormatRGBA8Unorm_sRGB:     return MTLPixelFormatRGBA8Unorm;
+        case MTLPixelFormatBGRA8Unorm_sRGB:     return MTLPixelFormatBGRA8Unorm;
+#if MVK_APPLE_SILICON
+        case MTLPixelFormatR8Unorm_sRGB:        return MTLPixelFormatR8Unorm;
+        case MTLPixelFormatRG8Unorm_sRGB:       return MTLPixelFormatRG8Unorm;
+#endif
+        case MTLPixelFormatBC1_RGBA_sRGB:       return MTLPixelFormatBC1_RGBA;
+        case MTLPixelFormatBC2_RGBA_sRGB:       return MTLPixelFormatBC2_RGBA;
+        case MTLPixelFormatBC3_RGBA_sRGB:       return MTLPixelFormatBC3_RGBA;
+        case MTLPixelFormatBC7_RGBAUnorm_sRGB:  return MTLPixelFormatBC7_RGBAUnorm;
+        case MTLPixelFormatETC2_RGB8_sRGB:      return MTLPixelFormatETC2_RGB8;
+        case MTLPixelFormatETC2_RGB8A1_sRGB:    return MTLPixelFormatETC2_RGB8A1;
+        case MTLPixelFormatEAC_RGBA8_sRGB:      return MTLPixelFormatEAC_RGBA8;
+        case MTLPixelFormatASTC_4x4_sRGB:       return MTLPixelFormatASTC_4x4_LDR;
+        case MTLPixelFormatASTC_5x4_sRGB:       return MTLPixelFormatASTC_5x4_LDR;
+        case MTLPixelFormatASTC_5x5_sRGB:       return MTLPixelFormatASTC_5x5_LDR;
+        case MTLPixelFormatASTC_6x5_sRGB:       return MTLPixelFormatASTC_6x5_LDR;
+        case MTLPixelFormatASTC_6x6_sRGB:       return MTLPixelFormatASTC_6x6_LDR;
+        case MTLPixelFormatASTC_8x5_sRGB:       return MTLPixelFormatASTC_8x5_LDR;
+        case MTLPixelFormatASTC_8x6_sRGB:       return MTLPixelFormatASTC_8x6_LDR;
+        case MTLPixelFormatASTC_8x8_sRGB:       return MTLPixelFormatASTC_8x8_LDR;
+        case MTLPixelFormatASTC_10x5_sRGB:      return MTLPixelFormatASTC_10x5_LDR;
+        case MTLPixelFormatASTC_10x6_sRGB:      return MTLPixelFormatASTC_10x6_LDR;
+        case MTLPixelFormatASTC_10x8_sRGB:      return MTLPixelFormatASTC_10x8_LDR;
+        case MTLPixelFormatASTC_10x10_sRGB:     return MTLPixelFormatASTC_10x10_LDR;
+        case MTLPixelFormatASTC_12x10_sRGB:     return MTLPixelFormatASTC_12x10_LDR;
+        case MTLPixelFormatASTC_12x12_sRGB:     return MTLPixelFormatASTC_12x12_LDR;
+        default:                                return MTLPixelFormatInvalid;
+    }
+}
+
+id<MTLTexture> MVKImageViewPlane::getMTLTextureForStorage() {
+    // For sRGB formats, return a non-sRGB texture view to prevent Metal from
+    // applying automatic linear-to-sRGB conversion on compute shader writes.
+    // Per the Vulkan spec, imageStore does not apply sRGB conversion.
+    MTLPixelFormat linearFmt = getLinearMTLPixelFormat(_mtlPixFmt);
+    if (linearFmt != MTLPixelFormatInvalid) {
+        if ( !_mtlTextureLinear ) {
+            lock_guard<mutex> lock(_imageView->_lock);
+            if ( !_mtlTextureLinear ) {
+                // Create the linear view from the underlying image texture directly,
+                // preserving the correct texture type, mip levels, and array slices.
+                id<MTLTexture> imgTex = _imageView->_image->getMTLTexture(_planeIndex);
+                NSRange levelRange = NSMakeRange(_imageView->_subresourceRange.baseMipLevel, _imageView->_subresourceRange.levelCount);
+                NSRange sliceRange = NSMakeRange(_imageView->_subresourceRange.baseArrayLayer, _imageView->_subresourceRange.layerCount);
+                _mtlTextureLinear = [imgTex newTextureViewWithPixelFormat: linearFmt
+                                                             textureType: _imageView->_mtlTextureType
+                                                                  levels: levelRange
+                                                                  slices: sliceRange];  // retained
+                if (_mtlTextureLinear) {
+                    getDevice()->getLiveResources().add(_mtlTextureLinear);
+                }
+            }
+        }
+        if (_mtlTextureLinear) { return _mtlTextureLinear; }
+    }
+    return getMTLTexture();
+}
+
 // Creates and returns a retained Metal texture as an
 // overlay on the Metal texture of the underlying image.
 id<MTLTexture> MVKImageViewPlane::newMTLTexture() {
@@ -1957,6 +2019,7 @@ MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
     _planeIndex = planeIndex;
     _mtlPixFmt = mtlPixFmt;
     _mtlTexture = nil;
+    _mtlTextureLinear = nil;
 
 	getVulkanAPIObject()->setConfigurationResult(initSwizzledMTLPixelFormat(pCreateInfo));
 
@@ -2113,6 +2176,10 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 }
 
 MVKImageViewPlane::~MVKImageViewPlane() {
+	if (id<MTLTexture> tex = _mtlTextureLinear) {
+		getDevice()->getLiveResources().remove(tex);
+		[tex release];
+	}
 	if (id<MTLTexture> tex = _mtlTexture) {
 		getDevice()->getLiveResources().remove(tex);
 		[tex release];


### PR DESCRIPTION
Metal hardware automatically applies linear-to-sRGB conversion when a compute shader writes to an sRGB-formatted texture via texture.write(). This violates the Vulkan spec, which says imageStore (OpImageWrite) does NOT apply sRGB conversion - only color attachment writes in render passes should.

Add getMTLTextureForStorage() to MVKImageViewPlane which returns a non-sRGB Metal texture view (using the linear variant of the pixel format). When a VkImageView is bound as VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, the non-sRGB texture is used, preventing Metal from applying unwanted conversion.