### PR TITLE
Revert "Fix channel corruption on Apple Silicon for color RTs used as transfer sources"

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,7 +24,6 @@ Released TBD
 - Fix incorrect varable usage in `MVKImagePlane::getMTLTexture()`.
 - Fix device loss when using imported `MTLTexture` objects with Metal argument buffers.
 - Update copyright notices to year 2026.
-- Fix channel corruption on Apple Silicon for color render targets used as transfer sources.
 - Update to latest SPIRV-Cross:
   - MSL: Fix `subgroupBallotExclusiveBitCount()` is not available for task shader and mesh shader.
   - MSL: `thread_execution_width` is deprecated as of Metal 3.0 , use `threads_per_simdgroup` instead.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -402,7 +402,6 @@ protected:
 	bool _isLinearForAtomics;
 	bool _is2DViewOn3DImageCompatible = false;
 	bool _isBlockTexelViewCompatible = false;
-	bool _isColorAttachmentTransferSrc = false;
 };
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -155,13 +155,8 @@ MTLTextureDescriptor* MVKImagePlane::newMTLTextureDescriptor() {
     mtlTexDesc.storageMode = _image->getMTLStorageMode();
     mtlTexDesc.cpuCacheMode = _image->getMTLCPUCacheMode();
     // For 2D views of 3D and block texel views, we alias the underlying memory.
-    // For color render targets used as transfer sources, MTLBlitCommandEncoder
-    // copies the lossless-compressed tile layout directly rather than the
-    // logical pixel values, which corrupts readback on Apple Silicon (#2220).
-    // Ensure layout remains consistent by disabling GPU layout optimization.
-    mtlTexDesc.allowGPUOptimizedContents = !_image->_is2DViewOn3DImageCompatible
-                                        && !_image->_isBlockTexelViewCompatible
-                                        && !_image->_isColorAttachmentTransferSrc;
+    // Ensure that it remains consistent by disabling GPU layout optimization.
+    mtlTexDesc.allowGPUOptimizedContents = !_image->_is2DViewOn3DImageCompatible && !_image->_isBlockTexelViewCompatible;
 
     return mtlTexDesc;
 }
@@ -1319,9 +1314,6 @@ MVKImage::MVKImage(MVKDevice* device, const VkImageCreateInfo* pCreateInfo) : MV
 
 	_is2DViewOn3DImageCompatible = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT);
 	_isBlockTexelViewCompatible = mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
-	_isColorAttachmentTransferSrc = mvkAreAllFlagsEnabled(pCreateInfo->usage,
-														  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-														  VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 }
 
 VkSampleCountFlagBits MVKImage::validateSamples(const VkImageCreateInfo* pCreateInfo, bool isAttachment) {


### PR DESCRIPTION
This reverts commit 595b0b2f17b6dced5b6bb7bfa933d892a3cb737a.

@etang-cw looked into the issue GZDoom was facing and determined it was relying on UB, rather than being a MoltenVK or Metal issue (thank you!). I checked with them for the root cause and it looks correct to me, so revert https://github.com/KhronosGroup/MoltenVK/pull/2724 to keep the full optimization we had.