### PR TITLE
Declare argument buffer resources with residency sets

### DIFF
--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -321,7 +321,9 @@ void MVKPipelineLayout::populateBindOperations(MVKPipelineBindScript& script, co
 						script.ops.push_back({ bindSamp, set, mslBinding.resourceBinding.msl_sampler, descIdx, nonTexOffset });
 				}
 			}
-		} else if (!_device->hasResidencySet()) {
+		} else {
+			// Residency sets do not perform hazard tracking. Keep explicit per-encoder
+			// declarations for resources referenced through an argument buffer.
 			MVKDescriptorBindOperationCode useTex = partiallyBound ? MVKDescriptorBindOperationCode::UseTextureWithLiveCheck : MVKDescriptorBindOperationCode::UseResource;
 			MVKDescriptorBindOperationCode useBuf = partiallyBound ? MVKDescriptorBindOperationCode::UseBufferWithLiveCheck  : MVKDescriptorBindOperationCode::UseResource;
 			MVKDescriptorGPULayout gpuLayout = desc.gpuLayout;


### PR DESCRIPTION
## AI usage disclosure

OpenAI Codex was used to inspect the MoltenVK and RPCS3 source and logs, design and write the code change, build the experimental variants, compare the results, and draft this pull-request description. I directed the investigation and performed the human validation on an Apple M4 Pro: I reproduced the flashing blocks, frame discontinuities, and animation corruption; repeatedly tested the supplied A/B builds in gameplay; and confirmed that retaining residency sets while restoring explicit resource declarations fixes those failures. I reviewed the observed behavior and authorized this submission under my account.

## Summary

Generate explicit per-encoder `useResource` operations for resources referenced through Metal argument buffers even when the device uses an `MTLResidencySet`.

## Root cause

MoltenVK currently treats a residency set as a replacement for the indirect-resource declarations generated by `MVKDescriptorSetLayout::populateShaderConversionConfig()`. Metal residency sets make allocations resident, but they do not perform hazard tracking. Argument-buffer resources still need explicit encoder declarations so Metal can track their access.

Apple documents both parts of this behavior:

- [MTLResidencySet](https://developer.apple.com/documentation/metal/mtlresidencyset?language=objc)
- [MTLRenderCommandEncoder useResource:usage:stages:](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/useresource%28_%3Ausage%3Astages%3A%29)

The existing per-encoder resource-use cache remains in place, so declarations are not blindly reissued for every draw.

## Impact

This fixes intermittent corruption of indirectly referenced resources while retaining residency sets and their existing fence synchronization.

On RPCS3 running LEGO Dimensions on an Apple M4 Pro, the failure appeared as flashing magenta blocks, vertical frame discontinuities, and animation frames jumping between stale contents.

## Validation

A/B tested the relevant paths:

- stock residency-set path: corruption reproduced
- argument buffers with residency-set creation disabled: fixed
- residency set retained, with explicit `useResource` declarations: fixed
- residency set retained but its custom fences disabled: severe corruption
- explicit declarations with the existing per-encoder cache: fixed

Also completed:

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer make macos`
- extended gameplay testing with the cached declaration path
