### PR TITLE
Fix incorrect placement heap check in MVKImagePlane::getMTLTexture()

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
   - `VK_KHR_external_semaphore_fd`
 - Fix buffer and heap out-of-sync in `initExternalMemory()`.
 - Fix incorrect varable usage in `MVKImagePlane::getMTLTexture()`.
+- Fix incorrect placement heap check in `MVKImagePlane::getMTLTexture()`.
 - Fix device loss when using imported `MTLTexture` objects with Metal argument buffers.
 - Update copyright notices to year 2026.
 - Update to latest SPIRV-Cross:

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -47,10 +47,15 @@ id<MTLTexture> MVKImagePlane::getMTLTexture() {
         MVKImageMemoryBinding* memoryBinding = getMemoryBinding();
 		MVKDeviceMemory* dvcMem = memoryBinding->_deviceMemory;
 
-        if (_image->_is2DViewOn3DImageCompatible && !dvcMem->ensureMTLHeap()) {
+        // 2D-view-on-3D and block-texel views need a heap-backed texture to alias the memory. ensureMTLHeap() can return
+        // true without creating a heap, so create one if possible, then check getMTLHeap() for an actual heap.
+        if (_image->_is2DViewOn3DImageCompatible || _image->_isBlockTexelViewCompatible) {
+            dvcMem->ensureMTLHeap();
+        }
+        if (_image->_is2DViewOn3DImageCompatible && !dvcMem->getMTLHeap()) {
             MVKAssert(0, "Creating a 2D view of a 3D texture currently requires a placement heap, which is not available.");
         }
-        if (_image->_isBlockTexelViewCompatible && !dvcMem->ensureMTLHeap()) {
+        if (_image->_isBlockTexelViewCompatible && !dvcMem->getMTLHeap()) {
             MVKAssert(0, "Creating an uncompressed view of a compressed texture currently requires a placement heap, which is not available.");
         }
 


### PR DESCRIPTION
Fixes #2668.

The 2D-view-on-3D and block-texel-view checks in `getMTLTexture()` test `ensureMTLHeap()`, which returns true even when no placement heap exists and only returns false on an actual creation failure, so they never catch the case where the feature needs a heap but none is available. This checks `getMTLHeap()` for a real heap instead, while still calling `ensureMTLHeap()` first so the heap is created when possible (the texture-creation path below depends on that).

The checks are `MVKAssert` (debug only), so release behavior is unchanged.

Verified with VK-GL-CTS on Apple M4 Pro (macOS, Metal 4), no regressions:
- `render_to_image.dedicated_allocation.3d.small.r8g8b8a8_unorm`: pass
- `render_to_image.*.3d.*`: 103/0
- `image.2d_array_compatible.*`: 6/0
- `image.texel_view_compatible.*`: 848/0