### PR TITLE
Fix channel corruption for color RTs used as xfer sources

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
 - Fix incorrect varable usage in `MVKImagePlane::getMTLTexture()`.
 - Fix device loss when using imported `MTLTexture` objects with Metal argument buffers.
 - Update copyright notices to year 2026.
+- Fix channel corruption on Apple Silicon for color render targets used as transfer sources.
 - Update to latest SPIRV-Cross:
   - MSL: Fix `subgroupBallotExclusiveBitCount()` is not available for task shader and mesh shader.
   - MSL: `thread_execution_width` is deprecated as of Metal 3.0 , use `threads_per_simdgroup` instead.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -402,6 +402,7 @@ protected:
 	bool _isLinearForAtomics;
 	bool _is2DViewOn3DImageCompatible = false;
 	bool _isBlockTexelViewCompatible = false;
+	bool _isColorAttachmentTransferSrc = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -155,8 +155,13 @@ MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
     mtlTexDesc.storageMode = _image->getMTLStorageMode();
     mtlTexDesc.cpuCacheMode = _image->getMTLCPUCacheMode();
     // For 2D views of 3D and block texel views, we alias the underlying memory.
-    // Ensure that it remains consistent by disabling GPU layout optimization.
-    mtlTexDesc.allowGPUOptimizedContents = !_image->_is2DViewOn3DImageCompatible && !_image->_isBlockTexelViewCompatible;
+    // For color render targets used as transfer sources, MTLBlitCommandEncoder
+    // copies the lossless-compressed tile layout directly rather than the
+    // logical pixel values, which corrupts readback on Apple Silicon (#2220).
+    // Ensure layout remains consistent by disabling GPU layout optimization.
+    mtlTexDesc.allowGPUOptimizedContents = !_image->_is2DViewOn3DImageCompatible
+                                        && !_image->_isBlockTexelViewCompatible
+                                        && !_image->_isColorAttachmentTransferSrc;
 
     return mtlTexDesc;
 }
@@ -1314,6 +1319,9 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
 
 	_is2DViewOn3DImageCompatible = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT);
 	_isBlockTexelViewCompatible = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
+	_isColorAttachmentTransferSrc = mvkAreAllFlagsEnabled(pCreateInfo->usage,
+														  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+														  VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 }
 
 VkSampleCountFlagBits MVKImage::validateSamples(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {


### PR DESCRIPTION
On Apple Silicon, a colour image used as both a render target and a transfer source reads back with corrupted channels (NaN or zero on three of the four components, depending on format). The pattern reproduces (often presenting as a pink/green tint) in gzdoom, Raze, vkdoom, ddnet-rs, and a Chromium WebGPU equivalent (chromium #388872587). The root cause is that `MTLBlitCommandEncoder` copies the lossless-compressed tile layout directly without going through the decompressor, so the bytes that land in the destination buffer don't match the logical pixel values.

Setting `MTLTextureDescriptor.allowGPUOptimizedContents = NO` opts out of lossless compression. The workaround in the issue thread (`pfv |= TRANSFER_SRC`) wasn't ideal as it disables compression on everything that uses `TRANSFER_SRC` for mip-chain generation. (In DXVK / vkd3d that's essentially every texture)

The predicate here narrows the carve-out to images that have **both** `VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT` and `VK_IMAGE_USAGE_TRANSFER_SRC_BIT`. That distinguishes render targets from asset textures (which carry `SAMPLED | TRANSFER_DST | TRANSFER_SRC` but not `COLOR_ATTACHMENT`), so the perf work in #2088 is preserved.

Verified on an Apple M3 with [a small probe (gist here)](https://gist.github.com/skooch/6f1b756afdccc66e9e122fb95cf9d79d) that creates VkImages across formats `RGBA16F`, `RGBA8`, `BGRA8`, `RGBA32F` and reads back `MTLTexture.allowGPUOptimizedContents` via `VK_EXT_metal_objects`.

<details><summary>Probe results (RGBA16F shown; identical pattern across RGBA8 / BGRA8 / RGBA32F)</summary>

| Image pattern (`VkImageUsageFlags`) | `allowGPUOpt` before | `allowGPUOpt` after |
|---|---|---|
| `COLOR \| SAMPLED \| TRANSFER_SRC` (#2220 set)    | YES | **NO**  |
| `COLOR \| SAMPLED \| TRANSFER_SRC \| TRANSFER_DST` (gzdoom `PipelineImage`) | YES | **NO**  |
| `COLOR \| TRANSFER_SRC` (swapchain-style)         | YES | **NO**  |
| `SAMPLED \| TRANSFER_DST \| TRANSFER_SRC` (mip-gen asset) | YES | YES (unchanged — preserves #2088) |
| `SAMPLED \| TRANSFER_DST` (plain asset) | YES | YES (unchanged) |
| `COLOR \| SAMPLED` (RT, no SRC) | YES | YES (unchanged) |
| `COLOR` (plain render target) | YES | YES (unchanged) |

`MTLTextureUsage` is unchanged for every row — the new predicate adjusts a separate descriptor field.

</details>

I wasn't able to repro the end-to-end corruption in an isolated single-pass test on my M3 device, consistent with no reporter producing a standalone repro outside their full engine: so the empirical verification is of the predicate, not the visible fix.

Verified end-to-end against UZDoom on my side, the pink tint regression on post-process intermediates is gone. Independent confirmation against the other affected engines (gzdoom, Raze, vkdoom, ddnet-rs, Chromium) would still be welcome.

Fixes #2220.