### PR TITLE
Fix areQueriesDeviceAvailable

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
@@ -92,8 +92,8 @@ public:
     /** Called from the MVKCmdBeginQuery command when it is added to the command buffer */
     virtual void beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) {};
 
-    /** Returns whether all the queries in [firstQuery, endQuery) are available on the device. */
-    bool areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQuery);
+    /**  Returns whether queryCount queries starting at firstQuery are available on the device. */
+    bool areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t queryCount);
 
 #pragma mark Construction
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.h
@@ -92,7 +92,7 @@ public:
     /** Called from the MVKCmdBeginQuery command when it is added to the command buffer */
     virtual void beginQueryAddedTo(uint32_t query, MVKCommandBuffer* cmdBuffer) {};
 
-    /**  Returns whether queryCount queries starting at firstQuery are available on the device. */
+    /** Returns whether queryCount queries starting at firstQuery are available on the device. */
     bool areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t queryCount);
 
 #pragma mark Construction

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -183,7 +183,7 @@ void MVKQueryPool::encodeCopyResults(MVKCommandEncoder* cmdEncoder,
 		state.bindStructBytes(mtlComputeCmdEnc, &queryCount, 3);
 		state.bindStructBytes(mtlComputeCmdEnc, &flags,      4);
 		_availabilityLock.lock();
-		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, _availability.data(), _availability.size() * sizeof(Status), 5);
+		cmdEncoder->setComputeBytes(mtlComputeCmdEnc, _availability.data() + firstQuery, queryCount * sizeof(Status), 5);
 		_availabilityLock.unlock();
 
 		// Run one thread per query. Try to fill up a subgroup.

--- a/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKQueryPool.mm
@@ -100,7 +100,8 @@ VkResult MVKQueryPool::getResults(uint32_t firstQuery,
 	return rqstRslt;
 }
 
-bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t endQuery) {
+bool MVKQueryPool::areQueriesDeviceAvailable(uint32_t firstQuery, uint32_t queryCount) {
+	uint32_t endQuery = firstQuery + queryCount;
     for (uint32_t query = firstQuery; query < endQuery; query++) {
         if ( _availability[query] < DeviceAvailable ) { return false; }
     }


### PR DESCRIPTION
`areQueriesDeviceAvailable` expects its second argument to be endQuery, while callers actually pass queryCount.

This causes vkCmdCopyQueryPoolResults() to incorrectly consider queries with nonzero firstQuery. With Venus query feedback this breaks occlusion queries, causing Portal and other Source Engine games to get stuck polling them indefinitely.