### PR TITLE
Fix behavior of VK_REMAINING_ARRAY_LAYERS with 2D array views of 3D images.

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -613,6 +613,12 @@ public:
 	/** Returns the Metal texture type of this image view. */
 	MTLTextureType getMTLTextureType() { return _mtlTextureType; }
 
+	bool getIs2dViewOf3d() {
+		return _image->_is2DViewOn3DImageCompatible &&
+				_image->getImageType() == VK_IMAGE_TYPE_3D &&
+				(_mtlTextureType == MTLTextureType2D || _mtlTextureType == MTLTextureType2DArray);
+	}
+
 	/**
 	 * Populates the texture of the specified render pass descriptor
 	 * with the Metal texture underlying this image.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1885,10 +1885,7 @@ id<MTLTexture> MVKImageViewPlane::newMTLTexture() {
     NSRange sliceRange = NSMakeRange(_imageView->_subresourceRange.baseArrayLayer, _imageView->_subresourceRange.layerCount);
 
     // Support 2D views of 3D textures and block texel views using memory aliasing.
-    const bool is2dViewOf3d = image->_is2DViewOn3DImageCompatible &&
-        image->getImageType() == VK_IMAGE_TYPE_3D &&
-        (_imageView->_mtlTextureType == MTLTextureType2D || _imageView->_mtlTextureType == MTLTextureType2DArray);
-
+    const bool is2dViewOf3d = _imageView->getIs2dViewOf3d();
     const bool imageCompressed = image->getIsCompressed();
     const bool viewCompressed = getPixelFormats()->getFormatType(_mtlPixFmt) == kMVKFormatCompressed;
     const bool isBlockTexelView = image->_isBlockTexelViewCompatible && imageCompressed && !viewCompressed;
@@ -2242,7 +2239,8 @@ MVKImageView::MVKImageView(MVKDevice* device, const VkImageViewCreateInfo* pCrea
 		_subresourceRange.levelCount = _image->getMipLevelCount() - _subresourceRange.baseMipLevel;
 	}
 	if (_subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS) {
-		_subresourceRange.layerCount = _image->getLayerCount() - _subresourceRange.baseArrayLayer;
+		uint32_t imgLayerCnt = getIs2dViewOf3d() ? _image->getExtent3D(0, _subresourceRange.baseMipLevel).depth : _image->getLayerCount();
+		_subresourceRange.layerCount = imgLayerCnt - _subresourceRange.baseArrayLayer;
 	}
 
 	auto& mtlFeats = getMetalFeatures();


### PR DESCRIPTION
When the image view is a 2D array view of a 3D image, `VK_REMAINING_ARRAY_LAYERS` should use the base image depth for the layer count calculation rather than the number of array layers.

Fixes this issue spotted in CTS:
```
Test case 'dEQP-VK.renderpasses.renderpass2.remaining_array_layers.single_layer_fb.1_1'..
_mtlValidateArgumentsForTextureViewOnDevice:1866: failed assertion `Texture Creation
newSliceRange.length must not be 0.
'
```

After:
```
Test case 'dEQP-VK.renderpasses.renderpass2.remaining_array_layers.single_layer_fb.1_1'..
  Pass (Pass)
```