### PR TITLE
Occlusion queries: wrap detection uses stale baseline, crashes when visibility buffer starts near end of pass

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -780,6 +780,9 @@ void MVKCommandEncoder::beginMetalRenderPass(MVKCommandUse cmdUse) {
 		if (!_pEncodingContext->visibilityResultBuffer.buffer()) {
 			_pEncodingContext->visibilityResultBuffer = _device->getVisibilityBuffer();
 		}
+		// Track the starting visibility offset for this Metal render pass so wrap detection compares
+		// against the correct baseline even when the buffer was already partially consumed.
+		_pEncodingContext->firstVisibilityResultOffsetInRenderPass = _pEncodingContext->visibilityResultBuffer.offset();
 		mtlRPDesc.visibilityResultBuffer = _pEncodingContext->visibilityResultBuffer.buffer();
 	}
 


### PR DESCRIPTION
Fix stale baseline in warp detection and may crash when visibility buffer starts near end of pass mentioned in #2682 