### PR TITLE
MVKQueue: Honour liveCheckAllResources even when a residency set is active

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueue.mm
@@ -486,7 +486,14 @@ VkResult MVKQueueCommandBufferSubmission::execute() {
 id<MTLCommandBuffer> MVKQueueCommandBufferSubmission::getActiveMTLCommandBuffer() {
 	if ( !_activeMTLCommandBuffer ) {
 		bool needsRetain = false;
-		if (!_device->hasResidencySet() && (getEnabledDescriptorIndexingFeatures().descriptorBindingPartiallyBound || getMVKConfig().liveCheckAllResources)) {
+		if (getMVKConfig().liveCheckAllResources) {
+			// A residency set guarantees residency, not lifetime: with retained references disabled, a
+			// resource the application destroys right after waiting on the submission fence is released
+			// (in detachMemory) while this completed-but-not-yet-released command buffer still references
+			// it, which Metal rejects. Honour an explicit liveCheckAllResources request even when a
+			// residency set is active.
+			needsRetain = true;
+		} else if (!_device->hasResidencySet() && getEnabledDescriptorIndexingFeatures().descriptorBindingPartiallyBound) {
 			// Partially bound descriptors will get bound by us even if they're not used at runtime by the shader.
 			// The application is free to destroy them even if they're not used at runtime even if we bound them.
 			// Metal will be very unhappy if we destroy something we bound, even if it isn't used at runtime.


### PR DESCRIPTION
`getActiveMTLCommandBuffer()` gates retained references on `!hasResidencySet()`, which also disables `liveCheckAllResources`: with a residency set active, `MVK_CONFIG_LIVE_CHECK_ALL_RESOURCES=1` does nothing.

A residency set keeps a resource resident, not alive. When the app destroys a resource right after waiting on the submission fence, `detachMemory` releases the `MTLResource` while the completed-but-not-yet-released command buffer still references it, and Metal loses the device. `liveCheckAllResources` is meant to force retained command buffers for exactly this case, so a residency set shouldn't silently disable it.

This reorders the check so an explicit `liveCheckAllResources` request always retains. The partially-bound path is unchanged, and with the flag off (default) behaviour is identical.

Hit with DXVK (D3D9) on Apple Silicon, macOS 15; confirmed the dangling release with `METAL_DEVICE_WRAPPER_TYPE=1`.
