### PR TITLE
Disable non-working quad control flow

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2516,12 +2516,14 @@ void MVKPhysicalDevice::initMetalFeatures() {
 
 		_metalFeatures.maxPerStageDynamicMTLBufferCount = _metalFeatures.maxPerStageBufferCount;
 		_metalFeatures.tileBasedDeferredRendering = true;
+		_metalFeatures.nativeTextureSwizzle = true;
 
 		// From testing, these guarantees are only true on Apple GPUs.
 		_metalFeatures.subgroupUniformControlFlow = true;
 		_metalFeatures.maximalReconvergence = true;
-		_metalFeatures.quadControlFlow = true;
-		_metalFeatures.nativeTextureSwizzle = true;
+
+		// FIXME: Fails tests using fragment terminate with quads on Apple GPUs.
+		_metalFeatures.quadControlFlow = false;
 
 		// Don't use barriers in render passes on Apple GPUs. Apple GPUs don't support them,
 		// and in fact Metal's validation layer will complain if you try to use them.


### PR DESCRIPTION
Originally in https://github.com/KhronosGroup/MoltenVK/pull/2533 it was assumed that some of the fragment terminate related quad control tests were failing due to other problems with demote vs terminate semantics in MoltenVK, but it has since been determined that they just do not work. So it makes sense to me to disable quad control for now until it gets fixed, if possible.

Disabling the flag in `_metalFeatures` will in turn disable the extension elsewhere.