### PR TITLE
Preserve execution dependencies across Metal encoders

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdPipeline.mm
@@ -104,6 +104,10 @@ VkResult MVKCmdPipelineBarrier<N>::setContent(MVKCommandBuffer* cmdBuff,
 	for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) {
 		_barriers.emplace_back(pImageMemoryBarriers[i], srcStageMask, dstStageMask);
 	}
+	if (_barriers.empty()) {
+		VkMemoryBarrier barrier = {VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+		_barriers.emplace_back(barrier, srcStageMask, dstStageMask);
+	}
 
 	return VK_SUCCESS;
 }

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.h
@@ -551,6 +551,7 @@ protected:
 	uint32_t _multiviewPassIndex;
     uint32_t _flushCount;
 	MVKCommandUse _mtlComputeEncoderUse;
+	uint32_t _mtlComputeEncoderStages;
 	MVKCommandUse _mtlBlitEncoderUse;
 	bool _isRenderingEntireAttachment;
 };

--- a/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandBuffer.mm
@@ -749,9 +749,10 @@ void MVKCommandEncoder::encodeBarrierUpdates() {
 	}
 
 	if (_mtlComputeEncoder) {
-		MVKBarrierStage stage = commandUseToBarrierStage(_mtlComputeEncoderUse);
-		if (stage != kMVKBarrierStageNone) {
-			barrierUpdate(stage, _mtlComputeEncoder);
+		for (int stage = 0; stage < kMVKBarrierStageCount; ++stage) {
+			if (mvkIsAnyFlagEnabled(_mtlComputeEncoderStages, 1 << stage)) {
+				barrierUpdate((MVKBarrierStage)stage, _mtlComputeEncoder);
+			}
 		}
 	}
 
@@ -1063,6 +1064,7 @@ void MVKCommandEncoder::endCurrentMetalEncoding() {
 	if (_mtlComputeEncoder && _cmdBuffer->_hasStageCounterTimestampCommand) { [_mtlComputeEncoder updateFence: getStageCountersMTLFence()]; }
 	endMetalEncoding(_mtlComputeEncoder);
 	_mtlComputeEncoderUse = kMVKCommandUseNone;
+	_mtlComputeEncoderStages = 0;
 
 	if (_mtlBlitEncoder && _cmdBuffer->_hasStageCounterTimestampCommand) { [_mtlBlitEncoder updateFence: getStageCountersMTLFence()]; }
 	endMetalEncoding(_mtlBlitEncoder);
@@ -1109,6 +1111,10 @@ id<MTLComputeCommandEncoder> MVKCommandEncoder::getMTLComputeEncoder(MVKCommandU
 	if (_mtlComputeEncoderUse != cmdUse) {
 		needWaits = true;
 		_mtlComputeEncoderUse = cmdUse;
+		MVKBarrierStage stage = commandUseToBarrierStage(cmdUse);
+		if (stage != kMVKBarrierStageNone) {
+			mvkEnableFlags(_mtlComputeEncoderStages, 1 << stage);
+		}
 		_cmdBuffer->setMetalObjectLabel(_mtlComputeEncoder, mvkMTLComputeCommandEncoderLabel(cmdUse));
 	}
 	if (needWaits) {
@@ -1350,6 +1356,7 @@ MVKCommandEncoder::MVKCommandEncoder(MVKCommandBuffer* cmdBuffer, MVKPrefillMeta
 	_mtlRenderEncoder = nil;
 	_mtlComputeEncoder = nil;
 	_mtlComputeEncoderUse = kMVKCommandUseNone;
+	_mtlComputeEncoderStages = 0;
 	_mtlBlitEncoder = nil;
 	_mtlBlitEncoderUse = kMVKCommandUseNone;
 	_pEncodingContext = nullptr;


### PR DESCRIPTION
Track every barrier stage used by a shared compute encoder, so closing it updates all required fences rather than only the last command's stage. Preserve the source and destination stages of legacy execution-only pipeline barriers when no memory barrier records are supplied. Both changes use the existing fence machinery and preserve encoder sharing.

Related to #2805.
