### PR TITLE
Avoid repeated state finalization for indexed indirect draws

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -1420,8 +1420,8 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
 
 			if (drawIdx == 0 || pipeline->isTessellationPipeline() || vtxAdjmts.needsAdjustment()) {
 				cmdEncoder->finalizeDrawState(stage);
-				if ( !pipeline->hasValidMTLPipelineStates() ) { return; }
 			}
+			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }
 
             switch (stage) {
                 case kMVKGraphicsStageVertex:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -1419,9 +1419,9 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
             }
 
 			if (drawIdx == 0 || pipeline->isTessellationPipeline() || vtxAdjmts.needsAdjustment()) {
-				cmdEncoder->finalizeDrawState(stage);
+				cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
 			}
-			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }
+			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
 
             switch (stage) {
                 case kMVKGraphicsStageVertex:

--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -1418,9 +1418,10 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
                 cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
-	        cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
-
-			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
+			if (drawIdx == 0 || pipeline->isTessellationPipeline() || vtxAdjmts.needsAdjustment()) {
+				cmdEncoder->finalizeDrawState(stage);
+				if ( !pipeline->hasValidMTLPipelineStates() ) { return; }
+			}
 
             switch (stage) {
                 case kMVKGraphicsStageVertex:


### PR DESCRIPTION
`vkCmdDrawIndexedIndirect` currently finalizes unchanged draw state before every draw in an ordinary indirect batch. This finalizes it once for that path while preserving per-draw behavior for tessellation, multiview and triangle-fan conversion. Pipeline validity is still checked for every draw.

In a submit-and-wait microbenchmark using one `vkCmdDrawIndexedIndirect` call and zero instances, 4,096 draws improved from 1.115 ms to 0.487 ms, 16,384 from 4.163 ms to 1.335 ms and 65,536 from 15.569 ms to 4.993 ms on a 15/16 M5 Pro. The code path is hardware-neutral; the M5 Pro is only the measured machine.

Debug and Release builds pass. The u16 and u32 correctness matrix passes, along with all 572 indexed render-pass and dynamic-rendering CTS cases.
