### PR TITLE
Fix regressions and crashes on Mac 1 (NVIDIA/Intel) GPUs

### DIFF
--- a/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
+++ b/MoltenVK/MoltenVK/API/mvk_deprecated_api.h
@@ -118,7 +118,7 @@ typedef struct {
 	VkBool32 fences;								/**< If true, Metal synchronization fences (MTLFence) are supported. Deprecated. Will always be true on all platforms. */
 	VkBool32 rasterOrderGroups;						/**< If true, Raster order groups in fragment shaders are supported. */
 	VkBool32 native3DCompressedTextures;			/**< If true, 3D compressed images are supported natively, without manual decompression. */
-	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. Deprecated. Will always be true on all platforms. */
+	VkBool32 nativeTextureSwizzle;					/**< If true, component swizzle is supported natively, without manual swizzling in shaders. */
 	VkBool32 placementHeaps;						/**< If true, MTLHeap objects support placement of resources. */
 	VkDeviceSize pushConstantSizeAlignment;			/**< The alignment used internally when allocating memory for push constants. Must be PoT. */
 	uint32_t maxTextureLayers;						/**< The maximum number of layers in an array texture. */

--- a/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdTransfer.mm
@@ -532,15 +532,20 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
         id<MTLTexture> srcMTLTex = _srcImage->getMTLTexture(srcPlaneIndex);
         id<MTLTexture> dstMTLTex = _dstImage->getMTLTexture(dstPlaneIndex);
         if (blitCnt && srcMTLTex && dstMTLTex) {
-			if (_srcImage->needsSwizzle()) {
-				// Use a view that has a swizzle on it.
-				srcMTLTex = [srcMTLTex newTextureViewWithPixelFormat:srcMTLTex.pixelFormat
-														 textureType:srcMTLTex.textureType
-															  levels:NSMakeRange(0, srcMTLTex.mipmapLevelCount)
-															  slices:NSMakeRange(0, srcMTLTex.arrayLength)
-															 swizzle:_srcImage->getPixelFormats()->getMTLTextureSwizzleChannels(_srcImage->getVkFormat())];
-				[cmdEncoder->_mtlCmdBuffer addCompletedHandler: ^(id<MTLCommandBuffer>) { [srcMTLTex release]; }];
-			}
+            uint32_t srcSwizzle = 0;
+            if (_srcImage->needsSwizzle()) {
+                if (mtlFeats.nativeTextureSwizzle) {
+                    // Use a view that has a swizzle on it.
+                    srcMTLTex = [srcMTLTex newTextureViewWithPixelFormat:srcMTLTex.pixelFormat
+                                                              textureType:srcMTLTex.textureType
+                                                                   levels:NSMakeRange(0, srcMTLTex.mipmapLevelCount)
+                                                                   slices:NSMakeRange(0, srcMTLTex.arrayLength)
+                                                                  swizzle:_srcImage->getPixelFormats()->getMTLTextureSwizzleChannels(_srcImage->getVkFormat())];
+                    [cmdEncoder->_mtlCmdBuffer addCompletedHandler: ^(id<MTLCommandBuffer>) { [srcMTLTex release]; }];
+                } else {
+                    srcSwizzle = mvkPackSwizzle(_srcImage->getPixelFormats()->getVkComponentMapping(_srcImage->getVkFormat()));
+                }
+            }
             cmdEncoder->endCurrentMetalEncoding();
 
             MTLRenderPassDescriptor* mtlRPD = [MTLRenderPassDescriptor renderPassDescriptor];
@@ -588,6 +593,7 @@ void MVKCmdBlitImage<N>::encode(MVKCommandEncoder* cmdEncoder, MVKCommandUse com
             blitKey.srcFilter = mvkMTLSamplerMinMagFilterFromVkFilter(_filter);
             blitKey.srcAspect = mvkIBR.region.srcSubresource.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
             blitKey.dstSampleCount = mvkSampleCountFromVkSampleCountFlagBits(_dstImage->getSampleCount());
+            blitKey.srcSwizzle = srcSwizzle;
             id<MTLRenderPipelineState> mtlRPS = cmdEncoder->getCommandEncodingPool()->getCmdBlitImageMTLRenderPipelineState(blitKey);
             bool isBlittingDepth = mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT));
             bool isBlittingStencil = mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_STENCIL_BIT));

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.h
@@ -121,6 +121,7 @@ struct MVKVulkanSharedCommandEncoderState {
 };
 
 struct MVKImplicitBufferData {
+	MVKSmallVector<uint32_t, 8> textureSwizzles;
 	MVKSmallVector<uint32_t, 8> bufferSizes;
 	MVKSmallVector<uint32_t, 8> dynamicOffsets;
 };

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -272,6 +272,7 @@ static uint32_t getCPUMetaOffset(MVKDescriptorCPULayout layout) {
 
 enum class ImplicitBufferData {
 	BufferSize,
+	TextureSwizzle,
 };
 
 static bool isTexelBuffer(VkDescriptorType type) {
@@ -312,12 +313,15 @@ static void bindImplicitBufferData(uint32_t* target, MVKDescriptorSetLayout* lay
 		uint32_t perDescCount;
 		switch (DataType) {
 			case ImplicitBufferData::BufferSize:     perDescCount = binding.perDescriptorResourceCount.buffer;  break;
+			case ImplicitBufferData::TextureSwizzle: perDescCount = binding.perDescriptorResourceCount.texture; break;
 		}
 		if (perDescCount == 0)
 			continue;
 		size_t stride = descriptorCPUSize(binding.cpuLayout);
 		size_t metaOff = getCPUMetaOffset(binding.cpuLayout);
-		if (metaOff == 0) {
+		if (DataType == ImplicitBufferData::TextureSwizzle && isTexelBuffer(binding.descriptorType)) {
+			mvkClear(target, count);
+		} else if (metaOff == 0) {
 			assert(DataType != ImplicitBufferData::BufferSize && "All buffers should have metadata");
 			mvkClear(target, count);
 		} else {
@@ -332,6 +336,9 @@ static void bindImplicitBufferData(uint32_t* target, MVKDescriptorSetLayout* lay
 							target[i] = reinterpret_cast<const MVKDescriptorMetaImage*>(base)->size;
 						else
 							target[i] = reinterpret_cast<const MVKDescriptorMetaBuffer*>(base)->size;
+						break;
+					case ImplicitBufferData::TextureSwizzle:
+						target[i] = reinterpret_cast<const MVKDescriptorMetaImage*>(base)->swizzle;
 						break;
 				}
 			}
@@ -374,6 +381,10 @@ static void bindDescriptorSets(MVKImplicitBufferData& target,
 		if (setLayout->argBufMode() == MVKArgumentBufferMode::Off) {
 			// If we grab these now, we can be guaranteed the sets are valid
 			// If we wait until draw time, we can only be guaranteed statically used sets are valid
+			if (stride.textureIndex) {
+				mvkEnsureSize(target.textureSwizzles, offsets.textureIndex + stride.textureIndex);
+				bindImplicitBufferData<ImplicitBufferData::TextureSwizzle>(&target.textureSwizzles[offsets.textureIndex], setLayout, set->cpuBuffer, vkStage, varCount);
+			}
 			if (stride.bufferIndex) {
 				mvkEnsureSize(target.bufferSizes, offsets.bufferIndex + stride.bufferIndex);
 				bindImplicitBufferData<ImplicitBufferData::BufferSize>(&target.bufferSizes[offsets.bufferIndex], setLayout, set->cpuBuffer, vkStage, varCount);
@@ -667,6 +678,9 @@ static void bindMetalResources(id<MTLCommandEncoder> encoder,
 		switch (nvbuffer) {
 			case MVKNonVolatileImplicitBuffer::PushConstant:
 				bindImmediateData(encoder, mvkEncoder, pushConstants, common._layout->getPushConstantsLength(), idx, binder);
+				break;
+			case MVKNonVolatileImplicitBuffer::Swizzle:
+				bindImmediateData(encoder, mvkEncoder, getImplicitBindingData(implicitBufferData.textureSwizzles, resourceCounts.textureIndex), idx, binder);
 				break;
 			case MVKNonVolatileImplicitBuffer::BufferSize:
 				bindImmediateData(encoder, mvkEncoder, getImplicitBindingData(implicitBufferData.bufferSizes, resourceCounts.bufferIndex), idx, binder);

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncoderState.mm
@@ -381,7 +381,7 @@ static void bindDescriptorSets(MVKImplicitBufferData& target,
 		if (setLayout->argBufMode() == MVKArgumentBufferMode::Off) {
 			// If we grab these now, we can be guaranteed the sets are valid
 			// If we wait until draw time, we can only be guaranteed statically used sets are valid
-			if (stride.textureIndex) {
+			if (!layout->getMetalFeatures().nativeTextureSwizzle && stride.textureIndex) {
 				mvkEnsureSize(target.textureSwizzles, offsets.textureIndex + stride.textureIndex);
 				bindImplicitBufferData<ImplicitBufferData::TextureSwizzle>(&target.textureSwizzles[offsets.textureIndex], setLayout, set->cpuBuffer, vkStage, varCount);
 			}
@@ -841,6 +841,7 @@ template <typename MTLState>
 static void invalidateDescriptorSetImplicitBuffers(MTLState& state) {
 	invalidateImplicitBuffer(state, MVKNonVolatileImplicitBuffer::BufferSize);
 	invalidateImplicitBuffer(state, MVKNonVolatileImplicitBuffer::DynamicOffset);
+	invalidateImplicitBuffer(state, MVKNonVolatileImplicitBuffer::Swizzle);
 }
 
 static bool isGraphicsStage(MVKShaderStage stage) {

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.h
@@ -44,6 +44,7 @@ typedef struct MVKRPSKeyBlitImg {
 	uint8_t srcFilter : 4;					/**< as MTLSamplerMinMagFilter */
 	uint8_t srcAspect = 0;					/**< as VkImageAspectFlags */
 	uint8_t dstSampleCount = 0;
+	uint32_t srcSwizzle = 0;
 
 	MVKRPSKeyBlitImg() : srcMTLPixelFormat(0), dstMTLPixelFormat(0), srcMTLTextureType(0), srcFilter(0) {}
 
@@ -54,6 +55,7 @@ typedef struct MVKRPSKeyBlitImg {
 		if (srcFilter != rhs.srcFilter) { return false; }
 		if (srcAspect != rhs.srcAspect) { return false; }
 		if (dstSampleCount != rhs.dstSampleCount) { return false; }
+		if (srcSwizzle != rhs.srcSwizzle) { return false; }
 		return true;
 	}
 
@@ -88,6 +90,9 @@ typedef struct MVKRPSKeyBlitImg {
 
 		hash <<= 8;
 		hash |= dstSampleCount;
+
+		hash <<= 32;
+		hash |= srcSwizzle;
 		return hash;
 	}
 

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -168,6 +168,32 @@ id<MTLRenderPipelineState> MVKCommandResourceFactory::newCmdClearMTLRenderPipeli
 	return rps;
 }
 
+static NSString* getSwizzleComponentExpr(VkComponentSwizzle swizzle, const char* identityComponent, bool isFloat) {
+	switch (swizzle) {
+		case VK_COMPONENT_SWIZZLE_ZERO:     return isFloat ? @"0.0" : @"0";
+		case VK_COMPONENT_SWIZZLE_ONE:      return isFloat ? @"1.0" : @"1";
+		case VK_COMPONENT_SWIZZLE_R:        return @"sample.x";
+		case VK_COMPONENT_SWIZZLE_G:        return @"sample.y";
+		case VK_COMPONENT_SWIZZLE_B:        return @"sample.z";
+		case VK_COMPONENT_SWIZZLE_A:        return @"sample.w";
+		case VK_COMPONENT_SWIZZLE_IDENTITY:
+		default:                            return [NSString stringWithUTF8String: identityComponent];
+	}
+}
+
+static NSString* getSwizzledSampleExpr(uint32_t packedSwizzle, NSString* typeStr) {
+	if (!packedSwizzle) { return @"sample"; }
+
+	VkComponentMapping swizzle = mvkUnpackSwizzle(packedSwizzle);
+	bool isFloat = [typeStr isEqualToString: @"float"];
+	return [NSString stringWithFormat: @"%@4(%@, %@, %@, %@)",
+			typeStr,
+			getSwizzleComponentExpr(swizzle.r, "sample.x", isFloat),
+			getSwizzleComponentExpr(swizzle.g, "sample.y", isFloat),
+			getSwizzleComponentExpr(swizzle.b, "sample.z", isFloat),
+			getSwizzleComponentExpr(swizzle.a, "sample.w", isFloat)];
+}
+
 id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg& blitKey) {
 	@autoreleasepool {
 		bool isLayeredBlit = blitKey.dstSampleCount > 1 ? getMetalFeatures().multisampleLayeredRendering : getMetalFeatures().layeredRendering;
@@ -272,7 +298,9 @@ id<MTLFunction> MVKCommandResourceFactory::newBlitFragFunction(MVKRPSKeyBlitImg&
 			[msl appendLineMVK];
 		}
 		if (!mvkIsAnyFlagEnabled(blitKey.srcAspect, (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
-			[msl appendFormat: @"    out.color = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod));", coordArg, sliceArg];
+			[msl appendFormat: @"    auto sample = tex.sample(ce_sampler, varyings.v_texCoord%@%@, level(subRez.lod));", coordArg, sliceArg];
+			[msl appendLineMVK];
+			[msl appendFormat: @"    out.color = %@;", getSwizzledSampleExpr(blitKey.srcSwizzle, typeStr)];
 			[msl appendLineMVK];
 		}
 		[msl appendLineMVK: @"    return out;"];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.h
@@ -137,9 +137,9 @@ struct MVKDescriptorResourceCount {
 /** Descriptor metadata for images. */
 struct MVKDescriptorMetaImage {
 	uint32_t size;
-	uint32_t pad;
+	uint32_t swizzle;
 	MVKDescriptorMetaImage() = default;
-	constexpr MVKDescriptorMetaImage(uint32_t size_): size(size_), pad(0) {}
+	constexpr MVKDescriptorMetaImage(uint32_t size_, uint32_t swizzle_ = 0): size(size_), swizzle(swizzle_) {}
 };
 static_assert(sizeof(MVKDescriptorMetaImage) == sizeof(uint64_t));
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -192,14 +192,16 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT))
 		return MVKArgumentBufferMode::Off;
 	auto gpuCaps = dev->getPhysicalDevice()->getMTLDeviceCapabilities();
+	auto* metalFeatures = dev->getPhysicalDevice()->getMetalFeatures();
 	if (dev->getPhysicalDevice()->isNVIDIAGPU() &&
 		gpuCaps.supportsMac1 && !gpuCaps.supportsMac2 &&
-		dev->getPhysicalDevice()->getMetalFeatures()->needsArgumentBufferEncoders) {
+		metalFeatures->needsArgumentBufferEncoders) {
 		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
 			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
 			if (bind.descriptorCount == 0)
 				continue;
-			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+				(!metalFeatures->nativeTextureSwizzle && bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE))
 				return MVKArgumentBufferMode::Off;
 		}
 	}
@@ -348,17 +350,20 @@ static MVKDescriptorCPULayout pickCPULayout(
 	if (count == 0)
 		return MVKDescriptorCPULayout::None;
 	bool nativeTAtomic = dev->getPhysicalDevice()->getMetalFeatures()->nativeTextureAtomics;
+	bool nativeTextureSwizzle = dev->getPhysicalDevice()->getMetalFeatures()->nativeTextureSwizzle;
 	switch (type) {
 		case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
 			// Multiplanar images are for ycbcr, which requires a swizzle of IDENTITY, so we don't need to store it.
 			// Immutable samplers are accessible from the layout so they also don't need to be stored.
+			if (!nativeTextureSwizzle && !planes.hasYCBCR())
+				return planes.hasImmutableSamplers() ? MVKDescriptorCPULayout::OneIDMeta : MVKDescriptorCPULayout::TwoIDMeta;
 			if (planes.planeCount() > 2)
 				return MVKDescriptorCPULayout::TwoIDMeta;
 			if (planes.planeCount() == 1 || planes.hasNonYCBCR())
 				return MVKDescriptorCPULayout::OneID;
 			return MVKDescriptorCPULayout::OneIDMeta;
 		case VK_DESCRIPTOR_TYPE_SAMPLER:                return planes.hasImmutableSamplers() ? MVKDescriptorCPULayout::None : MVKDescriptorCPULayout::OneID;
-		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:          return MVKDescriptorCPULayout::OneID;
+		case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:          return nativeTextureSwizzle ? MVKDescriptorCPULayout::OneID : MVKDescriptorCPULayout::OneIDMeta;
 		case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:          return nativeTAtomic ? MVKDescriptorCPULayout::OneID : MVKDescriptorCPULayout::TwoID2Meta;
 		case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:   return MVKDescriptorCPULayout::OneID;
 		case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:   return nativeTAtomic ? MVKDescriptorCPULayout::OneID : MVKDescriptorCPULayout::TwoID2Meta;
@@ -1206,7 +1211,7 @@ static void writeDescriptorSetCPUBuffer(
 								if (immutableSamplers[i]->isYCBCR())
 									desc->b = img->getMTLTexture(1);
 								else
-									desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]) };
+									desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]), img->getPackedSwizzle() };
 							} else {
 								*desc = {};
 							}
@@ -1222,7 +1227,7 @@ static void writeDescriptorSetCPUBuffer(
 						if (auto* img = reinterpret_cast<MVKImageView*>(static_cast<const VkDescriptorImageInfo*>(src)->imageView)) {
 							id<MTLTexture> tex = img->getMTLTexture();
 							desc->a = tex;
-							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]) };
+							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]), img->getPackedSwizzle() };
 						} else {
 							*desc = {};
 						}
@@ -1248,7 +1253,7 @@ static void writeDescriptorSetCPUBuffer(
 							desc->c = img->getMTLTexture(2);
 						} else {
 							desc->b = nullptr;
-							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]) };
+							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]), img->getPackedSwizzle() };
 						}
 					} else {
 						*desc = {};
@@ -1259,7 +1264,7 @@ static void writeDescriptorSetCPUBuffer(
 					if (img) {
 						id<MTLTexture> tex = img->getMTLTexture();
 						desc->a = tex;
-						desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]) };
+						desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]), img->getPackedSwizzle() };
 					} else {
 						desc->a = nil;
 						desc->meta = {};
@@ -1293,7 +1298,7 @@ static void writeDescriptorSetCPUBuffer(
 							desc->a = tex;
 							desc->b = [tex buffer];
 							desc->offset = [tex bufferOffset];
-							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]) };
+							desc->meta.img = { static_cast<uint32_t>([tex height] * [tex bufferBytesPerRow]), img->getPackedSwizzle() };
 						} else {
 							*desc = {};
 						}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -193,6 +193,17 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 		return MVKArgumentBufferMode::Off;
 	auto gpuCaps = dev->getPhysicalDevice()->getMTLDeviceCapabilities();
 	auto* metalFeatures = dev->getPhysicalDevice()->getMetalFeatures();
+	if (!metalFeatures->nativeTextureSwizzle) {
+		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
+			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
+			if (bind.descriptorCount == 0)
+				continue;
+			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+				bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
+				return MVKArgumentBufferMode::Off;
+		}
+	}
 	if (dev->getPhysicalDevice()->isNVIDIAGPU() &&
 		gpuCaps.supportsMac1 && !gpuCaps.supportsMac2 &&
 		metalFeatures->needsArgumentBufferEncoders) {
@@ -201,8 +212,7 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 			if (bind.descriptorCount == 0)
 				continue;
 			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
-				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT ||
-				(!metalFeatures->nativeTextureSwizzle && bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE))
+				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
 				return MVKArgumentBufferMode::Off;
 		}
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -191,7 +191,6 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 	// Push descriptors are always binding-based
 	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT))
 		return MVKArgumentBufferMode::Off;
-	auto gpuCaps = dev->getPhysicalDevice()->getMTLDeviceCapabilities();
 	auto* metalFeatures = dev->getPhysicalDevice()->getMetalFeatures();
 	if (!metalFeatures->nativeTextureSwizzle) {
 		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
@@ -204,9 +203,7 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 				return MVKArgumentBufferMode::Off;
 		}
 	}
-	if (dev->getPhysicalDevice()->isNVIDIAGPU() &&
-		gpuCaps.supportsMac1 && !gpuCaps.supportsMac2 &&
-		metalFeatures->needsArgumentBufferEncoders) {
+	if (dev->getPhysicalDevice()->isNVIDIAGPU() && metalFeatures->needsArgumentBufferEncoders) {
 		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
 			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
 			if (bind.descriptorCount == 0)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -192,24 +192,20 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT))
 		return MVKArgumentBufferMode::Off;
 	auto* metalFeatures = dev->getPhysicalDevice()->getMetalFeatures();
-	if (!metalFeatures->nativeTextureSwizzle) {
+	bool useMac1ArgumentEncoders = dev->getPhysicalDevice()->isMacGPUFamily1() && metalFeatures->needsArgumentBufferEncoders;
+	bool isIntelGPU = useMac1ArgumentEncoders && dev->getPhysicalDevice()->isIntelGPU();
+	bool isNVIDIAGPU = useMac1ArgumentEncoders && dev->getPhysicalDevice()->isNVIDIAGPU();
+	if (!metalFeatures->nativeTextureSwizzle || useMac1ArgumentEncoders) {
 		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
 			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
 			if (bind.descriptorCount == 0)
 				continue;
-			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
-				bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
-				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
-				return MVKArgumentBufferMode::Off;
-		}
-	}
-	if (dev->getPhysicalDevice()->isNVIDIAGPU() && metalFeatures->needsArgumentBufferEncoders) {
-		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
-			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
-			if (bind.descriptorCount == 0)
-				continue;
-			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
-				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
+			if ((!metalFeatures->nativeTextureSwizzle &&
+				 (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+				  bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+				  bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) ||
+				(isIntelGPU && bind.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
+				(isNVIDIAGPU && bind.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER))
 				return MVKArgumentBufferMode::Off;
 		}
 	}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -201,6 +201,7 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 			if (bind.descriptorCount == 0)
 				continue;
 			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+				bind.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT ||
 				(!metalFeatures->nativeTextureSwizzle && bind.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE))
 				return MVKArgumentBufferMode::Off;
 		}

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDescriptorSet.mm
@@ -191,6 +191,18 @@ static MVKArgumentBufferMode pickArgumentBufferMode(MVKDevice* dev, const VkDesc
 	// Push descriptors are always binding-based
 	if (mvkIsAnyFlagEnabled(pCreateInfo->flags, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT))
 		return MVKArgumentBufferMode::Off;
+	auto gpuCaps = dev->getPhysicalDevice()->getMTLDeviceCapabilities();
+	if (dev->getPhysicalDevice()->isNVIDIAGPU() &&
+		gpuCaps.supportsMac1 && !gpuCaps.supportsMac2 &&
+		dev->getPhysicalDevice()->getMetalFeatures()->needsArgumentBufferEncoders) {
+		for (uint32_t i = 0; i < pCreateInfo->bindingCount; i++) {
+			const VkDescriptorSetLayoutBinding& bind = pCreateInfo->pBindings[i];
+			if (bind.descriptorCount == 0)
+				continue;
+			if (bind.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+				return MVKArgumentBufferMode::Off;
+		}
+	}
 #if MVK_IOS || MVK_TVOS
 	// iOS Tier 1 argument buffers do not support writable images.
 	if (dev->getPhysicalDevice()->getMetalFeatures()->argumentBuffersTier < MTLArgumentBuffersTier2) {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -207,6 +207,12 @@ public:
 	/** Returns whether the GPU is an NVIDIA GPU. */
 	bool isNVIDIAGPU() const;
 
+	/** Returns whether the GPU is an Intel GPU. */
+	bool isIntelGPU() const;
+
+	/** Returns whether the GPU supports exactly Metal Mac GPU Family 1. */
+	bool isMacGPUFamily1() const;
+
 	/** Populates the specified structure with the format properties of this device. */
 	void getFormatProperties(VkFormat format, VkFormatProperties* pFormatProperties);
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -426,7 +426,7 @@ public:
 	MTLStorageMode getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 
 	/** Returns the MTLDevice capabilities. */
-	MVKMTLDeviceCapabilities getMTLDeviceCapabilities() const { return _gpuCapabilities; }
+	const MVKMTLDeviceCapabilities getMTLDeviceCapabilities() { return _gpuCapabilities; }
 
 	/** Returns info on the sizes of argument buffers. */
 	const MVKPhysicalDeviceArgumentBufferSizes& getArgumentBufferSizes() const { return _argumentBufferSizes; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -204,6 +204,9 @@ public:
 	/** Returns the name of this device. */
 	const char* getName() { return _properties.deviceName; }
 
+	/** Returns whether the GPU is an NVIDIA GPU. */
+	bool isNVIDIAGPU() const;
+
 	/** Populates the specified structure with the format properties of this device. */
 	void getFormatProperties(VkFormat format, VkFormatProperties* pFormatProperties);
 
@@ -423,7 +426,7 @@ public:
 	MTLStorageMode getMTLStorageModeFromVkMemoryPropertyFlags(VkMemoryPropertyFlags vkFlags);
 
 	/** Returns the MTLDevice capabilities. */
-	const MVKMTLDeviceCapabilities getMTLDeviceCapabilities() { return _gpuCapabilities; }
+	MVKMTLDeviceCapabilities getMTLDeviceCapabilities() const { return _gpuCapabilities; }
 
 	/** Returns info on the sizes of argument buffers. */
 	const MVKPhysicalDeviceArgumentBufferSizes& getArgumentBufferSizes() const { return _argumentBufferSizes; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3310,6 +3310,10 @@ void MVKPhysicalDevice::setMemoryType(uint32_t typeIndex, uint32_t heapIndex, Vk
 	_memoryProperties.memoryTypes[typeIndex].propertyFlags = propertyFlags;
 }
 
+bool MVKPhysicalDevice::isNVIDIAGPU() const {
+	return _properties.vendorID == kNVVendorId;
+}
+
 void MVKPhysicalDevice::initMemoryProperties() {
 
 	mvkClear(&_memoryProperties);	// Start with everything cleared

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2734,6 +2734,11 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.ioSurfaces = true;
 	_metalFeatures.renderWithoutAttachments = true;
 	_metalFeatures.nativeTextureSwizzle = true;
+
+	// NVIDIA Mac1 textures do not support native texture swizzle.
+	if (isNVIDIAGPU() && supportsMTLGPUFamily(Mac1) && !supportsMTLGPUFamily(Mac2)) {
+		_metalFeatures.nativeTextureSwizzle = false;
+	}
 }
 
 bool MVKPhysicalDevice::isTier2MetalArgumentBuffers() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3316,6 +3316,14 @@ bool MVKPhysicalDevice::isNVIDIAGPU() const {
 	return _properties.vendorID == kNVVendorId;
 }
 
+bool MVKPhysicalDevice::isIntelGPU() const {
+	return _properties.vendorID == kIntelVendorId;
+}
+
+bool MVKPhysicalDevice::isMacGPUFamily1() const {
+	return !_gpuCapabilities.isAppleGPU && _gpuCapabilities.supportsMac1 && !_gpuCapabilities.supportsMac2;
+}
+
 void MVKPhysicalDevice::initMemoryProperties() {
 
 	mvkClear(&_memoryProperties);	// Start with everything cleared

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2468,6 +2468,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.nativeTextureAtomics = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0) && (supportsMTLGPUFamily(Metal3) || supportsMTLGPUFamily(Apple6) || supportsMTLGPUFamily(Mac2));
 
 	_metalFeatures.renderLinearTextures = _gpuCapabilities.supportsRenderLinearTextures;
+	_metalFeatures.nativeTextureSwizzle = false;
 
 	if (supportsMTLGPUFamily(Mac1)) {
 		_metalFeatures.mtlBufferAlignment = 256;
@@ -2502,6 +2503,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.stencilResolve = true;
 		_metalFeatures.quadPermute = true;
 		_metalFeatures.simdReduction = true;
+		_metalFeatures.nativeTextureSwizzle = true;
     }
 
     if (supportsMTLGPUFamily(Apple1)) {
@@ -2519,6 +2521,7 @@ void MVKPhysicalDevice::initMetalFeatures() {
 		_metalFeatures.subgroupUniformControlFlow = true;
 		_metalFeatures.maximalReconvergence = true;
 		_metalFeatures.quadControlFlow = true;
+		_metalFeatures.nativeTextureSwizzle = true;
 
 		// Don't use barriers in render passes on Apple GPUs. Apple GPUs don't support them,
 		// and in fact Metal's validation layer will complain if you try to use them.
@@ -2733,12 +2736,6 @@ void MVKPhysicalDevice::initMetalFeatures() {
 	_metalFeatures.events = true;
 	_metalFeatures.ioSurfaces = true;
 	_metalFeatures.renderWithoutAttachments = true;
-	_metalFeatures.nativeTextureSwizzle = true;
-
-	// NVIDIA Mac1 textures do not support native texture swizzle.
-	if (isNVIDIAGPU() && supportsMTLGPUFamily(Mac1) && !supportsMTLGPUFamily(Mac2)) {
-		_metalFeatures.nativeTextureSwizzle = false;
-	}
 }
 
 bool MVKPhysicalDevice::isTier2MetalArgumentBuffers() {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.h
@@ -553,6 +553,9 @@ public:
 
     void releaseMTLTexture();
 
+	/** Returns the packed component swizzle of this image view. */
+	uint32_t getPackedSwizzle() { return _useShaderSwizzle ? mvkPackSwizzle(_componentSwizzle) : 0; }
+
     ~MVKImageViewPlane();
 
 protected:
@@ -568,7 +571,8 @@ protected:
     MTLPixelFormat _mtlPixFmt;
 	uint8_t _planeIndex;
     bool _useMTLTextureView;
-    bool _useSwizzle;
+	bool _useNativeSwizzle;
+	bool _useShaderSwizzle;
 };
 
 
@@ -606,8 +610,11 @@ public:
 	/** Returns the number of samples for each pixel of this image view. */
 	VkSampleCountFlagBits getSampleCount() { return _image->getSampleCount(); }
 
-    /** Returns the number of planes of this image view. */
-    uint8_t getPlaneCount() { return _planes.size(); }
+	/** Returns the packed component swizzle of this image view. */
+	uint32_t getPackedSwizzle() { return _planes.empty() ? 0 : _planes[0]->getPackedSwizzle(); }	// Guard against destroyed instance retained in a descriptor.
+
+	/** Returns the number of planes of this image view. */
+	uint8_t getPlaneCount() { return _planes.size(); }
 
 	/** Returns the Metal texture type of this image view. */
 	MTLTextureType getMTLTextureType() { return _mtlTextureType; }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -1927,7 +1927,7 @@ id<MTLTexture> MVKImageViewPlane::newMTLTexture() {
     }
 
     id<MTLTexture> texView = nil;
-    if (_useSwizzle) {
+    if (_useNativeSwizzle) {
         texView = [mtlTex newTextureViewWithPixelFormat: _mtlPixFmt
                                             textureType: _imageView->_mtlTextureType
                                                  levels: levelRange
@@ -1967,7 +1967,7 @@ MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
             _imageView->_subresourceRange.levelCount == _imageView->_image->_mipLevels &&
             (_imageView->_mtlTextureType == MTLTextureType3D ||
              _imageView->_subresourceRange.layerCount == _imageView->_image->_arrayLayers) &&
-            !_useSwizzle) {
+            !_useNativeSwizzle) {
             _useMTLTextureView = false;
         }
     } else {
@@ -1977,7 +1977,8 @@ MVKImageViewPlane::MVKImageViewPlane(MVKImageView* imageView,
 
 VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateInfo* pCreateInfo) {
 
-	_useSwizzle = false;
+	_useNativeSwizzle = false;
+	_useShaderSwizzle = false;
 	_componentSwizzle = pCreateInfo->components;
 	VkImageAspectFlags aspectMask = pCreateInfo->subresourceRange.aspectMask;
 
@@ -2105,7 +2106,9 @@ VkResult MVKImageViewPlane::initSwizzledMTLPixelFormat(const VkImageViewCreateIn
 		}
 	}
 
-	_useSwizzle = !mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A});
+	bool useSwizzle = !mvkVkComponentMappingsMatch(_componentSwizzle, {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A});
+	_useNativeSwizzle = useSwizzle && getMetalFeatures().nativeTextureSwizzle;
+	_useShaderSwizzle = useSwizzle && !getMetalFeatures().nativeTextureSwizzle;
 	return VK_SUCCESS;
 }
 
@@ -2132,7 +2135,7 @@ void MVKImageView::populateMTLRenderPassAttachmentDescriptor(MTLRenderPassAttach
     mtlAttDesc.texture = plane->getMTLTexture();
     // If a swizzle is being applied, use the unswizzled parent texture.
     // This is relevant for depth/stencil attachments that are also sampled and might have forced swizzles.
-    if (plane->_useSwizzle && mtlAttDesc.texture.parentTexture) {
+    if (plane->_useNativeSwizzle && mtlAttDesc.texture.parentTexture) {
         useView = false;
         mtlAttDesc.texture = mtlAttDesc.texture.parentTexture;
     }
@@ -2152,7 +2155,7 @@ void MVKImageView::populateMTLRenderPassAttachmentDescriptorResolve(MTLRenderPas
     mtlAttDesc.resolveTexture = plane->getMTLTexture();
     // If a swizzle is being applied, use the unswizzled parent texture.
     // This is relevant for depth/stencil attachments that are also sampled and might have forced swizzles.
-    if (plane->_useSwizzle && mtlAttDesc.resolveTexture.parentTexture) {
+    if (plane->_useNativeSwizzle && mtlAttDesc.resolveTexture.parentTexture) {
         useView = false;
         mtlAttDesc.resolveTexture = mtlAttDesc.resolveTexture.parentTexture;
     }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1653,7 +1653,7 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 		shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pFragmentSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT) ? 0 : mtlFeats.maxSubgroupSize;
 		shaderConfig.options.mslOptions.check_discarded_frag_stores = true;
 		// On NVIDIA, simd_is_helper_thread() can trigger a Metal compiler internal error.
-		if (getPhysicalDevice()->isNVIDIAGPU()) {
+		if (getPhysicalDevice()->isMacGPUFamily1()) {
 			shaderConfig.options.mslOptions.check_discarded_frag_stores = false;
 		}
 		/* Enabling makes dEQP-VK.fragment_shader_interlock.basic.discard.image.pixel_ordered.1xaa.no_sample_shading.1024x1024 and similar tests fail. Requires investigation */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -430,6 +430,7 @@ MVKPipeline::~MVKPipeline() {
 /** Populate a MVKStageResourceBits based on the resources used by the given shader info. */
 static void populateResourceUsage(MVKPipelineStageResourceInfo& dst, SPIRVToMSLConversionConfiguration& src, SPIRVToMSLConversionResultInfo& results, spv::ExecutionModel stage) {
 	dst.usesPhysicalStorageBufferAddresses = results.usesPhysicalStorageBufferAddressesCapability;
+	dst.implicitBuffers.needed |= MVKImplicitBufferList(MVKImplicitBuffer::Swizzle,       results.needsSwizzleBuffer);
 	dst.implicitBuffers.needed |= MVKImplicitBufferList(MVKImplicitBuffer::Output,        results.needsOutputBuffer);
 	dst.implicitBuffers.needed |= MVKImplicitBufferList(MVKImplicitBuffer::PatchOutput,   results.needsPatchOutputBuffer);
 	dst.implicitBuffers.needed |= MVKImplicitBufferList(MVKImplicitBuffer::BufferSize,    results.needsBufferSizeBuffer);
@@ -1437,6 +1438,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLTessRasterStageDescripto
 static constexpr const char* getImplicitBufferName(MVKImplicitBuffer buffer) {
 	switch (buffer) {
 		case MVKImplicitBuffer::PushConstant:   return "push constant";
+		case MVKImplicitBuffer::Swizzle:        return "swizzle";
 		case MVKImplicitBuffer::BufferSize:     return "buffer size";
 		case MVKImplicitBuffer::DynamicOffset:  return "dynamic offset";
 		case MVKImplicitBuffer::ViewRange:      return "view range";
@@ -1465,6 +1467,7 @@ static bool verifyImplicitBuffers(MVKImplicitBufferBindings& buffers, const char
 }
 
 static void addCommonImplicitBuffersToShaderConfig(SPIRVToMSLConversionConfiguration& dst, const MVKOnePerEnumEntry<uint8_t, MVKImplicitBuffer>& src) {
+	dst.options.mslOptions.swizzle_buffer_index = src[MVKImplicitBuffer::Swizzle];
 	dst.options.mslOptions.buffer_size_buffer_index = src[MVKImplicitBuffer::BufferSize];
 	dst.options.mslOptions.dynamic_offsets_buffer_index = src[MVKImplicitBuffer::DynamicOffset];
 }
@@ -2036,6 +2039,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
     shaderConfig.options.mslOptions.msl_version = mtlFeats.mslVersion;
     shaderConfig.options.mslOptions.texel_buffer_texture_width = mtlFeats.maxTextureDimension;
     shaderConfig.options.mslOptions.r32ui_linear_texture_alignment = (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT, this);
+    shaderConfig.options.mslOptions.swizzle_texture_samples = !mtlFeats.nativeTextureSwizzle;
 	shaderConfig.options.mslOptions.texture_buffer_native = true;
 
 	bool useMetalArgBuff = isUsingMetalArgumentBuffers();
@@ -2057,8 +2061,9 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
 		MVKShaderStage stage = (MVKShaderStage)i;
 		_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::DynamicOffset]  = getImplicitBufferIndex(stage, 0);
 		_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::BufferSize]     = getImplicitBufferIndex(stage, 1);
-		_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::Output]         = getImplicitBufferIndex(stage, 3);
-		uint32_t extra = getImplicitBufferIndex(stage, 2);
+		_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::Swizzle]        = getImplicitBufferIndex(stage, 2);
+		_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::Output]         = getImplicitBufferIndex(stage, 4);
+		uint32_t extra = getImplicitBufferIndex(stage, 3);
 		switch (stage) {
 			case kMVKShaderStageVertex:
 				// Since we currently can't use multiview with tessellation or geometry shaders,
@@ -2066,14 +2071,14 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
 				// view range buffer as for the tessellation index buffer.
 				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::ViewRange] = extra;
 				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::Index]     = extra;
-				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::DrawId]    = getImplicitBufferIndex(stage, 4);
+				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::DrawId]    = getImplicitBufferIndex(stage, 5);
 				break;
 			case kMVKShaderStageFragment:
 				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::ViewRange] = extra;
 				break;
 			case kMVKShaderStageTessCtl:
-				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::PatchOutput]    = getImplicitBufferIndex(stage, 4);
-				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::TessLevel]      = getImplicitBufferIndex(stage, 5);
+				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::PatchOutput]    = getImplicitBufferIndex(stage, 5);
+				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::TessLevel]      = getImplicitBufferIndex(stage, 6);
 				_stageResources[stage].implicitBuffers.ids[MVKImplicitBuffer::IndirectParams] = extra;
 				break;
 			case kMVKShaderStageTessEval:
@@ -2478,6 +2483,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
     shaderConfig.options.mslOptions.msl_version = mtlFeats.mslVersion;
     shaderConfig.options.mslOptions.texel_buffer_texture_width = mtlFeats.maxTextureDimension;
     shaderConfig.options.mslOptions.r32ui_linear_texture_alignment = (uint32_t)_device->getVkFormatTexelBufferAlignment(VK_FORMAT_R32_UINT, this);
+    shaderConfig.options.mslOptions.swizzle_texture_samples = !mtlFeats.nativeTextureSwizzle;
 	shaderConfig.options.mslOptions.texture_buffer_native = true;
 	shaderConfig.options.mslOptions.dispatch_base = _allowsDispatchBase;
 	shaderConfig.options.mslOptions.texture_1D_as_2D = mvkCfg.texture1DAs2D;
@@ -2505,7 +2511,8 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	// the limit of available buffers. But we can't know that until we compile the shaders.
 	_stageResources.implicitBuffers.ids[MVKImplicitBuffer::DynamicOffset] = getImplicitBufferIndex(0);
 	_stageResources.implicitBuffers.ids[MVKImplicitBuffer::BufferSize]    = getImplicitBufferIndex(1);
-	_stageResources.implicitBuffers.ids[MVKImplicitBuffer::DispatchBase]  = getImplicitBufferIndex(2);
+	_stageResources.implicitBuffers.ids[MVKImplicitBuffer::Swizzle]       = getImplicitBufferIndex(2);
+	_stageResources.implicitBuffers.ids[MVKImplicitBuffer::DispatchBase]  = getImplicitBufferIndex(3);
 
 	addCommonImplicitBuffersToShaderConfig(shaderConfig, _stageResources.implicitBuffers.ids);
 	shaderConfig.options.mslOptions.indirect_params_buffer_index = _stageResources.implicitBuffers.ids[MVKImplicitBuffer::DispatchBase];
@@ -3009,6 +3016,7 @@ namespace mvk {
 				scr.specializationMacros,
 				scr.isRasterizationDisabled,
 				scr.isPositionInvariant,
+				scr.needsSwizzleBuffer,
 				scr.needsOutputBuffer,
 				scr.needsPatchOutputBuffer,
 				scr.needsBufferSizeBuffer,
@@ -3174,7 +3182,7 @@ void mvkValidateCeralArchiveDefinitions() {
 	missingBytes += mvkValidateCerealArchiveSize<mvk::MSLResourceBinding>(2);
 	missingBytes += mvkValidateCerealArchiveSize<mvk::DescriptorBinding>();
 	missingBytes += mvkValidateCerealArchiveSize<mvk::SPIRVToMSLConversionConfiguration>(106);	// Contains collection
-	missingBytes += mvkValidateCerealArchiveSize<mvk::SPIRVToMSLConversionResultInfo>(41);		// Contains collection
+	missingBytes += mvkValidateCerealArchiveSize<mvk::SPIRVToMSLConversionResultInfo>(40);		// Contains collection
 	missingBytes += mvkValidateCerealArchiveSize<mvk::MSLSpecializationMacroInfo>(22);			// Contains string
 	missingBytes += mvkValidateCerealArchiveSize<MVKShaderModuleKey>();
 	missingBytes += mvkValidateCerealArchiveSize<MVKCompressor<std::string>>(20);				// Contains collection

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1652,8 +1652,8 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 		shaderConfig.options.mslOptions.capture_output_to_buffer = false;
 		shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pFragmentSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT) ? 0 : mtlFeats.maxSubgroupSize;
 		shaderConfig.options.mslOptions.check_discarded_frag_stores = true;
-		auto gpuCaps = getPhysicalDevice()->getMTLDeviceCapabilities();
-		if (getPhysicalDevice()->isNVIDIAGPU() && gpuCaps.supportsMac1 && !gpuCaps.supportsMac2) {
+		// On NVIDIA, simd_is_helper_thread() can trigger a Metal compiler internal error.
+		if (getPhysicalDevice()->isNVIDIAGPU()) {
 			shaderConfig.options.mslOptions.check_discarded_frag_stores = false;
 		}
 		/* Enabling makes dEQP-VK.fragment_shader_interlock.basic.discard.image.pixel_ordered.1xaa.no_sample_shading.1024x1024 and similar tests fail. Requires investigation */

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1652,6 +1652,10 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 		shaderConfig.options.mslOptions.capture_output_to_buffer = false;
 		shaderConfig.options.mslOptions.fixed_subgroup_size = mvkIsAnyFlagEnabled(pFragmentSS->flags, VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT) ? 0 : mtlFeats.maxSubgroupSize;
 		shaderConfig.options.mslOptions.check_discarded_frag_stores = true;
+		auto gpuCaps = getPhysicalDevice()->getMTLDeviceCapabilities();
+		if (getPhysicalDevice()->isNVIDIAGPU() && gpuCaps.supportsMac1 && !gpuCaps.supportsMac2) {
+			shaderConfig.options.mslOptions.check_discarded_frag_stores = false;
+		}
 		/* Enabling makes dEQP-VK.fragment_shader_interlock.basic.discard.image.pixel_ordered.1xaa.no_sample_shading.1024x1024 and similar tests fail. Requires investigation */
 		shaderConfig.options.mslOptions.force_fragment_with_side_effects_execution = false;
 		shaderConfig.options.mslOptions.input_attachment_is_ds_attachment = _inputAttachmentIsDSAttachment;

--- a/MoltenVK/MoltenVK/Utility/MVKStateTracking.h
+++ b/MoltenVK/MoltenVK/Utility/MVKStateTracking.h
@@ -168,6 +168,7 @@ struct std::hash<MVKMTLDepthStencilDescriptorData> {
 /** These buffers are dirty-tracked across draw calls, and need code to make sure they're invalidated if they ever change binding indices. */
 enum class MVKNonVolatileImplicitBuffer : uint32_t {
 	PushConstant,
+	Swizzle,
 	BufferSize,
 	DynamicOffset,
 	ViewRange,
@@ -176,6 +177,7 @@ enum class MVKNonVolatileImplicitBuffer : uint32_t {
 
 enum class MVKImplicitBuffer : uint32_t {
 	PushConstant  = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::PushConstant),
+	Swizzle       = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::Swizzle),
 	BufferSize    = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::BufferSize),
 	DynamicOffset = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::DynamicOffset),
 	ViewRange     = static_cast<uint32_t>(MVKNonVolatileImplicitBuffer::ViewRange),

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.cpp
@@ -358,6 +358,7 @@ MVK_PUBLIC_SYMBOL bool SPIRVToMSLConverter::convert(SPIRVToMSLConversionConfigur
 	populateEntryPoint(pMSLCompiler, shaderConfig.options, conversionResult.resultInfo.entryPoint);
 	conversionResult.resultInfo.isRasterizationDisabled = pMSLCompiler && pMSLCompiler->get_is_rasterization_disabled();
 	conversionResult.resultInfo.isPositionInvariant = pMSLCompiler && pMSLCompiler->is_position_invariant();
+	conversionResult.resultInfo.needsSwizzleBuffer = pMSLCompiler && pMSLCompiler->needs_swizzle_buffer();
 	conversionResult.resultInfo.needsOutputBuffer = pMSLCompiler && pMSLCompiler->needs_output_buffer();
 	conversionResult.resultInfo.needsPatchOutputBuffer = pMSLCompiler && pMSLCompiler->needs_patch_output_buffer();
 	conversionResult.resultInfo.needsBufferSizeBuffer = pMSLCompiler && pMSLCompiler->needs_buffer_size_buffer();

--- a/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
+++ b/MoltenVKShaderConverter/MoltenVKShaderConverter/SPIRVToMSLConverter.h
@@ -252,6 +252,7 @@ namespace mvk {
 		SPIRVEntryPoint entryPoint;
 		bool isRasterizationDisabled = false;
 		bool isPositionInvariant = false;
+		bool needsSwizzleBuffer = false;
 		bool needsOutputBuffer = false;
 		bool needsPatchOutputBuffer = false;
 		bool needsBufferSizeBuffer = false;


### PR DESCRIPTION
This PR fixes Mac1 regressions observed on Intel Iris / Iris Pro and NVIDIA GT 750M MacBook Pro hardware

The original version of this PR used broad feature disabling. After review and additional testing, the changes have been narrowed to the specific failing paths.

### 1. Native texture swizzle is advertised but not usable on NVIDIA Mac1
On NVIDIA Mac1, `NVMTLTexture` does not implement `newTextureViewWithPixelFormat:textureType:levels:slices:swizzle:`
Using MoltenVK's native texture swizzle path therefore crashes with an unrecognized selector. This PR marks nativeTextureSwizzle unavailable for NVIDIA Mac1 and restores the shader-side image-view swizzle fallback path.

### 2. Some Mac1 argument-buffer descriptor paths are unstable
Testing showed that some descriptor types need to stay on MoltenVK's discrete-resource path on Mac1

Current fallback list:

- When shader-side swizzle fallback is active:
- `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`
- `VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE`
- `VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT`

These descriptor types may require shader-side image-view swizzle metadata, which is handled correctly by the discrete-resource path.

- Intel Mac1:
  - `VK_DESCRIPTOR_TYPE_STORAGE_IMAGE`

This fixes vkQuake failures around `vkCreateComputePipelines(update_lightmap_pipeline)` / Metal compiler internal errors.

- NVIDIA Mac1:
  - `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER`

This fixes IOAF Code 9 / Invalid Resource device-loss failures observed in Flycast/vkQuake.

### 3. Discarded-fragment store checks fail to compile on Mac1
Flycast's OIT draw shader also triggered a Metal compiler internal error when SPIRV-Cross emitted `simd_is_helper_thread()` for discarded-fragment store checks. 
This PR disables check_discarded_frag_stores on NVIDIA Mac1 to avoid generating that failing shader path.

Attached are some logs for reference, v1.2.9 is used for comparing the recent crashes since v1.3.0
[1.2.9.txt](https://github.com/user-attachments/files/28957211/1.2.9.txt)
[1.3.0.txt](https://github.com/user-attachments/files/28957213/1.3.0.txt)
[1.4.2_92935d4c.txt](https://github.com/user-attachments/files/28957214/1.4.2_92935d4c.txt)

Closes #2727 