### PR TITLE
Add support for VK_EXT_nested_command_buffer.

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -370,6 +370,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
   - *Requires Metal 2.0.*
 - `VK_EXT_metal_objects`
 - `VK_EXT_metal_surface`
+- `VK_EXT_nested_command_buffer`
 - `VK_EXT_non_seamless_cube_map`
   - *Requires a build of MoltenVK with `MVK_USE_METAL_PRIVATE_API` enabled.*
 - `VK_EXT_pipeline_creation_cache_control`

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.4.3
 Released TBD
 
 - Add support for the following extensions:
+  - `VK_EXT_nested_command_buffer`
   - `VK_EXT_ycbcr_2plane_444_formats`
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -747,6 +747,16 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				legacyDitheringFeatures->legacyDithering = getMVKConfig().useMetalPrivateAPI;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT: {
+				auto* nestedCmdBuffFeatures = (VkPhysicalDeviceNestedCommandBufferFeaturesEXT*)next;
+				// Secondary command buffers are encoded by replaying their commands onto the
+				// command encoder, which is inherently recursive, and does not modify the
+				// secondary command buffer, so it can also be executing elsewhere.
+				nestedCmdBuffFeatures->nestedCommandBuffer = true;
+				nestedCmdBuffFeatures->nestedCommandBufferRendering = true;
+				nestedCmdBuffFeatures->nestedCommandBufferSimultaneousUse = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT: {
 				auto* nonSeamlessFeatures = (VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*)next;
 				nonSeamlessFeatures->nonSeamlessCubeMap = getMVKConfig().useMetalPrivateAPI;
@@ -1283,6 +1293,12 @@ void MVKPhysicalDevice::getProperties(VkPhysicalDeviceProperties2* properties) {
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT: {
 				auto* extMemHostProps = (VkPhysicalDeviceExternalMemoryHostPropertiesEXT*)next;
 				extMemHostProps->minImportedHostPointerAlignment = _metalFeatures.hostMemoryPageSize;
+				break;
+			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT: {
+				auto* nestedCmdBuffProps = (VkPhysicalDeviceNestedCommandBufferPropertiesEXT*)next;
+				// Nesting is handled by recursion on the host, so no limit is imposed.
+				nestedCmdBuffProps->maxCommandBufferNestingLevel = std::numeric_limits<uint32_t>::max();
 				break;
 			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR: {

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -104,6 +104,7 @@ MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState3,            EXTENDED_DYNAMIC_STATE
 MVK_DEVICE_FEATURE_EXTN(FragmentShaderInterlock,          FRAGMENT_SHADER_INTERLOCK,            EXT,   3)
 MVK_DEVICE_FEATURE_EXTN(Image2DViewOf3D,                  IMAGE_2D_VIEW_OF_3D,                  EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(LegacyDithering,                  LEGACY_DITHERING,                     EXT,   1)
+MVK_DEVICE_FEATURE_EXTN(NestedCommandBuffer,              NESTED_COMMAND_BUFFER,                EXT,   3)
 MVK_DEVICE_FEATURE_EXTN(NonSeamlessCubeMap,               NON_SEAMLESS_CUBE_MAP,                EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(PrimitiveTopologyListRestart,     PRIMITIVE_TOPOLOGY_LIST_RESTART,      EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(ProvokingVertex,                  PROVOKING_VERTEX,                     EXT,   2)

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -160,6 +160,7 @@ MVK_EXTENSION(EXT_load_store_op_none,                   EXT_LOAD_STORE_OP_NONE, 
 MVK_EXTENSION(EXT_memory_budget,                        EXT_MEMORY_BUDGET,                        DEVICE,   10.13, 11.0,  1.0)
 MVK_EXTENSION(EXT_metal_objects,                        EXT_METAL_OBJECTS,                        DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_metal_surface,                        EXT_METAL_SURFACE,                        INSTANCE, 10.11,  8.0,  1.0)
+MVK_EXTENSION(EXT_nested_command_buffer,                EXT_NESTED_COMMAND_BUFFER,                DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_non_seamless_cube_map,                EXT_NON_SEAMLESS_CUBE_MAP,                DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_pipeline_creation_cache_control,      EXT_PIPELINE_CREATION_CACHE_CONTROL,      DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_pipeline_creation_feedback,           EXT_PIPELINE_CREATION_FEEDBACK,           DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
Secondary command buffers are encoded by replaying their commands onto the command encoder, which is already recursive, so a secondary command buffer that executes another one needs no additional handling. Replaying does not modify the secondary command buffer, so it may also be executing elsewhere, and nesting is bounded only by host stack, so no nesting limit is reported.

dEQP-VK.api.command_buffers, the five cases covering nested command buffers:

  before   0 passed, 0 failed, 5 unsupported
  after    5 passed, 0 failed, 0 unsupported

Those cases cover each of the three features reported: nested_execute and nested_execute_multiple_levels for nestedCommandBuffer, nested_render_pass_continue for nestedCommandBufferRendering, and record_simul_use_nested and record_simul_use_twice_nested for nestedCommandBufferSimultaneousUse.

maxCommandBufferNestingLevel is reported as the maximum value, as the implementation imposes no limit of its own. Submitting chains of nested secondary command buffers succeeded at every depth tested, up to 65536.