### PR TITLE
Avoid redundant non-indexed indirect draw finalization

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -1033,7 +1033,9 @@ void MVKCmdDrawIndirect::encode(MVKCommandEncoder* cmdEncoder) {
                 cmdEncoder->beginMetalRenderPass(kMVKCommandUseRestartSubpass);
             }
 
-            cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
+            if (drawIdx == 0 || pipeline->isTessellationPipeline() || needsInstanceAdjustment) {
+                cmdEncoder->finalizeDrawState(stage);	// Ensure all updated state has been submitted to Metal
+            }
 
 			if ( !pipeline->hasValidMTLPipelineStates() ) { return; }	// Abort if this pipeline stage could not be compiled.
 


### PR DESCRIPTION
## Summary

Avoid calling `finalizeDrawState()` for every ordinary non-indexed indirect draw after the first draw has already submitted unchanged state.

Tessellation and instance-adjustment paths continue to finalize each draw because they update per-draw state. Pipeline validation remains unconditional.

This mirrors the state-finalization reduction made for indexed indirect draws in #2788.

## Validation

- Release MoltenVK build
- Metal-validation correctness probes for ordinary rendering and DrawID-only positioning at 1, 64, 256, 1,024, and 4,096 draws
- Dynamic viewport/scissor and active occlusion-query witnesses
- 105 targeted Vulkan CTS cases passed with zero failures
- Controlled M5 Pro A/B with command-buffer prefill disabled showed reductions of 13.3% at 4,096 draws, 17.1% at 16,384 draws, and 30.1% at 65,536 draws

Performance figures are local M5 Pro measurements only.
