### PR TITLE
Fix stage interface matching of 16-bit floating point variables.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -23,6 +23,7 @@ Released TBD
   - `VK_EXT_nested_command_buffer`
   - `VK_EXT_ycbcr_2plane_444_formats`
 - Fix inconsistent image `memoryTypeBits` when `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT` is used.
+- Fix shader stage interface matching of 16-bit floating point variables.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1248,76 +1248,22 @@ MTLComputePipelineDescriptor* MVKGraphicsPipeline::newMTLTessVertexStageDescript
 	return plDesc;
 }
 
-static VkFormat mvkFormatFromOutput(const SPIRVShaderOutput& output) {
-	switch (output.baseType) {
-		case SPIRType::SByte:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R8_SINT;
-				case 2: return VK_FORMAT_R8G8_SINT;
-				case 3: return VK_FORMAT_R8G8B8_SINT;
-				case 4: return VK_FORMAT_R8G8B8A8_SINT;
-			}
-			break;
-		case SPIRType::UByte:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R8_UINT;
-				case 2: return VK_FORMAT_R8G8_UINT;
-				case 3: return VK_FORMAT_R8G8B8_UINT;
-				case 4: return VK_FORMAT_R8G8B8A8_UINT;
-			}
-			break;
+// Returns how wide a stage interface variable is, for matching the interface of an adjoining stage.
+// The width is taken from the base type rather than from a Vulkan format, because a format describes
+// how many bits a color component occupies, and so reports a 16-bit float as a float. An interface
+// variable that the adjoining stage does not access is laid out from this width alone, so reporting
+// too wide a value silently shifts every later variable in the interface.
+static MSLShaderVariableFormat mvkInterfaceFormatFromBaseType(SPIRType::BaseType baseType) {
+	switch (baseType) {
+		case SPIRType::UByte:	return MSL_SHADER_VARIABLE_FORMAT_UINT8;
+		case SPIRType::UShort:	return MSL_SHADER_VARIABLE_FORMAT_UINT16;
 		case SPIRType::Short:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_SINT;
-				case 2: return VK_FORMAT_R16G16_SINT;
-				case 3: return VK_FORMAT_R16G16B16_SINT;
-				case 4: return VK_FORMAT_R16G16B16A16_SINT;
-			}
-			break;
-		case SPIRType::UShort:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_UINT;
-				case 2: return VK_FORMAT_R16G16_UINT;
-				case 3: return VK_FORMAT_R16G16B16_UINT;
-				case 4: return VK_FORMAT_R16G16B16A16_UINT;
-			}
-			break;
-		case SPIRType::Half:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R16_SFLOAT;
-				case 2: return VK_FORMAT_R16G16_SFLOAT;
-				case 3: return VK_FORMAT_R16G16B16_SFLOAT;
-				case 4: return VK_FORMAT_R16G16B16A16_SFLOAT;
-			}
-			break;
+		case SPIRType::Half:	return MSL_SHADER_VARIABLE_FORMAT_ANY16;
 		case SPIRType::Int:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_SINT;
-				case 2: return VK_FORMAT_R32G32_SINT;
-				case 3: return VK_FORMAT_R32G32B32_SINT;
-				case 4: return VK_FORMAT_R32G32B32A32_SINT;
-			}
-			break;
 		case SPIRType::UInt:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_UINT;
-				case 2: return VK_FORMAT_R32G32_UINT;
-				case 3: return VK_FORMAT_R32G32B32_UINT;
-				case 4: return VK_FORMAT_R32G32B32A32_UINT;
-			}
-			break;
-		case SPIRType::Float:
-			switch (output.vecWidth) {
-				case 1: return VK_FORMAT_R32_SFLOAT;
-				case 2: return VK_FORMAT_R32G32_SFLOAT;
-				case 3: return VK_FORMAT_R32G32B32_SFLOAT;
-				case 4: return VK_FORMAT_R32G32B32A32_SFLOAT;
-			}
-			break;
-		default:
-			break;
+		case SPIRType::Float:	return MSL_SHADER_VARIABLE_FORMAT_ANY32;
+		default:				return MSL_SHADER_VARIABLE_FORMAT_OTHER;
 	}
-	return VK_FORMAT_UNDEFINED;
 }
 
 // Returns a format of the same base type with vector length adjusted to fit size.
@@ -2264,30 +2210,7 @@ void MVKGraphicsPipeline::addNextStageInputToShaderConversionConfig(SPIRVToMSLCo
         sosv.vecsize = si.vecWidth;
 		sosv.rate = si.perPatch ? MSL_SHADER_VARIABLE_RATE_PER_PATCH : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
 
-        switch (getPixelFormats()->getFormatType(mvkFormatFromOutput(si) ) ) {
-            case kMVKFormatColorUInt8:
-                sosv.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-                break;
-
-            case kMVKFormatColorUInt16:
-                sosv.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-                break;
-
-			case kMVKFormatColorHalf:
-			case kMVKFormatColorInt16:
-				sosv.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-				break;
-
-			case kMVKFormatColorFloat:
-			case kMVKFormatColorInt32:
-			case kMVKFormatColorUInt32:
-				sosv.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-				break;
-
-            default:
-				sosv.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-                break;
-        }
+		sosv.format = mvkInterfaceFormatFromBaseType(si.baseType);
 
         shaderConfig.shaderOutputs.push_back(so);
     }
@@ -2309,30 +2232,7 @@ void MVKGraphicsPipeline::addPrevStageOutputToShaderConversionConfig(SPIRVToMSLC
         sisv.vecsize = so.vecWidth;
 		sisv.rate = so.perPatch ? MSL_SHADER_VARIABLE_RATE_PER_PATCH : MSL_SHADER_VARIABLE_RATE_PER_VERTEX;
 
-        switch (getPixelFormats()->getFormatType(mvkFormatFromOutput(so) ) ) {
-            case kMVKFormatColorUInt8:
-                sisv.format = MSL_SHADER_VARIABLE_FORMAT_UINT8;
-                break;
-
-            case kMVKFormatColorUInt16:
-                sisv.format = MSL_SHADER_VARIABLE_FORMAT_UINT16;
-                break;
-
-			case kMVKFormatColorHalf:
-			case kMVKFormatColorInt16:
-				sisv.format = MSL_SHADER_VARIABLE_FORMAT_ANY16;
-				break;
-
-			case kMVKFormatColorFloat:
-			case kMVKFormatColorInt32:
-			case kMVKFormatColorUInt32:
-				sisv.format = MSL_SHADER_VARIABLE_FORMAT_ANY32;
-				break;
-
-            default:
-				sisv.format = MSL_SHADER_VARIABLE_FORMAT_OTHER;
-                break;
-        }
+		sisv.format = mvkInterfaceFormatFromBaseType(so.baseType);
 
         shaderConfig.shaderInputs.push_back(si);
     }


### PR DESCRIPTION
When matching the interface between two shader stages, MoltenVK took each variable's width from a VkFormat mapped from its base type. A format describes how many bits a component occupies rather than how it is interpreted, so a 16-bit float was described as 32-bit, and no format is ever described as a half.

A variable the adjoining stage does not access is laid out from that width alone, so a tessellation control shader writing a half wrote two bytes where the evaluation shader reserved four, shifting every later variable in the interface.

Take the width from the base type directly, in both directions of the match. Only one base type changes: a half is now described as 16-bit.

CTS over dEQP-VK.memory, query_pool, dynamic_state, clipping, fragment_operations, multiview, descriptor_indexing, info, geometry, tessellation and conditional_rendering, 29692 tests:

  Pass 7072 -> 7092, Fail 44 -> 24, no test regressed.

The 20 newly passing tests are dEQP-VK.tessellation.tess_io.max_in_out.with_f16.*. The 64-bit integer equivalents, with_i64.*.tcs_vert_writes{,_reads}_tes_na, still fail, because an interface variable can currently be described only as 16-bit or 32-bit. The 64-bit float ones do not run, as shaderFloat64 is not supported.

https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#interfaces-iointerfaces-matching