### PR TITLE
Null-check pColorAttachmentInputIndices before reading.

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -150,9 +150,11 @@ VkResult MVKCommandBuffer::begin(const VkCommandBufferBeginInfo* pBeginInfo) {
 	}
 
 	if (pInheritInpAttIdxInfo) {
-		_secondaryInheritanceColorAttachmentInputIndices.assign(pInheritInpAttIdxInfo->pColorAttachmentInputIndices,
-																pInheritInpAttIdxInfo->pColorAttachmentInputIndices + pInheritInpAttIdxInfo->colorAttachmentCount);
-		_hasSecondaryInheritanceColorAttachmentInputIndices = true;
+		if (pInheritInpAttIdxInfo->pColorAttachmentInputIndices) {
+			_secondaryInheritanceColorAttachmentInputIndices.assign(pInheritInpAttIdxInfo->pColorAttachmentInputIndices,
+																	pInheritInpAttIdxInfo->pColorAttachmentInputIndices + pInheritInpAttIdxInfo->colorAttachmentCount);
+			_hasSecondaryInheritanceColorAttachmentInputIndices = true;
+		}
 
 		if (pInheritInpAttIdxInfo->pDepthInputAttachmentIndex) {
 			_secondaryInheritanceDepthAttachmentInputIndex = *pInheritInpAttIdxInfo->pDepthInputAttachmentIndex;


### PR DESCRIPTION
`pColorAttachmentInputIndices` can be null in `VkRenderingInputAttachmentIndexInfo`, so null-check it instead of assuming it is set.

Fixes the following error in CTS:
```
Test case 'dEQP-VK.renderpasses.dynamic_rendering.partial_secondary_cmd_buff.local_read.max_input_attachments'..
[mvk-warn] VK_ERROR_FEATURE_NOT_PRESENT: Metal does not support disabling primitive restart.
[mvk-warn] VK_ERROR_FEATURE_NOT_PRESENT: Metal does not support disabling primitive restart.
zsh: segmentation fault  ./deqp-vk 
```

After this change:
```
Test case 'dEQP-VK.renderpasses.dynamic_rendering.partial_secondary_cmd_buff.local_read.max_input_attachments'..
[mvk-warn] VK_ERROR_FEATURE_NOT_PRESENT: Metal does not support disabling primitive restart.
[mvk-warn] VK_ERROR_FEATURE_NOT_PRESENT: Metal does not support disabling primitive restart.
  Pass (Pass)
```