### PR TITLE
Fix spurious warning about blending on unsupported attachment formats.

### DIFF
--- a/Docs/Whats_New.md
+++ b/Docs/Whats_New.md
@@ -24,6 +24,7 @@ Released TBD
   - `VK_EXT_ycbcr_2plane_444_formats`
 - Fix inconsistent image `memoryTypeBits` when `VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT` is used.
 - Fix shader stage interface matching of 16-bit floating point variables.
+- Fix spurious warning about blending on attachment formats that do not support it.
 
 
 

--- a/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
+++ b/MoltenVK/MoltenVK/GPUObjects/MVKPipeline.mm
@@ -1938,7 +1938,7 @@ void MVKGraphicsPipeline::addFragmentOutputToPipeline(MTLRenderPipelineDescripto
 					plDesc.logicOperationMVK = mvkMTLLogicOperationFromVkLogicOp(pCreateInfo->pColorBlendState->logicOp);
 				}
 #endif
-            } else if (mtlPixFmt && !supportsBlend) {
+            } else if (mtlPixFmt && !supportsBlend && pCA->blendEnable) {
                 reportWarning(VK_ERROR_FEATURE_NOT_PRESENT, "Blending is enabled for attachment with format %s, which does not support it.", getPixelFormats()->getName(attachFmt));
             }
         }


### PR DESCRIPTION
When configuring a colour attachment, MoltenVK checks whether the attachment's Metal pixel format supports blending, and skips the blend state if it does not, since Metal asserts when blending is enabled for such a format. The accompanying warning, however, is emitted from the else branch on the format capability alone, without consulting `blendEnable`.

Fix: emit the warning only when the pipeline actually requested blending.