### PR TITLE
Make imported MTLBuffer resident in MVKDeviceMemory

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -352,11 +352,14 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 				// Setting Metal objects directly will override Vulkan settings.
 				// It is responsibility of app to ensure these are consistent. Not doing so results in undefined behavior.
 				const auto* pMTLBuffInfo = (VkImportMetalBufferInfoEXT*)next;
-				if (_mtlBuffer)
+				if (_mtlBuffer) {
+					_device->removeResidency(_mtlBuffer);
 					_device->getLiveResources().remove(_mtlBuffer);
+				}
 				[_mtlBuffer release];							// guard against dups
 				_device->getLiveResources().add(pMTLBuffInfo->mtlBuffer);
 				_mtlBuffer = [pMTLBuffInfo->mtlBuffer retain];	// retained
+				_device->makeResident(_mtlBuffer);
 				_mtlStorageMode = _mtlBuffer.storageMode;
 				_mtlCPUCacheMode = _mtlBuffer.cpuCacheMode;
 				_allocationSize = _mtlBuffer.length;
@@ -384,18 +387,13 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 					_allocationSize = _mtlHeap.size;
 				}
 				else if (pImportInfo->handleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_EXT) {
-					if (_mtlBuffer)
+					if (_mtlBuffer) {
+						_device->removeResidency(_mtlBuffer);
 						_device->getLiveResources().remove(_mtlBuffer);
+					}
 					[_mtlBuffer release];							// guard against dups
 					_device->getLiveResources().add(((id<MTLBuffer>)pImportInfo->handle));
 					_mtlBuffer = [((id<MTLBuffer>)pImportInfo->handle) retain];	// retained
-					/* On Metal 3 / Xcode 16+, GPU access to a buffer requires
-					 * the buffer be registered in the device's residency set.
-					 * The non-import path in ensureMTLBuffer() calls
-					 * _device->makeResident(buf) immediately after creation;
-					 * the import path here was missing that, so GPU writes
-					 * to a buffer imported via VkImportMemoryMetalHandleInfoEXT
-					 * silently went to a non-resident region the CPU can't see. */
 					_device->makeResident(_mtlBuffer);
 					_mtlStorageMode = _mtlBuffer.storageMode;
 					_mtlCPUCacheMode = _mtlBuffer.cpuCacheMode;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceMemory.mm
@@ -389,6 +389,14 @@ MVKDeviceMemory::MVKDeviceMemory(MVKDevice* device,
 					[_mtlBuffer release];							// guard against dups
 					_device->getLiveResources().add(((id<MTLBuffer>)pImportInfo->handle));
 					_mtlBuffer = [((id<MTLBuffer>)pImportInfo->handle) retain];	// retained
+					/* On Metal 3 / Xcode 16+, GPU access to a buffer requires
+					 * the buffer be registered in the device's residency set.
+					 * The non-import path in ensureMTLBuffer() calls
+					 * _device->makeResident(buf) immediately after creation;
+					 * the import path here was missing that, so GPU writes
+					 * to a buffer imported via VkImportMemoryMetalHandleInfoEXT
+					 * silently went to a non-resident region the CPU can't see. */
+					_device->makeResident(_mtlBuffer);
 					_mtlStorageMode = _mtlBuffer.storageMode;
 					_mtlCPUCacheMode = _mtlBuffer.cpuCacheMode;
 					_allocationSize = _mtlBuffer.length;


### PR DESCRIPTION
## Summary

When `VkDeviceMemory` is allocated via `VkImportMemoryMetalHandleInfoEXT` with `handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_EXT`, the imported `MTLBuffer` is added to `_liveResources` but was never registered with the device's residency set via `_device->makeResident()`.

On Metal 3 / Xcode 16+ (where `MTLResidencySet` is the residency mechanism), this means the GPU cannot access the buffer's memory: writes via `VkBuffer`s bound to that `VkDeviceMemory` go to a non-resident region the CPU side never sees through the same `MTLBuffer`. Metal raises no errors — the encoder accepts commands, the queue completes — the writes just don't land.

The non-import path in `MVKDeviceMemory::ensureMTLBuffer()` already calls `_device->makeResident(buf)` immediately after creating the `MTLBuffer` (whether wrapping host memory, copying it, or pure allocation). The `MTLHEAP` and `MTLTEXTURE` import branches likewise get residency tracking via their own paths (`MVKImage`'s `makeResident` calls, and the heap-derived buffer creation in `MVKBuffer::getMTLBuffer`).

Only the `MTLBUFFER` import branch was missing the equivalent. The fix is a single `_device->makeResident(_mtlBuffer);` call after the `_mtlBuffer` retain.

## Why this hadn't been hit before

A combination of filters narrows the population that would notice:

1. **`MTLResidencySet` is Xcode 16+ only.** On older toolchains, `MVKDevice::makeResident` is a no-op stub. The bug is only observable on Sequoia/Tahoe builds.
2. **`VK_EXT_external_memory_metal` import-of-MTLBuffer is rare.** Most macOS Vulkan apps don't import external memory at all. The few that do typically import `MTLTexture` (AVFoundation/Core Image bridges) or `MTLHeap` (heap-pool integrations) — both of which take other code paths that include `makeResident`. Plain `MTLBuffer` imports are mostly used by paravirt-Vulkan host implementations.
3. **The symptom is silent.** No errors, no validation layer triggers, just GPU writes that don't land. Apps using imported buffers for streaming (CPU-write/GPU-read) might not notice; apps that expect GPU writes to be visible to the importer (compute output, or CPU readback of fills/transfers) detect it cleanly.

## Repro

A standalone reproducer is available at https://github.com/atrium-os/MoltenVK/blob/main/test_mvk_import.m. ~175 lines, no dependencies beyond Metal/Foundation/Vulkan loader. Build:

```sh
clang -fobjc-arc -framework Metal -framework Foundation \
      -I$(brew --prefix)/include -L$(brew --prefix)/lib -lvulkan \
      -o /tmp/test_mvk_import test_mvk_import.m
VK_DRIVER_FILES=$(brew --prefix)/etc/vulkan/icd.d/MoltenVK_icd.json \
      /tmp/test_mvk_import
```

The test:
1. Allocates an `MTLBuffer` via `[device newBufferWithLength:options:Shared]`
2. CPU-init contents to `0xAAAAAAAA` via `[mtlBuf contents]`
3. Creates a Vulkan instance + device with `VK_EXT_external_memory_metal`
4. `vkAllocateMemory` with `VkImportMemoryMetalHandleInfoEXT` chained, MTLBUFFER handle
5. Binds a `VkBuffer` to the imported memory
6. `vkCmdFillBuffer(0xCAFEBABE)` + barrier + queue submit + wait
7. Reads back via the original `[mtlBuf contents]`

Pre-fix: buffer reads as `0xAAAAAAAA` (CPU init unchanged), exit 1, FAIL 0/9.
Post-fix: buffer reads as `0xCAFEBABE` (GPU fill), exit 0, PASS 9/9.

## Risk

The change is strictly an addition (no behavior modification on any non-buggy path). On pre-Xcode-16 builds, `makeResident` is a no-op stub, so this is also safe there.