### PR TITLE
WIP: Defer residency set removal until referencing command buffers complete

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 #include <os/lock.h>
 
 #import <Metal/Metal.h>
@@ -986,10 +987,10 @@ public:
 	void drainResidencyRemovals() {}
 	void flushResidencyRemovalsIfIdle() {}
 #else
-	/** Adds the allocation to the residency set, cancelling any pending removal of it. */
+	/** Adds the resource's underlying allocation to the residency set (reference-counted). */
 	void makeResident(id<MTLAllocation> allocation);
 
-	/** Queues removal of the allocation from the residency set once no command buffer can reference it. */
+	/** Queues removal of the resource's underlying allocation once no command buffer can reference it. */
 	void removeResidency(id<MTLAllocation> allocation);
 
 	/** Registers a command buffer being committed and returns its tracking sequence. */
@@ -1003,6 +1004,10 @@ public:
 
 	/** Executes all pending residency removals if no tracked command buffers are in flight. */
 	void flushResidencyRemovalsIfIdle();
+
+protected:
+	bool retireResidencyRemoval(id<MTLAllocation> allocation);
+public:
 #endif
 
 	void addResidencySet(id<MTLCommandQueue> queue) {
@@ -1119,13 +1124,14 @@ protected:
 	id<MTLBuffer> _dummyBlitMTLBuffer = nil;
 #if MVK_XCODE_16
 	struct MVKPendingResidencyRemoval {
-		id<MTLAllocation> allocation;	// retained until the removal executes
+		id<MTLAllocation> allocation;	// underlying allocation, retained until the removal executes
 		uint64_t cutoffSeq;				// newest cmd buf committed before the app destroyed the resource
 		bool isRipe;					// all cmd bufs up to cutoffSeq have completed; remove on the next drain
 	};
 	id<MTLResidencySet> _residencySet = nil;
 	MVKSmallVector<MVKPendingResidencyRemoval> _pendingResidencyRemovals;
 	std::set<uint64_t> _inFlightResidencyCmdBufSeqs;
+	std::unordered_map<void*, uint32_t> _residencyRefCounts;	// underlying allocation -> resident resource count
 	uint64_t _nextResidencyCmdBufSeq = 1;
 #endif
 	uint32_t _visibilityBufferCount = 0;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.h
@@ -30,6 +30,7 @@
 #include <shared_mutex>
 #include <string>
 #include <mutex>
+#include <set>
 #include <os/lock.h>
 
 #import <Metal/Metal.h>
@@ -979,24 +980,29 @@ public:
 
 #if !MVK_XCODE_16
 	void makeResident(id allocation) {}
-#else
-	void makeResident(id<MTLAllocation> allocation) {
-		@synchronized(_residencySet) {
-			[_residencySet addAllocation: allocation];
-			[_residencySet commit];
-		}
-	}
-#endif
-
-#if !MVK_XCODE_16
 	void removeResidency(id allocation) {}
+	uint64_t trackResidencyCmdBufCommit() { return 0; }
+	void residencyCmdBufCompleted(uint64_t seq) {}
+	void drainResidencyRemovals() {}
+	void flushResidencyRemovalsIfIdle() {}
 #else
-	void removeResidency(id<MTLAllocation> allocation) {
-		@synchronized(_residencySet) {
-			[_residencySet removeAllocation:allocation];
-			[_residencySet commit];
-		}
-	}
+	/** Adds the allocation to the residency set, cancelling any pending removal of it. */
+	void makeResident(id<MTLAllocation> allocation);
+
+	/** Queues removal of the allocation from the residency set once no command buffer can reference it. */
+	void removeResidency(id<MTLAllocation> allocation);
+
+	/** Registers a command buffer being committed and returns its tracking sequence. */
+	uint64_t trackResidencyCmdBufCommit();
+
+	/** Retires a tracked command buffer and drains pending residency removals. */
+	void residencyCmdBufCompleted(uint64_t seq);
+
+	/** Executes pending residency removals whose referencing command buffers have all completed. */
+	void drainResidencyRemovals();
+
+	/** Executes all pending residency removals if no tracked command buffers are in flight. */
+	void flushResidencyRemovalsIfIdle();
 #endif
 
 	void addResidencySet(id<MTLCommandQueue> queue) {
@@ -1112,7 +1118,15 @@ protected:
 	id<MTLSamplerState> _defaultMTLSamplerState = nil;
 	id<MTLBuffer> _dummyBlitMTLBuffer = nil;
 #if MVK_XCODE_16
+	struct MVKPendingResidencyRemoval {
+		id<MTLAllocation> allocation;	// retained until the removal executes
+		uint64_t cutoffSeq;				// newest cmd buf committed before the app destroyed the resource
+		bool isRipe;					// all cmd bufs up to cutoffSeq have completed; remove on the next drain
+	};
 	id<MTLResidencySet> _residencySet = nil;
+	MVKSmallVector<MVKPendingResidencyRemoval> _pendingResidencyRemovals;
+	std::set<uint64_t> _inFlightResidencyCmdBufSeqs;
+	uint64_t _nextResidencyCmdBufSeq = 1;
 #endif
 	uint32_t _visibilityBufferCount = 0;
 	int _capturePipeFileDesc = -1;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3858,6 +3858,113 @@ VkResult MVKDevice::waitIdle() {
 	return rslt;
 }
 
+#if MVK_XCODE_16
+
+// A MTLResidencySet retains its allocations, and command buffers on the residency-set
+// submission path are created with retainedReferences = NO, so the set's retain can be
+// the last reference keeping a destroyed resource alive while a command buffer that
+// references it is still in flight or not yet released. Removing an allocation the
+// instant the app destroys the resource can therefore drop that last reference too
+// early, and Metal aborts on the dangling reference (surfacing as VK_ERROR_DEVICE_LOST).
+//
+// Each pending removal is retained here and tagged with the newest command buffer
+// sequence committed before the destroy (its cutoff); command buffers committed later
+// cannot legally reference the destroyed resource. Once every sequence at or below the
+// cutoff has retired, the entry ripens, and it is executed on the next drain after
+// that, giving the completion machinery of the last referencing command buffer time to
+// let go of it. Drains run on tracked command buffer completions and on present
+// completions; waitIdle and device destruction retire whatever remains.
+
+void MVKDevice::makeResident(id<MTLAllocation> allocation) {
+	if ( !_residencySet || !allocation ) { return; }
+	@synchronized (_residencySet) {
+		// Cancel any pending removal of this allocation, so a removal queued by a
+		// previous owner cannot evict the re-added allocation later.
+		size_t dst = 0;
+		for (size_t src = 0; src < _pendingResidencyRemovals.size(); src++) {
+			auto& pr = _pendingResidencyRemovals[src];
+			if (pr.allocation == allocation) {
+				[pr.allocation release];	// retained by removeResidency()
+			} else {
+				_pendingResidencyRemovals[dst++] = pr;
+			}
+		}
+		while (_pendingResidencyRemovals.size() > dst) { _pendingResidencyRemovals.pop_back(); }
+
+		[_residencySet addAllocation: allocation];
+		[_residencySet commit];
+	}
+}
+
+void MVKDevice::removeResidency(id<MTLAllocation> allocation) {
+	if ( !_residencySet || !allocation ) { return; }
+	@synchronized (_residencySet) {
+		_pendingResidencyRemovals.push_back({ [allocation retain], _nextResidencyCmdBufSeq - 1, false });
+	}
+}
+
+uint64_t MVKDevice::trackResidencyCmdBufCommit() {
+	if ( !_residencySet ) { return 0; }
+	@synchronized (_residencySet) {
+		uint64_t seq = _nextResidencyCmdBufSeq++;
+		_inFlightResidencyCmdBufSeqs.insert(seq);
+		return seq;
+	}
+}
+
+void MVKDevice::residencyCmdBufCompleted(uint64_t seq) {
+	if ( !_residencySet || !seq ) { return; }
+	@synchronized (_residencySet) {
+		_inFlightResidencyCmdBufSeqs.erase(seq);
+	}
+	drainResidencyRemovals();
+}
+
+void MVKDevice::drainResidencyRemovals() {
+	if ( !_residencySet ) { return; }
+	MVKSmallVector<id<MTLAllocation>> retired;
+	@synchronized (_residencySet) {
+		if (_pendingResidencyRemovals.empty()) { return; }
+		uint64_t oldestInFlight = _inFlightResidencyCmdBufSeqs.empty()
+			? UINT64_MAX
+			: *_inFlightResidencyCmdBufSeqs.begin();
+		size_t dst = 0;
+		for (size_t src = 0; src < _pendingResidencyRemovals.size(); src++) {
+			auto pr = _pendingResidencyRemovals[src];
+			if (pr.isRipe) {
+				[_residencySet removeAllocation: pr.allocation];
+				retired.push_back(pr.allocation);
+			} else {
+				pr.isRipe = (oldestInFlight > pr.cutoffSeq);
+				_pendingResidencyRemovals[dst++] = pr;
+			}
+		}
+		if ( !retired.empty() ) {
+			while (_pendingResidencyRemovals.size() > dst) { _pendingResidencyRemovals.pop_back(); }
+			[_residencySet commit];
+		}
+	}
+	// Release outside the lock; this may be the allocation's last reference.
+	for (id<MTLAllocation> allocation : retired) { [allocation release]; }
+}
+
+void MVKDevice::flushResidencyRemovalsIfIdle() {
+	if ( !_residencySet ) { return; }
+	MVKSmallVector<id<MTLAllocation>> retired;
+	@synchronized (_residencySet) {
+		if (_pendingResidencyRemovals.empty() || !_inFlightResidencyCmdBufSeqs.empty()) { return; }
+		for (auto& pr : _pendingResidencyRemovals) {
+			[_residencySet removeAllocation: pr.allocation];
+			retired.push_back(pr.allocation);
+		}
+		_pendingResidencyRemovals.clear();
+		[_residencySet commit];
+	}
+	for (id<MTLAllocation> allocation : retired) { [allocation release]; }
+}
+
+#endif
+
 VkResult MVKDevice::markLost(bool alsoMarkPhysicalDevice) {
 	lock_guard<mutex> lock(_sem4Lock);
 
@@ -5553,6 +5660,13 @@ MVKDevice::~MVKDevice() {
 	for (auto &fences: _barrierFences) for (auto fence: fences) [fence release];
 
 #if MVK_XCODE_16
+	// Retire any residency removals still pending, so their allocations are
+	// removed from the set and released before the set itself goes away.
+	for (auto& pr : _pendingResidencyRemovals) {
+		[_residencySet removeAllocation: pr.allocation];
+		[pr.allocation release];
+	}
+	_pendingResidencyRemovals.clear();
 	[_residencySet release];
 #endif
 	[_defaultMTLSamplerState release];

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -3875,31 +3875,63 @@ VkResult MVKDevice::waitIdle() {
 // let go of it. Drains run on tracked command buffer completions and on present
 // completions; waitIdle and device destruction retire whatever remains.
 
-void MVKDevice::makeResident(id<MTLAllocation> allocation) {
-	if ( !_residencySet || !allocation ) { return; }
-	@synchronized (_residencySet) {
-		// Cancel any pending removal of this allocation, so a removal queued by a
-		// previous owner cannot evict the re-added allocation later.
-		size_t dst = 0;
-		for (size_t src = 0; src < _pendingResidencyRemovals.size(); src++) {
-			auto& pr = _pendingResidencyRemovals[src];
-			if (pr.allocation == allocation) {
-				[pr.allocation release];	// retained by removeResidency()
-			} else {
-				_pendingResidencyRemovals[dst++] = pr;
-			}
-		}
-		while (_pendingResidencyRemovals.size() > dst) { _pendingResidencyRemovals.pop_back(); }
+// Metal deduplicates residency-set membership by underlying allocation: adding a
+// heap- or buffer-backed resource registers its backing allocation, which several
+// live resources may share (e.g. sub-allocated textures on one heap). Track
+// membership per underlying allocation with a reference count, so destroying one
+// resource cannot evict an allocation that other resources still need.
+//
+// Normalization must be transitive and reach the same base for every resource
+// that aliases the same memory, or the reference counts diverge: a texel-buffer
+// texture (a texture created over a MTLBuffer) shares memory with that buffer,
+// and the buffer may itself be placed on a heap. Following texture -> buffer ->
+// heap collapses all three onto the heap, matching how Metal dedups the set. If
+// the texture stopped at the placed buffer instead, removing it would emit
+// removeAllocation: for a resource whose memory the heap's other resources still
+// reference, evicting them mid-frame.
+static id<MTLAllocation> mvkBaseAllocation(id<MTLAllocation> allocation) {
+	NSObject* obj = (NSObject*)allocation;
+	if ([obj conformsToProtocol: @protocol(MTLTexture)]) {
+		id<MTLTexture> tex = (id<MTLTexture>)obj;
+		while (tex.parentTexture) { tex = tex.parentTexture; }
+		if (tex.heap)   { return (id<MTLAllocation>)tex.heap; }
+		if (tex.buffer) { return mvkBaseAllocation((id<MTLAllocation>)tex.buffer); }
+		return (id<MTLAllocation>)tex;
+	}
+	if ([obj conformsToProtocol: @protocol(MTLBuffer)]) {
+		id<MTLBuffer> buf = (id<MTLBuffer>)obj;
+		if (buf.heap) { return (id<MTLAllocation>)buf.heap; }
+	}
+	return allocation;
+}
 
-		[_residencySet addAllocation: allocation];
-		[_residencySet commit];
+// Memoryless textures hold no allocation and are never added to the residency
+// set, so they must never be counted on either side or a removal would decrement
+// a heap that only its non-memoryless siblings registered, evicting them early.
+static bool mvkIsResidencyTracked(id<MTLAllocation> allocation) {
+	NSObject* obj = (NSObject*)allocation;
+	if ([obj conformsToProtocol: @protocol(MTLTexture)]) {
+		return ((id<MTLTexture>)obj).storageMode != MTLStorageModeMemoryless;
+	}
+	return true;
+}
+
+void MVKDevice::makeResident(id<MTLAllocation> allocation) {
+	if ( !_residencySet || !allocation || !mvkIsResidencyTracked(allocation) ) { return; }
+	id<MTLAllocation> base = mvkBaseAllocation(allocation);
+	@synchronized (_residencySet) {
+		if (_residencyRefCounts[(void*)base]++ == 0) {
+			[_residencySet addAllocation: base];
+			[_residencySet commit];
+		}
 	}
 }
 
 void MVKDevice::removeResidency(id<MTLAllocation> allocation) {
-	if ( !_residencySet || !allocation ) { return; }
+	if ( !_residencySet || !allocation || !mvkIsResidencyTracked(allocation) ) { return; }
+	id<MTLAllocation> base = mvkBaseAllocation(allocation);
 	@synchronized (_residencySet) {
-		_pendingResidencyRemovals.push_back({ [allocation retain], _nextResidencyCmdBufSeq - 1, false });
+		_pendingResidencyRemovals.push_back({ [base retain], _nextResidencyCmdBufSeq - 1, false });
 	}
 }
 
@@ -3920,6 +3952,18 @@ void MVKDevice::residencyCmdBufCompleted(uint64_t seq) {
 	drainResidencyRemovals();
 }
 
+// Retires one pending removal under the residency monitor: decrements the
+// underlying allocation's resident-resource count and removes it from the set
+// only when no live resource needs it any more. Returns true if it removed.
+bool MVKDevice::retireResidencyRemoval(id<MTLAllocation> allocation) {
+	auto it = _residencyRefCounts.find((void*)allocation);
+	if (it == _residencyRefCounts.end()) { return false; }		// never resident (e.g. memoryless)
+	if (--(it->second) > 0) { return false; }					// other resources still share it
+	_residencyRefCounts.erase(it);
+	[_residencySet removeAllocation: allocation];
+	return true;
+}
+
 void MVKDevice::drainResidencyRemovals() {
 	if ( !_residencySet ) { return; }
 	MVKSmallVector<id<MTLAllocation>> retired;
@@ -3928,11 +3972,12 @@ void MVKDevice::drainResidencyRemovals() {
 		uint64_t oldestInFlight = _inFlightResidencyCmdBufSeqs.empty()
 			? UINT64_MAX
 			: *_inFlightResidencyCmdBufSeqs.begin();
+		bool removedAny = false;
 		size_t dst = 0;
 		for (size_t src = 0; src < _pendingResidencyRemovals.size(); src++) {
 			auto pr = _pendingResidencyRemovals[src];
 			if (pr.isRipe) {
-				[_residencySet removeAllocation: pr.allocation];
+				removedAny |= retireResidencyRemoval(pr.allocation);
 				retired.push_back(pr.allocation);
 			} else {
 				pr.isRipe = (oldestInFlight > pr.cutoffSeq);
@@ -3941,7 +3986,7 @@ void MVKDevice::drainResidencyRemovals() {
 		}
 		if ( !retired.empty() ) {
 			while (_pendingResidencyRemovals.size() > dst) { _pendingResidencyRemovals.pop_back(); }
-			[_residencySet commit];
+			if (removedAny) { [_residencySet commit]; }
 		}
 	}
 	// Release outside the lock; this may be the allocation's last reference.
@@ -3953,12 +3998,13 @@ void MVKDevice::flushResidencyRemovalsIfIdle() {
 	MVKSmallVector<id<MTLAllocation>> retired;
 	@synchronized (_residencySet) {
 		if (_pendingResidencyRemovals.empty() || !_inFlightResidencyCmdBufSeqs.empty()) { return; }
+		bool removedAny = false;
 		for (auto& pr : _pendingResidencyRemovals) {
-			[_residencySet removeAllocation: pr.allocation];
+			removedAny |= retireResidencyRemoval(pr.allocation);
 			retired.push_back(pr.allocation);
 		}
 		_pendingResidencyRemovals.clear();
-		[_residencySet commit];
+		if (removedAny) { [_residencySet commit]; }
 	}
 	for (id<MTLAllocation> allocation : retired) { [allocation release]; }
 }

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -160,6 +160,7 @@ VkResult MVKQueue::waitIdle(MVKCommandUse cmdUse) {
 		[mtlCmdBuff commit];
 		[mtlCmdBuff waitUntilCompleted];
 	}
+	_device->flushResidencyRemovalsIfIdle();
 	return _device->getConfigurationResult();
 }
 
@@ -546,8 +547,10 @@ VkResult MVKQueueCommandBufferSubmission::commitActiveMTLCommandBuffer(bool sign
 	_activeMTLCommandBuffer = nil;
 
 	uint64_t startTime = getPerformanceTimestamp();
+	uint64_t residencySeq = mtlCmdBuff ? getDevice()->trackResidencyCmdBufCommit() : 0;
 	[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) {
 		addPerformanceInterval(getPerformanceStats().queue.mtlCommandBufferExecution, startTime);
+		getDevice()->residencyCmdBufCompleted(residencySeq);
 		if (signalCompletion) { this->finish(); }	// Must be the last thing the completetion callback does.
 	}];
 
@@ -743,7 +746,12 @@ VkResult MVKQueuePresentSurfaceSubmission::execute() {
 	// Retrieve the result first, because finish() will destroy this instance.
 	VkResult rslt = getConfigurationResult();
 	if (mtlCmdBuff) {
-		[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) { this->finish(); }];
+		[mtlCmdBuff addCompletedHandler: ^(id<MTLCommandBuffer> mtlCB) {
+			// Presents are drain points too, so pending residency removals retire
+			// even when the app is only presenting (e.g. sitting in a menu).
+			getDevice()->drainResidencyRemovals();
+			this->finish();
+		}];
 		[mtlCmdBuff commit];
 	} else {
 		finish();


### PR DESCRIPTION
## Problem

With `MTLResidencySet` enabled (Metal 3+), MoltenVK removed an allocation from the residency set the moment the app destroyed the resource — but committed command buffers may still reference it through argument-buffer descriptors, and per-draw `useResource:` tracking is off while a residency set exists. Reading non-resident memory on Apple GPUs loses the device or returns undefined data.

Two independent defects, one per commit:

**1 — Defer removals until referencing command buffers complete.** Removals are queued, tagged with the newest command-buffer sequence committed before the destroy, and executed one drain after that sequence completes (also on present completions; `waitIdle` and teardown flush the rest). Fixes `VK_ERROR_DEVICE_LOST`.

**2 — Reference-count membership by underlying allocation.** Metal dedups set membership by underlying allocation, which live resources can share (heap sub-allocations, buffer texture views); removing one destroyed resource evicted the shared allocation for its still-live siblings. Membership is now reference-counted per base allocation. Fixes full-screen white-out.

## Validation

macOS, Apple M2 (x86_64 under Rosetta), a DXVK D3D9 game via Wine with the Steam overlay injected — its continuous resource churn triggered both defects within seconds of launch. After: no device loss, no Metal validation failures, and the white-out is gone across repeated sessions. Standalone smoke tests (instance/device/buffer lifecycle, offscreen render + readback) also pass.

A separate color-fidelity issue on this stack (a subtle tint sampled as grayscale) is **not** residency-related — it reproduces with removals fully disabled — and is out of scope here.

Investigation, fix, and in-game validation done with the assistance of Claude Code.
