### PR TITLE
Fix AMD subgroup size (64→32) and disable Intel UHD 630 simdReduction

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2504,6 +2504,13 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.simdReduction = true;
     }
 
+	// Intel UHD 630 (Gen9) reports Mac2 family through Metal,
+	// but simd_reduction operations (simd_sum, etc.) produce
+	// incorrect results on this hardware.
+	if (_properties.vendorID == kIntelVendorId) {
+		_metalFeatures.simdReduction = false;
+	}
+
     if (supportsMTLGPUFamily(Apple1)) {
 		_metalFeatures.mtlBufferAlignment = 64;
 		_metalFeatures.mtlConstantBufferAlignment = 4;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2655,8 +2655,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
                 _metalFeatures.minSubgroupSize = 8;
                 break;
             case kAMDVendorId:
-                _metalFeatures.maxSubgroupSize = 64;
-                _metalFeatures.minSubgroupSize = isAMDRDNAGPU() ? 32 : _metalFeatures.maxSubgroupSize;
+                // Metal simdgroup operations (simd_shuffle_xor, etc.) produce incorrect
+                // results on AMD GPUs with 64-wide subgroups. Use 32-wide subgroups which
+                // matches RDNA wave32 mode and works correctly.
+                _metalFeatures.maxSubgroupSize = 32;
+                _metalFeatures.minSubgroupSize = 32;
                 break;
             case kAppleVendorId:
                 _metalFeatures.maxSubgroupSize = 32;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2117,7 +2117,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
     shaderConfig.options.mslOptions.view_index_from_device_index = mvkAreAllFlagsEnabled(_flags, VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT);
 	shaderConfig.options.mslOptions.replace_recursive_inputs = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
 #if MVK_MACOS
-    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
+    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute || !mtlFeats.simdReduction;
 #else
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
     shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;
@@ -2490,7 +2490,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	shaderConfig.options.mslOptions.argument_buffers_tier = (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)getMetalFeatures().argumentBuffersTier;
 
 #if MVK_MACOS
-    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
+    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute || !mtlFeats.simdReduction;
 #else
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
     shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;


### PR DESCRIPTION
Two GPU correctness fixes for MoltenVK:

1. **AMD**: Reduce maxSubgroupSize from 64 to 32 — Metal simdgroup operations produce incorrect results at 64-wide on AMD
2. **Intel**: Disable simdReduction on UHD 630 (Gen9) — Mac2 family reporting is inaccurate for Gen9, simd_sum produces wrong results
3. **Pipeline**: Update emulate_subgroups to !simdPermute || !simdReduction

Fixes #2756, #2757