### PR TITLE
Fix same-size swapchain recreation resulting in 1x1 `drawableSize`

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKSwapchain.mm
@@ -486,6 +486,18 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 	auto* mtlLayer = getCAMetalLayer();
 	if ( !mtlLayer || getIsSurfaceLost() ) { return; }
 
+	VkExtent2D prevSurfaceExtent = _surface->getExtent();
+	auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
+
+	// Because of a regression in Metal, the most recent one or two presentations may not
+	// complete and call back. Changing the CAMetalLayer drawableSize will force any incomplete
+	// presentations on the oldSwapchain to complete and call back, but if the drawableSize
+	// is not changing from the previous, we need to force those completions before resetting
+	// the layer to the same size on the replacement swapchain.
+	if (oldSwapchain && mvkVkExtent2DsAreEqual(pCreateInfo->imageExtent, prevSurfaceExtent)) {
+		oldSwapchain->forceUnpresentedImageCompletion();
+	}
+
 	auto minMagFilter = getMVKConfig().swapchainMinMagFilterUseNearest ? kCAFilterNearest : kCAFilterLinear;
 	mtlLayer.drawableSize = mvkCGSizeFromVkExtent2D(_imageExtent);
 	mtlLayer.device = getMTLDevice();
@@ -500,15 +512,6 @@ void MVKSwapchain::initCAMetalLayer(const VkSwapchainCreateInfoKHR* pCreateInfo,
 																			  VK_IMAGE_USAGE_SAMPLED_BIT |
 																			  VK_IMAGE_USAGE_STORAGE_BIT)) &&
 								!mvkAreAllFlagsEnabled(pCreateInfo->flags, VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR);
-
-	// Because of a regression in Metal, the most recent one or two presentations may not
-	// complete and call back. Changing the CAMetalLayer drawableSize will force any incomplete
-	// presentations on the oldSwapchain to complete and call back, but if the drawableSize
-	// is not changing from the previous, we force those completions first.
-	auto* oldSwapchain = (MVKSwapchain*)pCreateInfo->oldSwapchain;
-	if (oldSwapchain && mvkVkExtent2DsAreEqual(pCreateInfo->imageExtent, _surface->getExtent())) {
-		oldSwapchain->forceUnpresentedImageCompletion();
-	}
 
 	if (pCreateInfo->compositeAlpha != VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) {
 		mtlLayer.opaque = pCreateInfo->compositeAlpha == VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;


### PR DESCRIPTION
Hey! I've ran into #2226 with very similar symptoms, except without any validation errors.
In my case, changing the presentation mode from FIFO to IMMEDIATE without resizing the window would trigger the bug. The output of my game's rendering would be a constant color. Resizing the window would unbug it.

It seems that the root cause is just the order in which the `forceUnpresentedImageCompletion` workaround runs relative to the configuration of a new swapchain. If `forceUnpresentedImageCompletion` goes last, it will internally change the `CAMetalLayer` `drawableSize` to 1x1, overriding the `mtlLayer.drawableSize = ...` that was being done for the new swapchain.

I don't know how to test the Metal regression the comments discuss, but this change resolves the 1x1 drawable size issue for me. Tested on an MBP M1.

Fixes #2226