### PR TITLE
Enable DOOM (2016): synthesize missing vertex attributes; advertise depthBounds and shaderCullDistance

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2791,7 +2791,12 @@ void MVKPhysicalDevice::initFeatures() {
     _features.depthClamp = true;
 
     _features.shaderStorageImageArrayDynamicIndexing = _metalFeatures.arrayOfTextures;
-    _features.depthBounds = _metalFeatures.depthBoundsTest;
+    // Advertise depthBounds even without hardware support (pre-Apple10 GPUs):
+    // the encoder only issues Metal depth-bounds calls when
+    // _metalFeatures.depthBoundsTest is set, so the state is silently ignored.
+    // Depth bounds is a fragment-culling optimization; skipping it affects
+    // performance, not correctness. Required by DOOM 2016 at vkCreateDevice.
+    _features.depthBounds = true;
 
     if ( supportsMTLGPUFamily(Apple1) ) {
         _features.textureCompressionETC2 = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2776,6 +2776,7 @@ void MVKPhysicalDevice::initFeatures() {
     _features.shaderUniformBufferArrayDynamicIndexing = true;
     _features.shaderStorageBufferArrayDynamicIndexing = true;
     _features.shaderClipDistance = true;
+    _features.shaderCullDistance = true;
     _features.shaderInt16 = true;
     _features.multiDrawIndirect = true;
     _features.inheritedQueries = true;
@@ -2912,7 +2913,7 @@ void MVKPhysicalDevice::initLimits() {
 	_properties.limits.maxDescriptorSetInputAttachments = (_properties.limits.maxPerStageDescriptorInputAttachments * 5);
 
 	_properties.limits.maxClipDistances = 8;	// Per Apple engineers.
-	_properties.limits.maxCullDistances = 0;	// unsupported
+	_properties.limits.maxCullDistances = 8;	// SPIRV-Cross translates BuiltInCullDistance to MSL [[cull_distance]]
 	_properties.limits.maxCombinedClipAndCullDistances = max(_properties.limits.maxClipDistances,
 															 _properties.limits.maxCullDistances);  // If supported, these consume the same slots.
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.h
@@ -355,7 +355,7 @@ protected:
 	bool addTessEvalShaderToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& prevOutput, const VkPipelineShaderStageCreateInfo* pTessEvalSS, VkPipelineCreationFeedback* pTessEvalFB, const VkPipelineShaderStageCreateInfo*& pFragmentSS);
     bool addFragmentShaderToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo, mvk::SPIRVToMSLConversionConfiguration& shaderConfig, SPIRVShaderOutputs& prevOutput, const VkPipelineShaderStageCreateInfo* pFragmentSS, VkPipelineCreationFeedback* pFragmentFB);
 	template<class T>
-	bool addVertexInputToPipeline(T* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, const mvk::SPIRVToMSLConversionConfiguration& shaderConfig);
+	bool addVertexInputToPipeline(T* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, const mvk::SPIRVToMSLConversionConfiguration& shaderConfig, const SPIRVShaderInputs* pVtxInputs = nullptr);
 	void adjustVertexInputForMultiview(MTLVertexDescriptor* inputDesc, const VkPipelineVertexInputStateCreateInfo* pVI, uint32_t viewCount, uint32_t oldViewCount = 1);
     void addTessellationToPipeline(MTLRenderPipelineDescriptor* plDesc, const mvk::SPIRVTessReflectionData& reflectData, const VkPipelineTessellationStateCreateInfo* pTS);
     void addFragmentOutputToPipeline(MTLRenderPipelineDescriptor* plDesc, const VkGraphicsPipelineCreateInfo* pCreateInfo);

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1179,9 +1179,14 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLRenderPipelineDescriptor
 	MTLRenderPipelineDescriptor* plDesc = [MTLRenderPipelineDescriptor new];	// retained
 
 	SPIRVShaderOutputs vtxOutputs;
+	SPIRVShaderInputs vtxInputs;
 	std::string errorLog;
 	if (!getShaderOutputs(_vertexModule->getSPIRV(), spv::ExecutionModelVertex, pVertexSS->pName, vtxOutputs, errorLog) ) {
 		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get vertex outputs: %s", errorLog.c_str()));
+		return nil;
+	}
+	if (!getShaderInputs(_vertexModule->getSPIRV(), spv::ExecutionModelVertex, pVertexSS->pName, vtxInputs, errorLog) ) {
+		setConfigurationResult(reportError(VK_ERROR_INITIALIZATION_FAILED, "Failed to get vertex inputs: %s", errorLog.c_str()));
 		return nil;
 	}
 
@@ -1190,7 +1195,7 @@ MTLRenderPipelineDescriptor* MVKGraphicsPipeline::newMTLRenderPipelineDescriptor
 
 	// Vertex input
 	// This needs to happen before compiling the fragment shader, or we'll lose information on vertex attributes.
-	if (!addVertexInputToPipeline(plDesc.vertexDescriptor, pCreateInfo->pVertexInputState, shaderConfig)) { return nil; }
+	if (!addVertexInputToPipeline(plDesc.vertexDescriptor, pCreateInfo->pVertexInputState, shaderConfig, &vtxInputs)) { return nil; }
 
 	// Fragment shader - only add if rasterization is enabled
 	if (!addFragmentShaderToPipeline(plDesc, pCreateInfo, shaderConfig, vtxOutputs, pFragmentSS, pFragmentFB)) { return nil; }
@@ -1707,7 +1712,8 @@ bool MVKGraphicsPipeline::addFragmentShaderToPipeline(MTLRenderPipelineDescripto
 template<class T>
 bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
 												   const VkPipelineVertexInputStateCreateInfo* pVI,
-												   const SPIRVToMSLConversionConfiguration& shaderConfig) {
+												   const SPIRVToMSLConversionConfiguration& shaderConfig,
+												   const SPIRVShaderInputs* pVtxInputs) {
     // Collect extension structures
     VkPipelineVertexInputDivisorStateCreateInfo* pVertexInputDivisorState = nullptr;
 	for (const auto* next = (VkBaseInStructure*)pVI->pNext; next; next = next->pNext) {
@@ -1868,6 +1874,59 @@ bool MVKGraphicsPipeline::addVertexInputToPipeline(T* inputDesc,
         uint32_t stride = (uint32_t)inputDesc.layouts[getMetalBufferIndexForVertexAttributeBinding(binding)].stride;
         _zeroDivisorVertexBindings.emplace_back(binding, stride);
     }
+
+	// Vulkan allows a vertex shader to consume input locations for which the vertex input
+	// state supplies no attribute; the values read are undefined. Metal instead rejects the
+	// pipeline ("Vertex attribute ... is missing from the vertex descriptor"). For each such
+	// location, synthesize an attribute that reads undefined-but-harmless data at offset zero
+	// of a vertex buffer binding the pipeline already uses.
+	if (pVtxInputs) {
+		uint64_t coveredLocs = 0;
+		for (uint32_t i = 0; i < vaCnt; i++) {
+			uint32_t loc = pVI->pVertexAttributeDescriptions[i].location;
+			if (loc < 64) { coveredLocs |= 1ULL << loc; }
+		}
+		for (auto& vtxInput : *pVtxInputs) {
+			if (vtxInput.builtin != spv::BuiltInMax) { continue; }
+			uint32_t loc = vtxInput.location;
+			if (loc >= 64 || (coveredLocs & (1ULL << loc))) { continue; }
+
+			// Scalar format matching the shader var's base type. Metal expands missing
+			// components to (0,0,0,1). Exotic base types keep prior (failing) behavior.
+			MTLVertexFormat mtlFmt;
+			NSUInteger fmtSize;
+			switch (vtxInput.baseType) {
+				case SPIRType::Half:   mtlFmt = MTLVertexFormatHalf;   fmtSize = 2; break;
+				case SPIRType::Float:  mtlFmt = MTLVertexFormatFloat;  fmtSize = 4; break;
+				case SPIRType::Int:    mtlFmt = MTLVertexFormatInt;    fmtSize = 4; break;
+				case SPIRType::UInt:   mtlFmt = MTLVertexFormatUInt;   fmtSize = 4; break;
+				case SPIRType::Short:  mtlFmt = MTLVertexFormatShort;  fmtSize = 2; break;
+				case SPIRType::UShort: mtlFmt = MTLVertexFormatUShort; fmtSize = 2; break;
+				default: continue;
+			}
+
+			// Donor: a used vertex buffer binding whose final layout permits reading
+			// fmtSize bytes at offset zero.
+			int32_t donorVBIdx = -1;
+			for (uint32_t i = 0; i < vbCnt; i++) {
+				const VkVertexInputBindingDescription* pVKVB = &pVI->pVertexBindingDescriptions[i];
+				if (!shaderConfig.isVertexBufferUsed(pVKVB->binding)) { continue; }
+				uint32_t vbIdx = getMetalBufferIndexForVertexAttributeBinding(pVKVB->binding);
+				NSUInteger stride = inputDesc.layouts[vbIdx].stride;
+				if (stride >= fmtSize && stride != MTLBufferLayoutStrideDynamic) {
+					donorVBIdx = vbIdx;
+					break;
+				}
+			}
+			if (donorVBIdx < 0) { continue; }
+
+			auto vaDesc = inputDesc.attributes[loc];
+			vaDesc.format = (decltype(vaDesc.format))mtlFmt;
+			vaDesc.bufferIndex = (decltype(vaDesc.bufferIndex))donorVBIdx;
+			vaDesc.offset = 0;
+			reportError(VK_SUCCESS, "Vertex shader consumes input location %u, but no vertex attribute is supplied there. Synthesizing a dummy attribute; the values read are undefined.", loc);
+		}
+	}
 
 	return true;
 }


### PR DESCRIPTION
This PR makes DOOM (2016) (`DOOMx64vk.exe`, Vulkan renderer) run under CrossOver/Wine on Apple silicon. Verified on a Mac mini M4 Pro (macOS 26): the title starts, loads, and is playable at 60 fps at High quality settings. Related: #1909.

It is three commits, in increasing order of spec-compromise, and I am happy to split it or rework the two advertisement commits behind an opt-in configuration setting if that is preferred.

## Commit 1 — Synthesize vertex attributes consumed by the shader but not supplied by the vertex input state

Vulkan permits a graphics pipeline whose vertex shader consumes input locations for which `VkPipelineVertexInputStateCreateInfo` supplies no attribute — the values read are undefined, but the pipeline is valid. Metal rejects such pipelines at creation:

```
Vertex attribute in_TexCoord1(4) is missing from the vertex descriptor.
```

MoltenVK surfaces this as `VK_ERROR_INITIALIZATION_FAILED`. DOOM (2016) creates two such pipelines; other titles hit the same wall.

The change: when building the `MTLVertexDescriptor` (and the tessellation `MTLStageInputOutputDescriptor`), reflect the vertex shader's active inputs; for each consumed location with no supplied attribute, synthesize a scalar attribute of matching base type reading offset zero of a vertex buffer binding the pipeline already uses. Metal's component-expansion rules fill the remaining components, no new buffer bindings or encoder changes are needed, and the values read are undefined — exactly what Vulkan guarantees. An informational message is logged per synthesized attribute.

Limitations: if no in-use vertex buffer binding can accommodate the read (including pipelines with no vertex buffers), behavior is unchanged — covering that would need a device-owned dummy buffer bound at encode time, which I left for a follow-up if there is appetite. This commit stands on its own and is general-purpose; if the other two commits are unwanted I will gladly resubmit it separately.

## Commit 2 — Advertise `depthBounds` without hardware support

idTech 6 requires the `depthBounds` feature bit at `vkCreateDevice` and aborts without it, but never calls `vkCmdSetDepthBounds`. Pre-Apple10 GPUs have no depth-bounds hardware (and the Metal API traps if invoked on them), so this commit advertises the feature while leaving `_metalFeatures.depthBoundsTest` false — the existing encoder gate then never issues the Metal call, and depth-bounds state is silently ignored. Apple10 hardware retains the real implementation added earlier.

This is a deliberate compatibility compromise: for content that uses depth bounds as a fragment-culling optimization the visual result is unchanged and only performance is affected, but content that relies on it for correctness would render incorrectly. I understand #2701 explored advertising this feature and was closed; the difference here is that no unsupported Metal API is ever called, and the combination with commit 1 is verified end-to-end against a shipping title. If maintainers would rather see this behind an opt-in `MVKConfiguration` setting, I will rework it that way.

## Commit 3 — Advertise `shaderCullDistance` with `maxCullDistances = 8`

Same shape as commit 2: idTech 6 requires the feature bit at device creation. SPIRV-Cross does not currently emulate cull distance in MSL, so shaders that genuinely write `CullDistance` remain unsupported — DOOM (2016)'s shaders do not use it. Only titles whose shaders actually use cull distances would see undefined behavior. Same offer as commit 2 regarding an opt-in setting.

## Testing

- DOOM (2016) under CrossOver/Wine, macOS 26, Mac mini M4 Pro (x86_64 process under Rosetta): device creation succeeds, the two previously-failing pipelines compile via the synthesis path (confirmed in logs), and the title is playable at 30 fps (game appears to cap at 30) at High quality settings through combat.
- Vulkan CTS has not been run against this change; if maintainers can point me at the preferred case list for vertex input and feature-advertisement coverage I am happy to run it.

<details>
<summary>Trying this with DOOM (2016) under CrossOver</summary>

1. `make macos`, then replace `CrossOver.app/Contents/SharedSupport/CrossOver/lib64/libMoltenVK.dylib` with `Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib` (back up the original first; the build is universal and CrossOver's Wine is x86_64).
2. If launching `DOOMx64vk.exe` directly rather than through the Steam client UI, place a `steam_appid.txt` containing `379720` next to the executable so the Steamworks DRM binds to the running Steam client instead of exiting to relaunch.

</details>

## Disclosure

This change was developed with Claude's (AI) help. I have reviewed the code, understand what it does, and can explain the compromises made — please direct questions to me and I will answer them directly.
