### PR TITLE
Add support for VK_EXT_depth_clip_enable

### DIFF
--- a/Docs/MoltenVK_Runtime_UserGuide.md
+++ b/Docs/MoltenVK_Runtime_UserGuide.md
@@ -335,6 +335,7 @@ In addition to core *Vulkan* functionality, **MoltenVK**  also supports the foll
 - `VK_EXT_debug_report`
 - `VK_EXT_debug_utils`
 - `VK_EXT_depth_clip_control`
+- `VK_EXT_depth_clip_enable`
 - `VK_EXT_descriptor_indexing`
   - *Initial release limited to Metal Tier 1: 96/128 textures,
     16 samplers, except macOS 11.0 (Big Sur) or later, or on older versions of macOS using

--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -19,6 +19,7 @@ MoltenVK 1.4.3
 Released TBD
 
 - Add support for the following extensions:
+  - `VK_EXT_depth_clip_enable`
   - `VK_EXT_multi_draw`
   - `VK_EXT_nested_command_buffer`
   - `VK_EXT_ycbcr_2plane_444_formats`

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -682,6 +682,11 @@ void MVKPhysicalDevice::getFeatures(VkPhysicalDeviceFeatures2* features) {
 				depthFeatures->depthClipControl = true;
 				break;
 			}
+			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT: {
+				auto* depthClipFeatures = (VkPhysicalDeviceDepthClipEnableFeaturesEXT*)next;
+				depthClipFeatures->depthClipEnable = true;
+				break;
+			}
 			case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
 				auto* extDynState = (VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*)next;
 				extDynState->extendedDynamicState = true;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDeviceFeatureStructs.def
@@ -98,6 +98,7 @@ MVK_DEVICE_FEATURE_EXTN(ShaderSubgroupUniformControlFlow, SHADER_SUBGROUP_UNIFOR
 MVK_DEVICE_FEATURE_EXTN(SwapchainMaintenance1,            SWAPCHAIN_MAINTENANCE_1,              KHR,   1)
 MVK_DEVICE_FEATURE_EXTN(4444Formats,                      4444_FORMATS,                         EXT,   2)
 MVK_DEVICE_FEATURE_EXTN(DepthClipControl,                 DEPTH_CLIP_CONTROL,                   EXT,   1)
+MVK_DEVICE_FEATURE_EXTN(DepthClipEnable,                  DEPTH_CLIP_ENABLE,                    EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState,             EXTENDED_DYNAMIC_STATE,               EXT,   1)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState2,            EXTENDED_DYNAMIC_STATE_2,             EXT,   3)
 MVK_DEVICE_FEATURE_EXTN(ExtendedDynamicState3,            EXTENDED_DYNAMIC_STATE_3,             EXT,  31)

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -824,6 +824,23 @@ MVKGraphicsPipeline::MVKGraphicsPipeline(MVKDevice* device,
 
 	if (const VkPipelineRasterizationStateCreateInfo* rs = pCreateInfo->pRasterizationState) {
 		_staticStateData.enable.set(MVKRenderStateEnableFlag::DepthClamp, rs->depthClampEnable);
+
+		// VK_EXT_depth_clip_enable decouples depth CLIPPING from depthClampEnable, which in core
+		// Vulkan implicitly disables clipping. Metal's single MTLDepthClipMode expresses exactly one
+		// of clip or clamp, and that is sufficient here rather than a limitation:
+		//
+		//   clipping ENABLED  -> MTLDepthClipModeClip. depthClampEnable is unobservable in this case,
+		//                        because clipping removes everything outside the near/far planes, so
+		//                        every surviving fragment's depth already lies inside the viewport's
+		//                        [minDepth, maxDepth] and clamping to that range is a no-op.
+		//   clipping DISABLED -> MTLDepthClipModeClamp, which keeps the fragments and clamps them.
+		//
+		// So the clip mode follows depthClipEnable alone. Without the struct, the core rule applies
+		// and clipping is enabled exactly when depthClampEnable is false, which is what the
+		// depthClampEnable assignment above already encodes.
+		if (const auto* depthClip = mvkFindStructInChain<VkPipelineRasterizationDepthClipStateCreateInfoEXT>(rs, VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT)) {
+			_staticStateData.enable.set(MVKRenderStateEnableFlag::DepthClamp, !depthClip->depthClipEnable);
+		}
 		_staticStateData.enable.set(MVKRenderStateEnableFlag::DepthBias, rs->depthBiasEnable);
 		_staticStateData.setCullMode(rs->cullMode);
 		_staticStateData.setFrontFace(rs->frontFace);

--- a/MoltenVK/MoltenVK/Layers/MVKExtensions.def
+++ b/MoltenVK/MoltenVK/Layers/MVKExtensions.def
@@ -136,6 +136,7 @@ MVK_EXTENSION(EXT_debug_marker,                         EXT_DEBUG_MARKER,       
 MVK_EXTENSION(EXT_debug_report,                         EXT_DEBUG_REPORT,                         INSTANCE, 10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_debug_utils,                          EXT_DEBUG_UTILS,                          INSTANCE, 10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_depth_clip_control,                   EXT_DEPTH_CLIP_CONTROL,                   DEVICE,   10.11,  8.0,  1.0)
+MVK_EXTENSION(EXT_depth_clip_enable,                    EXT_DEPTH_CLIP_ENABLE,                    DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_descriptor_indexing,                  EXT_DESCRIPTOR_INDEXING,                  DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_extended_dynamic_state,               EXT_EXTENDED_DYNAMIC_STATE,               DEVICE,   10.11,  8.0,  1.0)
 MVK_EXTENSION(EXT_extended_dynamic_state2,              EXT_EXTENDED_DYNAMIC_STATE_2,             DEVICE,   10.11,  8.0,  1.0)


### PR DESCRIPTION
`VK_EXT_depth_clip_enable` decouples depth clipping from `depthClampEnable`, which in core Vulkan implicitly disables clipping.

Metal exposes depth clipping directly through `MTLDepthClipMode`, which MoltenVK already drives for `depthClampEnable`, so this maps onto existing machinery without emulation.

### Mapping

The clip mode follows `depthClipEnable` alone:

* clipping **enabled** → `MTLDepthClipModeClip`
* clipping **disabled** → `MTLDepthClipModeClamp`

`depthClampEnable` needs no special case when `VkPipelineRasterizationDepthClipStateCreateInfoEXT` is present. With clipping enabled nothing survives outside the near and far planes, so every remaining fragment's depth already lies within the viewport's `[minDepth, maxDepth]`, and clamping to that range is a no-op. When the struct is absent the core rule applies unchanged: clipping is enabled exactly when `depthClampEnable` is `VK_FALSE`.

### Verification

Tested on Apple M2 Max, macOS 26.5.1. A triangle is rendered offscreen to a colour + depth target, depth test `VK_COMPARE_OP_LESS_OR_EQUAL`, depth cleared to `1.0`, and the result is checked for whether the primitive survived rasterisation:

| gl_Position.z | depthClipEnable | depthClampEnable | result |
|---|---|---|---|
| 0.5 | enabled | disabled | drawn |
| 0.5 | disabled | disabled | drawn |
| 0.5 | enabled | enabled | drawn |
| 1.5 | enabled | disabled | clipped |
| 1.5 | disabled | disabled | drawn |
| 1.5 | enabled | enabled | clipped |
| 1.5 | disabled | enabled | drawn |

The `z = 0.5` rows are controls. They confirm the pipeline rasterises at all, so that a pipeline drawing nothing could not make the clipped rows pass by accident. The `z = 1.5` rows are the behaviour under test: identical geometry beyond the far plane is removed with clipping enabled and retained with it disabled, and the two `depthClampEnable = enabled` rows confirm that clipping takes precedence as described above.

Without this change the extension is not advertised, and the same test reports it as unavailable.

### Notes

* No new files, so no new copyright headers.
* No Vulkan validation is added; the mapping covers every combination without a deviation to report.
* No `autorelease` use.
* Documentation updated in `Docs/MoltenVK_Runtime_UserGuide.md` and `Docs/Whats_New.md`.
