### PR TITLE
Disable 64-bit float control properties

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -836,7 +836,7 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	supportedProps12.roundingModeIndependence = VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE;
 	supportedProps12.shaderSignedZeroInfNanPreserveFloat16 = true;
 	supportedProps12.shaderSignedZeroInfNanPreserveFloat32 = true;
-	supportedProps12.shaderSignedZeroInfNanPreserveFloat64 = true;
+	supportedProps12.shaderSignedZeroInfNanPreserveFloat64 = false;
 	supportedProps12.shaderDenormPreserveFloat16 = false;
 	supportedProps12.shaderDenormPreserveFloat32 = false;
 	supportedProps12.shaderDenormPreserveFloat64 = false;
@@ -845,7 +845,7 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 	supportedProps12.shaderDenormFlushToZeroFloat64 = false;
 	supportedProps12.shaderRoundingModeRTEFloat16 = true;
 	supportedProps12.shaderRoundingModeRTEFloat32 = true;
-	supportedProps12.shaderRoundingModeRTEFloat64 = true;
+	supportedProps12.shaderRoundingModeRTEFloat64 = false;
 	supportedProps12.shaderRoundingModeRTZFloat16 = false;
 	supportedProps12.shaderRoundingModeRTZFloat32 = false;
 	supportedProps12.shaderRoundingModeRTZFloat64 = false;


### PR DESCRIPTION
These were enabled due to problems with CTS falsely requiring them, but said problems are being fixed. We do not support 64-bit floats.

See https://github.com/KhronosGroup/VK-GL-CTS/issues/610