### PR TITLE
Correct tessellation patch counts and indexed-indirect command layout

### DIFF
--- a/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
+++ b/MoltenVK/MoltenVK/Commands/MVKCmdDraw.mm
@@ -199,11 +199,14 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
 		uint32_t inControlPointCount = 0;
 		uint32_t patchCount = 0;
 	} tessParams;
+    uint32_t tessVertexCount = 0;
     uint32_t outControlPointCount = 0;
     if (pipeline->isTessellationPipeline()) {
         tessParams.inControlPointCount = cmdEncoder->getVkGraphics().getPatchControlPoints();
         outControlPointCount = pipeline->getOutputControlPointCount();
-        tessParams.patchCount = mvkCeilingDivide(_vertexCount, tessParams.inControlPointCount) * _instanceCount;
+        tessVertexCount = _vertexCount / tessParams.inControlPointCount * tessParams.inControlPointCount;
+        tessParams.patchCount = tessVertexCount / tessParams.inControlPointCount * _instanceCount;
+        if (!tessParams.patchCount) { return; }
     }
     if (pipeline->needsDrawIdBuffer()) {
         tempDrawIDBuff = cmdEncoder->getTempMTLBuffer(sizeof(uint32_t));
@@ -233,16 +236,16 @@ void MVKCmdDraw::encode(MVKCommandEncoder* cmdEncoder) {
                                           offset: tempDrawIDBuff->_offset
                                          atIndex: pipeline->getImplicitBuffers(kMVKShaderStageVertex).ids[MVKImplicitBuffer::DrawId]];
                 }
-				[mtlTessCtlEncoder setStageInRegion: MTLRegionMake2D(_firstVertex, _firstInstance, _vertexCount, _instanceCount)];
+				[mtlTessCtlEncoder setStageInRegion: MTLRegionMake2D(_firstVertex, _firstInstance, tessVertexCount, _instanceCount)];
 				// If there are vertex bindings with a zero vertex divisor, I need to offset them by
 				// _firstInstance * stride, since that is the expected behaviour for a divisor of 0.
                 cmdEncoder->getState().offsetZeroDivisorVertexBuffers(*cmdEncoder, stage, pipeline, _firstInstance);
 				id<MTLComputePipelineState> vtxState = pipeline->getTessVertexStageState();
 				if (mtlFeats.nonUniformThreadgroups) {
-					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(_vertexCount, _instanceCount, 1)
+					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(tessVertexCount, _instanceCount, 1)
 					             threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
 				} else {
-					[mtlTessCtlEncoder dispatchThreadgroups: MTLSizeMake(mvkCeilingDivide(_vertexCount, vtxState.threadExecutionWidth), _instanceCount, 1)
+					[mtlTessCtlEncoder dispatchThreadgroups: MTLSizeMake(mvkCeilingDivide(tessVertexCount, vtxState.threadExecutionWidth), _instanceCount, 1)
                                       threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
 				}
                 break;
@@ -483,11 +486,14 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 		uint32_t inControlPointCount = 0;
 		uint32_t patchCount = 0;
 	} tessParams;
+    uint32_t tessVertexCount = 0;
     uint32_t outControlPointCount = 0;
     if (pipeline->isTessellationPipeline()) {
         tessParams.inControlPointCount = cmdEncoder->getVkGraphics().getPatchControlPoints();
         outControlPointCount = pipeline->getOutputControlPointCount();
-        tessParams.patchCount = mvkCeilingDivide(_indexCount, tessParams.inControlPointCount) * _instanceCount;
+        tessVertexCount = _indexCount / tessParams.inControlPointCount * tessParams.inControlPointCount;
+        tessParams.patchCount = tessVertexCount / tessParams.inControlPointCount * _instanceCount;
+        if (!tessParams.patchCount) { return; }
     }
     if (pipeline->needsDrawIdBuffer()) {
         tempDrawIDBuff = cmdEncoder->getTempMTLBuffer(sizeof(uint32_t));
@@ -519,16 +525,16 @@ void MVKCmdDrawIndexed::encode(MVKCommandEncoder* cmdEncoder) {
 				[mtlTessCtlEncoder setBuffer: ibb.mtlBuffer
                                       offset: idxBuffOffset
                                      atIndex: pipeline->getImplicitBuffers(kMVKShaderStageVertex).ids[MVKImplicitBuffer::Index]];
-				[mtlTessCtlEncoder setStageInRegion: MTLRegionMake2D(_vertexOffset, _firstInstance, _indexCount, _instanceCount)];
+				[mtlTessCtlEncoder setStageInRegion: MTLRegionMake2D(_vertexOffset, _firstInstance, tessVertexCount, _instanceCount)];
 				// If there are vertex bindings with a zero vertex divisor, I need to offset them by
 				// _firstInstance * stride, since that is the expected behaviour for a divisor of 0.
                 cmdEncoder->getState().offsetZeroDivisorVertexBuffers(*cmdEncoder, stage, pipeline, _firstInstance);
 				id<MTLComputePipelineState> vtxState = ibb.mtlIndexType == MTLIndexTypeUInt16 ? pipeline->getTessVertexStageIndex16State() : pipeline->getTessVertexStageIndex32State();
 				if (mtlFeats.nonUniformThreadgroups) {
-					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(_indexCount, _instanceCount, 1)
+					[mtlTessCtlEncoder dispatchThreads: MTLSizeMake(tessVertexCount, _instanceCount, 1)
 					             threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
 				} else {
-					[mtlTessCtlEncoder dispatchThreadgroups: MTLSizeMake(mvkCeilingDivide(_indexCount, vtxState.threadExecutionWidth), _instanceCount, 1)
+					[mtlTessCtlEncoder dispatchThreadgroups: MTLSizeMake(mvkCeilingDivide(tessVertexCount, vtxState.threadExecutionWidth), _instanceCount, 1)
                                       threadsPerThreadgroup: MTLSizeMake(vtxState.threadExecutionWidth, 1, 1)];
 				}
                 break;
@@ -1300,7 +1306,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
         outControlPointCount = pipeline->getOutputControlPointCount();
         vertexCount = kMVKMaxDrawIndirectVertexCount;
         patchCount = mvkCeilingDivide(vertexCount, inControlPointCount);
-        VkDeviceSize indirectSize = (sizeof(MTLDispatchThreadgroupsIndirectArguments) + sizeof(MTLDrawPatchIndirectArguments) + sizeof(MTLStageInRegionIndirectArguments)) * _drawCount;
+        VkDeviceSize indirectSize = (2 * sizeof(MTLDispatchThreadgroupsIndirectArguments) + sizeof(MTLDrawPatchIndirectArguments) + sizeof(MTLStageInRegionIndirectArguments)) * _drawCount;
 		paramsIncr = std::max((size_t)dvcLimits.minUniformBufferOffsetAlignment, sizeof(uint32_t) * 2);
 		VkDeviceSize paramsSize = paramsIncr * _drawCount;
         tempIndirectBuff = cmdEncoder->getTempMTLBuffer(indirectSize, true);
@@ -1391,7 +1397,7 @@ void MVKCmdDrawIndexedIndirect::encode(MVKCommandEncoder* cmdEncoder, const MVKI
                 [mtlTessCtlEncoder dispatchThreadgroupsWithIndirectBuffer: mtlIndBuff
 													 indirectBufferOffset: mtlTempIndBuffOfst + sizeof(MTLStageInRegionIndirectArguments)
                                                     threadsPerThreadgroup: MTLSizeMake(vtxThreadExecWidth, 1, 1)];
-				mtlIndBuffOfst += sizeof(MTLDrawIndexedPrimitivesIndirectArguments);
+				mtlIndBuffOfst += indirectBufferStride;
             } else if (drawIdx == 0 && vtxAdjmts.needsAdjustment()) {
                 // Similarly, for multiview, we need to adjust the instance count now.
                 // Unfortunately, this requires switching to compute. Luckily, we don't also

--- a/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
+++ b/MoltenVK/MoltenVK/Commands/MVKCommandPipelineStateFactoryShaderSource.h
@@ -397,10 +397,11 @@ kernel void cmdDrawIndirectTessConvertBuffers(const device char* srcBuff [[buffe
 	device auto& destVtx = *(device MTLDispatchThreadgroupsIndirectArguments*)dest;
 	device auto& destTC = *(device MTLDispatchThreadgroupsIndirectArguments*)(dest + sizeof(MTLDispatchThreadgroupsIndirectArguments));
 	device auto& destTE = *(device MTLDrawPatchIndirectArguments*)(dest + sizeof(MTLDispatchThreadgroupsIndirectArguments) * 2);
-	uint32_t patchCount = (src.vertexCount * src.instanceCount + inControlPointCount - 1) / inControlPointCount;
+	uint32_t vertexCount = src.vertexCount / inControlPointCount * inControlPointCount;
+	uint32_t patchCount = vertexCount / inControlPointCount * src.instanceCount;
 	params[0] = inControlPointCount;
 	params[1] = patchCount;
-	destVtx.threadgroupsPerGrid[0] = (src.vertexCount + vtxThreadExecWidth - 1) / vtxThreadExecWidth;
+	destVtx.threadgroupsPerGrid[0] = (vertexCount + vtxThreadExecWidth - 1) / vtxThreadExecWidth;
 	destVtx.threadgroupsPerGrid[1] = src.instanceCount;
 	destVtx.threadgroupsPerGrid[2] = 1;
 	destTC.threadgroupsPerGrid[0] = (patchCount * outControlPointCount + tcWorkgroupSize - 1) / tcWorkgroupSize;
@@ -411,7 +412,7 @@ kernel void cmdDrawIndirectTessConvertBuffers(const device char* srcBuff [[buffe
 	destSI.stageInOrigin[0] = src.vertexStart;
 	destSI.stageInOrigin[1] = src.baseInstance;
 	destSI.stageInOrigin[2] = 0;
-	destSI.stageInSize[0] = src.vertexCount;
+	destSI.stageInSize[0] = vertexCount;
 	destSI.stageInSize[1] = src.instanceCount;
 	destSI.stageInSize[2] = 1;
 }
@@ -436,10 +437,11 @@ kernel void cmdDrawIndexedIndirectTessConvertBuffers(const device char* srcBuff 
 	device auto& destVtx = *(device MTLDispatchThreadgroupsIndirectArguments*)dest;
 	device auto& destTC = *(device MTLDispatchThreadgroupsIndirectArguments*)(dest + sizeof(MTLDispatchThreadgroupsIndirectArguments));
 	device auto& destTE = *(device MTLDrawPatchIndirectArguments*)(dest + sizeof(MTLDispatchThreadgroupsIndirectArguments) * 2);
-	uint32_t patchCount = (src.indexCount * src.instanceCount + inControlPointCount - 1) / inControlPointCount;
+	uint32_t vertexCount = src.indexCount / inControlPointCount * inControlPointCount;
+	uint32_t patchCount = vertexCount / inControlPointCount * src.instanceCount;
 	params[0] = inControlPointCount;
 	params[1] = patchCount;
-	destVtx.threadgroupsPerGrid[0] = (src.indexCount + vtxThreadExecWidth - 1) / vtxThreadExecWidth;
+	destVtx.threadgroupsPerGrid[0] = (vertexCount + vtxThreadExecWidth - 1) / vtxThreadExecWidth;
 	destVtx.threadgroupsPerGrid[1] = src.instanceCount;
 	destVtx.threadgroupsPerGrid[2] = 1;
 	destTC.threadgroupsPerGrid[0] = (patchCount * outControlPointCount + tcWorkgroupSize - 1) / tcWorkgroupSize;
@@ -450,7 +452,7 @@ kernel void cmdDrawIndexedIndirectTessConvertBuffers(const device char* srcBuff 
 	destSI.stageInOrigin[0] = src.baseVertex;
 	destSI.stageInOrigin[1] = src.baseInstance;
 	destSI.stageInOrigin[2] = 0;
-	destSI.stageInSize[0] = src.indexCount;
+	destSI.stageInSize[0] = vertexCount;
 	destSI.stageInSize[1] = src.instanceCount;
 	destSI.stageInSize[2] = 1;
 }


### PR DESCRIPTION
Discard incomplete patches per instance and pack the captured vertices accordingly, so direct and indirect draws produce the same complete patches. Also reserve both dispatch records written by indexed-indirect conversion and advance source commands by their supplied stride.

The index-copy dispatch offset is already fixed by #2817 and is excluded from this proposal.

Related to #2376.
