### PR TITLE
Add support for VK_EXT_ycbcr_2plane_444_formats.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -410,6 +410,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
   - *iOS and macOS, requires family 6 (A13) or better Apple GPU.*
 - `VK_EXT_tooling_info`
 - `VK_EXT_vertex_attribute_divisor`
+- `VK_EXT_ycbcr_2plane_444_formats`
 - `VK_AMD_gpu_shader_half_float`
 - `VK_AMD_negative_viewport_height`
 - `VK_AMD_shader_image_load_store_lod`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -18,7 +18,8 @@ MoltenVK 1.4.3
 
 Released TBD
 
-- 
+- Add support for the following extensions:
+  - `VK_EXT_ycbcr_2plane_444_formats`
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -786,6 +786,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				texelBuffAlignFeatures->texelBufferAlignment = true;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT: {
+				auto* ycbcr2Plane444Features = (VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*)next;
+				ycbcr2Plane444Features->ycbcr2plane444Formats = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {
 				auto* shaderIntFuncsFeatures = (VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*)next;
 				shaderIntFuncsFeatures->shaderIntegerFunctions2 = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -109,6 +109,7 @@ MVK_DEVICE_FEATURE_EXTN(PrimitiveTopologyListRestart,     PRIMITIVE_TOPOLOGY_LIS
 MVK_DEVICE_FEATURE_EXTN(ProvokingVertex,                  PROVOKING_VERTEX,                     EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(ShaderAtomicFloat,                SHADER_ATOMIC_FLOAT,                  EXT,  12)
 MVK_DEVICE_FEATURE_EXTN(TexelBufferAlignment,             TEXEL_BUFFER_ALIGNMENT,               EXT,   1)
+MVK_DEVICE_FEATURE_EXTN(Ycbcr2Plane444Formats,            YCBCR_2_PLANE_444_FORMATS,            EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ShaderIntegerFunctions2,          SHADER_INTEGER_FUNCTIONS_2,           INTEL, 1)
 
 #pragma pop_macro("INTEL")

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -1039,6 +1039,12 @@ void MVKPixelFormats::initVkFormatCapabilities() {
     addVkFormatDescChromaSubsampling( G16_B16R16_2PLANE_422_UNORM, Invalid, 2, 16, 2, 1, 8 );
     addVkFormatDescChromaSubsampling( G16_B16_R16_3PLANE_444_UNORM, Invalid, 3, 16, 1, 1, 6 );
 
+	// Extension VK_EXT_ycbcr_2plane_444_formats
+    addVkFormatDescChromaSubsampling( G8_B8R8_2PLANE_444_UNORM, Invalid, 2, 8, 1, 1, 3 );
+    addVkFormatDescChromaSubsampling( G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16, Invalid, 2, 10, 1, 1, 6 );
+    addVkFormatDescChromaSubsampling( G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, Invalid, 2, 12, 1, 1, 6 );
+    addVkFormatDescChromaSubsampling( G16_B16R16_2PLANE_444_UNORM, Invalid, 2, 16, 1, 1, 6 );
+
 	_vkFormatDescriptions.shrink_to_fit();
 }
 

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -187,6 +187,7 @@ MVK_EXTENSION(EXT_texel_buffer_alignment,               EXT_TEXEL_BUFFER_ALIGNME
 MVK_EXTENSION(EXT_texture_compression_astc_hdr,         EXT_TEXTURE_COMPRESSION_ASTC_HDR,         DEVICE,   11.0,  13.0,  1.0)
 MVK_EXTENSION(EXT_tooling_info,                         EXT_TOOLING_INFO,                         DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_vertex_attribute_divisor,             EXT_VERTEX_ATTRIBUTE_DIVISOR,             DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(EXT_ycbcr_2plane_444_formats,             EXT_YCBCR_2PLANE_444_FORMATS,             DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(AMD_draw_indirect_count,                  AMD_DRAW_INDIRECT_COUNT,                  DEVICE,   MVK_NA, MVK_NA, MVK_NA)
 MVK_EXTENSION(AMD_gpu_shader_half_float,                AMD_GPU_SHADER_HALF_FLOAT,                DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(AMD_negative_viewport_height,             AMD_NEGATIVE_VIEWPORT_HEIGHT,             DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
Adds the four 2-plane 444 chroma-subsampled formats. The existing plane-splitting code is already generic over plane count, component bits and resolution, so only the format descriptions are needed.