### PR TITLE
Prevent null dereference in MVKPixelFormats

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -121,6 +121,7 @@ typedef struct MVKMTLDeviceCapabilities {
 	bool supportsDepth24Stencil8;
 	bool supports32BitFloatFiltering;
 	bool supports32BitMSAA;
+	bool supportsRenderLinearTextures;
 
 	uint8_t getHighestAppleGPU() const;
 	uint8_t getHighestMacGPU() const;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -126,6 +126,9 @@ MVKMTLDeviceCapabilities::MVKMTLDeviceCapabilities(id<MTLDevice> mtlDev) {
 #if MVK_MACOS
 	supportsDepth24Stencil8 = mtlDev.isDepth24Stencil8PixelFormatSupported;
 #endif
+#if !MVK_OS_SIMULATOR
+	supportsRenderLinearTextures = supportsApple1;
+#endif
 }
 
 
@@ -2462,6 +2465,8 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.dynamicVertexStride = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Apple4) || supportsMTLGPUFamily(Mac2));
 	_metalFeatures.nativeTextureAtomics = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Metal3) || supportsMTLGPUFamily(Apple6) || supportsMTLGPUFamily(Mac2));
 
+	_metalFeatures.renderLinearTextures = _gpuCapabilities.supportsRenderLinearTextures;
+
 	if (supportsMTLGPUFamily(Mac2)) {
 		_metalFeatures.mtlBufferAlignment = 256;
 		_metalFeatures.mtlConstantBufferAlignment = 32;
@@ -2503,7 +2508,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.maxQueryBufferSize = (64 * KIBI);
 
 		_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
-		_metalFeatures.renderLinearTextures = true;
 		_metalFeatures.tileBasedDeferredRendering = true;
 
 		// From testing, these guarantees are only true on Apple GPUs.
@@ -2576,7 +2580,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 #if MVK_OS_SIMULATOR
 	_metalFeatures.mtlBufferAlignment = 256;	// Even on Apple Silicon
 	_metalFeatures.mtlConstantBufferAlignment = 256;
-	_metalFeatures.renderLinearTextures = false;
 #endif
 
 #define setMSLVersion(maj, min)	\

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -602,7 +602,7 @@ MTLTextureUsage MVKPixelFormats::getMTLTextureUsage(VkImageUsageFlags vkImageUsa
 	bool isStencilFmt = isStencilFormat(mtlFormat);
 	bool isCombinedDepthStencilFmt = isDepthFmt && isStencilFmt;
 	bool isColorFormat = !(isDepthFmt || isStencilFmt);
-	bool linearRenderSupported = _physicalDevice->getMetalFeatures()->renderLinearTextures;
+	bool linearRenderSupported = _physicalDevice && _physicalDevice->getMetalFeatures()->renderLinearTextures;
 	MVKMTLFmtCaps mtlFmtCaps = getCapabilities(mtlFormat, isExtended);
 
 	MTLTextureUsage mtlUsage = MTLTextureUsageUnknown;
@@ -1612,7 +1612,7 @@ void MVKPixelFormats::setFormatProperties(MVKVkFormatDesc& vkDesc, const MVKMTLD
 		// Start with optimal tiling features, and modify.
 		vkProps.linearTilingFeatures = vkProps.optimalTilingFeatures;
 
-        if (!_physicalDevice->getMetalFeatures()->renderLinearTextures) {
+        if (!gpuCaps.supportsRenderLinearTextures) {
             // On macOS IMR GPUs, linear textures cannot be used as attachments, so disable those features.
             mvkDisableFlags(vkProps.linearTilingFeatures, (kMVKVkFormatFeatureFlagsTexColorAtt |
                                                            kMVKVkFormatFeatureFlagsTexDSAtt |


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/MoltenVK/issues/2715