### PR TITLE
Fix image memoryTypeBits consistency

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -22,6 +22,7 @@ Released TBD
   - `VK_EXT_multi_draw`
   - `VK_EXT_nested_command_buffer`
   - `VK_EXT_ycbcr_2plane_444_formats`
+- Fix inconsistent image `memoryTypeBits` when `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT` is used.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKImage.mm
@@ -954,13 +954,12 @@ VkResult MVKImage::getMemoryRequirements(VkMemoryRequirements* pMemoryRequiremen
 		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getPrivateMemoryTypes());
 	}
 
-    // Only transient attachments may use memoryless storage.
-	// Using memoryless as an input attachment requires shader framebuffer fetch, which MoltenVK does not support yet.
-	// TODO: support framebuffer fetch so VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT uses color(m) in shader instead of setFragmentTexture:, which crashes Metal
-    if (!mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ||
-		 mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) ) {
-        mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getLazilyAllocatedMemoryTypes());
-    }
+	// Only transient attachments may use memoryless storage. Vulkan requires memoryTypeBits to be
+	// identical for all images sharing a tiling, sparse binding flag, external handle types, and
+	// transient attachment usage, so no other usage bit may be taken into account here.
+	if ( !mvkIsAnyFlagEnabled(combinedUsage, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ) {
+		mvkDisableFlags(pMemoryRequirements->memoryTypeBits, mvkPD->getLazilyAllocatedMemoryTypes());
+	}
 
     return getMemoryBinding(planeIndex)->getMemoryRequirements(pMemoryRequirements);
 }
@@ -1145,6 +1144,16 @@ MTLStorageMode MVKImage::getMTLStorageMode() {
     MTLStorageMode stgMode = _memoryBindings[0]->_deviceMemory->getMTLStorageMode();
 
     if (_ioSurface && stgMode == MTLStorageModePrivate) { stgMode = MTLStorageModeShared; }
+
+	// An input attachment is read through a texture binding, which memoryless storage does not
+	// support, so commit the memory instead. Lazily allocated memory only promises that an
+	// implementation may defer the allocation, and never that it must.
+	// TODO: support framebuffer fetch so VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT reads color(m) in the
+	// shader rather than a texture binding, and memoryless storage can be kept here.
+	if (stgMode == MTLStorageModeMemoryless &&
+		mvkIsAnyFlagEnabled(getCombinedUsage(), VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
+		stgMode = MTLStorageModePrivate;
+	}
 
     return stgMode;
 }


### PR DESCRIPTION
Fix inconsistent image memoryTypeBits for input attachments

Vulkan requires identical memoryTypeBits for all images sharing a tiling, sparse binding flag, external handle types and transient attachment usage. MoltenVK also withheld the lazily allocated memory type from images using VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, which is not permitted to affect it.

That exclusion existed because an input attachment is read through a texture binding, which memoryless storage does not support. It is dropped, and the memory is instead committed when binding such an image.

https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VkMemoryRequirements
https://registry.khronos.org/vulkan/specs/latest/man/html/VkMemoryPropertyFlagBits.html
https://developer.apple.com/documentation/metal/mtlstoragemode/memoryless