### PR TITLE
Do not enable blending when unsupported by format

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1934,7 +1934,9 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
 			uint32_t caLoc = _colorAttachmentLocations[caIdx];
 			if (caLoc == VK_ATTACHMENT_UNUSED) { continue; }
 
-			MTLPixelFormat mtlPixFmt = getPixelFormats()->getMTLPixelFormat(pRendInfo->pColorAttachmentFormats[caIdx]);
+			VkFormat attachFmt = pRendInfo->pColorAttachmentFormats[caIdx];
+			MTLPixelFormat mtlPixFmt = getPixelFormats()->getMTLPixelFormat(attachFmt);
+			bool supportsBlend = getPixelFormats()->getCapabilities(mtlPixFmt) & kMVKMTLFmtCapsBlend;
 			MTLRenderPipelineColorAttachmentDescriptor* colorDesc = plDesc.colorAttachments[caLoc];
             colorDesc.pixelFormat = mtlPixFmt;
 
@@ -1950,7 +1952,11 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
             // Don't set the blend state if we're not using this attachment.
             // The pixel format will be MTLPixelFormatInvalid in that case, and
             // Metal asserts if we turn on blending with that pixel format.
-            if (mtlPixFmt) {
+            // Metal will also assert if we turn on blending for any format that
+            // does not support it. This is UB since we advertise it in feature
+            // bits, but some applications will not bother to check. We can just
+            // skip and log a warning in this case to avoid crashing.
+            if (mtlPixFmt && supportsBlend) {
                 colorDesc.blendingEnabled = pCA->blendEnable;
                 colorDesc.rgbBlendOperation = mvkMTLBlendOperationFromVkBlendOp(pCA->colorBlendOp);
                 colorDesc.sourceRGBBlendFactor = mvkMTLBlendFactorFromVkBlendFactor(pCA->srcColorBlendFactor);
@@ -1964,6 +1970,8 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
 					plDesc.logicOperationMVK = mvkMTLLogicOperationFromVkLogicOp(pCreateInfo->pColorBlendState->logicOp);
 				}
 #endif
+            } else if (mtlPixFmt && !supportsBlend) {
+                reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Blending is enabled for attachment with format %s, which does not support it.", getPixelFormats()->getName(attachFmt));
             }
         }
     }


### PR DESCRIPTION
This is heading into UB territory, but if a game insists on trying to blend with a format that does not support it, we can avoid the application crashing from a Metal assert by not setting blending on the pipeline and instead logging our own warning.

Fixes an assert encountered in https://github.com/KhronosGroup/MoltenVK/issues/2054