### PR TITLE
Remove the unused kMVKFormatColorHalf format type.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
   - `VK_EXT_ycbcr_2plane_444_formats`
 - Fix inconsistent image `memoryTypeBits` when `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT` is used.
 - Fix shader stage interface matching of 16-bit floating point variables.
+- Remove the unused `kMVKFormatColorHalf` format type.
 
 
 

--- a/MoltenVK/MoltenVK/API/mvk_datatypes.h
+++ b/MoltenVK/MoltenVK/API/mvk_datatypes.h
@@ -45,7 +45,6 @@ extern "C" {
 /** Enumerates the data type of a format. */
 typedef enum {
     kMVKFormatNone,             /**< Format type is unknown. */
-	kMVKFormatColorHalf,		/**< A 16-bit floating point color. */
     kMVKFormatColorFloat,		/**< A 32-bit floating point color. */
 	kMVKFormatColorInt8,        /**< A signed 8-bit integer color. */
 	kMVKFormatColorUInt8,		/**< An unsigned 8-bit integer color. */

--- a/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandEncodingPool.mm
@@ -112,7 +112,6 @@ static constexpr uint32_t getRenderpassLoadStoreStateIndex(MVKFormatType type, b
 	// Kernels for array textures are stored from slot 3 onwards
 	uint32_t layeredOffset = isTextureArray ? 3u : 0u;
 	switch (type) {
-		case kMVKFormatColorHalf:
 		case kMVKFormatColorFloat:
 			return 0 + layeredOffset;
 		case kMVKFormatColorInt8:

--- a/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandResourceFactory.mm
@@ -400,7 +400,6 @@ NSString* MVKCommandResourceFactory::getMTLFormatTypeString(MTLPixelFormat mtlPi
 		case kMVKFormatColorUInt16:		return @"ushort";
 		case kMVKFormatColorInt32:		return @"int";
 		case kMVKFormatColorUInt32:		return @"uint";
-		case kMVKFormatColorHalf:		return @"half";
 		case kMVKFormatColorFloat:
 		case kMVKFormatDepthStencil:
 		case kMVKFormatCompressed:		return @"float";
@@ -532,7 +531,6 @@ id<MTLComputePipelineState> MVKCommandResourceFactory::newCmdClearColorImageMTLC
 					bool isTextureArray) {
 	const char* funcName;
 	switch (type) {
-		case kMVKFormatColorHalf:
 		case kMVKFormatColorFloat:
 			funcName = isTextureArray ? "cmdClearColorImage2DFloatArray" : "cmdClearColorImage2DFloat";
 			break;
@@ -558,7 +556,6 @@ id<MTLComputePipelineState> MVKCommandResourceFactory::newCmdResolveColorImageMT
 																									  bool isTextureArray) {
 	const char* funcName;
 	switch (type) {
-		case kMVKFormatColorHalf:
 		case kMVKFormatColorFloat:
 			funcName = isTextureArray ? "cmdResolveColorImage2DFloatArray" : "cmdResolveColorImage2DFloat";
 			break;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKDevice.mm
@@ -2989,7 +2989,6 @@ void MVKPhysicalDevice::initLimits() {
             case kMVKFormatColorUInt8:
                 texelSize = 1;
                 break;
-            case kMVKFormatColorHalf:
             case kMVKFormatColorInt16:
             case kMVKFormatColorUInt16:
                 texelSize = 2;

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPixelFormats.mm
@@ -421,7 +421,6 @@ MTLClearColor MVKPixelFormats::getMTLClearColor(VkClearColorValue clearValue, Vk
 	// n.b. Bad things might happen if the original swizzle isn't one-to-one!
 	VkComponentMapping inverseMap = getInverseComponentMapping(vkFormat);
 	switch (getFormatType(vkFormat)) {
-		case kMVKFormatColorHalf:
 		case kMVKFormatColorFloat: {
 			mtlClr.red		= mvkVkClearColorFloatValueFromVkComponentSwizzle(clearValue.float32, 0, inverseMap.r);
 			mtlClr.green	= mvkVkClearColorFloatValueFromVkComponentSwizzle(clearValue.float32, 1, inverseMap.g);


### PR DESCRIPTION
No format descriptor ever produced it. Every 16-bit floating point format is registered as kMVKFormatColorFloat, so getFormatType() could not return it, and the six switches naming it were unreachable.

Five of those switches shared an arm with kMVKFormatColorFloat and are unaffected. The sixth, getMTLFormatTypeString(), was the only one to give it a distinct result, a half MSL type for the attachment clear shader; a 16-bit float attachment already reaches the float arm there.

This removes an enumerator from a public header, so a value of MVKFormatType compiled against an earlier release no longer matches.