### PR TITLE
Do not enable subgroup emulation for reduction

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -2140,7 +2140,7 @@ void MVKGraphicsPipeline::initShaderConversionConfig(SPIRVToMSLConversionConfigu
     shaderConfig.options.mslOptions.view_index_from_device_index = mvkAreAllFlagsEnabled(_flags, VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT);
 	shaderConfig.options.mslOptions.replace_recursive_inputs = mvkOSVersionIsAtLeast(14.0, 17.0, 1.0);
 #if MVK_MACOS
-    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute || !mtlFeats.simdReduction;
+    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
 #else
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
     shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;
@@ -2514,7 +2514,7 @@ MVKMTLFunction MVKComputePipeline::getMTLFunction(const VkComputePipelineCreateI
 	shaderConfig.options.mslOptions.argument_buffers_tier = (SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::ArgumentBuffersTier)getMetalFeatures().argumentBuffersTier;
 
 #if MVK_MACOS
-    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute || !mtlFeats.simdReduction;
+    shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.simdPermute;
 #else
     shaderConfig.options.mslOptions.emulate_subgroups = !mtlFeats.quadPermute;
     shaderConfig.options.mslOptions.ios_use_simdgroup_functions = !!mtlFeats.simdPermute;


### PR DESCRIPTION
Fixes regression https://github.com/KhronosGroup/MoltenVK/issues/2783 in 1.4.2-rc1

SPIRV-Cross basically only supports subgroup op emulation for `OpGroupNonUniformElect`. This is in line with how, with no Metal SIMD capabilities, we only advertise `VK_SUBGROUP_FEATURE_BASIC_BIT`.

The `emulate_subgroups` flag cannot be enabled when just `simdReduction` is disabled, as in https://github.com/KhronosGroup/MoltenVK/pull/2755, because:
* It violates the SPIRV-Cross assumption that we only support `VK_SUBGROUP_FEATURE_BASIC_BIT` (i.e. `OpGroupNonUniformElect`) when emulating subgroups, causing subgroup ops that are natively available to take the emulation path and fail.
* It does not support emulating these ops anyway, so it makes no sense.

When `simdReduction` is false, we will already correctly not advertise the associated subgroup op bits. If emulation is needed to support GPUs without working reduction ops, it would need to be implemented in SPIRV-Cross first, along with changes to ensure other native ops can still be used.